### PR TITLE
ci: add GitHub Actions workflow (lint + test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: pip install ruff>=0.8
+
+      - name: Ruff check
+        run: ruff check nous/ tests/
+
+      - name: Ruff format check
+        run: ruff format --check nous/ tests/
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    needs: lint
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_DB: nous
+          POSTGRES_USER: nous
+          POSTGRES_PASSWORD: nous_dev_password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U nous"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]" httpx
+
+      - name: Initialize database schema
+        env:
+          PGHOST: localhost
+          PGUSER: nous
+          PGPASSWORD: nous_dev_password
+          PGDATABASE: nous
+        run: |
+          psql -f sql/init.sql
+          psql -f sql/seed.sql
+
+      - name: Run tests
+        env:
+          DB_HOST: localhost
+          DB_PORT: "5432"
+          DB_USER: nous
+          DB_PASSWORD: nous_dev_password
+          DB_NAME: nous
+        run: pytest tests/ -v --tb=short

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "pgvector>=0.3,<1.0",
     "pydantic>=2.0,<3.0",
     "pydantic-settings>=2.0,<3.0",
+    "httpx>=0.27,<1.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## What

Adds CI pipeline for the Nous repo.

### Lint job
- Ruff check (errors, imports, formatting, py312 upgrades)
- Ruff format verification

### Test job
- Spins up `pgvector/pgvector:pg17` as a service container
- Runs `sql/init.sql` + `sql/seed.sql` via psql
- Runs full pytest suite against real Postgres
- Depends on lint passing first

### Fix
- Added missing `httpx` to `pyproject.toml` dependencies (used by `nous/brain/embeddings.py` but not declared)

### Concurrency
- Auto-cancels superseded runs on same branch

⚡ Emerson