### PR TITLE
feat: replace Claude Agent SDK with direct Anthropic API (005.2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# DB connection — shared by docker-compose AND Python app
+# DB connection -- shared by docker-compose AND Python app
 DB_HOST=localhost
 DB_PORT=5432
 DB_USER=nous
@@ -7,10 +7,10 @@ DB_NAME=nous
 
 # LLM
 ANTHROPIC_API_KEY=your_anthropic_key_here
-# Dual auth: SDK uses ANTHROPIC_AUTH_TOKEN if set (takes precedence)
+# Dual auth: Bearer token takes precedence over API key
 ANTHROPIC_AUTH_TOKEN=
 
-# Embeddings (optional — keyword-only search if omitted)
+# Embeddings (optional -- keyword-only search if omitted)
 OPENAI_API_KEY=your_openai_key_here
 
 # Agent
@@ -21,9 +21,9 @@ NOUS_LOG_LEVEL=info
 NOUS_MCP_ENABLED=true
 NOUS_PORT=8000
 
-# Claude Agent SDK
-NOUS_SDK_MAX_TURNS=10
-NOUS_SDK_PERMISSION_MODE=default
-NOUS_SDK_WORKSPACE=/tmp/nous-workspace
-# JSON format required for list fields:
-# NOUS_SDK_ALLOWED_TOOLS=["record_decision","learn_fact","recall_deep","create_censor"]
+# Direct API settings
+NOUS_MAX_TURNS=10
+NOUS_API_BASE_URL=https://api.anthropic.com
+NOUS_API_TIMEOUT_CONNECT=10
+NOUS_API_TIMEOUT_READ=120
+NOUS_WORKSPACE_DIR=/tmp/nous-workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,12 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-# Install psql client, curl, Node.js, and Claude Code CLI (required by Claude Agent SDK)
+# Install psql client and curl (no Node.js needed)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    postgresql-client curl gnupg && \
-    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-    apt-get install -y --no-install-recommends nodejs && \
-    rm -rf /var/lib/apt/lists/* && \
-    npm install -g @anthropic-ai/claude-code
+    postgresql-client curl && \
+    rm -rf /var/lib/apt/lists/*
 
-# Create SDK workspace directory
+# Create workspace directory
 RUN mkdir -p /tmp/nous-workspace
 
 # Copy source BEFORE pip install (F5: non-editable install)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,10 +18,8 @@ services:
       - NOUS_MODEL=${NOUS_MODEL:-claude-sonnet-4-5-20250514}
       - NOUS_LOG_LEVEL=${NOUS_LOG_LEVEL:-info}
       - NOUS_MCP_ENABLED=${NOUS_MCP_ENABLED:-true}
-      - NOUS_SDK_MAX_TURNS=${NOUS_SDK_MAX_TURNS:-10}
-      - NOUS_SDK_PERMISSION_MODE=${NOUS_SDK_PERMISSION_MODE:-default}
-      - NOUS_SDK_WORKSPACE=${NOUS_SDK_WORKSPACE:-/tmp/nous-workspace}
-      # SDK_ALLOWED_TOOLS uses default from config.py (list type requires JSON format if overridden)
+      - NOUS_MAX_TURNS=${NOUS_MAX_TURNS:-10}
+      - NOUS_WORKSPACE_DIR=${NOUS_WORKSPACE_DIR:-/tmp/nous-workspace}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/implementation/005.2-direct-api-rewrite-plan.md
+++ b/docs/implementation/005.2-direct-api-rewrite-plan.md
@@ -1,0 +1,230 @@
+# 005.2 Direct API Rewrite — Implementation Plan
+
+**Source spec:** `005.2-direct-api-rewrite.md`
+**Review team:** nous-arch-052, nous-api-052, nous-devil-052
+**Review decision IDs:** `b761d571`, `45b454b3`, `64b69e40`
+**Synthesis decision ID:** `c6128a0f`
+**Date:** 2026-02-23
+
+## Review Summary
+
+3 reviewers produced 49 findings. After dedup: **8 P0 blockers, 9 P1 issues, ~10 P2/P3**.
+
+### Convergence Matrix (P0 Blockers)
+
+| Finding | Arch | API | Devil | Fix |
+|---------|------|-----|-------|-----|
+| Missing `anthropic-version` header | P0 | P0 | P1 | Add to httpx default headers |
+| Conv history in system prompt, not messages[] | P0 | P1 | P1 | Use `_format_messages()` for messages array |
+| Tool loop must preserve assistant tool_use msgs | — | P0 | P1 | Append full assistant response + user tool_results |
+| `record_decision` field "decision" vs "description" | P1 | P1 | P0 | Keep "description" from existing code |
+| `record_decision` drops required category/stakes | P1 | P1 | P0 | Keep 4 required fields from existing schema |
+| `dispatch(args)` vs closures expect `**kwargs` | — | — | P0 | Use `handler(**args)` |
+| `ToolDispatcher.__init__` missing `_schemas` | P1 | P1 | P0 | Add `self._schemas = {}` |
+| Bash workspace dir config removed | — | — | P0 | Add `workspace_dir` config field |
+
+### Lead Overrides
+
+- **Frame-gated tools (D5):** Implement but sync with `_get_frame_instructions()`. P2, not blocking.
+- **Retry logic:** Simple inline retry (1x for 429/500), no `tenacity` dep. P2.
+- **Prompt caching:** Keep D9 approach but make conditional on auth type. P2.
+
+## Implementation Phases
+
+### Phase A: Config + API Client (~45 min)
+
+**Files:** `nous/config.py`, `nous/api/runner.py`
+
+1. **Config changes** (`config.py`):
+   - Remove: `sdk_max_turns`, `sdk_permission_mode`, `sdk_workspace`, `sdk_allowed_tools`
+   - Add: `max_turns: int = 10`, `api_base_url: str = "https://api.anthropic.com"`, `api_timeout_connect: int = 10`, `api_timeout_read: int = 120`, `workspace_dir: str = "/tmp/nous-workspace"`
+
+2. **httpx.AsyncClient** (`runner.py`):
+   - Create in `start()`, close with `await self._http.aclose()` in `close()`
+   - Default headers: `anthropic-version: 2023-06-01`, `content-type: application/json`
+   - Auth header per D1: Bearer token takes precedence over x-api-key
+   - Timeout: `httpx.Timeout(connect=settings.api_timeout_connect, read=settings.api_timeout_read, write=10, pool=10)`
+   - Connection limits: `httpx.Limits(max_connections=10, max_keepalive_connections=5)`
+
+3. **`_call_api()` method** (`runner.py`):
+   - Single API call: POST `/v1/messages` with `model`, `max_tokens`, `system`, `messages`, `tools`
+   - Parse response: extract `content` blocks and `stop_reason`
+   - Error handling: parse `error.type` + `error.message` from response body
+   - Simple retry: 1x for 429 (with `Retry-After` header), 1x for 500/529
+
+### Phase B: Tool Loop + Dispatcher (~1h)
+
+**Files:** `nous/api/tools.py`, `nous/api/runner.py`
+
+1. **ToolDispatcher class** (`tools.py`):
+   ```python
+   class ToolDispatcher:
+       def __init__(self):
+           self._handlers: dict[str, Callable] = {}
+           self._schemas: dict[str, dict] = {}
+
+       def register(self, name: str, handler: Callable, schema: dict):
+           self._handlers[name] = handler
+           self._schemas[name] = schema
+
+       async def dispatch(self, name: str, args: dict) -> tuple[str, bool]:
+           """Returns (result_text, is_error)."""
+           handler = self._handlers.get(name)
+           if not handler:
+               return f"Unknown tool: {name}", True
+           try:
+               result = await handler(**args)  # **kwargs unpacking
+               # Extract text from MCP-format response
+               return result["content"][0]["text"], False
+           except Exception as e:
+               return f"Tool error: {e}", True
+
+       def tool_definitions(self) -> list[dict]:
+           return [
+               {"name": n, "description": s.get("description", ""), "input_schema": s}
+               for n, s in self._schemas.items()
+           ]
+   ```
+
+2. **Tool registration** — Keep existing closures from `create_nous_tools()`, register with existing `_*_SCHEMA` dicts. Schema field names stay as-is ("description", not "decision"). Required fields stay as-is.
+
+3. **Remove** `create_nous_mcp_server()` function and all `claude_agent_sdk` imports from `tools.py`.
+
+4. **`_tool_loop()` method** (`runner.py`):
+   - Build messages array using `_format_messages()` (not system prompt injection)
+   - System prompt = cognitive context + frame instructions only (stable, cacheable)
+   - Loop:
+     ```
+     while turns < max_turns:
+         response = await _call_api(system_prompt, messages, tools)
+         if response.stop_reason != "tool_use":
+             break  # handles end_turn, max_tokens, etc.
+         # Append FULL assistant response (all content blocks)
+         messages.append({"role": "assistant", "content": response.content})
+         # Dispatch ALL tool_use blocks, collect results
+         tool_results = []
+         for block in response.content:
+             if block.type == "tool_use":
+                 text, is_error = await dispatcher.dispatch(block.name, block.input)
+                 tool_results.append({
+                     "type": "tool_result",
+                     "tool_use_id": block.id,
+                     "content": text,
+                     "is_error": is_error,
+                 })
+         # All results in SINGLE user message
+         messages.append({"role": "user", "content": tool_results})
+         turns += 1
+     ```
+
+5. **Message dataclass update** — Extend `Message.content` to store structured blocks for tool_use/tool_result roundtrips, OR accumulate messages as raw dicts in the tool loop (simpler).
+
+6. **Reflection path** — `end_conversation()` calls `_call_api()` directly without tool loop (no tools needed for reflection).
+
+7. **Frame-gated tools** — Implement D5 `FRAME_TOOLS` map. Filter `dispatcher.tool_definitions()` by active frame. Sync `_get_frame_instructions()` to only mention available tools.
+
+### Phase C: Built-in Tools (~45 min)
+
+**File:** `nous/api/builtin_tools.py` (new)
+
+1. **bash tool:**
+   - `asyncio.create_subprocess_shell` with configurable timeout (default 30s, max 300s)
+   - Working directory: `settings.workspace_dir`
+   - Output truncation at 100KB
+   - Return stdout + stderr
+
+2. **read_file tool:**
+   - `asyncio.to_thread(Path(path).read_text)` — no `aiofiles` dependency
+   - Path validation: must be under workspace_dir or explicit allowed paths
+   - Size limit: 1MB
+   - Support offset/limit for large files
+
+3. **write_file tool:**
+   - `asyncio.to_thread(Path(path).write_text, content)` — no `aiofiles` dependency
+   - Path validation: same as read_file
+   - Auto-create parent directories
+
+4. **Registration:** Register all built-in tools in dispatcher at startup, gated by frame.
+
+### Phase D: Cleanup + Tests (~1h)
+
+**Files:** `pyproject.toml`, `Dockerfile`, `docker-compose.yml`, `.env.example`, `nous/main.py`, `tests/`
+
+1. **pyproject.toml:**
+   - Remove `claude-agent-sdk>=0.1.39` from `[project.optional-dependencies].runtime`
+   - Keep `mcp>=1.0` in runtime (MCP server in `mcp.py` still uses it)
+   - No new deps needed (no aiofiles, no tenacity)
+
+2. **Dockerfile:**
+   - Remove Node.js installation and Claude Code CLI
+   - Keep `mkdir -p /tmp/nous-workspace`
+   - Result: ~224MB smaller image
+
+3. **docker-compose.yml:**
+   - Remove: `NOUS_SDK_MAX_TURNS`, `NOUS_SDK_PERMISSION_MODE`, `NOUS_SDK_WORKSPACE`
+   - Add: `NOUS_MAX_TURNS`, `NOUS_API_BASE_URL` (optional), `NOUS_API_TIMEOUT_READ` (optional)
+
+4. **.env.example:**
+   - Remove SDK section
+   - Add new config fields with defaults
+
+5. **main.py:**
+   - Update logging to reference new config field names
+   - Remove any `sdk_*` references
+
+6. **Test updates:**
+   - `test_runner.py`: Rename all `_call_sdk` mocks to `_call_api`, remove `create_nous_mcp_server` patches, rewrite `test_start_credentials` to verify httpx headers, delete `test_permission_mode_from_settings`, add tool loop tests
+   - `test_tools.py`: Keep closure tests, add ToolDispatcher tests (registration, dispatch, unknown tool, error handling)
+   - New `test_builtin_tools.py`: bash timeout, path validation, output truncation
+   - New `test_tool_loop.py`: mock API responses with tool_use, verify loop termination on end_turn/max_tokens/max_turns
+
+## Files Changed (Complete)
+
+### Modified
+| File | Changes |
+|------|---------|
+| `nous/config.py` | Remove sdk_* settings, add max_turns/api_base_url/api_timeout_*/workspace_dir |
+| `nous/api/runner.py` | Replace _call_sdk with _call_api + _tool_loop, httpx client lifecycle, messages array |
+| `nous/api/tools.py` | Remove SDK wrapper, add ToolDispatcher class, keep closures + schemas |
+| `pyproject.toml` | Remove claude-agent-sdk dep |
+| `Dockerfile` | Remove Node.js/Claude Code CLI |
+| `docker-compose.yml` | Replace SDK env vars with new config vars |
+| `.env.example` | Replace SDK section with new config section |
+| `nous/main.py` | Update config references |
+| `tests/test_runner.py` | Migrate all mocks from _call_sdk to _call_api |
+| `tests/test_tools.py` | Add ToolDispatcher tests |
+
+### New
+| File | Purpose |
+|------|---------|
+| `nous/api/builtin_tools.py` | bash, read_file, write_file handlers |
+| `tests/test_builtin_tools.py` | Built-in tool unit tests |
+| `tests/test_tool_loop.py` | Tool loop integration tests |
+
+## Acceptance Criteria
+
+- [ ] API key auth works (x-api-key header)
+- [ ] Auth token works (Bearer header, takes precedence)
+- [ ] Single-turn chat without tools works
+- [ ] Multi-turn conversation maintains history in messages array
+- [ ] Tool loop executes and terminates on end_turn
+- [ ] Tool loop terminates on max_tokens
+- [ ] Tool loop terminates on max_turns limit
+- [ ] Parallel tool calls dispatched, results in single user message
+- [ ] record_decision tool works end-to-end
+- [ ] recall_deep tool works end-to-end
+- [ ] Frame-gated tool filtering active
+- [ ] bash tool with timeout
+- [ ] read_file/write_file with path validation
+- [ ] Reflection on conversation end works
+- [ ] Docker image builds without Node.js
+- [ ] All existing tests pass (migrated)
+- [ ] All new tests pass
+
+## Team Structure
+
+| Role | Agent | Scope |
+|------|-------|-------|
+| python-engineer | Implementation | Phases A, B, C — all source code |
+| test-engineer | Tests | Phase D — all test code + config cleanup |
+| code-reviewer | Review | Final pass on all changes |

--- a/nous/api/builtin_tools.py
+++ b/nous/api/builtin_tools.py
@@ -1,0 +1,289 @@
+"""Built-in tools for the Nous agent: bash, read_file, write_file.
+
+These tools give the agent system access capabilities, gated by
+cognitive frames (D5).  All tools return MCP-format responses for
+consistent handling by ToolDispatcher.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any
+
+from nous.api.tools import ToolDispatcher
+from nous.config import Settings
+
+logger = logging.getLogger(__name__)
+
+# Limits
+_MAX_BASH_TIMEOUT = 300  # seconds
+_MAX_OUTPUT_CHARS = 100 * 1024  # 100KB
+_MAX_FILE_SIZE = 1 * 1024 * 1024  # 1MB
+
+
+def _mcp_response(text: str) -> dict[str, Any]:
+    """Build MCP-format response."""
+    return {"content": [{"type": "text", "text": text}]}
+
+
+def _validate_path(path_str: str, workspace_dir: str) -> Path:
+    """Validate that a path is under workspace_dir.
+
+    Raises ValueError if path escapes workspace.
+    """
+    workspace = Path(workspace_dir).resolve()
+    target = (workspace / path_str).resolve() if not Path(path_str).is_absolute() else Path(path_str).resolve()
+
+    if not target.is_relative_to(workspace):
+        raise ValueError(
+            f"Path '{path_str}' is outside workspace '{workspace_dir}'. "
+            "Only paths within the workspace directory are allowed."
+        )
+    return target
+
+
+# ---------------------------------------------------------------------------
+# Tool handlers
+# ---------------------------------------------------------------------------
+
+
+async def bash_tool(
+    command: str,
+    timeout: int = 30,
+    *,
+    _workspace_dir: str = "/tmp/nous-workspace",
+) -> dict[str, Any]:
+    """Execute a shell command in the workspace directory.
+
+    Args:
+        command: Shell command to execute
+        timeout: Timeout in seconds (default 30, max 300)
+        _workspace_dir: Internal param set by registration closure
+
+    Returns:
+        MCP-format response with stdout + stderr
+    """
+    try:
+        # Clamp timeout
+        effective_timeout = max(1, min(timeout, _MAX_BASH_TIMEOUT))
+
+        # Ensure workspace exists
+        workspace = Path(_workspace_dir)
+        workspace.mkdir(parents=True, exist_ok=True)
+
+        proc = await asyncio.create_subprocess_shell(
+            command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=str(workspace),
+        )
+
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=effective_timeout
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            return _mcp_response(
+                f"Command timed out after {effective_timeout}s.\n"
+                f"Command: {command}"
+            )
+
+        # Decode and truncate
+        stdout_text = stdout.decode("utf-8", errors="replace")
+        stderr_text = stderr.decode("utf-8", errors="replace")
+
+        # Truncate if needed
+        if len(stdout_text) > _MAX_OUTPUT_CHARS:
+            stdout_text = stdout_text[:_MAX_OUTPUT_CHARS] + "\n... [output truncated at 100KB]"
+        if len(stderr_text) > _MAX_OUTPUT_CHARS:
+            stderr_text = stderr_text[:_MAX_OUTPUT_CHARS] + "\n... [stderr truncated at 100KB]"
+
+        parts = []
+        if stdout_text:
+            parts.append(stdout_text)
+        if stderr_text:
+            parts.append(f"STDERR:\n{stderr_text}")
+        if proc.returncode != 0:
+            parts.append(f"Exit code: {proc.returncode}")
+
+        output = "\n".join(parts) if parts else "(no output)"
+        return _mcp_response(output)
+
+    except Exception as e:
+        logger.exception("bash_tool error")
+        return _mcp_response(f"Error executing command: {e}")
+
+
+async def read_file_tool(
+    path: str,
+    offset: int = 0,
+    limit: int = 0,
+    *,
+    _workspace_dir: str = "/tmp/nous-workspace",
+) -> dict[str, Any]:
+    """Read a file from the workspace directory.
+
+    Args:
+        path: File path (relative to workspace or absolute within workspace)
+        offset: Line offset to start reading from (0-indexed)
+        limit: Number of lines to read (0 = all)
+        _workspace_dir: Internal param set by registration closure
+
+    Returns:
+        MCP-format response with file contents
+    """
+    try:
+        target = _validate_path(path, _workspace_dir)
+
+        if not target.exists():
+            return _mcp_response(f"File not found: {path}")
+
+        if not target.is_file():
+            return _mcp_response(f"Not a file: {path}")
+
+        # Check size
+        file_size = target.stat().st_size
+        if file_size > _MAX_FILE_SIZE:
+            return _mcp_response(
+                f"File too large: {file_size:,} bytes (limit: {_MAX_FILE_SIZE:,} bytes). "
+                f"Use offset/limit to read portions."
+            )
+
+        # Read file in thread
+        content = await asyncio.to_thread(target.read_text, encoding="utf-8", errors="replace")
+
+        # Apply offset/limit
+        if offset > 0 or limit > 0:
+            lines = content.splitlines(keepends=True)
+            if offset > 0:
+                lines = lines[offset:]
+            if limit > 0:
+                lines = lines[:limit]
+            content = "".join(lines)
+
+        return _mcp_response(content if content else "(empty file)")
+
+    except ValueError as e:
+        return _mcp_response(str(e))
+    except Exception as e:
+        logger.exception("read_file_tool error")
+        return _mcp_response(f"Error reading file: {e}")
+
+
+async def write_file_tool(
+    path: str,
+    content: str,
+    *,
+    _workspace_dir: str = "/tmp/nous-workspace",
+) -> dict[str, Any]:
+    """Write content to a file in the workspace directory.
+
+    Args:
+        path: File path (relative to workspace or absolute within workspace)
+        content: Content to write
+        _workspace_dir: Internal param set by registration closure
+
+    Returns:
+        MCP-format response confirming write
+    """
+    try:
+        target = _validate_path(path, _workspace_dir)
+
+        # Auto-create parent directories
+        await asyncio.to_thread(target.parent.mkdir, parents=True, exist_ok=True)
+
+        # Write file
+        await asyncio.to_thread(target.write_text, content, encoding="utf-8")
+
+        return _mcp_response(
+            f"File written successfully: {target}\n"
+            f"Size: {len(content):,} bytes"
+        )
+
+    except ValueError as e:
+        return _mcp_response(str(e))
+    except Exception as e:
+        logger.exception("write_file_tool error")
+        return _mcp_response(f"Error writing file: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+_BASH_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": "Execute a shell command in the workspace directory",
+    "properties": {
+        "command": {"type": "string", "description": "Shell command to execute"},
+        "timeout": {
+            "type": "integer",
+            "description": "Timeout in seconds (default 30, max 300)",
+            "default": 30,
+            "minimum": 1,
+            "maximum": 300,
+        },
+    },
+    "required": ["command"],
+}
+
+_READ_FILE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": "Read a file from the workspace directory",
+    "properties": {
+        "path": {"type": "string", "description": "File path (relative or absolute within workspace)"},
+        "offset": {
+            "type": "integer",
+            "description": "Line offset to start reading from (0-indexed)",
+            "default": 0,
+            "minimum": 0,
+        },
+        "limit": {
+            "type": "integer",
+            "description": "Number of lines to read (0 = all)",
+            "default": 0,
+            "minimum": 0,
+        },
+    },
+    "required": ["path"],
+}
+
+_WRITE_FILE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": "Write content to a file in the workspace directory",
+    "properties": {
+        "path": {"type": "string", "description": "File path (relative or absolute within workspace)"},
+        "content": {"type": "string", "description": "Content to write to the file"},
+    },
+    "required": ["path", "content"],
+}
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def register_builtin_tools(dispatcher: ToolDispatcher, settings: Settings) -> None:
+    """Register built-in tools (bash, read_file, write_file) with the dispatcher.
+
+    Creates closure wrappers that inject workspace_dir from settings.
+    """
+    workspace = settings.workspace_dir
+
+    async def _bash(command: str, timeout: int = 30) -> dict[str, Any]:
+        return await bash_tool(command, timeout, _workspace_dir=workspace)
+
+    async def _read_file(path: str, offset: int = 0, limit: int = 0) -> dict[str, Any]:
+        return await read_file_tool(path, offset, limit, _workspace_dir=workspace)
+
+    async def _write_file(path: str, content: str) -> dict[str, Any]:
+        return await write_file_tool(path, content, _workspace_dir=workspace)
+
+    dispatcher.register("bash", _bash, _BASH_SCHEMA)
+    dispatcher.register("read_file", _read_file, _READ_FILE_SCHEMA)
+    dispatcher.register("write_file", _write_file, _WRITE_FILE_SCHEMA)

--- a/nous/config.py
+++ b/nous/config.py
@@ -36,7 +36,7 @@ class Settings(BaseSettings):
     host: str = "0.0.0.0"
     port: int = 8000
     anthropic_api_key: str = Field("", validation_alias="ANTHROPIC_API_KEY")
-    # Dual auth: auth_token takes precedence over api_key (SDK uses auth_token)
+    # Dual auth: auth_token (Bearer) takes precedence over api_key (x-api-key)
     anthropic_auth_token: str = Field("", validation_alias="ANTHROPIC_AUTH_TOKEN")
 
     # Agent identity
@@ -51,18 +51,12 @@ class Settings(BaseSettings):
     model: str = "claude-sonnet-4-5-20250514"
     max_tokens: int = 4096
 
-    # SDK settings (claude-agent-sdk)
-    sdk_max_turns: int = 10  # Max tool use iterations per query
-    sdk_permission_mode: str = "default"  # default, acceptEdits, plan, bypassPermissions
-    sdk_workspace: str = "/tmp/nous-workspace"
-    sdk_allowed_tools: list[str] = Field(
-        default_factory=lambda: [
-            "record_decision",
-            "learn_fact",
-            "recall_deep",
-            "create_censor",
-        ]
-    )
+    # Direct API settings
+    max_turns: int = 10  # Max tool use iterations per turn
+    api_base_url: str = "https://api.anthropic.com"
+    api_timeout_connect: int = 10  # seconds
+    api_timeout_read: int = 120  # seconds
+    workspace_dir: str = "/tmp/nous-workspace"
 
     @property
     def db_url(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ runtime = [
     "uvicorn>=0.30,<1.0",
     "starlette>=0.40,<1.0",
     "mcp>=1.0,<2.0",
-    "claude-agent-sdk>=0.1.39,<1.0",
 ]
 dev = [
     "pytest>=8.0",

--- a/tests/test_builtin_tools.py
+++ b/tests/test_builtin_tools.py
@@ -1,0 +1,287 @@
+"""Unit tests for nous/api/builtin_tools.py -- bash, read_file, write_file.
+
+All tests are pure async (no database required). Filesystem tests use
+the pytest tmp_path fixture for workspace isolation. Platform-aware
+commands use python -c for cross-platform compatibility.
+"""
+
+import sys
+
+import pytest
+
+from nous.api.builtin_tools import (
+    _MAX_FILE_SIZE,
+    _MAX_OUTPUT_CHARS,
+    bash_tool,
+    read_file_tool,
+    write_file_tool,
+)
+
+
+def _extract_text(result: dict) -> str:
+    """Extract text from MCP-format response."""
+    return result["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# bash_tool tests
+# ---------------------------------------------------------------------------
+
+
+class TestBashTool:
+    """Tests for the bash shell execution tool."""
+
+    @pytest.mark.asyncio
+    async def test_bash_tool_success(self, tmp_path):
+        """Simple command -> stdout captured in response."""
+        result = await bash_tool(
+            command=f'{sys.executable} -c "print(\'hello from bash tool\')"',
+            _workspace_dir=str(tmp_path),
+        )
+        text = _extract_text(result)
+        assert "hello from bash tool" in text
+
+    @pytest.mark.asyncio
+    async def test_bash_tool_timeout(self, tmp_path):
+        """Command exceeding timeout -> killed and timeout message returned."""
+        result = await bash_tool(
+            command=f'{sys.executable} -c "import time; time.sleep(30)"',
+            timeout=1,
+            _workspace_dir=str(tmp_path),
+        )
+        text = _extract_text(result)
+        assert "timed out" in text.lower()
+        assert "1s" in text
+
+    @pytest.mark.asyncio
+    async def test_bash_tool_output_truncation(self, tmp_path):
+        """Output exceeding 100KB -> truncated with marker."""
+        # Generate ~150KB of output (well over 100KB limit)
+        result = await bash_tool(
+            command=f'{sys.executable} -c "print(\'x\' * 200000)"',
+            _workspace_dir=str(tmp_path),
+        )
+        text = _extract_text(result)
+        assert "truncated" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_bash_tool_stderr(self, tmp_path):
+        """Stderr output captured and labeled."""
+        result = await bash_tool(
+            command=f'{sys.executable} -c "import sys; sys.stderr.write(\'warning msg\\n\')"',
+            _workspace_dir=str(tmp_path),
+        )
+        text = _extract_text(result)
+        assert "STDERR" in text
+        assert "warning msg" in text
+
+    @pytest.mark.asyncio
+    async def test_bash_tool_nonzero_exit(self, tmp_path):
+        """Non-zero exit code reported in output."""
+        result = await bash_tool(
+            command=f'{sys.executable} -c "import sys; sys.exit(42)"',
+            _workspace_dir=str(tmp_path),
+        )
+        text = _extract_text(result)
+        assert "Exit code: 42" in text
+
+    @pytest.mark.asyncio
+    async def test_bash_tool_creates_workspace(self, tmp_path):
+        """Workspace directory auto-created if it doesn't exist."""
+        workspace = tmp_path / "deep" / "nested" / "workspace"
+        assert not workspace.exists()
+
+        result = await bash_tool(
+            command=f'{sys.executable} -c "print(\'created\')"',
+            _workspace_dir=str(workspace),
+        )
+        text = _extract_text(result)
+        assert "created" in text
+        assert workspace.exists()
+
+
+# ---------------------------------------------------------------------------
+# read_file_tool tests
+# ---------------------------------------------------------------------------
+
+
+class TestReadFileTool:
+    """Tests for the file reading tool."""
+
+    @pytest.mark.asyncio
+    async def test_read_file_success(self, tmp_path):
+        """Read an existing file -> contents returned."""
+        test_file = tmp_path / "hello.txt"
+        test_file.write_text("Hello, world!\nLine 2\nLine 3", encoding="utf-8")
+
+        result = await read_file_tool(
+            path="hello.txt",
+            _workspace_dir=str(tmp_path),
+        )
+        text = _extract_text(result)
+        assert "Hello, world!" in text
+        assert "Line 2" in text
+        assert "Line 3" in text
+
+    @pytest.mark.asyncio
+    async def test_read_file_not_found(self, tmp_path):
+        """Missing file -> 'File not found' message (not exception)."""
+        result = await read_file_tool(
+            path="nonexistent.txt",
+            _workspace_dir=str(tmp_path),
+        )
+        text = _extract_text(result)
+        assert "File not found" in text
+
+    @pytest.mark.asyncio
+    async def test_read_file_size_limit(self, tmp_path):
+        """File exceeding 1MB -> size limit message."""
+        large_file = tmp_path / "large.bin"
+        # Write just over 1MB
+        large_file.write_bytes(b"x" * (_MAX_FILE_SIZE + 1))
+
+        result = await read_file_tool(
+            path="large.bin",
+            _workspace_dir=str(tmp_path),
+        )
+        text = _extract_text(result)
+        assert "too large" in text.lower()
+        assert "offset/limit" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_read_file_with_offset_and_limit(self, tmp_path):
+        """offset/limit parameters slice file by lines."""
+        test_file = tmp_path / "lines.txt"
+        test_file.write_text("line0\nline1\nline2\nline3\nline4\n", encoding="utf-8")
+
+        # Read lines 1-2 (0-indexed offset=1, limit=2)
+        result = await read_file_tool(
+            path="lines.txt",
+            offset=1,
+            limit=2,
+            _workspace_dir=str(tmp_path),
+        )
+        text = _extract_text(result)
+        assert "line1" in text
+        assert "line2" in text
+        assert "line0" not in text
+        assert "line3" not in text
+
+    @pytest.mark.asyncio
+    async def test_read_file_path_validation(self, tmp_path):
+        """Path outside workspace -> rejection message."""
+        # Try to escape workspace via parent traversal
+        result = await read_file_tool(
+            path="../../../etc/passwd",
+            _workspace_dir=str(tmp_path),
+        )
+        text = _extract_text(result)
+        assert "outside workspace" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_read_file_absolute_path_outside_workspace(self, tmp_path):
+        """Absolute path outside workspace -> rejection."""
+        # Use an absolute path that's definitely outside tmp_path
+        if sys.platform == "win32":
+            outside_path = "C:\\Windows\\System32\\drivers\\etc\\hosts"
+        else:
+            outside_path = "/etc/passwd"
+
+        result = await read_file_tool(
+            path=outside_path,
+            _workspace_dir=str(tmp_path),
+        )
+        text = _extract_text(result)
+        assert "outside workspace" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_read_file_empty(self, tmp_path):
+        """Empty file -> '(empty file)' message."""
+        empty_file = tmp_path / "empty.txt"
+        empty_file.write_text("", encoding="utf-8")
+
+        result = await read_file_tool(
+            path="empty.txt",
+            _workspace_dir=str(tmp_path),
+        )
+        text = _extract_text(result)
+        assert "empty file" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# write_file_tool tests
+# ---------------------------------------------------------------------------
+
+
+class TestWriteFileTool:
+    """Tests for the file writing tool."""
+
+    @pytest.mark.asyncio
+    async def test_write_file_success(self, tmp_path):
+        """Write content to a new file, verify contents on disk."""
+        result = await write_file_tool(
+            path="output.txt",
+            content="Written by test",
+            _workspace_dir=str(tmp_path),
+        )
+        text = _extract_text(result)
+        assert "written successfully" in text.lower()
+
+        # Verify actual file contents
+        written = (tmp_path / "output.txt").read_text(encoding="utf-8")
+        assert written == "Written by test"
+
+    @pytest.mark.asyncio
+    async def test_write_file_creates_dirs(self, tmp_path):
+        """Write to nested path -> parent directories auto-created."""
+        result = await write_file_tool(
+            path="deep/nested/dir/file.txt",
+            content="Nested content",
+            _workspace_dir=str(tmp_path),
+        )
+        text = _extract_text(result)
+        assert "written successfully" in text.lower()
+
+        # Verify nested file exists
+        nested_file = tmp_path / "deep" / "nested" / "dir" / "file.txt"
+        assert nested_file.exists()
+        assert nested_file.read_text(encoding="utf-8") == "Nested content"
+
+    @pytest.mark.asyncio
+    async def test_write_file_path_validation(self, tmp_path):
+        """Path outside workspace -> rejection message."""
+        result = await write_file_tool(
+            path="../../../tmp/evil.txt",
+            content="malicious content",
+            _workspace_dir=str(tmp_path),
+        )
+        text = _extract_text(result)
+        assert "outside workspace" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_write_file_overwrites_existing(self, tmp_path):
+        """Writing to existing file overwrites it."""
+        target = tmp_path / "overwrite.txt"
+        target.write_text("original content", encoding="utf-8")
+
+        result = await write_file_tool(
+            path="overwrite.txt",
+            content="new content",
+            _workspace_dir=str(tmp_path),
+        )
+        text = _extract_text(result)
+        assert "written successfully" in text.lower()
+
+        assert target.read_text(encoding="utf-8") == "new content"
+
+    @pytest.mark.asyncio
+    async def test_write_file_reports_size(self, tmp_path):
+        """Response includes file size in bytes."""
+        content = "Hello " * 100  # 600 bytes
+        result = await write_file_tool(
+            path="sized.txt",
+            content=content,
+            _workspace_dir=str(tmp_path),
+        )
+        text = _extract_text(result)
+        assert "600" in text  # Size: 600 bytes

--- a/tests/test_tool_loop.py
+++ b/tests/test_tool_loop.py
@@ -1,0 +1,368 @@
+"""Integration tests for the AgentRunner._tool_loop() method.
+
+Tests mock _call_api() to return controlled ApiResponse objects and
+use a real ToolDispatcher with mock tool handlers. This verifies the
+tool loop's message accumulation, dispatch, termination conditions,
+and parallel tool handling.
+"""
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+
+from nous.api.runner import AgentRunner, ApiResponse, Conversation, Message
+from nous.api.tools import ToolDispatcher
+from nous.cognitive.schemas import FrameSelection, TurnContext
+from nous.config import Settings
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_api_response(
+    text: str = "",
+    stop_reason: str = "end_turn",
+    tool_uses: list[dict] | None = None,
+) -> ApiResponse:
+    """Build an ApiResponse with text and/or tool_use blocks."""
+    content = []
+    if text:
+        content.append({"type": "text", "text": text})
+    if tool_uses:
+        for tu in tool_uses:
+            content.append({
+                "type": "tool_use",
+                "id": tu.get("id", f"toolu_{uuid.uuid4().hex[:12]}"),
+                "name": tu["name"],
+                "input": tu.get("input", {}),
+            })
+    return ApiResponse(content=content, stop_reason=stop_reason)
+
+
+def _make_conversation(messages: list[tuple[str, str]] | None = None) -> Conversation:
+    """Build a Conversation with optional (role, content) message pairs."""
+    conv = Conversation(session_id=f"test-{uuid.uuid4().hex[:8]}")
+    if messages:
+        for role, content in messages:
+            conv.messages.append(Message(role=role, content=content))
+    return conv
+
+
+class MockCognitiveLayer:
+    """Minimal mock for runner constructor."""
+
+    async def pre_turn(self, *a, **kw):
+        return TurnContext(
+            system_prompt="test",
+            frame=FrameSelection(
+                frame_id="task", frame_name="Task",
+                confidence=0.9, match_method="default",
+            ),
+        )
+
+    async def post_turn(self, *a, **kw):
+        pass
+
+    async def end_session(self, *a, **kw):
+        pass
+
+
+class MockBrain:
+    async def close(self):
+        pass
+
+
+class MockHeart:
+    async def close(self):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tool_settings():
+    """Settings with low max_turns for testing loop termination."""
+    return Settings(
+        ANTHROPIC_API_KEY="test-key",
+        agent_id="test-agent",
+        max_turns=3,
+        max_tokens=1024,
+    )
+
+
+@pytest.fixture
+def echo_dispatcher():
+    """ToolDispatcher with a simple echo tool registered."""
+    dispatcher = ToolDispatcher()
+
+    async def echo_tool(message: str = "default") -> dict:
+        return {"content": [{"type": "text", "text": f"Echo: {message}"}]}
+
+    dispatcher.register("echo", echo_tool, {
+        "type": "object",
+        "description": "Echo tool",
+        "properties": {"message": {"type": "string"}},
+        "required": ["message"],
+    })
+
+    # Register a second tool for parallel dispatch tests
+    async def add_tool(a: float = 0, b: float = 0) -> dict:
+        return {"content": [{"type": "text", "text": str(a + b)}]}
+
+    dispatcher.register("add", add_tool, {
+        "type": "object",
+        "description": "Add tool",
+        "properties": {"a": {"type": "number"}, "b": {"type": "number"}},
+        "required": ["a", "b"],
+    })
+
+    return dispatcher
+
+
+@pytest_asyncio.fixture
+async def loop_runner(tool_settings, echo_dispatcher):
+    """AgentRunner with mocked _call_api and real ToolDispatcher."""
+    cognitive = MockCognitiveLayer()
+    brain = MockBrain()
+    heart = MockHeart()
+    r = AgentRunner(cognitive, brain, heart, tool_settings)
+    r.set_dispatcher(echo_dispatcher)
+    # _call_api will be mocked per-test
+    yield r
+    await r.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolLoop:
+    """Tests for the _tool_loop method of AgentRunner."""
+
+    @pytest.mark.asyncio
+    async def test_tool_loop_end_turn(self, loop_runner):
+        """API returns end_turn on first call -> single API call, text extracted."""
+        loop_runner._call_api = AsyncMock(return_value=_make_api_response(
+            text="Simple response",
+            stop_reason="end_turn",
+        ))
+
+        conv = _make_conversation([("user", "Hello")])
+        response_text, tool_results = await loop_runner._tool_loop(
+            system_prompt="Test prompt",
+            conversation=conv,
+            frame_id="task",
+        )
+
+        assert response_text == "Simple response"
+        assert tool_results == []
+        loop_runner._call_api.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_tool_loop_with_tool_use(self, loop_runner):
+        """API returns tool_use then end_turn -> dispatch + 2 API calls."""
+        # First call: tool_use
+        tool_response = _make_api_response(
+            stop_reason="tool_use",
+            tool_uses=[{"name": "echo", "input": {"message": "test"}, "id": "toolu_001"}],
+        )
+        # Second call: end_turn with final text
+        final_response = _make_api_response(
+            text="Done after tool call",
+            stop_reason="end_turn",
+        )
+        loop_runner._call_api = AsyncMock(side_effect=[tool_response, final_response])
+
+        conv = _make_conversation([("user", "Use a tool")])
+        response_text, tool_results = await loop_runner._tool_loop(
+            system_prompt="Test prompt",
+            conversation=conv,
+            frame_id="task",
+        )
+
+        assert response_text == "Done after tool call"
+        assert len(tool_results) == 1
+        assert tool_results[0].tool_name == "echo"
+        assert tool_results[0].result == "Echo: test"
+        assert tool_results[0].error is None
+        assert tool_results[0].duration_ms is not None
+        assert loop_runner._call_api.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_tool_loop_max_turns(self, loop_runner):
+        """API always returns tool_use -> stops at max_turns (3) and makes final call."""
+        # Always return tool_use (will hit max_turns=3)
+        tool_response = _make_api_response(
+            stop_reason="tool_use",
+            tool_uses=[{"name": "echo", "input": {"message": "loop"}, "id": "toolu_loop"}],
+        )
+        # Final call (no tools) returns text
+        final_text_response = _make_api_response(
+            text="Reached max turns",
+            stop_reason="end_turn",
+        )
+        # 3 tool_use responses + 1 final call = 4 total
+        loop_runner._call_api = AsyncMock(
+            side_effect=[tool_response, tool_response, tool_response, final_text_response]
+        )
+
+        conv = _make_conversation([("user", "Keep using tools")])
+        response_text, tool_results = await loop_runner._tool_loop(
+            system_prompt="Test prompt",
+            conversation=conv,
+            frame_id="task",
+        )
+
+        # Should have dispatched echo 3 times
+        assert len(tool_results) == 3
+        # Final text comes from the last _call_api (no tools)
+        assert response_text == "Reached max turns"
+        # 3 loop iterations + 1 final call = 4 total API calls
+        assert loop_runner._call_api.call_count == 4
+
+    @pytest.mark.asyncio
+    async def test_tool_loop_max_tokens(self, loop_runner):
+        """API returns max_tokens stop_reason -> loop breaks, text extracted."""
+        loop_runner._call_api = AsyncMock(return_value=_make_api_response(
+            text="Partial response due to token limit",
+            stop_reason="max_tokens",
+        ))
+
+        conv = _make_conversation([("user", "Long request")])
+        response_text, tool_results = await loop_runner._tool_loop(
+            system_prompt="Test prompt",
+            conversation=conv,
+            frame_id="task",
+        )
+
+        assert response_text == "Partial response due to token limit"
+        assert tool_results == []
+        loop_runner._call_api.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_tool_loop_parallel_tools(self, loop_runner):
+        """API returns 2 tool_use blocks -> both dispatched, single user message with 2 tool_results."""
+        # Response with two tool_use blocks (parallel tool calls)
+        parallel_response = _make_api_response(
+            stop_reason="tool_use",
+            tool_uses=[
+                {"name": "echo", "input": {"message": "first"}, "id": "toolu_par1"},
+                {"name": "add", "input": {"a": 2, "b": 3}, "id": "toolu_par2"},
+            ],
+        )
+        # Final response after tool results
+        final_response = _make_api_response(
+            text="Both tools completed",
+            stop_reason="end_turn",
+        )
+        loop_runner._call_api = AsyncMock(side_effect=[parallel_response, final_response])
+
+        conv = _make_conversation([("user", "Use both tools")])
+        response_text, tool_results = await loop_runner._tool_loop(
+            system_prompt="Test prompt",
+            conversation=conv,
+            frame_id="task",
+        )
+
+        assert response_text == "Both tools completed"
+        assert len(tool_results) == 2
+        assert tool_results[0].tool_name == "echo"
+        assert tool_results[0].result == "Echo: first"
+        assert tool_results[1].tool_name == "add"
+        assert tool_results[1].result == "5"  # 2 + 3
+        assert loop_runner._call_api.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_tool_loop_preserves_messages(self, loop_runner):
+        """Verify assistant response + tool_results are appended to messages array.
+
+        After a tool_use round, messages should contain:
+        1. Original user message (from conversation)
+        2. Assistant response (full content blocks including tool_use)
+        3. User message with tool_result blocks
+        """
+        tool_response = _make_api_response(
+            stop_reason="tool_use",
+            tool_uses=[{"name": "echo", "input": {"message": "msg"}, "id": "toolu_msg1"}],
+        )
+        final_response = _make_api_response(
+            text="Final answer",
+            stop_reason="end_turn",
+        )
+        loop_runner._call_api = AsyncMock(side_effect=[tool_response, final_response])
+
+        conv = _make_conversation([("user", "Test message preservation")])
+        await loop_runner._tool_loop(
+            system_prompt="Test prompt",
+            conversation=conv,
+            frame_id="task",
+        )
+
+        # Inspect what _call_api received on its second call
+        # The messages arg should contain the original user msg + assistant + tool_results
+        second_call_args = loop_runner._call_api.call_args_list[1]
+        messages = second_call_args.kwargs.get("messages") or second_call_args.args[1]
+
+        # Should have: user message, assistant (tool_use), user (tool_results)
+        assert len(messages) >= 3
+        # Last message before the second API call should be a user message with tool_results
+        tool_result_msg = messages[-1]
+        assert tool_result_msg["role"] == "user"
+        assert isinstance(tool_result_msg["content"], list)
+        assert tool_result_msg["content"][0]["type"] == "tool_result"
+        assert tool_result_msg["content"][0]["tool_use_id"] == "toolu_msg1"
+
+        # Second-to-last should be assistant with tool_use content
+        assistant_msg = messages[-2]
+        assert assistant_msg["role"] == "assistant"
+
+    @pytest.mark.asyncio
+    async def test_tool_loop_no_dispatcher_raises(self, tool_settings):
+        """_tool_loop without dispatcher set -> RuntimeError."""
+        cognitive = MockCognitiveLayer()
+        r = AgentRunner(cognitive, MockBrain(), MockHeart(), tool_settings)
+        # Don't call set_dispatcher
+
+        conv = _make_conversation([("user", "Hello")])
+        with pytest.raises(RuntimeError, match="No tool dispatcher"):
+            await r._tool_loop(
+                system_prompt="Test",
+                conversation=conv,
+                frame_id="task",
+            )
+        await r.close()
+
+    @pytest.mark.asyncio
+    async def test_tool_loop_tool_dispatch_error(self, loop_runner):
+        """Tool dispatch error -> tracked as error in tool_results, loop continues."""
+        # Return a tool_use for an unknown tool, then end_turn
+        unknown_tool_response = _make_api_response(
+            stop_reason="tool_use",
+            tool_uses=[{"name": "nonexistent_tool", "input": {}, "id": "toolu_unk"}],
+        )
+        final_response = _make_api_response(
+            text="Handled error",
+            stop_reason="end_turn",
+        )
+        loop_runner._call_api = AsyncMock(side_effect=[unknown_tool_response, final_response])
+
+        conv = _make_conversation([("user", "Call unknown tool")])
+        response_text, tool_results = await loop_runner._tool_loop(
+            system_prompt="Test prompt",
+            conversation=conv,
+            frame_id="task",
+        )
+
+        assert response_text == "Handled error"
+        assert len(tool_results) == 1
+        assert tool_results[0].tool_name == "nonexistent_tool"
+        assert tool_results[0].error is not None
+        assert "Unknown tool" in tool_results[0].error

--- a/uv.lock
+++ b/uv.lock
@@ -160,22 +160,6 @@ wheels = [
 ]
 
 [[package]]
-name = "claude-agent-sdk"
-version = "0.1.39"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "mcp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/29/86/52c75a8737d96524611b738fa649d4555eff361b9f8ae393557644fb15e9/claude_agent_sdk-0.1.39.tar.gz", hash = "sha256:dcf0ebd5a638c9a7d9f3af7640932a9212b2705b7056e4f08bd3968a865b4268", size = 61612, upload-time = "2026-02-19T23:43:48.836Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/bc/405ac4a079cd9257d3e39c8ede213e6ca7d8cb358486b7cfedf01ef1a7fe/claude_agent_sdk-0.1.39-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6ed6a79781f545b761b9fe467bc5ae213a103c9d3f0fe7a9dad3c01790ed58fa", size = 55221981, upload-time = "2026-02-19T23:43:32.845Z" },
-    { url = "https://files.pythonhosted.org/packages/70/40/09e75b15f606def0c67a7ef86580f8c4d431a25549fcca28a3748b478323/claude_agent_sdk-0.1.39-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:0c03b5a3772eaec42e29ea39240c7d24b760358082f2e36336db9e71dde3dda4", size = 69964932, upload-time = "2026-02-19T23:43:37.004Z" },
-    { url = "https://files.pythonhosted.org/packages/83/77/80888ccf8da8e4ff6b86d82ac1384a179e959d06af40a4f2090a6215b4ed/claude_agent_sdk-0.1.39-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:d2665c9e87b6ffece590bcdd6eb9def47cde4809b0d2f66e0a61a719189be7c9", size = 70577920, upload-time = "2026-02-19T23:43:41.662Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/d1/22afacdb20da881c82fd4c5c53f0e22a76a66010b3b11133ddc975d898d4/claude_agent_sdk-0.1.39-py3-none-win_amd64.whl", hash = "sha256:d03324daf7076be79d2dd05944559aabf4cc11c98d3a574b992a442a7c7a26d6", size = 72886448, upload-time = "2026-02-19T23:43:45.965Z" },
-]
-
-[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -488,7 +472,6 @@ dev = [
     { name = "ruff" },
 ]
 runtime = [
-    { name = "claude-agent-sdk" },
     { name = "mcp" },
     { name = "starlette" },
     { name = "uvicorn" },
@@ -498,7 +481,6 @@ runtime = [
 requires-dist = [
     { name = "asyncpg", specifier = ">=0.30,<1.0" },
     { name = "cel-python", specifier = ">=0.4,<1.0" },
-    { name = "claude-agent-sdk", marker = "extra == 'runtime'", specifier = ">=0.1.39,<1.0" },
     { name = "httpx", specifier = ">=0.27,<1.0" },
     { name = "mcp", marker = "extra == 'runtime'", specifier = ">=1.0,<2.0" },
     { name = "pgvector", specifier = ">=0.3,<1.0" },


### PR DESCRIPTION
## Summary

- **Remove `claude-agent-sdk`** dependency (224MB bundled CLI binary) — replace with direct `httpx` calls to the Anthropic Messages API
- **Fix OAuth auth incompatibility** — Bearer token auth now works correctly for Max subscription
- **Fix Docker MCP crash** — no more `CLIConnectionError: ProcessTransport is not ready`
- **Add explicit tool loop** with proper message alternation, parallel tool dispatch, and max_turns safety
- **Add ToolDispatcher** registry pattern for clean tool management
- **Add built-in tools** (bash, read_file, write_file) with path validation and timeout controls
- **Add frame-gated tool access** (D5) — active cognitive frame controls which tools are available
- **Move conversation history** from system prompt injection to proper `messages[]` array — enables prompt caching

## Changes

### Modified (11 files)
| File | Change |
|------|--------|
| `nous/api/runner.py` | Replace `_call_sdk()` with `_call_api()` + `_tool_loop()`, httpx client lifecycle, FRAME_TOOLS |
| `nous/api/tools.py` | Add `ToolDispatcher` class, remove SDK wrapper, keep closures |
| `nous/config.py` | Remove `sdk_*` settings, add `max_turns`, `api_base_url`, `api_timeout_*`, `workspace_dir` |
| `nous/main.py` | Wire ToolDispatcher + built-in tool registration at startup |
| `pyproject.toml` | Remove `claude-agent-sdk` from runtime deps |
| `Dockerfile` | Remove Node.js + Claude Code CLI (~224MB savings) |
| `docker-compose.yml` | Replace SDK env vars with new config vars |
| `.env.example` | Replace SDK section with Direct API settings |
| `tests/test_runner.py` | Migrate all mocks from `_call_sdk` to `_call_api`/`_tool_loop` |
| `tests/test_tools.py` | Add ToolDispatcher unit tests |
| `uv.lock` | Regenerated without claude-agent-sdk |

### New (3 files)
| File | Purpose |
|------|---------|
| `nous/api/builtin_tools.py` | bash, read_file, write_file handlers (~290 lines) |
| `tests/test_builtin_tools.py` | 17 tests for built-in tools |
| `tests/test_tool_loop.py` | 8 tests for tool loop behavior |

## Review Process

- 3-agent review team (architect, API specialist, devil's advocate) analyzed the spec
- Found 8 P0 blockers, 9 P1 issues — all addressed in implementation plan
- 3-agent implementation team (python-engineer, test-engineer, code-reviewer)
- Code reviewer: **APPROVED WITH CONDITIONS** (1 P1 fixed: path validation `is_relative_to`)

## Test plan

- [x] 63 new/migrated tests across 4 test files — all pass
- [x] 308/308 full test suite — 0 regressions
- [x] Auth header verification (API key + Bearer token)
- [x] Tool loop: end_turn, max_tokens, max_turns, parallel tools
- [x] Built-in tools: bash timeout, path validation, output truncation
- [x] Frame-gated tool filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)