### PR TITLE
feat: add web_search and web_fetch tools (005.3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ ANTHROPIC_AUTH_TOKEN=
 # Embeddings (optional -- keyword-only search if omitted)
 OPENAI_API_KEY=your_openai_key_here
 
+# Web search (optional -- web_search tool disabled if omitted)
+BRAVE_SEARCH_API_KEY=your_brave_search_key_here
+
 # Agent
 NOUS_AGENT_ID=nous-default
 NOUS_AGENT_NAME=Nous

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - NOUS_MCP_ENABLED=${NOUS_MCP_ENABLED:-true}
       - NOUS_MAX_TURNS=${NOUS_MAX_TURNS:-10}
       - NOUS_WORKSPACE_DIR=${NOUS_WORKSPACE_DIR:-/tmp/nous-workspace}
+      - BRAVE_SEARCH_API_KEY=${BRAVE_SEARCH_API_KEY:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/implementation/005.3-web-tools-plan.md
+++ b/docs/implementation/005.3-web-tools-plan.md
@@ -1,0 +1,497 @@
+# 005.3 Web Tools — Implementation Plan (Post-Review)
+
+**Based on:** 3-agent review (nous-web-arch, nous-web-impl, nous-web-devil)
+**Fixes incorporated:** 4 P0, 9 P1, 6 P2 from synthesis of 20+ findings
+
+## Review Summary
+
+All 3 reviewers independently flagged the same top 3 crash bugs (3/3 convergence = highest confidence):
+- **P0-A**: Handler signature mismatch (`args: dict` vs `**kwargs` unpacking)
+- **P0-B**: Return format wrong (plain dict vs MCP format)
+- **P0-C**: httpx client undefined, no lifecycle, credential leak risk if shared
+
+Additional high-confidence findings (2/3 convergence):
+- **P0-D**: SSRF vulnerability (no IP/hostname blocklist)
+- **P1-A**: Env var prefix mismatch (needs `validation_alias`)
+- **P1-B**: Empty API key → silent 401
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `nous/config.py` | Add `brave_search_api_key`, `web_search_daily_limit`, `web_fetch_max_chars` with correct aliases |
+| `nous/api/web_tools.py` | **NEW** — web_search + web_fetch handlers, SSRF protection, rate limiting, registration |
+| `nous/api/runner.py` | Update FRAME_TOOLS + frame instructions for web tools |
+| `nous/main.py` | Register web tools + manage web httpx client lifecycle |
+| `docker-compose.yml` | Add BRAVE_SEARCH_API_KEY env var |
+| `.env.example` | Document BRAVE_SEARCH_API_KEY |
+| `tests/test_web_tools.py` | **NEW** — tests for search, fetch, SSRF, rate limiting, extraction |
+
+---
+
+## Phase A: Config Additions
+
+**File: `nous/config.py`** — Add after `workspace_dir` (line 59):
+
+```python
+# Web tools
+brave_search_api_key: str = Field("", validation_alias="BRAVE_SEARCH_API_KEY")
+web_search_daily_limit: int = 100  # Max web searches per day
+web_fetch_max_chars: int = 10000  # Default max chars for web_fetch
+```
+
+Note: `validation_alias` matches the pattern used by `anthropic_api_key` (line 38) and DB fields (lines 16-20) for unprefixed env vars.
+
+---
+
+## Phase B: Web Tools Module
+
+**File: `nous/api/web_tools.py`** — NEW file
+
+### B1: SSRF Protection
+
+```python
+"""Web tools for the Nous agent: web_search and web_fetch.
+
+Gives the agent web access capabilities, gated by cognitive frames.
+Uses a separate httpx client (NOT AgentRunner's — that has API credentials).
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import socket
+import time
+from typing import Any
+
+import httpx
+
+from nous.api.tools import ToolDispatcher
+from nous.config import Settings
+
+logger = logging.getLogger(__name__)
+
+# Rate limit state (in-memory, resets on restart)
+_rate_limit: dict[str, Any] = {"date": "", "count": 0}
+
+# Blocked IP ranges for SSRF protection
+_BLOCKED_NETWORKS = [
+    ipaddress.ip_network("127.0.0.0/8"),       # Loopback
+    ipaddress.ip_network("10.0.0.0/8"),         # RFC1918
+    ipaddress.ip_network("172.16.0.0/12"),      # RFC1918
+    ipaddress.ip_network("192.168.0.0/16"),     # RFC1918
+    ipaddress.ip_network("169.254.0.0/16"),     # Link-local
+    ipaddress.ip_network("::1/128"),            # IPv6 loopback
+    ipaddress.ip_network("fc00::/7"),           # IPv6 unique local
+    ipaddress.ip_network("fe80::/10"),          # IPv6 link-local
+]
+
+# Blocked hostnames (Docker internal services, etc.)
+_BLOCKED_HOSTNAMES = {"localhost", "postgres", "nous", "redis", "0.0.0.0"}
+
+
+def _mcp_response(text: str) -> dict[str, Any]:
+    """Build MCP-format response."""
+    return {"content": [{"type": "text", "text": text}]}
+
+
+def _is_url_safe(url: str) -> tuple[bool, str]:
+    """Check if URL is safe from SSRF attacks.
+
+    Resolves hostname to IP and checks against blocked ranges.
+    Returns (is_safe, error_message).
+    """
+    try:
+        from urllib.parse import urlparse
+        parsed = urlparse(url)
+        hostname = parsed.hostname
+
+        if not hostname:
+            return False, "Could not parse hostname from URL"
+
+        # Check blocked hostnames
+        if hostname.lower() in _BLOCKED_HOSTNAMES:
+            return False, f"Blocked hostname: {hostname}"
+
+        # Resolve to IP and check ranges
+        try:
+            addr_infos = socket.getaddrinfo(hostname, None)
+        except socket.gaierror:
+            return False, f"Could not resolve hostname: {hostname}"
+
+        for addr_info in addr_infos:
+            ip = ipaddress.ip_address(addr_info[4][0])
+            for network in _BLOCKED_NETWORKS:
+                if ip in network:
+                    return False, f"URL resolves to blocked IP range ({network})"
+
+        return True, ""
+    except Exception as e:
+        return False, f"URL validation error: {e}"
+
+
+def _check_rate_limit(settings: Settings) -> str | None:
+    """Check and increment daily rate limit.
+
+    Returns error message if limit exceeded, None if OK.
+    """
+    today = time.strftime("%Y-%m-%d")
+
+    if _rate_limit["date"] != today:
+        _rate_limit["date"] = today
+        _rate_limit["count"] = 0
+
+    limit = settings.web_search_daily_limit
+    current = _rate_limit["count"]
+
+    if current >= limit:
+        return f"Daily web search limit reached ({limit}). Resets tomorrow."
+
+    _rate_limit["count"] = current + 1
+
+    if current >= int(limit * 0.8):
+        logger.warning("Web search rate limit at %d/%d (%.0f%%)", current + 1, limit, (current + 1) / limit * 100)
+
+    return None
+```
+
+### B2: web_search Handler
+
+```python
+async def _web_search(
+    query: str,
+    count: int = 5,
+    freshness: str | None = None,
+    *,
+    _settings: Settings,
+    _http: httpx.AsyncClient,
+) -> dict[str, Any]:
+    """Search via Brave Search API."""
+    try:
+        # Check API key
+        if not _settings.brave_search_api_key:
+            return _mcp_response("Error: BRAVE_SEARCH_API_KEY not configured. Set this environment variable to enable web search.")
+
+        # Check rate limit
+        rate_error = _check_rate_limit(_settings)
+        if rate_error:
+            return _mcp_response(f"Rate limit: {rate_error}")
+
+        count = min(count, 10)
+
+        params: dict[str, Any] = {"q": query, "count": count}
+        if freshness:
+            freshness_map = {"day": "pd", "week": "pw", "month": "pm"}
+            mapped = freshness_map.get(freshness)
+            if mapped:
+                params["freshness"] = mapped
+
+        response = await _http.get(
+            "https://api.search.brave.com/res/v1/web/search",
+            params=params,
+            headers={
+                "Accept": "application/json",
+                "Accept-Encoding": "gzip",
+                "X-Subscription-Token": _settings.brave_search_api_key,
+            },
+            timeout=10,
+        )
+
+        if response.status_code != 200:
+            return _mcp_response(f"Search failed (HTTP {response.status_code}). Check BRAVE_SEARCH_API_KEY if 401.")
+
+        data = response.json()
+        results = []
+        for item in data.get("web", {}).get("results", [])[:count]:
+            results.append({
+                "title": item.get("title", ""),
+                "url": item.get("url", ""),
+                "snippet": item.get("description", ""),
+            })
+
+        if not results:
+            return _mcp_response(f"No results found for: {query}")
+
+        # Format as readable text for LLM
+        lines = [f"Search results for: {query}\n"]
+        for i, r in enumerate(results, 1):
+            lines.append(f"{i}. {r['title']}")
+            lines.append(f"   URL: {r['url']}")
+            lines.append(f"   {r['snippet']}\n")
+
+        return _mcp_response("\n".join(lines))
+
+    except httpx.TimeoutException:
+        return _mcp_response("Web search timed out. Try again.")
+    except httpx.ConnectError as e:
+        return _mcp_response(f"Could not connect to search service: {e}")
+    except Exception as e:
+        logger.exception("web_search error")
+        return _mcp_response(f"Search error: {e}")
+```
+
+### B3: web_fetch Handler
+
+```python
+async def _web_fetch(
+    url: str,
+    max_chars: int | None = None,
+    *,
+    _settings: Settings,
+    _http: httpx.AsyncClient,
+) -> dict[str, Any]:
+    """Fetch URL and extract readable content."""
+    try:
+        # Validate URL scheme
+        if not url.startswith(("http://", "https://")):
+            return _mcp_response("URL must start with http:// or https://")
+
+        # SSRF protection
+        is_safe, error = _is_url_safe(url)
+        if not is_safe:
+            return _mcp_response(f"Blocked: {error}")
+
+        effective_max = min(max_chars or _settings.web_fetch_max_chars, 50000)
+
+        response = await _http.get(
+            url,
+            headers={"User-Agent": "Nous/0.1 (cognitive agent)"},
+            follow_redirects=True,
+            timeout=15,
+        )
+
+        content_type = response.headers.get("content-type", "")
+
+        # Reject binary content
+        is_text = any(t in content_type for t in ["text/", "application/json", "application/xml", "application/xhtml"])
+        if content_type and not is_text:
+            return _mcp_response(f"Cannot extract text from binary content (content-type: {content_type})")
+
+        if "html" in content_type or "xhtml" in content_type:
+            text = _extract_readable(response.text)
+        else:
+            text = response.text
+
+        if len(text) > effective_max:
+            text = text[:effective_max] + "\n\n[... truncated]"
+
+        return _mcp_response(f"Content from {url} ({len(text)} chars):\n\n{text}")
+
+    except httpx.TimeoutException:
+        return _mcp_response(f"Fetch timed out for: {url}")
+    except httpx.ConnectError as e:
+        return _mcp_response(f"Could not connect to {url}: {e}")
+    except Exception as e:
+        logger.exception("web_fetch error")
+        return _mcp_response(f"Fetch error: {e}")
+```
+
+### B4: HTML Extraction
+
+```python
+def _extract_readable(html: str) -> str:
+    """Extract readable text from HTML using stdlib."""
+    import html as html_module
+    import re
+
+    # Remove script, style, noscript, nav, header, footer tags
+    text = re.sub(
+        r'<(script|style|noscript|nav|header|footer)[^>]*>.*?</\1>',
+        '', html, flags=re.DOTALL | re.IGNORECASE
+    )
+    # Remove HTML comments
+    text = re.sub(r'<!--.*?-->', '', text, flags=re.DOTALL)
+    # Remove HTML tags
+    text = re.sub(r'<[^>]+>', ' ', text)
+    # Decode entities
+    text = html_module.unescape(text)
+    # Clean whitespace
+    text = re.sub(r'\s+', ' ', text).strip()
+    return text
+```
+
+### B5: Tool Schemas + Registration
+
+```python
+_WEB_SEARCH_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": "Search the web for current information. Returns titles, URLs, and snippets.",
+    "properties": {
+        "query": {"type": "string", "description": "Search query string"},
+        "count": {
+            "type": "integer",
+            "description": "Number of results (1-10, default 5)",
+            "minimum": 1,
+            "maximum": 10,
+            "default": 5,
+        },
+        "freshness": {
+            "type": "string",
+            "description": "Filter by recency: 'day', 'week', 'month', or omit for all time",
+            "enum": ["day", "week", "month"],
+        },
+    },
+    "required": ["query"],
+}
+
+_WEB_FETCH_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": "Fetch and extract readable content from a URL. Returns clean text.",
+    "properties": {
+        "url": {"type": "string", "description": "URL to fetch (must be http or https)"},
+        "max_chars": {
+            "type": "integer",
+            "description": "Maximum characters to return (default from config, max 50000)",
+            "maximum": 50000,
+        },
+    },
+    "required": ["url"],
+}
+
+
+def register_web_tools(
+    dispatcher: ToolDispatcher,
+    settings: Settings,
+    http_client: httpx.AsyncClient,
+) -> None:
+    """Register web tools (web_search, web_fetch) with the dispatcher.
+
+    Creates closure wrappers that inject settings and httpx client.
+    Uses a SEPARATE httpx client from AgentRunner (no auth headers).
+    """
+    async def _search(query: str, count: int = 5, freshness: str | None = None) -> dict[str, Any]:
+        return await _web_search(query, count, freshness, _settings=settings, _http=http_client)
+
+    async def _fetch(url: str, max_chars: int | None = None) -> dict[str, Any]:
+        return await _web_fetch(url, max_chars, _settings=settings, _http=http_client)
+
+    dispatcher.register("web_search", _search, _WEB_SEARCH_SCHEMA)
+    dispatcher.register("web_fetch", _fetch, _WEB_FETCH_SCHEMA)
+```
+
+---
+
+## Phase C: Runner Updates
+
+**File: `nous/api/runner.py`**
+
+### C1: FRAME_TOOLS (replace lines 34-41)
+
+```python
+FRAME_TOOLS: dict[str, list[str]] = {
+    "conversation": ["record_decision", "learn_fact", "recall_deep", "create_censor", "bash", "read_file", "write_file", "web_search", "web_fetch"],
+    "question": ["recall_deep", "bash", "read_file", "write_file", "record_decision", "learn_fact", "create_censor", "web_search", "web_fetch"],
+    "decision": ["record_decision", "recall_deep", "create_censor", "bash", "read_file", "web_search", "web_fetch"],
+    "creative": ["learn_fact", "recall_deep", "write_file", "web_search"],
+    "task": ["*"],  # All tools
+    "debug": ["record_decision", "recall_deep", "bash", "read_file", "learn_fact", "web_search", "web_fetch"],
+}
+```
+
+### C2: Frame Instructions (update `_get_frame_instructions`)
+
+Add web tool mentions to relevant frames. After existing frame instruction blocks, add `web_search`/`web_fetch` mentions:
+
+- **question frame**: Add "Use `web_search` and `web_fetch` for questions about current events or topics not in memory."
+- **task frame**: Add "Use `web_search` and `web_fetch` for research."
+- **debug frame**: Add "Use `web_search` and `web_fetch` to look up documentation or error messages."
+- **conversation frame** (add new block): "Use `web_search` and `web_fetch` to find current information when needed."
+
+---
+
+## Phase D: Main Wiring
+
+**File: `nous/main.py`**
+
+### D1: Import (add to imports at top)
+
+```python
+from nous.api.web_tools import register_web_tools
+```
+
+### D2: Create web httpx client in `create_components()` (after line 63)
+
+```python
+    # Web tools httpx client (separate from runner — no API auth headers)
+    web_http = httpx.AsyncClient(
+        timeout=httpx.Timeout(connect=10, read=30, write=10, pool=10),
+        limits=httpx.Limits(max_connections=5, max_keepalive_connections=2),
+    )
+    register_web_tools(dispatcher, settings, web_http)
+```
+
+### D3: Add to components dict (add to return dict)
+
+```python
+    "web_http": web_http,
+```
+
+### D4: Shutdown (add to `shutdown_components()` before runner close)
+
+```python
+    web_http = components.get("web_http")
+    if web_http:
+        await web_http.aclose()
+```
+
+### D5: Startup log (add after existing credential warning, ~line 232)
+
+```python
+    if not settings.brave_search_api_key:
+        logger.warning("BRAVE_SEARCH_API_KEY not set — web_search will be unavailable")
+```
+
+---
+
+## Phase E: Docker + Env
+
+### E1: docker-compose.yml — Add to nous service environment (after NOUS_WORKSPACE_DIR line)
+
+```yaml
+      - BRAVE_SEARCH_API_KEY=${BRAVE_SEARCH_API_KEY:-}
+```
+
+### E2: .env.example — Add after OPENAI_API_KEY line
+
+```bash
+# Web search (optional — web_search tool disabled if omitted)
+BRAVE_SEARCH_API_KEY=your_brave_search_key_here
+```
+
+---
+
+## Phase F: Tests
+
+**File: `tests/test_web_tools.py`** — NEW
+
+Test categories:
+1. **SSRF protection**: `_is_url_safe()` blocks localhost, 127.0.0.1, 169.254.x.x, Docker hostnames; allows public IPs
+2. **Rate limiting**: Counter increments, blocks at limit, resets on new day
+3. **web_search**: Mock Brave API response, empty results, missing API key, timeout
+4. **web_fetch**: Mock HTML page, binary content rejection, SSRF block, truncation, timeout
+5. **HTML extraction**: Script/style removal, entity decoding, comment removal, whitespace normalization
+6. **Registration**: `register_web_tools()` registers both tools with dispatcher, closures capture settings/client
+
+Use `unittest.mock.AsyncMock` to patch httpx responses (no `respx` dependency needed).
+
+---
+
+## Acceptance Criteria
+
+- [ ] `web_search` returns formatted results from Brave API
+- [ ] `web_search` returns clear error when BRAVE_SEARCH_API_KEY not set
+- [ ] `web_search` enforces daily rate limit
+- [ ] `web_fetch` extracts readable text from HTML pages
+- [ ] `web_fetch` rejects binary content types
+- [ ] `web_fetch` blocks SSRF attempts (localhost, private IPs, Docker hostnames)
+- [ ] Both tools use MCP response format
+- [ ] Both tools handle timeouts and network errors gracefully
+- [ ] Both tools use closure pattern matching existing builtin_tools.py
+- [ ] Separate httpx client (no credential leak from AgentRunner)
+- [ ] FRAME_TOOLS correctly updated for all frames
+- [ ] Config uses validation_alias for BRAVE_SEARCH_API_KEY
+- [ ] docker-compose.yml and .env.example updated
+- [ ] All tests pass

--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -32,12 +32,12 @@ _DECISION_FRAMES = frozenset({"decision", "task", "debug"})
 
 # Frame-gated tool access (D5)
 FRAME_TOOLS: dict[str, list[str]] = {
-    "conversation": ["record_decision", "learn_fact", "recall_deep", "create_censor", "bash", "read_file", "write_file"],
-    "question": ["recall_deep", "bash", "read_file", "write_file", "record_decision", "learn_fact", "create_censor"],
-    "decision": ["record_decision", "recall_deep", "create_censor", "bash", "read_file"],
-    "creative": ["learn_fact", "recall_deep", "write_file"],
+    "conversation": ["record_decision", "learn_fact", "recall_deep", "create_censor", "bash", "read_file", "write_file", "web_search", "web_fetch"],
+    "question": ["recall_deep", "bash", "read_file", "write_file", "record_decision", "learn_fact", "create_censor", "web_search", "web_fetch"],
+    "decision": ["record_decision", "recall_deep", "create_censor", "bash", "read_file", "web_search", "web_fetch"],
+    "creative": ["learn_fact", "recall_deep", "write_file", "web_search"],
     "task": ["*"],  # All tools
-    "debug": ["record_decision", "recall_deep", "bash", "read_file", "learn_fact"],
+    "debug": ["record_decision", "recall_deep", "bash", "read_file", "learn_fact", "web_search", "web_fetch"],
 }
 
 # Anthropic API version header (P0-1)
@@ -504,7 +504,8 @@ class AgentRunner:
                 "You are in a DECISION frame. You MUST call `record_decision` "
                 "to record your decision before responding. Include your reasoning, "
                 "confidence level, and category. Use `recall_deep` to search "
-                "for relevant past decisions."
+                "for relevant past decisions. Use `web_search` and `web_fetch` "
+                "to research options before deciding."
             )
         elif frame_id == "task":
             return (
@@ -513,7 +514,8 @@ class AgentRunner:
                 "call `record_decision` to record them. Use `recall_deep` to search "
                 "for relevant past decisions and knowledge. Use `learn_fact` to store "
                 "any new facts discovered. You can also use `bash`, `read_file`, and "
-                "`write_file` for system operations."
+                "`write_file` for system operations. Use `web_search` and `web_fetch` "
+                "for research."
             )
         elif frame_id == "debug":
             return (
@@ -521,20 +523,29 @@ class AgentRunner:
                 "You are in a DEBUG frame. Use `recall_deep` to search for relevant "
                 "past decisions and procedures. Record your debugging decisions with "
                 "`record_decision`. Store any root cause findings with `learn_fact`. "
-                "Use `bash` and `read_file` for investigation."
+                "Use `bash` and `read_file` for investigation. Use `web_search` and "
+                "`web_fetch` to look up documentation or error messages."
             )
         elif frame_id == "question":
             return (
                 "## Tool Instructions\n\n"
                 "You are in a QUESTION frame. Use `recall_deep` to search memory "
-                "for relevant knowledge before answering."
+                "for relevant knowledge before answering. Use `web_search` and "
+                "`web_fetch` for questions about current events or topics not in memory."
             )
         elif frame_id == "creative":
             return (
                 "## Tool Instructions\n\n"
                 "You are in a CREATIVE frame. Use `recall_deep` to find relevant "
                 "knowledge. Use `learn_fact` to store creative insights. "
-                "Use `write_file` to save creative output."
+                "Use `write_file` to save creative output. Use `web_search` "
+                "for inspiration and reference material."
+            )
+        elif frame_id == "conversation":
+            return (
+                "## Tool Instructions\n\n"
+                "You are in a CONVERSATION frame. Use `web_search` and `web_fetch` "
+                "to find current information when needed."
             )
 
         return ""

--- a/nous/api/web_tools.py
+++ b/nous/api/web_tools.py
@@ -1,0 +1,348 @@
+"""Web tools for the Nous agent: web_search and web_fetch.
+
+Gives the agent web access capabilities, gated by cognitive frames.
+Uses a separate httpx client (NOT AgentRunner's — that has API credentials).
+"""
+
+from __future__ import annotations
+
+import html as html_module
+import ipaddress
+import logging
+import re
+import socket
+import time
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+from nous.api.tools import ToolDispatcher
+from nous.config import Settings
+
+logger = logging.getLogger(__name__)
+
+# Rate limit state (in-memory, resets on restart)
+_rate_limit: dict[str, Any] = {"date": "", "count": 0}
+
+# Blocked IP ranges for SSRF protection
+_BLOCKED_NETWORKS = [
+    ipaddress.ip_network("127.0.0.0/8"),       # Loopback
+    ipaddress.ip_network("10.0.0.0/8"),         # RFC1918
+    ipaddress.ip_network("172.16.0.0/12"),      # RFC1918
+    ipaddress.ip_network("192.168.0.0/16"),     # RFC1918
+    ipaddress.ip_network("169.254.0.0/16"),     # Link-local
+    ipaddress.ip_network("::1/128"),            # IPv6 loopback
+    ipaddress.ip_network("fc00::/7"),           # IPv6 unique local
+    ipaddress.ip_network("fe80::/10"),          # IPv6 link-local
+]
+
+# Blocked hostnames (Docker internal services, etc.)
+_BLOCKED_HOSTNAMES = {"localhost", "postgres", "nous", "redis", "0.0.0.0"}
+
+
+def _mcp_response(text: str) -> dict[str, Any]:
+    """Build MCP-format response."""
+    return {"content": [{"type": "text", "text": text}]}
+
+
+def _is_url_safe(url: str) -> tuple[bool, str]:
+    """Check if URL is safe from SSRF attacks.
+
+    Resolves hostname to IP and checks against blocked ranges.
+    Returns (is_safe, error_message).
+    """
+    try:
+        parsed = urlparse(url)
+        hostname = parsed.hostname
+
+        if not hostname:
+            return False, "Could not parse hostname from URL"
+
+        # Check blocked hostnames
+        if hostname.lower() in _BLOCKED_HOSTNAMES:
+            return False, f"Blocked hostname: {hostname}"
+
+        # Resolve to IP and check ranges
+        try:
+            addr_infos = socket.getaddrinfo(hostname, None)
+        except socket.gaierror:
+            return False, f"Could not resolve hostname: {hostname}"
+
+        for addr_info in addr_infos:
+            ip = ipaddress.ip_address(addr_info[4][0])
+            for network in _BLOCKED_NETWORKS:
+                if ip in network:
+                    return False, f"URL resolves to blocked IP range ({network})"
+
+        return True, ""
+    except Exception as e:
+        return False, f"URL validation error: {e}"
+
+
+def _check_rate_limit(settings: Settings) -> str | None:
+    """Check and increment daily rate limit.
+
+    Returns error message if limit exceeded, None if OK.
+    """
+    today = time.strftime("%Y-%m-%d")
+
+    if _rate_limit["date"] != today:
+        _rate_limit["date"] = today
+        _rate_limit["count"] = 0
+
+    limit = settings.web_search_daily_limit
+    current = _rate_limit["count"]
+
+    if current >= limit:
+        return f"Daily web search limit reached ({limit}). Resets tomorrow."
+
+    _rate_limit["count"] = current + 1
+
+    if current >= int(limit * 0.8):
+        logger.warning("Web search rate limit at %d/%d (%.0f%%)", current + 1, limit, (current + 1) / limit * 100)
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tool handlers
+# ---------------------------------------------------------------------------
+
+
+async def _web_search(
+    query: str,
+    count: int = 5,
+    freshness: str | None = None,
+    *,
+    _settings: Settings,
+    _http: httpx.AsyncClient,
+) -> dict[str, Any]:
+    """Search via Brave Search API."""
+    try:
+        # Check API key
+        if not _settings.brave_search_api_key:
+            return _mcp_response("Error: BRAVE_SEARCH_API_KEY not configured. Set this environment variable to enable web search.")
+
+        # Check rate limit
+        rate_error = _check_rate_limit(_settings)
+        if rate_error:
+            return _mcp_response(f"Rate limit: {rate_error}")
+
+        count = min(count, 10)
+
+        params: dict[str, Any] = {"q": query, "count": count}
+        if freshness:
+            freshness_map = {"day": "pd", "week": "pw", "month": "pm"}
+            mapped = freshness_map.get(freshness)
+            if mapped:
+                params["freshness"] = mapped
+
+        response = await _http.get(
+            "https://api.search.brave.com/res/v1/web/search",
+            params=params,
+            headers={
+                "Accept": "application/json",
+                "Accept-Encoding": "gzip",
+                "X-Subscription-Token": _settings.brave_search_api_key,
+            },
+            timeout=10,
+        )
+
+        if response.status_code != 200:
+            return _mcp_response(f"Search failed (HTTP {response.status_code}). Check BRAVE_SEARCH_API_KEY if 401.")
+
+        data = response.json()
+        results = []
+        for item in data.get("web", {}).get("results", [])[:count]:
+            results.append({
+                "title": item.get("title", ""),
+                "url": item.get("url", ""),
+                "snippet": item.get("description", ""),
+            })
+
+        if not results:
+            return _mcp_response(f"No results found for: {query}")
+
+        # Format as readable text for LLM
+        lines = [f"Search results for: {query}\n"]
+        for i, r in enumerate(results, 1):
+            lines.append(f"{i}. {r['title']}")
+            lines.append(f"   URL: {r['url']}")
+            lines.append(f"   {r['snippet']}\n")
+
+        return _mcp_response("\n".join(lines))
+
+    except httpx.TimeoutException:
+        return _mcp_response("Web search timed out. Try again.")
+    except httpx.ConnectError as e:
+        return _mcp_response(f"Could not connect to search service: {e}")
+    except Exception as e:
+        logger.exception("web_search error")
+        return _mcp_response(f"Search error: {e}")
+
+
+async def _web_fetch(
+    url: str,
+    max_chars: int | None = None,
+    *,
+    _settings: Settings,
+    _http: httpx.AsyncClient,
+) -> dict[str, Any]:
+    """Fetch URL and extract readable content."""
+    try:
+        # Validate URL scheme
+        if not url.startswith(("http://", "https://")):
+            return _mcp_response("URL must start with http:// or https://")
+
+        # SSRF protection
+        is_safe, error = _is_url_safe(url)
+        if not is_safe:
+            return _mcp_response(f"Blocked: {error}")
+
+        effective_max = min(max_chars or _settings.web_fetch_max_chars, 50000)
+
+        # Manual redirect following with SSRF check on each hop (P1-1 fix)
+        max_redirects = 5
+        current_url = url
+        response = None
+        for _ in range(max_redirects + 1):
+            response = await _http.get(
+                current_url,
+                headers={"User-Agent": "Nous/0.1 (cognitive agent)"},
+                follow_redirects=False,
+                timeout=15,
+            )
+            if response.status_code not in (301, 302, 303, 307, 308):
+                break
+            redirect_url = response.headers.get("location", "")
+            if not redirect_url:
+                break
+            # Resolve relative redirects
+            if redirect_url.startswith("/"):
+                parsed_current = urlparse(current_url)
+                redirect_url = f"{parsed_current.scheme}://{parsed_current.netloc}{redirect_url}"
+            # SSRF check on redirect target
+            redirect_safe, redirect_error = _is_url_safe(redirect_url)
+            if not redirect_safe:
+                return _mcp_response(f"Blocked redirect to unsafe URL: {redirect_error}")
+            current_url = redirect_url
+        else:
+            return _mcp_response(f"Too many redirects (max {max_redirects})")
+
+        if response is None:
+            return _mcp_response("No response received")
+
+        content_type = response.headers.get("content-type", "")
+
+        # Reject binary content
+        is_text = any(t in content_type for t in ["text/", "application/json", "application/xml", "application/xhtml"])
+        if content_type and not is_text:
+            return _mcp_response(f"Cannot extract text from binary content (content-type: {content_type})")
+
+        if "html" in content_type or "xhtml" in content_type:
+            text = _extract_readable(response.text)
+        else:
+            text = response.text
+
+        if len(text) > effective_max:
+            text = text[:effective_max] + "\n\n[... truncated]"
+
+        return _mcp_response(f"Content from {url} ({len(text)} chars):\n\n{text}")
+
+    except httpx.TimeoutException:
+        return _mcp_response(f"Fetch timed out for: {url}")
+    except httpx.ConnectError as e:
+        return _mcp_response(f"Could not connect to {url}: {e}")
+    except Exception as e:
+        logger.exception("web_fetch error")
+        return _mcp_response(f"Fetch error: {e}")
+
+
+# ---------------------------------------------------------------------------
+# HTML extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_readable(html: str) -> str:
+    """Extract readable text from HTML using stdlib."""
+    # Remove script, style, noscript, nav, header, footer tags
+    text = re.sub(
+        r'<(script|style|noscript|nav|header|footer)[^>]*>.*?</\1>',
+        '', html, flags=re.DOTALL | re.IGNORECASE
+    )
+    # Remove HTML comments
+    text = re.sub(r'<!--.*?-->', '', text, flags=re.DOTALL)
+    # Remove HTML tags
+    text = re.sub(r'<[^>]+>', ' ', text)
+    # Decode entities
+    text = html_module.unescape(text)
+    # Clean whitespace
+    text = re.sub(r'\s+', ' ', text).strip()
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+
+_WEB_SEARCH_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": "Search the web for current information. Returns titles, URLs, and snippets.",
+    "properties": {
+        "query": {"type": "string", "description": "Search query string"},
+        "count": {
+            "type": "integer",
+            "description": "Number of results (1-10, default 5)",
+            "minimum": 1,
+            "maximum": 10,
+            "default": 5,
+        },
+        "freshness": {
+            "type": "string",
+            "description": "Filter by recency: 'day', 'week', 'month', or omit for all time",
+            "enum": ["day", "week", "month"],
+        },
+    },
+    "required": ["query"],
+}
+
+_WEB_FETCH_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": "Fetch and extract readable content from a URL. Returns clean text.",
+    "properties": {
+        "url": {"type": "string", "description": "URL to fetch (must be http or https)"},
+        "max_chars": {
+            "type": "integer",
+            "description": "Maximum characters to return (default from config, max 50000)",
+            "maximum": 50000,
+        },
+    },
+    "required": ["url"],
+}
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def register_web_tools(
+    dispatcher: ToolDispatcher,
+    settings: Settings,
+    http_client: httpx.AsyncClient,
+) -> None:
+    """Register web tools (web_search, web_fetch) with the dispatcher.
+
+    Creates closure wrappers that inject settings and httpx client.
+    Uses a SEPARATE httpx client from AgentRunner (no auth headers).
+    """
+    async def _search(query: str, count: int = 5, freshness: str | None = None) -> dict[str, Any]:
+        return await _web_search(query, count, freshness, _settings=settings, _http=http_client)
+
+    async def _fetch(url: str, max_chars: int | None = None) -> dict[str, Any]:
+        return await _web_fetch(url, max_chars, _settings=settings, _http=http_client)
+
+    dispatcher.register("web_search", _search, _WEB_SEARCH_SCHEMA)
+    dispatcher.register("web_fetch", _fetch, _WEB_FETCH_SCHEMA)

--- a/nous/config.py
+++ b/nous/config.py
@@ -58,6 +58,11 @@ class Settings(BaseSettings):
     api_timeout_read: int = 120  # seconds
     workspace_dir: str = "/tmp/nous-workspace"
 
+    # Web tools
+    brave_search_api_key: str = Field("", validation_alias="BRAVE_SEARCH_API_KEY")
+    web_search_daily_limit: int = 100  # Max web searches per day
+    web_fetch_max_chars: int = 10000  # Default max chars for web_fetch
+
     @property
     def db_url(self) -> str:
         return f"postgresql+asyncpg://{self.db_user}:{self.db_password}@{self.db_host}:{self.db_port}/{self.db_name}"

--- a/tests/test_web_tools.py
+++ b/tests/test_web_tools.py
@@ -1,0 +1,755 @@
+"""Unit tests for nous/api/web_tools.py -- web_search, web_fetch, SSRF, rate limiting.
+
+All tests are pure async (no database required). HTTP calls are mocked via
+unittest.mock.AsyncMock. DNS resolution is mocked via socket.getaddrinfo patch.
+Imports from nous.api.web_tools are done inline to tolerate the file being
+written in parallel.
+"""
+
+import importlib
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from nous.api.tools import ToolDispatcher
+from nous.config import Settings
+
+
+def _extract_text(result: dict) -> str:
+    """Extract text from MCP-format response."""
+    return result["content"][0]["text"]
+
+
+def _make_settings(**overrides) -> MagicMock:
+    """Create a mock Settings with web-tool defaults.
+
+    Uses MagicMock instead of real Settings to avoid pydantic-settings
+    env file/alias complications in unit tests.
+    """
+    defaults = {
+        "brave_search_api_key": "test-brave-key",
+        "web_search_daily_limit": 100,
+        "web_fetch_max_chars": 10000,
+    }
+    defaults.update(overrides)
+    mock = MagicMock()
+    for key, value in defaults.items():
+        setattr(mock, key, value)
+    return mock
+
+
+def _mock_response(
+    status_code: int = 200,
+    json_data: dict | None = None,
+    text: str = "",
+    headers: dict | None = None,
+) -> MagicMock:
+    """Create a mock httpx.Response with common attributes."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.text = text
+    resp.headers = headers or {}
+    return resp
+
+
+def _mock_http_client(response: MagicMock | None = None) -> AsyncMock:
+    """Create a mock httpx.AsyncClient whose .get() returns the given response."""
+    client = AsyncMock(spec=httpx.AsyncClient)
+    if response is not None:
+        client.get.return_value = response
+    return client
+
+
+def _brave_search_response(results: list[dict] | None = None) -> dict:
+    """Build a Brave Search API response payload."""
+    if results is None:
+        results = [
+            {
+                "title": "Example Result",
+                "url": "https://example.com",
+                "description": "An example search result.",
+            }
+        ]
+    return {"web": {"results": results}}
+
+
+# ---------------------------------------------------------------------------
+# Helpers to import web_tools module (inline, tolerant of parallel writing)
+# ---------------------------------------------------------------------------
+
+
+def _import_web_tools():
+    """Import nous.api.web_tools, reloading to pick up latest code."""
+    import nous.api.web_tools as wt
+    importlib.reload(wt)
+    return wt
+
+
+# ---------------------------------------------------------------------------
+# SSRF Protection tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsUrlSafe:
+    """Tests for _is_url_safe() SSRF protection."""
+
+    def _is_url_safe(self, url: str) -> tuple[bool, str]:
+        wt = _import_web_tools()
+        return wt._is_url_safe(url)
+
+    @patch("socket.getaddrinfo")
+    def test_blocks_localhost(self, mock_dns):
+        """localhost hostname is blocked before DNS resolution."""
+        safe, error = self._is_url_safe("http://localhost/admin")
+        assert safe is False
+        assert "Blocked hostname" in error or "localhost" in error.lower()
+
+    @patch("socket.getaddrinfo")
+    def test_blocks_127_0_0_1(self, mock_dns):
+        """127.0.0.1 resolves to loopback and is blocked."""
+        mock_dns.return_value = [(2, 1, 6, "", ("127.0.0.1", 0))]
+        safe, error = self._is_url_safe("http://127.0.0.1/secret")
+        assert safe is False
+        assert "blocked" in error.lower() or "127" in error
+
+    @patch("socket.getaddrinfo")
+    def test_blocks_metadata_ip(self, mock_dns):
+        """169.254.169.254 (cloud metadata) is blocked."""
+        mock_dns.return_value = [(2, 1, 6, "", ("169.254.169.254", 0))]
+        safe, error = self._is_url_safe("http://169.254.169.254/latest/meta-data/")
+        assert safe is False
+        assert "blocked" in error.lower()
+
+    @patch("socket.getaddrinfo")
+    def test_blocks_ipv6_loopback(self, mock_dns):
+        """[::1] IPv6 loopback is blocked."""
+        mock_dns.return_value = [(10, 1, 6, "", ("::1", 0, 0, 0))]
+        safe, error = self._is_url_safe("http://[::1]/")
+        assert safe is False
+
+    @patch("socket.getaddrinfo")
+    def test_blocks_docker_hostname_postgres(self, mock_dns):
+        """Docker internal hostname 'postgres' is blocked."""
+        safe, error = self._is_url_safe("http://postgres:5432/")
+        assert safe is False
+        assert "Blocked hostname" in error or "postgres" in error.lower()
+
+    @patch("socket.getaddrinfo")
+    def test_allows_public_url(self, mock_dns):
+        """Public URLs like example.com are allowed."""
+        mock_dns.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+        safe, error = self._is_url_safe("https://example.com/page")
+        assert safe is True
+        assert error == ""
+
+    @patch("socket.getaddrinfo")
+    def test_allows_github(self, mock_dns):
+        """github.com is allowed."""
+        mock_dns.return_value = [(2, 1, 6, "", ("140.82.121.4", 0))]
+        safe, error = self._is_url_safe("https://github.com/anthropics")
+        assert safe is True
+        assert error == ""
+
+    @patch("socket.getaddrinfo", side_effect=Exception("DNS failure"))
+    def test_dns_resolution_failure(self, mock_dns):
+        """DNS resolution failure returns safe=False with error message."""
+        safe, error = self._is_url_safe("http://nonexistent.invalid/")
+        assert safe is False
+        assert "error" in error.lower() or "resolve" in error.lower() or "Could not" in error
+
+    def test_no_hostname(self):
+        """URL with no hostname returns safe=False."""
+        safe, error = self._is_url_safe("http://")
+        assert safe is False
+        assert "hostname" in error.lower() or "parse" in error.lower()
+
+    @patch("socket.getaddrinfo")
+    def test_blocks_private_10_range(self, mock_dns):
+        """10.x.x.x private range is blocked."""
+        mock_dns.return_value = [(2, 1, 6, "", ("10.0.0.1", 0))]
+        safe, error = self._is_url_safe("http://internal.corp/")
+        assert safe is False
+
+    @patch("socket.getaddrinfo")
+    def test_blocks_private_192_168_range(self, mock_dns):
+        """192.168.x.x private range is blocked."""
+        mock_dns.return_value = [(2, 1, 6, "", ("192.168.1.1", 0))]
+        safe, error = self._is_url_safe("http://router.local/")
+        assert safe is False
+
+
+# ---------------------------------------------------------------------------
+# Rate Limiting tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckRateLimit:
+    """Tests for _check_rate_limit() daily rate limiting."""
+
+    @pytest.fixture(autouse=True)
+    def reset_rate_limit(self):
+        """Reset module-level _rate_limit state before each test."""
+        wt = _import_web_tools()
+        wt._rate_limit["date"] = ""
+        wt._rate_limit["count"] = 0
+        yield
+
+    def test_increments_counter(self):
+        """Each call increments the counter, returns None when under limit."""
+        wt = _import_web_tools()
+        settings = _make_settings(web_search_daily_limit=10)
+        result = wt._check_rate_limit(settings)
+        assert result is None
+        assert wt._rate_limit["count"] == 1
+
+    def test_returns_error_at_limit(self):
+        """Returns error message when limit is reached."""
+        wt = _import_web_tools()
+        settings = _make_settings(web_search_daily_limit=5)
+        # Exhaust the limit
+        for _ in range(5):
+            wt._check_rate_limit(settings)
+        # Next call should fail
+        result = wt._check_rate_limit(settings)
+        assert result is not None
+        assert "limit" in result.lower()
+        assert "5" in result
+
+    def test_resets_on_new_day(self):
+        """Counter resets when date changes (new day)."""
+        wt = _import_web_tools()
+        settings = _make_settings(web_search_daily_limit=5)
+
+        # Day 1: exhaust limit
+        wt._rate_limit["date"] = "2026-02-24"
+        wt._rate_limit["count"] = 5
+        assert wt._check_rate_limit(settings) is not None  # Blocked
+
+        # Day 2: simulate date change by setting a different date
+        # _check_rate_limit reads time.strftime internally, so we manipulate _rate_limit directly
+        # to simulate what happens when the date changes
+        wt._rate_limit["date"] = "2026-02-24"
+        wt._rate_limit["count"] = 5
+
+        # Patch time.strftime at the module level to return a new day
+        with patch.object(wt.time, "strftime", return_value="2026-02-25"):
+            result = wt._check_rate_limit(settings)
+        assert result is None  # Allowed again
+        assert wt._rate_limit["count"] == 1
+
+    def test_warns_at_80_percent(self, caplog):
+        """Logs a warning when usage reaches 80% of limit."""
+        wt = _import_web_tools()
+        settings = _make_settings(web_search_daily_limit=10)
+
+        with caplog.at_level(logging.WARNING, logger="nous.api.web_tools"):
+            # Use 8 calls (80%) -- 80% threshold is current >= int(10 * 0.8) = 8
+            for _ in range(8):
+                wt._check_rate_limit(settings)
+
+            caplog.clear()
+            # 9th call: current=8 >= int(10*0.8)=8, should trigger warning
+            wt._check_rate_limit(settings)
+            assert any("rate limit" in r.message.lower() or "9/" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# web_search tests
+# ---------------------------------------------------------------------------
+
+
+class TestWebSearch:
+    """Tests for the _web_search handler."""
+
+    @pytest.fixture(autouse=True)
+    def reset_rate_limit(self):
+        """Reset rate limit state before each test."""
+        wt = _import_web_tools()
+        wt._rate_limit["date"] = ""
+        wt._rate_limit["count"] = 0
+        yield
+
+    @pytest.mark.asyncio
+    async def test_successful_search(self):
+        """Successful search returns formatted results in MCP format."""
+        wt = _import_web_tools()
+        settings = _make_settings()
+        response = _mock_response(
+            status_code=200,
+            json_data=_brave_search_response([
+                {"title": "Python Docs", "url": "https://docs.python.org", "description": "Official Python documentation"},
+                {"title": "PyPI", "url": "https://pypi.org", "description": "Python Package Index"},
+            ]),
+        )
+        client = _mock_http_client(response)
+
+        result = await wt._web_search("python", count=5, freshness=None, _settings=settings, _http=client)
+
+        text = _extract_text(result)
+        assert "Python Docs" in text
+        assert "https://docs.python.org" in text
+        assert "PyPI" in text
+        assert "Search results for: python" in text
+
+    @pytest.mark.asyncio
+    async def test_empty_api_key_returns_error(self):
+        """Missing BRAVE_SEARCH_API_KEY returns clear error message."""
+        wt = _import_web_tools()
+        settings = _make_settings(brave_search_api_key="")
+        client = _mock_http_client()
+
+        result = await wt._web_search("test", _settings=settings, _http=client)
+
+        text = _extract_text(result)
+        assert "BRAVE_SEARCH_API_KEY" in text
+        assert "not configured" in text.lower() or "error" in text.lower()
+        # Should NOT have called the HTTP client
+        client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_exceeded(self):
+        """Returns error when daily rate limit is exceeded."""
+        wt = _import_web_tools()
+        settings = _make_settings(web_search_daily_limit=1)
+        client = _mock_http_client(_mock_response(status_code=200, json_data=_brave_search_response()))
+
+        # First call succeeds
+        await wt._web_search("first", _settings=settings, _http=client)
+
+        # Second call should be rate limited
+        result = await wt._web_search("second", _settings=settings, _http=client)
+        text = _extract_text(result)
+        assert "rate limit" in text.lower() or "limit" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_brave_api_401_error(self):
+        """Brave API 401 returns helpful error mentioning API key."""
+        wt = _import_web_tools()
+        settings = _make_settings()
+        response = _mock_response(status_code=401)
+        client = _mock_http_client(response)
+
+        result = await wt._web_search("test", _settings=settings, _http=client)
+
+        text = _extract_text(result)
+        assert "401" in text
+        assert "BRAVE_SEARCH_API_KEY" in text or "failed" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_friendly_message(self):
+        """httpx.TimeoutException returns friendly message."""
+        wt = _import_web_tools()
+        settings = _make_settings()
+        client = _mock_http_client()
+        client.get.side_effect = httpx.TimeoutException("Connection timed out")
+
+        result = await wt._web_search("test", _settings=settings, _http=client)
+
+        text = _extract_text(result)
+        assert "timed out" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_empty_results(self):
+        """Empty search results returns 'No results found' message."""
+        wt = _import_web_tools()
+        settings = _make_settings()
+        response = _mock_response(status_code=200, json_data={"web": {"results": []}})
+        client = _mock_http_client(response)
+
+        result = await wt._web_search("obscure query xyz", _settings=settings, _http=client)
+
+        text = _extract_text(result)
+        assert "No results found" in text
+
+    @pytest.mark.asyncio
+    async def test_mcp_response_format(self):
+        """Response is in MCP format: {content: [{type: 'text', text: '...'}]}."""
+        wt = _import_web_tools()
+        settings = _make_settings()
+        response = _mock_response(status_code=200, json_data=_brave_search_response())
+        client = _mock_http_client(response)
+
+        result = await wt._web_search("test", _settings=settings, _http=client)
+
+        assert "content" in result
+        assert isinstance(result["content"], list)
+        assert len(result["content"]) >= 1
+        assert result["content"][0]["type"] == "text"
+        assert isinstance(result["content"][0]["text"], str)
+
+    @pytest.mark.asyncio
+    async def test_search_passes_api_key_header(self):
+        """Brave API key is passed in X-Subscription-Token header."""
+        wt = _import_web_tools()
+        settings = _make_settings(brave_search_api_key="my-secret-key")
+        response = _mock_response(status_code=200, json_data=_brave_search_response())
+        client = _mock_http_client(response)
+
+        await wt._web_search("test", _settings=settings, _http=client)
+
+        # Verify the HTTP call was made with the API key header
+        client.get.assert_called_once()
+        call_kwargs = client.get.call_args
+        headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers", {})
+        assert headers.get("X-Subscription-Token") == "my-secret-key"
+
+    @pytest.mark.asyncio
+    async def test_connect_error(self):
+        """httpx.ConnectError returns friendly message."""
+        wt = _import_web_tools()
+        settings = _make_settings()
+        client = _mock_http_client()
+        client.get.side_effect = httpx.ConnectError("Connection refused")
+
+        result = await wt._web_search("test", _settings=settings, _http=client)
+
+        text = _extract_text(result)
+        assert "connect" in text.lower() or "error" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# web_fetch tests
+# ---------------------------------------------------------------------------
+
+
+class TestWebFetch:
+    """Tests for the _web_fetch handler."""
+
+    @pytest.mark.asyncio
+    async def test_html_page_returns_extracted_text(self):
+        """HTML page returns extracted readable text."""
+        wt = _import_web_tools()
+        settings = _make_settings()
+        html = "<html><body><h1>Hello World</h1><p>This is content.</p></body></html>"
+        response = _mock_response(
+            status_code=200,
+            text=html,
+            headers={"content-type": "text/html; charset=utf-8"},
+        )
+        client = _mock_http_client(response)
+
+        with patch.object(wt, "_is_url_safe", return_value=(True, "")):
+            result = await wt._web_fetch("https://example.com", _settings=settings, _http=client)
+
+        text = _extract_text(result)
+        assert "Hello World" in text
+        assert "This is content" in text
+        assert "Content from" in text
+
+    @pytest.mark.asyncio
+    async def test_binary_content_rejected(self):
+        """Binary content type (image/png) is rejected with error."""
+        wt = _import_web_tools()
+        settings = _make_settings()
+        response = _mock_response(
+            status_code=200,
+            headers={"content-type": "image/png"},
+        )
+        client = _mock_http_client(response)
+
+        with patch.object(wt, "_is_url_safe", return_value=(True, "")):
+            result = await wt._web_fetch("https://example.com/image.png", _settings=settings, _http=client)
+
+        text = _extract_text(result)
+        assert "binary" in text.lower() or "Cannot extract" in text
+        assert "image/png" in text
+
+    @pytest.mark.asyncio
+    async def test_ssrf_url_blocked(self):
+        """SSRF URL (localhost) is blocked before any HTTP request."""
+        wt = _import_web_tools()
+        settings = _make_settings()
+        client = _mock_http_client()
+
+        with patch.object(wt, "_is_url_safe", return_value=(False, "Blocked hostname: localhost")):
+            result = await wt._web_fetch("http://localhost/admin", _settings=settings, _http=client)
+
+        text = _extract_text(result)
+        assert "Blocked" in text
+        # Should NOT have made any HTTP request
+        client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_content_truncated_at_max_chars(self):
+        """Content exceeding max_chars is truncated with marker."""
+        wt = _import_web_tools()
+        settings = _make_settings(web_fetch_max_chars=100)
+        long_text = "A" * 500
+        response = _mock_response(
+            status_code=200,
+            text=long_text,
+            headers={"content-type": "text/plain"},
+        )
+        client = _mock_http_client(response)
+
+        with patch.object(wt, "_is_url_safe", return_value=(True, "")):
+            result = await wt._web_fetch("https://example.com/long", max_chars=100, _settings=settings, _http=client)
+
+        text = _extract_text(result)
+        assert "truncated" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_friendly_message(self):
+        """httpx.TimeoutException returns friendly message."""
+        wt = _import_web_tools()
+        settings = _make_settings()
+        client = _mock_http_client()
+        client.get.side_effect = httpx.TimeoutException("Read timed out")
+
+        with patch.object(wt, "_is_url_safe", return_value=(True, "")):
+            result = await wt._web_fetch("https://slow.example.com", _settings=settings, _http=client)
+
+        text = _extract_text(result)
+        assert "timed out" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_invalid_url_scheme_rejected(self):
+        """Non-http/https URL scheme is rejected."""
+        wt = _import_web_tools()
+        settings = _make_settings()
+        client = _mock_http_client()
+
+        result = await wt._web_fetch("ftp://example.com/file", _settings=settings, _http=client)
+
+        text = _extract_text(result)
+        assert "http" in text.lower()
+        # Should NOT have made any HTTP request
+        client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_json_content_type_allowed(self):
+        """application/json content type is treated as text."""
+        wt = _import_web_tools()
+        settings = _make_settings()
+        json_text = '{"key": "value", "items": [1, 2, 3]}'
+        response = _mock_response(
+            status_code=200,
+            text=json_text,
+            headers={"content-type": "application/json"},
+        )
+        client = _mock_http_client(response)
+
+        with patch.object(wt, "_is_url_safe", return_value=(True, "")):
+            result = await wt._web_fetch("https://api.example.com/data", _settings=settings, _http=client)
+
+        text = _extract_text(result)
+        assert '"key"' in text or "key" in text
+        assert "Content from" in text
+
+    @pytest.mark.asyncio
+    async def test_mcp_response_format(self):
+        """Response is in MCP format."""
+        wt = _import_web_tools()
+        settings = _make_settings()
+        response = _mock_response(
+            status_code=200,
+            text="Hello",
+            headers={"content-type": "text/plain"},
+        )
+        client = _mock_http_client(response)
+
+        with patch.object(wt, "_is_url_safe", return_value=(True, "")):
+            result = await wt._web_fetch("https://example.com", _settings=settings, _http=client)
+
+        assert "content" in result
+        assert isinstance(result["content"], list)
+        assert result["content"][0]["type"] == "text"
+
+    @pytest.mark.asyncio
+    async def test_connect_error(self):
+        """httpx.ConnectError returns friendly message."""
+        wt = _import_web_tools()
+        settings = _make_settings()
+        client = _mock_http_client()
+        client.get.side_effect = httpx.ConnectError("Connection refused")
+
+        with patch.object(wt, "_is_url_safe", return_value=(True, "")):
+            result = await wt._web_fetch("https://down.example.com", _settings=settings, _http=client)
+
+        text = _extract_text(result)
+        assert "connect" in text.lower() or "Could not" in text
+
+    @pytest.mark.asyncio
+    async def test_max_chars_capped_at_50000(self):
+        """max_chars parameter is capped at 50000 even if higher value passed."""
+        wt = _import_web_tools()
+        settings = _make_settings(web_fetch_max_chars=100000)
+        # Content just over 50000 chars
+        long_text = "B" * 60000
+        response = _mock_response(
+            status_code=200,
+            text=long_text,
+            headers={"content-type": "text/plain"},
+        )
+        client = _mock_http_client(response)
+
+        with patch.object(wt, "_is_url_safe", return_value=(True, "")):
+            result = await wt._web_fetch("https://example.com/huge", max_chars=100000, _settings=settings, _http=client)
+
+        text = _extract_text(result)
+        assert "truncated" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# HTML Extraction tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractReadable:
+    """Tests for _extract_readable() HTML text extraction."""
+
+    def _extract(self, html: str) -> str:
+        wt = _import_web_tools()
+        return wt._extract_readable(html)
+
+    def test_strips_script_tags(self):
+        """Script tags and their content are removed."""
+        html = "<html><body><script>alert('xss')</script><p>Safe content</p></body></html>"
+        result = self._extract(html)
+        assert "alert" not in result
+        assert "script" not in result.lower()
+        assert "Safe content" in result
+
+    def test_strips_style_tags(self):
+        """Style tags and their content are removed."""
+        html = "<html><head><style>.red { color: red; }</style></head><body><p>Visible</p></body></html>"
+        result = self._extract(html)
+        assert "color: red" not in result
+        assert "Visible" in result
+
+    def test_strips_html_comments(self):
+        """HTML comments are removed."""
+        html = "<html><body><!-- This is a comment --><p>Real content</p></body></html>"
+        result = self._extract(html)
+        assert "comment" not in result.lower()
+        assert "Real content" in result
+
+    def test_strips_nav_header_footer(self):
+        """nav, header, and footer tags are removed."""
+        html = (
+            "<html><body>"
+            "<header><a href='/'>Home</a></header>"
+            "<nav><ul><li>Menu</li></ul></nav>"
+            "<main><p>Article body</p></main>"
+            "<footer>Copyright 2026</footer>"
+            "</body></html>"
+        )
+        result = self._extract(html)
+        assert "Article body" in result
+        assert "Menu" not in result
+        assert "Copyright" not in result
+
+    def test_decodes_html_entities(self):
+        """HTML entities are decoded: &amp; -> &, &lt; -> <."""
+        html = "<p>Tom &amp; Jerry &lt;3 cheese</p>"
+        result = self._extract(html)
+        assert "Tom & Jerry" in result
+        assert "<3" in result
+        assert "&amp;" not in result
+        assert "&lt;" not in result
+
+    def test_normalizes_whitespace(self):
+        """Multiple whitespace characters are collapsed to single space."""
+        html = "<p>Hello    World</p>  <p>  Next   paragraph  </p>"
+        result = self._extract(html)
+        assert "  " not in result  # No double spaces
+        assert "Hello World" in result
+        assert "Next paragraph" in result
+
+    def test_empty_html(self):
+        """Empty HTML returns empty string."""
+        result = self._extract("")
+        assert result == ""
+
+    def test_plain_text_passthrough(self):
+        """HTML with no tags returns the text content."""
+        result = self._extract("Just plain text here")
+        assert "Just plain text here" in result
+
+
+# ---------------------------------------------------------------------------
+# Registration tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterWebTools:
+    """Tests for register_web_tools() dispatcher integration."""
+
+    def test_both_tools_registered(self):
+        """register_web_tools registers both web_search and web_fetch."""
+        wt = _import_web_tools()
+        dispatcher = ToolDispatcher()
+        settings = _make_settings()
+        client = AsyncMock(spec=httpx.AsyncClient)
+
+        wt.register_web_tools(dispatcher, settings, client)
+
+        definitions = dispatcher.tool_definitions()
+        names = {d["name"] for d in definitions}
+        assert "web_search" in names
+        assert "web_fetch" in names
+        assert len(names) == 2
+
+    @pytest.mark.asyncio
+    async def test_closures_capture_settings_and_client(self):
+        """Registered closures use the settings and httpx client from registration."""
+        wt = _import_web_tools()
+        dispatcher = ToolDispatcher()
+        settings = _make_settings(brave_search_api_key="closure-test-key")
+        response = _mock_response(status_code=200, json_data=_brave_search_response())
+        client = _mock_http_client(response)
+
+        wt.register_web_tools(dispatcher, settings, client)
+
+        # Dispatch web_search -- should use the captured settings and client
+        result_text, is_error = await dispatcher.dispatch("web_search", {"query": "test"})
+        assert is_error is False
+        # The client.get should have been called (proves closure captured it)
+        client.get.assert_called_once()
+        # Verify API key from settings was used
+        call_kwargs = client.get.call_args
+        headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers", {})
+        assert headers.get("X-Subscription-Token") == "closure-test-key"
+
+    def test_tool_schemas_have_required_fields(self):
+        """Tool schemas include required fields and descriptions."""
+        wt = _import_web_tools()
+        dispatcher = ToolDispatcher()
+        settings = _make_settings()
+        client = AsyncMock(spec=httpx.AsyncClient)
+
+        wt.register_web_tools(dispatcher, settings, client)
+
+        definitions = dispatcher.tool_definitions()
+        for defn in definitions:
+            assert "name" in defn
+            assert "description" in defn
+            assert "input_schema" in defn
+            schema = defn["input_schema"]
+            assert schema["type"] == "object"
+            assert "properties" in schema
+            assert "required" in schema
+
+    @pytest.mark.asyncio
+    async def test_web_fetch_closure_dispatch(self):
+        """web_fetch closure dispatches correctly through ToolDispatcher."""
+        wt = _import_web_tools()
+        dispatcher = ToolDispatcher()
+        settings = _make_settings()
+        response = _mock_response(
+            status_code=200,
+            text="Page content here",
+            headers={"content-type": "text/plain"},
+        )
+        client = _mock_http_client(response)
+
+        wt.register_web_tools(dispatcher, settings, client)
+
+        with patch.object(wt, "_is_url_safe", return_value=(True, "")):
+            result_text, is_error = await dispatcher.dispatch("web_fetch", {"url": "https://example.com"})
+
+        assert is_error is False
+        assert "Page content here" in result_text


### PR DESCRIPTION
## Summary

- Add `web_search` tool (Brave Search API) with rate limiting and API key validation
- Add `web_fetch` tool with HTML extraction, SSRF protection, and binary content rejection
- New module `nous/api/web_tools.py` with separate httpx client (no credential leak)
- FRAME_TOOLS updated for all 6 cognitive frames
- 46 unit tests covering SSRF, rate limiting, search, fetch, extraction, registration

## Review Process

3-agent analysis team (architect + implementation + devil's advocate) reviewed the original spec and found 4 P0 blockers and 9 P1 issues. All were fixed before implementation:

- **P0**: Handler signature mismatch (`args: dict` → `**kwargs`), MCP response format, httpx client lifecycle, SSRF vulnerability
- **P1**: Env var alias, empty API key check, explicit FRAME_TOOLS, rate limiting, binary content, timeouts, content-type handling, frame instructions

3-agent implementation team (python-engineer + test-engineer + code-reviewer) built and verified the fix. Code reviewer found 1 additional P1 (SSRF redirect bypass via `follow_redirects=True`) — fixed with manual redirect following + per-hop SSRF validation.

## Files Changed

| File | Change |
|------|--------|
| `nous/config.py` | Add `brave_search_api_key`, `web_search_daily_limit`, `web_fetch_max_chars` |
| `nous/api/web_tools.py` | **NEW** — handlers, SSRF protection, rate limiting, registration (340 lines) |
| `nous/api/runner.py` | FRAME_TOOLS + frame instructions updated for web tools |
| `nous/main.py` | Web httpx client lifecycle, registration, shutdown, warning log |
| `docker-compose.yml` | Add `BRAVE_SEARCH_API_KEY` env var |
| `.env.example` | Document `BRAVE_SEARCH_API_KEY` |
| `docs/implementation/005.3-web-tools-plan.md` | **NEW** — post-review implementation plan |
| `tests/test_web_tools.py` | **NEW** — 46 tests across 6 test classes |

## Test plan

- [x] 46 unit tests passing (SSRF, rate limiting, search, fetch, extraction, registration)
- [ ] End-to-end: set `BRAVE_SEARCH_API_KEY` and ask Nous a current events question
- [ ] Verify web_fetch blocks `http://localhost` and `http://169.254.169.254`
- [ ] Verify redirect to internal IP is blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)