### PR TITLE
feat: 006.2 Context Quality — supersession, episode dedup, decision noise filter

### DIFF
--- a/tests/test_context_quality.py
+++ b/tests/test_context_quality.py
@@ -423,7 +423,7 @@ class TestEpisodeDedup:
         inp = EpisodeInput(summary="Show me your current status and tools")
         await manager._start(inp, mock_session)
 
-        # No dedup -> new episode added
+        # No dedup — new episode added
         mock_session.add.assert_called_once()
 
     # Test 12: Episode start no dedup after 30 min


### PR DESCRIPTION
## Problem

Context pollution from 4 sources:
1. Stale facts persist ("006 PLANNED" stays active after doc update)
2. Duplicate episodes ("show status" creates 2 identical episodes)
3. Informational responses recorded as decisions (5 pending status dumps)
4. Near-identical decisions all injected into context (5x noise)

## Fixes

### Fix A: Subject + Similarity Fact Supersession
- Supersedes older facts when BOTH same subject AND cosine similarity >0.80
- Prevents "Nous version 0.2" from nuking "Nous uses PostgreSQL"
- Guarded by `check_contradictions` flag (bulk import safe)
- Functional index: `idx_facts_lower_subject`

### Fix B: Episode Dedup
- Reuses ongoing episodes with >0.80 word overlap within 30-min window
- Correct ORM fields (`ended_at.is_(None)`, not `status`)
- Re-fetches via `_get_episode_orm()` (MissingGreenlet prevention)

### Fix C: Informational Response Filter
- Detects status dumps and memory recalls via conservative patterns
- Abandons orphaned deliberations (marks confidence=0.0, outcome=failure)
- Prevents "Plan: ..." records from polluting future context
- `record_decision` tool call overrides filter

### Fix D: Decision Recall Dedup
- Sorts newest-first, then dedup by description overlap >0.80
- Only dedup when SAME outcome (preserves success/failure pairs)

### Shared
- `nous/utils.py` — `text_overlap()` filters words <3 chars (stop word resistance)

## Review Process

Plan reviewed by 3-agent team before implementation:
- 🔬 Correctness: Found Episode.status doesn't exist, MissingGreenlet, import issues
- 🏗️ Architecture: Found orphaned deliberation feedback loop, dedup ordering bug
- 😈 Devil's Advocate: Found subject-only supersession too coarse, decision outcome erasure

All P1/P2 findings addressed in revised plan.

## Files (9 changed, +949)
- `nous/utils.py` — NEW: text_overlap()
- `nous/heart/facts.py` — _supersede_by_subject() + _cosine_similarity()
- `nous/heart/episodes.py` — Dedup in _start()
- `nous/cognitive/deliberation.py` — abandon() method
- `nous/cognitive/layer.py` — _is_informational() + abandon path
- `nous/cognitive/context.py` — _dedup_decisions()
- `sql/migrations/006.2_context_quality.sql` — Subject index
- `tests/test_context_quality.py` — 32 tests
- `docs/implementation/006.2-context-quality-plan.md` — Revised plan