### PR TITLE
fix: add essential tools to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-# Install psql client and curl (no Node.js needed)
+# Install system tools for agent use
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    postgresql-client curl && \
+    postgresql-client curl wget \
+    git jq tree ripgrep \
+    sqlite3 && \
     rm -rf /var/lib/apt/lists/*
 
 # Create workspace directory


### PR DESCRIPTION
## What

Add commonly needed tools to the Docker image so the agent has them available out of the box.

## Added

- `git` — version control, repo cloning
- `jq` — JSON parsing from bash
- `tree` — directory visualization
- `ripgrep` — fast text/code search
- `wget` — web requests
- `sqlite3` — local DB inspection

## Why

Previously only `postgresql-client` and `curl` were installed. When Nous needed git, it attempted fragile portable binary installs into the workspace volume, which broke across rebuilds.

All packages are from Debian repos and add minimal image size on `python:3.12-slim`.