### PR TITLE
docs: add NOUS_IDENTITY_PROMPT to all config surfaces (#42)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,11 @@ BRAVE_SEARCH_API_KEY=your_brave_search_key_here
 # Agent
 NOUS_AGENT_ID=nous-default
 NOUS_AGENT_NAME=Nous
+
+# Identity prompt — injected as the first section of every system prompt.
+# This is how Nous knows who it is, what tools it has, and how to behave.
+# Override to customize personality and behavior. Leave empty to use the built-in default.
+# NOUS_IDENTITY_PROMPT=You are Nous, a cognitive AI agent that learns from experience...
 NOUS_MODEL=claude-sonnet-4-5-20250514
 NOUS_LOG_LEVEL=info
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,7 @@ DB connection vars are **unprefixed** (shared with docker-compose). All others u
 | `DB_NAME` | `nous` | Database name |
 | `ANTHROPIC_API_KEY` | — | Anthropic API key |
 | `ANTHROPIC_AUTH_TOKEN` | — | OAT token (Max subscription, uses Bearer auth) |
+| `NOUS_IDENTITY_PROMPT` | Built-in default | **Agent identity.** First section of every system prompt. How Nous knows who it is, what tools it has, and how to behave. Override to customize. |
 | `NOUS_AGENT_ID` | `nous-default` | Agent identifier |
 | `NOUS_AGENT_NAME` | `Nous` | Agent display name |
 | `NOUS_MODEL` | `claude-sonnet-4-5-20250514` | LLM model for chat |

--- a/README.md
+++ b/README.md
@@ -256,6 +256,20 @@ Both projects evolve independently. The shared asset is the philosophy, not the 
 
 7. **How does Fredkin's Paradox interact with stakes?** Low-stakes decisions should resolve fast. High-stakes decisions need more deliberation. What's the mapping?
 
+## Configuration
+
+Key environment variables (see `.env.example` for the full list):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NOUS_IDENTITY_PROMPT` | Built-in default | **Agent identity.** Injected as the first section of every system prompt. This is how Nous knows who it is and how to behave. Override to customize personality. |
+| `NOUS_MODEL` | `claude-sonnet-4-5-20250514` | LLM model for the main agent loop |
+| `NOUS_MAX_TURNS` | `10` | Max tool-use iterations per turn. Increase for complex multi-step tasks. |
+| `NOUS_THINKING_MODE` | `off` | Extended thinking: `off`, `adaptive` (recommended for 4.6), or `manual` |
+| `NOUS_EFFORT` | `high` | Thinking depth for adaptive mode: `low`, `medium`, `high`, `max` |
+| `NOUS_EVENT_BUS_ENABLED` | `true` | Enable async event handlers (episode summarizer, fact extractor) |
+| `NOUS_WORKSPACE_DIR` | `/tmp/nous-workspace` | Agent workspace directory |
+
 ## Status
 
 🚀 **v0.1.0 — shipped and deployed.**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - NOUS_SESSION_TIMEOUT=${NOUS_SESSION_TIMEOUT:-1800}
       - NOUS_SLEEP_TIMEOUT=${NOUS_SLEEP_TIMEOUT:-7200}
       - NOUS_SLEEP_CHECK_INTERVAL=${NOUS_SLEEP_CHECK_INTERVAL:-60}
+      - NOUS_IDENTITY_PROMPT=${NOUS_IDENTITY_PROMPT:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/nous/config.py
+++ b/nous/config.py
@@ -44,7 +44,13 @@ class Settings(BaseSettings):
     # Agent identity
     agent_name: str = "Nous"
     agent_description: str = "A thinking agent that learns from experience"
-    identity_prompt: str = ""
+    identity_prompt: str = (
+        "You are Nous, a cognitive AI agent that learns from experience. "
+        "You record decisions with reasoning (record_decision), extract and store facts (learn_fact), "
+        "search all memory types (recall_deep), and create guardrails (create_censor). "
+        "Be concise, honest, and thoughtful. When you make a choice, record it. "
+        "When you learn something new, store it as a fact."
+    )
 
     # Event Bus
     event_bus_enabled: bool = True


### PR DESCRIPTION
Closes #42

## What

The `NOUS_IDENTITY_PROMPT` env var was completely undocumented and defaulted to empty string, meaning Nous had no identity in its system prompt unless manually configured.

## Changes

| File | Change |
|------|--------|
| `config.py` | Ship sensible built-in default instead of empty string |
| `docker-compose.yml` | Propagate `NOUS_IDENTITY_PROMPT` from `.env` to container |
| `.env.example` | Document with explanation |
| `README.md` | Add Configuration section with key env vars table |
| `CLAUDE.md` | Add to env var reference table |

## Default Identity Prompt

> You are Nous, a cognitive AI agent that learns from experience. You record decisions with reasoning (record_decision), extract and store facts (learn_fact), search all memory types (recall_deep), and create guardrails (create_censor). Be concise, honest, and thoughtful. When you make a choice, record it. When you learn something new, store it as a fact.

Can be overridden via `NOUS_IDENTITY_PROMPT` env var for custom deployments.