### PR TITLE
spec: 007.1 Thinking Indicators in Telegram (#48)

### DIFF
--- a/docs/implementation/007.1-thinking-indicators.md
+++ b/docs/implementation/007.1-thinking-indicators.md
@@ -1,0 +1,161 @@
+# 007.1 — Thinking Indicators in Telegram
+
+> **Status:** Planned
+> **Priority:** P1
+> **Depends on:** 007 (Extended Thinking)
+> **Issue:** #48
+> **Estimated effort:** ~1-2 hours
+
+## Problem
+
+When adaptive/extended thinking is enabled, the Telegram bot shows only a typing indicator for 10-30 seconds while Nous thinks. No visibility into what it's reasoning about.
+
+## Solution
+
+Show a truncated preview of thinking content, similar to how tool indicators work:
+
+```
+💭 Thinking: Let me analyze the current state of the procedures table...
+```
+
+## Streaming Events Available
+
+The runner already emits these SSE events:
+
+| Event | Fields | When |
+|-------|--------|------|
+| `thinking_start` | `block_index` | New thinking block begins |
+| `thinking_delta` | `text` | Incremental thinking text |
+| `redacted_thinking` | — | Redacted block (no content) |
+
+Interleaved thinking (Sonnet/Opus 4.6) can emit multiple thinking blocks per turn — one before each tool call.
+
+## Implementation
+
+### 1. StreamingMessage: Add thinking state
+
+```python
+# telegram_bot.py — StreamingMessage class
+
+def __init__(self, bot, chat_id):
+    ...
+    self._thinking_text = ""        # accumulated thinking content
+    self._thinking_count = 0        # number of thinking blocks
+    self._thinking_displayed = False  # whether we've shown an indicator
+
+async def start_thinking(self):
+    """Called on thinking_start event."""
+    self._thinking_count += 1
+    self._thinking_text = ""
+    self._thinking_displayed = False
+
+async def append_thinking(self, text: str):
+    """Called on thinking_delta event."""
+    self._thinking_text += text
+
+    # Show preview after accumulating enough text (first 100 chars)
+    if not self._thinking_displayed and len(self._thinking_text) >= 50:
+        preview = self._thinking_text[:100].replace("\n", " ").strip()
+        if len(self._thinking_text) > 100:
+            preview += "..."
+        indicator = f"💭 Thinking: {preview}"
+        # Display as a temporary line before the response
+        await self._update_or_send(indicator)
+        self._thinking_displayed = True
+```
+
+### 2. Streaming loop: Handle thinking events
+
+```python
+# telegram_bot.py — _chat_streaming()
+
+async for line in response.aiter_lines():
+    if not line.startswith("data: "):
+        continue
+    event = json.loads(line[6:])
+
+    if event.get("type") == "text_delta":
+        last_text_time = time.time()
+        await streamer.append_text(event.get("text", ""))
+    elif event.get("type") == "thinking_start":
+        await streamer.start_thinking()
+    elif event.get("type") == "thinking_delta":
+        last_text_time = time.time()  # reset typing indicator timer
+        await streamer.append_thinking(event.get("text", ""))
+    elif event.get("type") == "redacted_thinking":
+        await streamer.start_thinking()  # count it but no content
+    elif event.get("type") == "tool_start":
+        await streamer.append_tool_indicator(event.get("tool_name", ""))
+    ...
+```
+
+### 3. Finalize: Include thinking summary in output
+
+```python
+# telegram_bot.py — StreamingMessage.finalize()
+
+async def finalize(self):
+    parts = []
+
+    # Thinking summary (before response text)
+    if self._thinking_count > 0:
+        if self._thinking_text:
+            preview = self._thinking_text[:100].replace("\n", " ").strip()
+            if len(self._thinking_text) > 100:
+                preview += "..."
+            parts.append(f"💭 {preview}")
+        else:
+            # Redacted thinking — no content available
+            parts.append("💭 Thinking... (redacted)")
+
+    # Tool indicators (existing)
+    if self._tool_count > 0:
+        parts.append(f"🔧 Ran {self._tool_count} tool{'s' if self._tool_count > 1 else ''}")
+
+    # Response text
+    parts.append(self.text)
+
+    # Usage footer
+    if self._usage:
+        parts.append(format_usage_footer(self._usage))
+
+    final_text = "\n\n".join(parts)
+    ...
+```
+
+### 4. Interleaved thinking (multiple blocks)
+
+With Sonnet/Opus 4.6 adaptive thinking, Nous can think multiple times per turn (between tool calls). Handle by showing only the **first** thinking preview during streaming, and a summary count in the final message:
+
+```
+💭 Thinking (3 blocks): Let me analyze the current state...
+🔧 Ran 4 tools
+
+[response text]
+
+📊 8.2K in / 943 out
+```
+
+## Display Rules
+
+| Scenario | Display |
+|----------|---------|
+| Single thinking block | `💭 Let me analyze the current state of...` |
+| Multiple thinking blocks | `💭 Thinking (3): Let me analyze the current...` |
+| Redacted thinking | `💭 Thinking... (redacted)` |
+| No thinking (mode=off) | Nothing shown |
+| Short thinking (<50 chars) | Wait for more text before displaying |
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `nous/telegram_bot.py` | Add thinking handlers to StreamingMessage + streaming loop (~40 lines) |
+| `tests/test_telegram_formatting.py` | Tests for thinking display (~50 lines) |
+
+## Notes
+
+- Thinking previews use plain text (no parse_mode) like tool indicators during streaming
+- Final message uses HTML with `<i>` for the thinking preview
+- The `thinking_delta` timer reset prevents unnecessary typing indicator refreshes while thinking streams
+- Redacted thinking blocks (Anthropic safety) show a generic message — don't pretend content exists


### PR DESCRIPTION
Implementation spec for showing thinking block previews in Telegram output.

## What

When adaptive/extended thinking is enabled, show a truncated preview instead of just a typing indicator:

```
💭 Thinking: Let me analyze the current state of the procedures table...
🔧 Ran 4 tools

[response text]
```

## Covers

- `thinking_start` / `thinking_delta` / `redacted_thinking` SSE event handling
- Truncated preview (first 100 chars) after 50+ chars accumulated
- Interleaved thinking (multiple blocks): `💭 Thinking (3): ...`
- Redacted blocks: `💭 Thinking... (redacted)`
- ~40 lines in telegram_bot.py + ~50 lines tests

Closes #48