### PR TITLE
feat: add thinking indicators to Telegram streaming

### DIFF
--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -627,13 +627,14 @@ class AgentRunner:
                         if event.usage:
                             total_usage["input_tokens"] += event.usage.get("input_tokens", 0)
 
-                    # -- Thinking blocks (not yielded to client) --
+                    # -- Thinking blocks (yielded to client for thinking indicators) --
                     elif event.type == "thinking_start":
                         all_blocks[event.block_index] = {
                             "type": "thinking",
                             "thinking_parts": [],
                             "signature": "",
                         }
+                        yield event
 
                     elif event.type == "redacted_thinking":
                         # Complete block — data arrives in start event
@@ -641,11 +642,13 @@ class AgentRunner:
                             "type": "redacted_thinking",
                             "data": event.text,
                         }
+                        yield event
 
                     elif event.type == "thinking_delta":
                         block = all_blocks.get(event.block_index)
                         if block and block["type"] == "thinking":
                             block["thinking_parts"].append(event.text)
+                        yield event
 
                     elif event.type == "signature_delta":
                         block = all_blocks.get(event.block_index)


### PR DESCRIPTION
## Summary
- Yield `thinking_start`, `thinking_delta`, and `redacted_thinking` SSE events from the runner to clients
- Add thinking state tracking and preview display to `StreamingMessage` in the Telegram bot
- Show truncated thinking preview (💭) during streaming, with block count for interleaved thinking
- Handle redacted thinking blocks with generic fallback message
- 15 new tests covering all thinking indicator scenarios

## Files Changed
| File | Change |
|------|--------|
| `nous/api/runner.py` | Yield 3 thinking event types to SSE stream (+3 lines) |
| `nous/telegram_bot.py` | Thinking state, display, handlers in StreamingMessage (~50 lines) |
| `tests/test_telegram_formatting.py` | 15 new tests for `TestStreamingMessageThinking` |

## Spec
Implements [007.1 — Thinking Indicators in Telegram](docs/implementation/007.1-thinking-indicators.md)
Closes #48

## Test plan
- [x] All 61 tests pass in `test_telegram_formatting.py` (46 existing + 15 new)
- [x] All 34 tests pass in `test_streaming.py` (2 pre-existing failures unrelated to this PR)
- [ ] Manual test: send message with extended thinking enabled, verify 💭 preview appears in Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)