### PR TITLE
spec: 007.2, 007.3, 007.4 implementation specs

### DIFF
--- a/docs/implementation/007.2-topic-aware-recall.md
+++ b/docs/implementation/007.2-topic-aware-recall.md
@@ -1,0 +1,100 @@
+# 007.2 — Topic-Aware Context Recall
+
+> **Status:** Planned
+> **Priority:** P0
+> **Issue:** #52
+> **Estimated effort:** ~2-3 hours
+
+## Problem
+
+When the user switches topics (e.g. from Nous to cognition-engines), RECALL still returns decisions, facts, and episodes from the dominant topic. All 15 recalled items can be completely irrelevant because RECALL uses pure semantic similarity with no topic awareness.
+
+Working memory correctly shows the new topic, but the context engine ignores it.
+
+## Root Cause
+
+`context.py` passes `input_text` (the raw user message) as the query to all memory searches:
+```python
+decisions = await self._brain.query(q_text, limit=limit, session=session)
+facts = await self._heart.search_facts(q_text, limit=limit, session=session)
+episodes = await self._heart.search_episodes(q_text, limit=limit, session=session)
+```
+
+When the user says "switch to cognition-engines, what do you know?" the query is generic — and the most similar items in the DB are from the dominant topic (Nous).
+
+## Solution
+
+### 1. Topic-Enhanced Query
+
+Use working memory's current topic to enhance the recall query:
+
+```python
+# context.py — build()
+
+# Get current topic from working memory
+wm = await self._heart.get_working_memory(session_id, session=session)
+current_topic = wm.current_task if wm else None
+
+# Enhance query with topic context
+if current_topic:
+    q_text = f"{current_topic}: {input_text}"
+```
+
+This shifts the embedding toward topic-relevant results without requiring any schema changes.
+
+### 2. Subject-Based Diversity Filter
+
+After recall, enforce diversity — don't let one subject dominate:
+
+```python
+# context.py — after retrieving decisions
+
+def _enforce_diversity(self, items: list, max_per_subject: int = 2) -> list:
+    """Prevent one topic from dominating recall results."""
+    seen_subjects: dict[str, int] = {}
+    result = []
+    for item in items:
+        subject = getattr(item, 'subject', None) or 'unknown'
+        # Normalize subject to first word (e.g. "nous spec 006.1" -> "nous")
+        topic_key = subject.split()[0].lower() if subject else 'unknown'
+        count = seen_subjects.get(topic_key, 0)
+        if count < max_per_subject:
+            result.append(item)
+            seen_subjects[topic_key] = count + 1
+    return result
+```
+
+Apply to each memory type after retrieval:
+```python
+decisions = self._enforce_diversity(decisions, max_per_subject=2)
+facts = self._enforce_diversity(facts, max_per_subject=2)
+episodes = self._enforce_diversity(episodes, max_per_subject=2)
+```
+
+### 3. Frame-Topic Alignment Check
+
+If the frame and working memory topic are misaligned with the recalled content, log a warning and reduce confidence:
+
+```python
+# After recall, check alignment
+topic_tokens = set(current_topic.lower().split()) if current_topic else set()
+for decision in decisions:
+    desc_tokens = set(decision.description[:100].lower().split())
+    if topic_tokens and not topic_tokens & desc_tokens:
+        # This decision has zero overlap with current topic
+        decision._relevance_penalty = 0.3  # Applied during ranking
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `nous/cognitive/context.py` | Topic-enhanced query, diversity filter (~40 lines) |
+| `tests/test_context.py` | Tests for topic-aware recall (~80 lines) |
+
+## Notes
+
+- Topic enhancement is additive — if no working memory topic exists, behavior is unchanged
+- Diversity filter is applied post-retrieval, before formatting — no DB changes needed
+- The `max_per_subject=2` limit is conservative — allows some same-topic results while ensuring variety
+- Works with existing `_format_*` methods unchanged

--- a/docs/implementation/007.3-is-informational.md
+++ b/docs/implementation/007.3-is-informational.md
@@ -1,0 +1,141 @@
+# 007.3 — Improve `_is_informational()` Detection
+
+> **Status:** Planned
+> **Priority:** P0
+> **Issue:** #38
+> **Estimated effort:** ~1-2 hours
+
+## Problem
+
+`_is_informational()` in `layer.py` only matches 5 keyword patterns:
+```python
+info_patterns = [
+    "current status", "available tools",
+    "i remember", "my memory", "what i know",
+]
+```
+
+This misses most informational responses — git pull status dumps, project summaries, acknowledgments, confirmations, and simple Q&A answers all slip through and become "decisions" in the DB.
+
+## Root Cause
+
+The filter was deliberately conservative (006.2 design) to avoid false positives. But it's too conservative — the DB has 8+ junk decisions that are clearly informational.
+
+## Solution
+
+### 1. Expand Keyword Patterns
+
+Add patterns observed in actual junk decisions:
+
+```python
+info_patterns = [
+    # Status & inventory
+    "current status", "available tools", "here's what",
+    "here is what", "here are the", "summary of",
+    
+    # Memory recall
+    "i remember", "my memory", "what i know",
+    "i recall", "from memory", "i found",
+    
+    # Git / repo status
+    "repo pulled", "repo is at", "git pull",
+    "latest commit", "new branch", "new pr",
+    "commits since", "merged to main",
+    
+    # Acknowledgment / confirmation
+    "got it", "understood", "noted", "will do",
+    "sure thing", "okay,", "alright,",
+    
+    # Simple answers
+    "the answer is", "it means", "this is because",
+    "that's correct", "you're right",
+    
+    # Lists / enumerations
+    "here's a list", "the following",
+]
+```
+
+### 2. Structural Signals
+
+Beyond keywords, check structural indicators:
+
+```python
+def _is_informational(self, turn_result: TurnResult) -> bool:
+    # If agent explicitly recorded a decision, it's real
+    tools_used = {r.tool_name for r in turn_result.tool_results}
+    if "record_decision" in tools_used:
+        return False
+
+    response = turn_result.response_text
+    response_lower = response[:500].lower()
+
+    # 1. Keyword patterns (expanded)
+    if any(p in response_lower for p in self._INFO_PATTERNS):
+        return True
+
+    # 2. Structural: starts with emoji + header (status dump pattern)
+    import re
+    if re.match(r'^[🔧🤖📊🧠📌⚡🟢]\s', response[:10]):
+        return True
+
+    # 3. Structural: very short response (< 50 chars) = likely acknowledgment
+    if len(response.strip()) < 50 and not tools_used:
+        return True
+
+    # 4. Structural: response is mostly a list (> 60% lines start with - or •)
+    lines = [l.strip() for l in response.split('\n') if l.strip()]
+    if lines:
+        list_lines = sum(1 for l in lines if l.startswith(('-', '•', '*', '📌', '🔧')))
+        if list_lines / len(lines) > 0.6 and len(lines) > 3:
+            return True
+
+    # 5. No decision language: lacks words suggesting a choice was made
+    decision_signals = [
+        "decided", "chose", "will use", "going with",
+        "switching to", "plan:", "approach:",
+        "trade-off", "instead of", "rather than",
+    ]
+    if not any(s in response_lower for s in decision_signals):
+        # If no decision language AND matches a question frame, it's informational
+        # (answering questions != making decisions)
+        return True  # TODO: this may be too aggressive, consider frame check
+
+    return False
+```
+
+### 3. Frame-Based Heuristic
+
+Conversation frame responses are almost never decisions:
+
+```python
+# If frame is conversation AND no record_decision tool used, it's informational
+if turn_context.frame.frame_id == "conversation" and "record_decision" not in tools_used:
+    return True
+```
+
+## Phased Approach
+
+**Phase 1 (this PR):** Expand keyword patterns + add emoji/short-response structural checks. Low risk.
+
+**Phase 2 (future):** Add decision-language detection + frame heuristic. Higher risk of false positives — needs tuning.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `nous/cognitive/layer.py` | Expand `_is_informational()` (~30 lines) |
+| `tests/test_cognitive_layer.py` | Tests for new patterns (~60 lines) |
+
+## Test Cases
+
+```python
+# Should be informational (True)
+assert _is_informational("🤖 Nous — Current Status\n🟢 Agent...")  # emoji header
+assert _is_informational("Got it, will do.")  # acknowledgment  
+assert _is_informational("✅ Repo pulled — now at efedacd")  # git status
+assert _is_informational("Here's what I found in memory...")  # recall
+
+# Should NOT be informational (False) 
+assert not _is_informational("Decided to use Option B because...")  # real decision
+assert not _is_informational("[record_decision called]")  # explicit tool
+```

--- a/docs/implementation/007.4-unpopulated-columns.md
+++ b/docs/implementation/007.4-unpopulated-columns.md
@@ -1,0 +1,171 @@
+# 007.4 — Fix Unpopulated Database Columns
+
+> **Status:** Planned
+> **Priority:** P0
+> **Issue:** #36
+> **Estimated effort:** ~2-3 hours
+
+## Problem
+
+Three columns are defined in the schema but never written:
+
+| Table | Column | Expected Source | Current Value |
+|-------|--------|-----------------|---------------|
+| `system.events` | `session_id` | Event emitters | Always NULL |
+| `heart.episodes` | `user_id` | Telegram/REST caller | Always NULL |
+| `heart.episodes` | `user_display_name` | Telegram/REST caller | Always NULL |
+| `system.agents` | `last_active` | Updated on each turn | Always NULL |
+
+## Root Cause
+
+### events.session_id
+The `EventBus.emit()` method creates Event records but the session_id from the emitting context isn't passed through. Event handlers have `event.session_id` available but it's populated from the event data dict, not from the ORM column.
+
+### episodes.user_id / user_display_name
+`CognitiveLayer.pre_turn()` accepts `user_display_name` parameter and passes it to episode creation, but:
+- The Telegram bot doesn't pass the Telegram user ID or display name
+- The REST API doesn't pass caller identity
+
+### agents.last_active
+No code ever updates this column. The `system.agents` table is seeded on startup but never touched again.
+
+## Solution
+
+### Fix 1: Wire session_id into Events
+
+```python
+# event_bus.py — emit()
+
+async def emit(self, event_type: str, data: dict, agent_id: str,
+               session_id: str | None = None, session: AsyncSession | None = None):
+    """Emit an event with optional session context."""
+    event = Event(
+        agent_id=agent_id,
+        session_id=session_id,  # Now passed through
+        event_type=event_type,
+        data=data,
+    )
+    ...
+```
+
+Update all callers to pass `session_id`:
+- `cognitive/layer.py` — `pre_turn`, `post_turn` (has session_id in scope)
+- `handlers/*.py` — handlers receive events with session_id, pass it when re-emitting
+
+### Fix 2: Pass user identity from Telegram and REST
+
+```python
+# telegram_bot.py — _chat_streaming()
+
+# Extract Telegram user info
+user_id = str(update.message.from_user.id)
+display_name = update.message.from_user.first_name
+
+# Pass to chat endpoint or directly to cognitive layer
+payload = {
+    "message": text,
+    "session_id": session_id,
+    "user_id": user_id,
+    "user_display_name": display_name,
+}
+```
+
+```python
+# rest.py — POST /chat
+
+@router.post("/chat")
+async def chat(request: ChatRequest):
+    # ChatRequest gets optional user_id + user_display_name fields
+    result = await cognitive.turn(
+        agent_id=request.agent_id or default_agent,
+        session_id=request.session_id,
+        user_input=request.message,
+        user_id=request.user_id,
+        user_display_name=request.user_display_name,
+    )
+```
+
+```python
+# cognitive/layer.py — pre_turn()
+
+# Pass user info to episode creation
+episode = await self._heart.start_episode(
+    EpisodeInput(
+        title=user_input[:100],
+        summary=user_input,
+        trigger="user_message",
+        participants=[agent_id, user_id] if user_id else [agent_id],
+        tags=[],
+    ),
+    session_id=session_id,
+    user_id=user_id,
+    user_display_name=user_display_name,
+    session=session,
+)
+```
+
+### Fix 3: Update agents.last_active
+
+Add a lightweight update at the start of each turn:
+
+```python
+# cognitive/layer.py — pre_turn()
+
+# Update agent's last_active timestamp
+await session.execute(
+    update(Agent)
+    .where(Agent.agent_id == agent_id)
+    .values(last_active=func.now())
+)
+```
+
+This is a single UPDATE per turn — negligible overhead.
+
+## Schema Changes
+
+### ChatRequest (REST API)
+
+```python
+class ChatRequest(BaseModel):
+    message: str
+    session_id: str | None = None
+    agent_id: str | None = None
+    platform: str | None = None
+    user_id: str | None = None           # NEW
+    user_display_name: str | None = None  # NEW
+```
+
+### EpisodeManager.start()
+
+```python
+async def start(self, input: EpisodeInput, session_id: str,
+                user_id: str | None = None,
+                user_display_name: str | None = None,
+                session: AsyncSession | None = None) -> EpisodeDetail:
+    episode = Episode(
+        ...
+        user_id=user_id,
+        user_display_name=user_display_name,
+    )
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `nous/event_bus.py` | Add session_id param to emit() (~5 lines) |
+| `nous/cognitive/layer.py` | Pass session_id to emit, user info to episodes, update last_active (~15 lines) |
+| `nous/telegram_bot.py` | Extract and pass user_id + display_name (~5 lines) |
+| `nous/api/rest.py` | Add user_id/user_display_name to ChatRequest (~5 lines) |
+| `nous/api/schemas.py` | Update ChatRequest model (~2 lines) |
+| `nous/heart/episodes.py` | Accept user_id/user_display_name in start() (~5 lines) |
+| `tests/test_unpopulated_columns.py` | Tests (~100 lines) |
+
+**Estimated:** ~40 lines modified, ~100 lines tests
+
+## Notes
+
+- All changes are backwards compatible — new params are optional with None defaults
+- `last_active` update is per-turn, not per-event — avoids excessive writes
+- Telegram user info is available from `update.message.from_user` (already in scope)
+- REST callers can optionally pass user identity; not required


### PR DESCRIPTION
Three implementation specs for P0 context quality fixes:

### 007.2 — Topic-Aware Recall (#52)
- Topic-enhanced query using working memory current task
- Subject-based diversity filter (max 2 per topic)
- ~40 lines in context.py + ~80 lines tests

### 007.3 — Improve `_is_informational()` (#38)
- Expand from 5 patterns to ~30 (status dumps, git output, acknowledgments)
- Add structural signals: emoji headers, short responses, list-heavy output
- Phased approach: Phase 1 (safe patterns), Phase 2 (decision-language detection)
- ~30 lines in layer.py + ~60 lines tests

### 007.4 — Fix Unpopulated Columns (#36)
- Wire session_id through EventBus.emit()
- Pass Telegram user_id + display_name to episodes
- Update agents.last_active per turn
- ~40 lines modified + ~100 lines tests

All backwards compatible. No schema changes needed.