### PR TITLE
spec: 007.5 Minimum relevance threshold for RECALL (#57)

### DIFF
--- a/docs/implementation/007.5-recall-min-threshold.md
+++ b/docs/implementation/007.5-recall-min-threshold.md
@@ -1,0 +1,128 @@
+# 007.5 — Minimum Relevance Threshold for RECALL
+
+> **Status:** Planned
+> **Priority:** P0
+> **Issue:** #57
+> **Estimated effort:** ~1 hour
+
+## Problem
+
+RECALL always returns top-K results regardless of actual relevance. A weather query gets 808 tokens of Nous-internal context (5 decisions, 3 facts, 2 episodes) — all irrelevant. The context engine fills its budget with noise rather than returning empty sections.
+
+## Solution
+
+Add `min_score` filtering to all recall paths. Results below the threshold are excluded entirely.
+
+### 1. Add min_score to Brain._query()
+
+```python
+# brain.py — _query()
+
+async def _query(
+    self, query: str, limit: int = 5, min_score: float = 0.0,
+    session: AsyncSession | None = None, **kwargs
+) -> tuple[list[DecisionDetail], int]:
+    ...
+    # After retrieval, filter by score
+    if min_score > 0 and results:
+        results = [r for r in results if r.score >= min_score]
+    return results, len(results)
+```
+
+### 2. Add min_score to Heart.search_facts()
+
+```python
+# heart/facts.py — search()
+
+async def search(
+    self, query: str, limit: int = 5, min_score: float = 0.0,
+    session: AsyncSession | None = None
+) -> list[FactDetail]:
+    ...
+    if min_score > 0:
+        results = [r for r in results if r.score >= min_score]
+    return results
+```
+
+### 3. Add min_score to Heart.search_episodes()
+
+```python
+# heart/episodes.py — _search()
+
+async def _search(
+    self, query: str, limit: int = 5, min_score: float = 0.0,
+    session: AsyncSession | None = None
+) -> list[EpisodeDetail]:
+    ...
+    if min_score > 0:
+        results = [r for r in results if r.score >= min_score]
+    return results
+```
+
+### 4. Context Engine passes thresholds
+
+```python
+# context.py — build()
+
+# Default thresholds per memory type
+MIN_SCORES = {
+    "decision": 0.3,
+    "fact": 0.25,      # Facts can be more loosely related
+    "procedure": 0.3,
+    "episode": 0.3,
+}
+
+# In each retrieval section:
+decisions = await self._brain.query(
+    q_text, limit=limit, min_score=MIN_SCORES["decision"], session=session
+)
+facts = await self._heart.search_facts(
+    q_text, limit=limit, min_score=MIN_SCORES["fact"], session=session
+)
+episodes = await self._heart.search_episodes(
+    q_text, limit=limit, min_score=MIN_SCORES["episode"], session=session
+)
+```
+
+### 5. Score availability check
+
+Verify that all search methods actually populate a `score` attribute on results. Check:
+- `Brain._query()` — uses `hybrid_search()` which returns scored results ✅
+- `Heart.search_facts()` — uses `hybrid_search()` ✅  
+- `Heart.search_episodes()` — uses `hybrid_search()` ✅
+- `Heart._search_recent_by_embedding()` — raw SQL with `<=>` distance, needs score conversion
+
+For `_search_recent_by_embedding`, convert pgvector distance to similarity:
+```python
+# cosine distance to similarity: score = 1 - distance
+score = 1.0 - row.distance
+```
+
+## Threshold Selection
+
+| Threshold | Effect |
+|-----------|--------|
+| 0.2 | Very loose — only removes truly unrelated |
+| 0.3 | **Recommended** — removes noise, keeps tangentially related |
+| 0.4 | Tight — may miss useful context for broad queries |
+| 0.5 | Aggressive — only strong matches survive |
+
+Start with 0.3 for decisions/episodes, 0.25 for facts (facts benefit from looser matching since they're short and may match partially).
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `nous/brain/brain.py` | Add min_score param to `_query()` (~3 lines) |
+| `nous/heart/facts.py` | Add min_score param to `search()` (~3 lines) |
+| `nous/heart/episodes.py` | Add min_score param to `_search()` (~3 lines) |
+| `nous/cognitive/context.py` | Pass min_score thresholds (~6 lines) |
+| `tests/test_recall_threshold.py` | Tests (~60 lines) |
+
+**Estimated:** ~15 lines modified, ~60 lines tests
+
+## Expected Impact
+
+Weather query context: 808 tokens → ~0-100 tokens (only if something genuinely weather-related exists in memory).
+
+General effect: queries about topics not in memory get clean, empty context — letting the LLM use tools without distraction.


### PR DESCRIPTION
Add `min_score` filtering to all recall paths. Results below threshold excluded entirely.

- Decisions/episodes: `min_score=0.3`
- Facts: `min_score=0.25` (looser — short text, partial matches useful)
- ~15 lines modified + ~60 lines tests

**Impact:** Weather query goes from 808 tokens of irrelevant Nous context → ~0-100 tokens.

Closes #57