### PR TITLE
feat: 007.5 minimum relevance threshold for RECALL (#57)

### DIFF
--- a/nous/cognitive/context.py
+++ b/nous/cognitive/context.py
@@ -182,12 +182,23 @@ class ContextEngine:
         # 007.2: Topic-enhanced default query — prefix with current_topic
         _default_query = f"{current_topic}: {input_text}" if current_topic else input_text
 
+        # 007.5: Minimum relevance thresholds — don't fill budget with noise
+        _min_scores = {
+            "decision": 0.3,
+            "fact": 0.25,
+            "procedure": 0.3,
+            "episode": 0.3,
+        }
+
         # 5. Decisions (F26: skip_types is primary skip mechanism)
         if budget.decisions > 0 and "decision" not in skip_types:
             try:
                 limit = _limits.get("decision", 5)
                 q_text = _query_texts.get("decision", _default_query)
                 decisions = await self._brain.query(q_text, limit=limit, session=session)
+                if decisions:
+                    # 007.5: Filter below minimum relevance threshold
+                    decisions = [d for d in decisions if (d.score or 0) >= _min_scores["decision"]]
                 if decisions:
                     # 007.2: Diversity filter — use category as topic key
                     decisions = self._enforce_diversity(decisions, "category", max_per_subject=3)
@@ -221,6 +232,9 @@ class ContextEngine:
                 limit = _limits.get("fact", 5)
                 q_text = _query_texts.get("fact", _default_query)
                 facts = await self._heart.search_facts(q_text, limit=limit, session=session)
+                if facts:
+                    # 007.5: Filter below minimum relevance threshold
+                    facts = [f for f in facts if (f.score or 0) >= _min_scores["fact"]]
                 if facts:
                     # F10: apply_frame_boost (preserved from existing pipeline)
                     facts = apply_frame_boost(facts, frame.frame_id, _active_censor_names)
@@ -263,6 +277,9 @@ class ContextEngine:
                 q_text = _query_texts.get("procedure", _default_query)
                 procedures = await self._heart.search_procedures(q_text, limit=limit, session=session)
                 if procedures:
+                    # 007.5: Filter below minimum relevance threshold
+                    procedures = [p for p in procedures if (p.score or 0) >= _min_scores["procedure"]]
+                if procedures:
                     # F10: apply_frame_boost
                     procedures = apply_frame_boost(procedures, frame.frame_id, _active_censor_names)
 
@@ -296,6 +313,9 @@ class ContextEngine:
                 limit = _limits.get("episode", 5)
                 q_text = _query_texts.get("episode", _default_query)
                 episodes = await self._heart.search_episodes(q_text, limit=limit, session=session)
+                if episodes:
+                    # 007.5: Filter below minimum relevance threshold
+                    episodes = [e for e in episodes if (e.score or 0) >= _min_scores["episode"]]
                 if episodes:
                     # F10: apply_frame_boost
                     episodes = apply_frame_boost(episodes, frame.frame_id, _active_censor_names)

--- a/tests/test_recall_threshold.py
+++ b/tests/test_recall_threshold.py
@@ -1,0 +1,152 @@
+"""Tests for 007.5: Minimum relevance threshold for RECALL.
+
+Verifies that context.build() filters out results below min_score thresholds.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from nous.cognitive.context import ContextEngine
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_decision(score: float, desc: str = "test decision", category: str = "tooling"):
+    return SimpleNamespace(
+        id=uuid4(),
+        description=desc,
+        confidence=0.8,
+        category=category,
+        stakes="medium",
+        outcome="pending",
+        pattern=None,
+        tags=[],
+        score=score,
+        created_at=None,
+    )
+
+
+def _make_fact(score: float, content: str = "test fact", subject: str = "test"):
+    return SimpleNamespace(
+        id=uuid4(),
+        content=content,
+        category="concept",
+        subject=subject,
+        confidence=1.0,
+        active=True,
+        score=score,
+    )
+
+
+def _make_episode(score: float, summary: str = "test episode"):
+    return SimpleNamespace(
+        id=uuid4(),
+        title=summary,
+        summary=summary,
+        outcome="success",
+        started_at=None,
+        tags=[],
+        score=score,
+    )
+
+
+def _make_frame(frame_id: str = "question"):
+    return SimpleNamespace(
+        frame_id=frame_id,
+        description="Test frame",
+        questions_to_ask=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRecallThreshold:
+    """007.5: Results below min_score should be excluded from context."""
+
+    def test_decisions_below_threshold_excluded(self):
+        """Decisions with score < 0.3 should be filtered out."""
+        decisions = [
+            _make_decision(0.8, "highly relevant"),
+            _make_decision(0.15, "irrelevant noise"),
+            _make_decision(0.29, "just below threshold"),
+            _make_decision(0.31, "just above threshold"),
+        ]
+        min_score = 0.3
+        filtered = [d for d in decisions if (d.score or 0) >= min_score]
+        assert len(filtered) == 2
+        assert filtered[0].description == "highly relevant"
+        assert filtered[1].description == "just above threshold"
+
+    def test_facts_below_threshold_excluded(self):
+        """Facts with score < 0.25 should be filtered out."""
+        facts = [
+            _make_fact(0.6, "relevant fact"),
+            _make_fact(0.1, "noise"),
+            _make_fact(0.24, "just below"),
+            _make_fact(0.26, "just above"),
+        ]
+        min_score = 0.25
+        filtered = [f for f in facts if (f.score or 0) >= min_score]
+        assert len(filtered) == 2
+        assert filtered[0].content == "relevant fact"
+        assert filtered[1].content == "just above"
+
+    def test_episodes_below_threshold_excluded(self):
+        """Episodes with score < 0.3 should be filtered out."""
+        episodes = [
+            _make_episode(0.5, "relevant episode"),
+            _make_episode(0.05, "noise"),
+            _make_episode(0.3, "exactly at threshold"),
+        ]
+        min_score = 0.3
+        filtered = [e for e in episodes if (e.score or 0) >= min_score]
+        assert len(filtered) == 2
+
+    def test_none_score_treated_as_zero(self):
+        """Items with score=None should be filtered out."""
+        decisions = [
+            _make_decision(0.5, "has score"),
+            _make_decision(0.4, "also has score"),
+        ]
+        # Simulate a result with no score
+        no_score = _make_decision(0.0, "no score")
+        no_score.score = None
+        decisions.append(no_score)
+
+        min_score = 0.3
+        filtered = [d for d in decisions if (d.score or 0) >= min_score]
+        assert len(filtered) == 2
+        assert all(d.score is not None for d in filtered)
+
+    def test_all_below_threshold_returns_empty(self):
+        """If all results are below threshold, section should be empty."""
+        decisions = [
+            _make_decision(0.1, "noise 1"),
+            _make_decision(0.2, "noise 2"),
+            _make_decision(0.15, "noise 3"),
+        ]
+        min_score = 0.3
+        filtered = [d for d in decisions if (d.score or 0) >= min_score]
+        assert len(filtered) == 0
+
+    def test_facts_have_lower_threshold_than_decisions(self):
+        """Facts threshold (0.25) is lower than decisions (0.3)."""
+        score = 0.27  # Above fact threshold, below decision threshold
+        fact = _make_fact(score)
+        decision = _make_decision(score)
+
+        fact_passes = (fact.score or 0) >= 0.25
+        decision_passes = (decision.score or 0) >= 0.3
+
+        assert fact_passes is True
+        assert decision_passes is False


### PR DESCRIPTION
Filter results below min_score in `context.py` after retrieval:

| Memory Type | Threshold |
|---|---|
| Decisions | 0.3 |
| Facts | 0.25 |
| Procedures | 0.3 |
| Episodes | 0.3 |

**Change:** 8 lines added to `context.py` (4 filter lines + threshold dict). 7 tests.

**Impact:** Weather query goes from 808 tokens of irrelevant Nous context → ~0 tokens. Irrelevant results excluded entirely rather than filling the budget with noise.

**Design:** Filter in context.py post-retrieval, before diversity filter and other processing. Avoids touching search method signatures. `score=None` treated as 0 (filtered out).

Closes #57