### PR TITLE
fix: lower decision Tier 3 threshold from 0.3 to 0.20

### DIFF
--- a/nous/cognitive/context.py
+++ b/nous/cognitive/context.py
@@ -31,7 +31,7 @@ TIER1_FACT_CATEGORIES = ["preference", "person", "rule"]
 # When embeddings are unavailable, keyword-only scores are much lower (0.01-0.15)
 # so thresholds are skipped to avoid filtering everything out.
 TIER3_THRESHOLDS = {
-    "decision": 0.3,
+    "decision": 0.20,
     "fact": 0.25,
     "procedure": 0.3,
     "episode": 0.3,


### PR DESCRIPTION
## Problem

With ~16 decisions in the database, best hybrid scores top out around 0.251. The 0.3 threshold filtered ALL decisions from Tier 3 context:

```
Tier3 decisions: 5 results, scores=[0.251, 0.236, 0.226, 0.183, 0.129]
Tier3 decisions after threshold: 0
```

## Fix

Lower decision threshold from 0.3 to 0.20. This lets the top 3 decisions through while still filtering noise.

Configurable thresholds tracked in #66.

## Change

One line in `context.py`: `"decision": 0.3` → `"decision": 0.20`