### PR TITLE
docs: Spec 008.3 - Episode Summary Backfill & Lifecycle Fix

### DIFF
--- a/docs/implementation/008.3-episode-summary-backfill.md
+++ b/docs/implementation/008.3-episode-summary-backfill.md
@@ -1,0 +1,201 @@
+# Spec 008.3: Episode Summary Backfill & Lifecycle Fix
+
+**Status:** Draft
+**Depends on:** 008 (Tiered Context), 006 (Event Bus)
+**Related:** 008.1 (Conversation Compaction), F010 (Memory Improvements)
+
+## Problem
+
+The episode summarizer generates excellent structured summaries (JSON with title, summary, key_points, topics, outcome) but **does not backfill** the episode's text columns. Additionally, episodes are never marked inactive when closed.
+
+### Current State (from DB investigation)
+
+| Column | Expected | Actual |
+|--------|----------|--------|
+| `title` | Descriptive title from LLM | Always `NULL` — never set |
+| `summary` | Prose summary of episode | First user message verbatim (set at creation) |
+| `detail` | Extended description | Always `NULL` — never set |
+| `lessons_learned` | Key takeaways | Always `NULL` — never set |
+| `structured_summary` | Full JSON summary | ✅ Working — 20/22 episodes have it |
+| `active` | `false` when closed | Always `true` — never flipped |
+
+### Why This Matters
+
+1. **Search degradation:** Semantic search uses `title + summary + outcome + lessons_learned` for embeddings (line 185 in `episodes.py`). With summary = first user message and everything else NULL, episode recall quality is poor.
+
+2. **Context pollution:** Tiered context (Spec 008) pulls episode summaries into the prompt. Showing "hey what is the weather today?" instead of "Weather Check, Research Doc 016 Review, and Memory Gap Discussion" wastes tokens and provides no value.
+
+3. **Active flag drift:** All episodes stay `active=true` forever. Any query filtering on `active` returns everything, defeating the purpose of the flag.
+
+4. **Duplicate detection weakness:** Episode dedup uses `text_overlap(existing_ep.summary, ...)`. Comparing raw user input against raw user input catches exact repeats but misses semantic duplicates that proper summaries would surface.
+
+---
+
+## Root Cause Analysis
+
+### Issue 1: `_update_summary()` only writes `structured_summary`
+
+```python
+# episodes.py line 133-141
+async def _update_summary(self, episode_id, summary, session):
+    episode = result.scalar_one_or_none()
+    if episode:
+        episode.structured_summary = summary  # ← Only this field
+        await session.flush()
+```
+
+The structured JSON has `title`, `summary`, `key_points`, and `topics` — all the data needed to populate the text columns. But `_update_summary()` ignores them.
+
+### Issue 2: `_end()` doesn't set `active=false`
+
+```python
+# episodes.py _end() sets:
+episode.ended_at = now
+episode.duration_seconds = ...
+episode.outcome = outcome
+episode.lessons_learned = lessons_learned
+# Missing: episode.active = False
+```
+
+Only `deactivate_episode()` sets `active=false`, but that's only called for trivial (single-turn) episodes that get soft-deleted.
+
+### Issue 3: Embedding not refreshed after summary update
+
+When `_update_summary()` stores the structured summary, it does not regenerate the episode's embedding vector. The embedding was computed at creation time from `title + summary` — which was just the first user message with no title. After the real summary arrives, the embedding remains stale.
+
+---
+
+## Solution
+
+### Change 1: Backfill text columns from structured summary
+
+**File:** `nous/heart/episodes.py` — `_update_summary()`
+
+After storing `structured_summary`, extract and write:
+
+```python
+async def _update_summary(self, episode_id, summary, session):
+    episode = result.scalar_one_or_none()
+    if episode:
+        episode.structured_summary = summary
+
+        # Backfill text columns from structured summary
+        if isinstance(summary, dict):
+            if summary.get("title"):
+                episode.title = summary["title"]
+            if summary.get("summary"):
+                episode.summary = summary["summary"]
+            if summary.get("key_points"):
+                episode.lessons_learned = summary["key_points"]
+
+        # Refresh embedding with real content
+        embed_text = f"{episode.title or ''} {episode.summary or ''}".strip()
+        if embed_text and self._embed:
+            try:
+                episode.embedding = await self._embed(embed_text)
+            except Exception:
+                logger.debug("Failed to refresh episode embedding")
+
+        await session.flush()
+```
+
+**Fields mapped:**
+
+| Structured JSON | → Episode Column | Rationale |
+|----------------|-----------------|-----------|
+| `title` | `title` | Direct mapping |
+| `summary` | `summary` | Replaces raw user input with prose summary |
+| `key_points` | `lessons_learned` | Array of takeaways — matches column type |
+| `topics` | (not mapped) | Already stored in `structured_summary` JSONB |
+| `outcome` | (not mapped) | Episode outcome set by `end()`, not summarizer |
+
+### Change 2: Set `active=false` on episode close
+
+**File:** `nous/heart/episodes.py` — `_end()`
+
+Add one line:
+
+```python
+episode.active = False
+```
+
+After setting `ended_at`, `duration_seconds`, `outcome`, and `lessons_learned`.
+
+### Change 3: Refresh embedding after backfill
+
+Already included in Change 1. The embedding is recomputed from `title + summary` after the real values are written, replacing the stale first-message embedding.
+
+---
+
+## Files Changed
+
+| File | Change | Lines |
+|------|--------|-------|
+| `nous/heart/episodes.py` | `_update_summary()` backfill + embedding refresh | ~15 |
+| `nous/heart/episodes.py` | `_end()` set `active=false` | 1 |
+| `tests/test_episodes.py` | Test backfill, test active flag on close | ~40 |
+
+**Total:** ~56 lines changed. No new files, no new dependencies.
+
+---
+
+## Migration
+
+### One-time backfill of existing episodes
+
+After deploying, run SQL to backfill the 20 episodes that already have `structured_summary`:
+
+```sql
+UPDATE heart.episodes
+SET
+    title = structured_summary->>'title',
+    summary = structured_summary->>'summary',
+    lessons_learned = ARRAY(
+        SELECT jsonb_array_elements_text(structured_summary->'key_points')
+    ),
+    active = false
+WHERE structured_summary IS NOT NULL
+  AND title IS NULL;
+```
+
+For the 2 episodes without structured summaries, they remain as-is (short sessions that didn't trigger summarization).
+
+---
+
+## Test Plan
+
+### Unit Tests
+
+1. **test_update_summary_backfills_columns** — Verify `title`, `summary`, `lessons_learned` are populated from structured summary dict
+2. **test_update_summary_partial_data** — Verify graceful handling when structured summary is missing fields
+3. **test_update_summary_refreshes_embedding** — Verify embedding is recomputed after backfill
+4. **test_end_sets_active_false** — Verify `active=false` after `end()`
+5. **test_deactivate_still_works** — Verify trivial episode deactivation unchanged
+
+### Integration Verification
+
+After deployment:
+1. Start a new conversation with Nous (3+ turns)
+2. Wait for session timeout → episode close → summarizer fires
+3. Query DB: verify `title`, `summary`, `lessons_learned` are populated, `active=false`
+4. Query DB: verify embedding is different from pre-summary embedding
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Embedding refresh fails | Try/except with debug log — episode still gets text backfill |
+| Structured summary missing expected fields | Defensive `summary.get()` with `if` guards — no crash |
+| `lessons_learned` type mismatch (list vs text[]) | PostgreSQL ARRAY type accepts Python lists via SQLAlchemy |
+| Existing queries filter on `active=true` | This is the **desired** behavior — closed episodes should be excluded from "active" queries. Verify no query accidentally excludes closed episodes that should be recalled. |
+
+---
+
+## Not In Scope
+
+- **`detail` column:** Not populated. Structured summary doesn't have a `detail` equivalent, and the field purpose overlaps with `summary`. Leave NULL for now.
+- **`conversation_state` emptiness:** By design — state is ephemeral session recovery, deleted on session end. Not a bug.
+- **Summarizer prompt improvements:** The structured summaries are already high quality. Prompt tuning is a separate concern.
+- **Backfilling `source_episode_id` on facts:** Facts aren't linked to episodes — separate issue (#34 adjacent).


### PR DESCRIPTION
## Spec 008.3: Episode Summary Backfill & Lifecycle Fix

DB investigation revealed 3 issues with episode summarization:

### Findings
1. **`title` always NULL** — structured_summary has great titles but `_update_summary()` only writes to JSONB, never backfills text columns
2. **`summary` = first user message** — set at episode creation, never updated with the LLM prose summary
3. **`active` always true** — `_end()` sets outcome/duration but never flips `active=false`
4. **Stale embeddings** — computed from first user message, not refreshed after real summary arrives

### Proposed Fix (~56 lines)
- `_update_summary()`: backfill `title`, `summary`, `lessons_learned` from structured JSON + refresh embedding
- `_end()`: add `episode.active = False`
- Migration SQL for existing 20 episodes
- 5 unit tests

Spec only — no code changes in this PR.