### PR TITLE
fix: 008.3 episode summary backfill + active flag lifecycle

### DIFF
--- a/docs/implementation/008.4-summary-quality.md
+++ b/docs/implementation/008.4-summary-quality.md
@@ -1,0 +1,289 @@
+# Spec 008.4: Episode Summary Quality Improvements
+
+**Status:** Draft
+**Depends on:** 008.3 (Backfill fix), 006 (Event Bus)
+**Related:** F007 (Metrics & Growth), F010 (Memory Improvements)
+
+## Problem
+
+The episode summarizer produces structured summaries that work but have systematic quality gaps. With 008.3 fixing the plumbing (backfilling text columns), the next step is improving *what* gets summarized and *how well*.
+
+### Current Quality Issues
+
+#### 1. Outcome Classification is Weak
+Almost every episode returns `"outcome": "partial"` regardless of actual completion:
+
+| Episode | Actual Outcome | Summarizer Says |
+|---------|---------------|-----------------|
+| Weather check → answered | Resolved | `partial` |
+| Research doc written and committed | Resolved | `partial` |
+| A2A communication established | Resolved | `partial` |
+
+**Root cause:** The summarizer prompt has no definition of what constitutes "resolved" vs "partial" vs "informational". The LLM defaults to `partial` when uncertain.
+
+#### 2. No Decision Awareness
+The summarizer only sees the transcript. It doesn't know about:
+- Brain decisions made during the episode (confidence, reasoning, outcome)
+- Deliberation traces (thinking blocks)
+- Tools used and their results
+
+A session where Nous made 3 architecture decisions appears identical to a casual weather check from the summarizer's perspective — just text.
+
+#### 3. Lessons Are "What Happened" Not "What Was Learned"
+Current `key_points`:
+```json
+["Weather was 12C and sunny", "Decided on Astro framework"]
+```
+
+Better `key_points` (reusable knowledge):
+```json
+["Astro chosen over Next.js for static-first sites with minimal JS needs",
+ "Tim prefers direct architecture decisions over lengthy exploration"]
+```
+
+The current prompt asks for points about what happened. It should ask for what would be useful to remember next time.
+
+#### 4. Transcript Truncation is Crude
+Current approach (line ~94 in `episode_summarizer.py`):
+```python
+if len(transcript) > 8000:
+    half = 3800
+    transcript = transcript[:half] + "\n[... middle truncated ...]\n" + transcript[-half:]
+```
+
+This cuts the middle indiscriminately. Tool-heavy turns (bash output, API responses) dominate character count but contain the least summarizable content. Decision-making turns and discussions get cut.
+
+#### 5. No Fact Extraction Guidance
+The summarizer and `FactExtractor` are separate handlers both triggered by `session_ended`/`episode_summarized`. They don't coordinate:
+- Summarizer doesn't flag candidate facts
+- Fact extractor re-reads the transcript independently
+- Sometimes the same insight appears in both `lessons_learned` and as a separate fact — or gets missed by both
+
+---
+
+## Proposed Changes
+
+### Change 1: Enhanced Summary Prompt
+
+Replace `_SUMMARY_PROMPT` with a more structured prompt that:
+
+```python
+_SUMMARY_PROMPT = """You are summarizing a conversation episode for an AI agent's long-term memory.
+
+Context:
+- Agent: Nous (cognitive agent framework)
+- This summary will be used for: semantic search recall, context assembly, calibration
+
+Transcript:
+{transcript}
+
+{decision_context}
+
+Return ONLY valid JSON:
+{{
+  "title": "<5-10 word descriptive title focusing on WHAT WAS ACCOMPLISHED>",
+  "summary": "<100-150 word prose summary emphasizing decisions made, problems solved, and outcomes>",
+  "key_points": [
+    "<lesson or reusable knowledge, not just event description>",
+    "<pattern or insight that would help in similar future situations>"
+  ],
+  "outcome": "<resolved|partial|unresolved|informational>",
+  "outcome_rationale": "<1 sentence explaining why this outcome classification>",
+  "topics": ["<topic1>", "<topic2>"],
+  "candidate_facts": [
+    "<factual statement worth storing as long-term knowledge>"
+  ]
+}}
+
+Outcome guidelines:
+- resolved: The user's request was fully addressed, task completed, question answered
+- partial: Work started but not finished, or only some requests addressed
+- unresolved: Failed to complete the task, hit blockers
+- informational: Casual chat, status check, no actionable work done
+
+For key_points: Focus on WHAT WAS LEARNED, not what happened. Ask yourself:
+"If this agent faces a similar situation, what from this episode would help?"
+
+For candidate_facts: Extract concrete, reusable knowledge (tool configs, preferences,
+architectural decisions, API behaviors) that should persist as standalone facts."""
+```
+
+**Key improvements:**
+- Outcome guidelines with clear definitions
+- `outcome_rationale` forces reasoning about classification
+- `key_points` reframed as lessons, not events
+- `candidate_facts` bridges to fact extraction
+- Decision context injected (see Change 2)
+
+### Change 2: Inject Decision Context
+
+When the summarizer fires, fetch episode-linked decisions from Brain and include them in the prompt:
+
+```python
+async def _build_decision_context(self, episode_id: str) -> str:
+    """Fetch decisions linked to this episode for richer summarization."""
+    try:
+        decisions = await self._brain.get_episode_decisions(UUID(episode_id))
+        if not decisions:
+            return ""
+
+        lines = ["Decisions made during this episode:"]
+        for d in decisions:
+            lines.append(
+                f"- [{d.category}/{d.stakes}] {d.description} "
+                f"(confidence: {d.confidence})"
+            )
+        return "\n".join(lines)
+    except Exception:
+        return ""
+```
+
+This requires the summarizer to receive a `Brain` reference (currently only has `Heart`).
+
+### Change 3: Smarter Transcript Truncation
+
+Replace crude middle-cut with a priority-based approach:
+
+```python
+def _truncate_transcript(self, transcript: str, max_chars: int = 8000) -> str:
+    """Truncate transcript preserving high-value turns."""
+    if len(transcript) <= max_chars:
+        return transcript
+
+    lines = transcript.split("\n\n")
+
+    # Score each turn by information density
+    scored = []
+    for line in lines:
+        score = 1.0
+        lower = line.lower()
+        # Boost: decision language, questions, conclusions
+        if any(w in lower for w in ["decided", "chose", "because", "learned", "conclusion"]):
+            score += 2.0
+        # Boost: user turns (directives)
+        if lower.startswith("user:"):
+            score += 1.0
+        # Penalize: long tool outputs, raw data
+        if len(line) > 500 and ("```" in line or line.count("\n") > 10):
+            score -= 1.0
+        scored.append((score, line))
+
+    # Keep first and last turns always, fill middle by score
+    first = lines[0]
+    last = lines[-1]
+    budget = max_chars - len(first) - len(last) - 100  # buffer
+
+    middle = sorted(scored[1:-1], key=lambda x: -x[0])
+    kept = []
+    used = 0
+    for score, line in middle:
+        if used + len(line) > budget:
+            break
+        kept.append(line)
+        used += len(line)
+
+    # Reconstruct in original order
+    kept_set = set(id(line) for _, line in middle[:len(kept)])
+    result = [first]
+    for score, line in scored[1:-1]:
+        if id(line) in kept_set:
+            result.append(line)
+    result.append(last)
+
+    return "\n\n".join(result)
+```
+
+### Change 4: Candidate Fact Passthrough
+
+The new `candidate_facts` field in the structured summary gets emitted with the `episode_summarized` event. The `FactExtractor` handler can use these as pre-filtered candidates instead of re-processing the full transcript.
+
+**In `episode_summarizer.py`:**
+```python
+await self._bus.emit(Event(
+    type="episode_summarized",
+    data={
+        "episode_id": episode_id,
+        "summary": summary,
+        "candidate_facts": summary.get("candidate_facts", []),  # NEW
+    },
+))
+```
+
+**In `fact_extractor.py`** (optional enhancement):
+```python
+async def handle(self, event: Event) -> None:
+    candidates = event.data.get("candidate_facts", [])
+    if candidates:
+        # Use pre-filtered candidates instead of re-parsing transcript
+        for fact_text in candidates:
+            await self._store_fact(fact_text, episode_id, session)
+        return
+    # Fall back to transcript extraction if no candidates
+    ...
+```
+
+---
+
+## Files Changed
+
+| File | Change | Lines (est.) |
+|------|--------|-------------|
+| `nous/handlers/episode_summarizer.py` | New prompt, decision context, smart truncation | ~80 |
+| `nous/handlers/fact_extractor.py` | Accept candidate_facts from event | ~15 |
+| `tests/test_event_bus.py` | Test new prompt fields, candidate_facts passthrough | ~40 |
+
+**Total:** ~135 lines. No schema changes, no new tables.
+
+---
+
+## Incremental Delivery
+
+This can be shipped in phases:
+
+### Phase 1: Better Prompt (~30 lines)
+- New `_SUMMARY_PROMPT` with outcome guidelines and lesson-focused key_points
+- `outcome_rationale` field
+- Immediately improves all new episodes
+
+### Phase 2: Decision Context (~40 lines)
+- `_build_decision_context()` method
+- Brain reference in summarizer constructor
+- Richer summaries for decision-heavy sessions
+
+### Phase 3: Smart Truncation (~50 lines)
+- Priority-based transcript truncation
+- Better summaries for long tool-heavy sessions
+
+### Phase 4: Fact Coordination (~15 lines)
+- `candidate_facts` in event data
+- Fact extractor accepts pre-filtered candidates
+
+---
+
+## Success Metrics
+
+| Metric | Current | Target |
+|--------|---------|--------|
+| Outcome = "partial" rate | ~90% | < 40% |
+| Episodes with useful lessons | ~20% | > 70% |
+| Fact source tracing (from episode) | 0% | > 50% (via candidate_facts) |
+| Summary token efficiency | ~300 tokens avg | ~250 tokens avg (less noise) |
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Longer prompt = more tokens per summarization | Background model (Haiku-class) is cheap. Budget increase ~200 tokens/episode. |
+| Decision context fetch adds latency | Async fetch, cached in event data. Falls back to empty string on error. |
+| `candidate_facts` may duplicate fact extractor output | Fact dedup (`_find_duplicate()` cosine > 0.95) already handles this. |
+| Smart truncation heuristics may cut wrong things | Conservative scoring — user turns and decision language always kept. |
+
+---
+
+## Not In Scope
+
+- **Summarizer model upgrade:** Currently uses `background_model` (Haiku-class). Upgrading to Sonnet would improve quality but costs 10x more per episode. Separate cost/benefit analysis needed.
+- **Retroactive re-summarization:** Re-running the summarizer on existing 22 episodes with the new prompt. Could be a one-time script but not part of this spec.
+- **Summary versioning:** Storing multiple summary versions as the prompt evolves. Overkill for now.

--- a/nous/heart/episodes.py
+++ b/nous/heart/episodes.py
@@ -514,6 +514,7 @@ class EpisodeManager:
             lessons_learned=episode.lessons_learned or [],
             tags=episode.tags or [],
             decision_ids=decision_ids,
+            active=episode.active,
             structured_summary=episode.structured_summary,
             user_id=episode.user_id,
             user_display_name=episode.user_display_name,

--- a/nous/heart/schemas.py
+++ b/nous/heart/schemas.py
@@ -54,6 +54,7 @@ class EpisodeDetail(BaseModel):
     lessons_learned: list[str]
     tags: list[str]
     decision_ids: list[UUID]  # From episode_decisions join
+    active: bool = True
     structured_summary: dict | None = None
     user_id: str | None = None
     user_display_name: str | None = None

--- a/tests/test_episodes.py
+++ b/tests/test_episodes.py
@@ -269,7 +269,7 @@ async def test_update_summary_partial_data(heart, session):
     updated = await heart.get_episode(detail.id, session=session)
     assert updated.title == "Quick Chat"
     assert updated.summary == "test input"  # Not overwritten — no "summary" in structured
-    assert updated.lessons_learned is None  # Not set — no "key_points"
+    assert updated.lessons_learned == []  # Not set — no "key_points" (_to_detail converts None → [])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements Spec 008.3.

_update_summary(): backfill title, summary, lessons_learned from structured JSON + refresh embedding.
_end(): set active=false on close.
4 new tests.