### PR TITLE
fix: /new command now ends session properly

### DIFF
--- a/nous/telegram_bot.py
+++ b/nous/telegram_bot.py
@@ -443,9 +443,17 @@ class NousTelegramBot:
             await self._send(chat_id, "🧠 *Nous* is ready\\. Send me a message\\!", parse_mode="MarkdownV2")
             return
 
-        # Handle /new - reset session
+        # Handle /new - end current session properly, then start fresh
         if text == "/new":
-            self._sessions.pop(chat_id, None)
+            old_session_id = self._sessions.pop(chat_id, None)
+            if old_session_id:
+                try:
+                    await self._http.delete(
+                        f"{self.nous_url}/chat/{old_session_id}",
+                        timeout=10,
+                    )
+                except Exception:
+                    logger.warning("Failed to end session %s via API", old_session_id)
             await self._send(chat_id, "🔄 New session started.")
             return
 


### PR DESCRIPTION
## Problem

`/new` on Telegram just did `self._sessions.pop()` — dropped the local session dict entry but never called `DELETE /chat/{session_id}`. This means `session_ended` never fired, so:
- Episode summarizer never ran on Telegram sessions
- Decision reviewer (008.5) never triggered

This is why we saw 0 reviewed decisions despite 008.5 being deployed.

## Fix

Call `DELETE /chat/{session_id}` before clearing the local state. This fires `end_session` → `session_ended` event → all handlers run (episode summarizer, decision reviewer sweep).

## Testing

1. Chat with Nous on Telegram
2. Type `/new`
3. Check container logs for `DecisionReviewer` and `EpisodeSummarizer` activity
4. Check DB: `SELECT * FROM brain.decisions WHERE reviewed_at IS NOT NULL`