### PR TITLE
feat: add Telegram bot to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,18 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  telegram:
+    build: .
+    container_name: nous-telegram
+    command: python -m nous.telegram_bot
+    environment:
+      TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN:-}
+      NOUS_API_URL: http://nous:8000
+      NOUS_ALLOWED_USERS: ${NOUS_ALLOWED_USERS:-}
+    depends_on:
+      - nous
+    restart: unless-stopped
+
   postgres:
     image: pgvector/pgvector:pg17
     container_name: nous-postgres


### PR DESCRIPTION
## Summary
- Add `telegram` service to `docker-compose.yml` that runs `python -m nous.telegram_bot` alongside the agent
- Update `docs/quickstart.md` to document three-container deployment, Telegram env vars in `.env` examples, and Docker vs standalone usage

## Changes
- **docker-compose.yml**: New `telegram` service — builds from same Dockerfile, overrides command, connects to `nous` via internal network, configurable via `TELEGRAM_BOT_TOKEN` and `NOUS_ALLOWED_USERS`
- **docs/quickstart.md**: Updated container table (3 containers), `.env` template, Telegram section (Docker + standalone), architecture diagram label, production config example

## Test plan
- [ ] `docker compose up -d` starts all three containers
- [ ] Bot exits gracefully if `TELEGRAM_BOT_TOKEN` is not set
- [ ] `docker compose up -d nous postgres` skips the bot
- [ ] Bot connects to agent via `http://nous:8000` internal URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)