### PR TITLE
Spec: 011.2 Multimodal File Support

### DIFF
--- a/docs/implementation/011.2-multimodal-file-support.md
+++ b/docs/implementation/011.2-multimodal-file-support.md
@@ -1,0 +1,808 @@
+# 011.2 — Multimodal File Support
+
+**Status:** Draft (post-review v2)  
+**Depends on:** 005.2 (Direct API), 008.1 (History Compaction)  
+**Feature:** F024 — Accept and process images, documents, and other files across all input channels  
+**Reviewed:** 2025-03-02 — Security, DX/Implementation, Architecture (see `docs/reviews/011.2-*`)
+
+## Problem
+
+Nous currently only accepts plain text messages. The `Message` dataclass has `content: str`, the REST API `/chat` endpoint expects a `message` string, and the Telegram bot's `_handle_update` extracts only `message.text`. If a user sends a photo, PDF, or any other file, it is silently ignored.
+
+Claude's Messages API natively supports multimodal content blocks — images (JPEG, PNG, GIF, WebP) and documents (PDF) via base64, URL, or the Files API. Text-based files (.py, .json, .csv, .md, etc.) can be injected as text content blocks. This spec adds end-to-end multimodal support from Telegram and REST through the runner to Claude.
+
+## Design Decision: Base64 vs Anthropic Files API
+
+Base64 inline encoding, **not** the Anthropic Files API. Rationale:
+- **Auth blocker** — Nous uses OAT token auth (Max subscription). Files API requires `x-api-key` (direct API key). May not be compatible.
+- **Still in beta** — `files-api-2025-04-14`, explicitly excluded from Zero Data Retention. User files would persist on Anthropic's servers.
+- **Not portable** — Files API is Anthropic-only. Not available on Bedrock/Vertex.
+- **Creates unnecessary state** — Files persist until deleted, requiring TTL tracking, cleanup logic, extra API calls.
+- **Usage pattern doesn't benefit** — Telegram photo → analyze once → done. No repeated references across turns.
+
+**Revisit when:** OAT tokens support Files API, it exits beta, or we build a document library feature.
+
+## Claude API Capabilities
+
+### Natively Supported Content Block Types
+
+- **Images** (`image` block) — `image/jpeg`, `image/png`, `image/gif`, `image/webp` — up to ~20 MB (recommend <5 MB), base64 source
+- **PDF Documents** (`document` block) — `application/pdf` — up to 32 MB / 100 pages, base64 source
+
+### Text-Extractable File Types (read as text content blocks)
+
+These are not sent as binary — contents are read and injected as `text` content blocks with a filename header:
+
+- **Code:** `.py`, `.js`, `.ts`, `.jsx`, `.tsx`, `.html`, `.css`, `.c`, `.cpp`, `.h`, `.java`, `.go`, `.rs`, `.rb`, `.php`, `.sh`, `.sql`, `.yaml`, `.yml`, `.toml`
+- **Data:** `.json`, `.csv`, `.tsv`, `.xml`, `.env`, `.ini`, `.cfg`
+- **Text:** `.txt`, `.md`, `.rst`, `.log`
+- **Config:** `.dockerfile`, `Makefile`, `.gitignore`, `.editorconfig`
+
+### Unsupported (Require External Processing)
+
+- **Office docs:** `.docx`, `.xlsx`, `.pptx` — would need `python-docx`/`openpyxl` conversion (out of scope)
+- **Audio/Video:** `.ogg`, `.mp3`, `.mp4` — Claude has no native audio/video processing (out of scope)
+- **Archives:** `.zip`, `.tar.gz` — would need extraction (out of scope)
+
+## Architecture
+
+```
+Telegram photo/doc ──┐
+                     ├─► Attachment normalization ──► REST API ──► Runner ──► Claude API
+REST multipart/JSON ─┘      (download, classify,       (accepts      (builds
+                              sanitize, base64 encode)  attachments)   content blocks)
+```
+
+### Blob Lifecycle (Critical Path)
+
+This ordering **must** be followed to prevent base64 blobs from persisting to the database or leaking into memory subsystems:
+
+```
+1. Input layer downloads file, creates Attachment with base64 data
+2. Runner validates attachment, builds multimodal content blocks
+3. Content blocks sent to Claude API (base64 included)
+4. Claude response received
+5. IMMEDIATELY: compact_message_for_history() strips base64 from user message
+6. IMMEDIATELY: Clear attachment.data_base64 = "" to allow GC
+7. THEN: Append assistant response to conversation
+8. THEN: _save_conversation() persists (base64 already stripped)
+9. Cognitive layer uses text_content for episodes/summaries (never sees base64)
+```
+
+### Module Map
+
+```
+nous/api/attachments.py          NEW — pure functions
+  ├── sanitize_filename()        ← telegram_bot.py, rest.py
+  ├── classify_attachment()      ← telegram_bot.py, rest.py
+  ├── validate_attachment()      ← runner.py
+  ├── validate_base64_size()     ← runner.py (for REST, don't trust client size)
+  ├── build_content_blocks()     ← runner.py
+  └── compact_message_for_history() ← runner.py (after API call)
+
+nous/api/models.py               UPDATED
+  ├── Attachment (new dataclass)
+  └── Message (content type union, attachments field, text_content field)
+
+nous/api/runner.py               UPDATED
+  ├── run_turn() — accepts attachments param
+  ├── stream_chat() — accepts attachments param
+  ├── _format_messages() — no changes needed (already passes content directly)
+  └── _save_conversation() — no changes needed (compaction happens before this)
+
+nous/api/compaction.py           UPDATED
+  └── TokenEstimator.estimate_message() — multimodal-aware
+
+nous/api/rest.py                 UPDATED
+  ├── /chat — accepts optional attachments array
+  └── /chat/stream — accepts optional attachments array
+
+nous/telegram_bot.py             UPDATED
+  ├── download_telegram_file() — new helper with error handling
+  └── _handle_update() — photo/document/sticker handling
+```
+
+### Message.content Consumer Migration
+
+All existing consumers of `Message.content` that assume `str` type must be updated:
+
+- `runner.py` — `recent_messages` extraction (2 locations: `run_turn` ~line 299, `stream_chat` ~line 617)
+  - **Change:** Use `m.text_content or (m.content if isinstance(m.content, str) else "")`
+- `runner.py` — `_format_history_text()` (~line 1321) — builds reflection text
+  - **Change:** Use `m.text_content or (m.content if isinstance(m.content, str) else "[multimodal message]")`
+- `runner.py` — `_save_conversation()` (~line 1334) — persists to DB
+  - **Change:** No code change needed IF compaction runs before this (see Blob Lifecycle above). Verify with test.
+- `compaction.py` — `estimate_messages()` — token counting
+  - **Change:** Use new `estimate_message()` method that handles `list[dict]` content
+- `compaction.py` — `_has_image_content()` — already handles list content ✅
+
+## Data Model
+
+### New: `Attachment` Dataclass
+
+```python
+# nous/api/models.py
+
+@dataclass
+class Attachment:
+    """A file attachment accompanying a message."""
+    filename: str            # Sanitized filename
+    media_type: str          # MIME type: image/jpeg, application/pdf, text/plain, etc.
+    data_base64: str         # Base64-encoded file content (cleared after compaction)
+    size_bytes: int          # Original file size (validated, not trusted from client)
+    source: str = "upload"   # "telegram", "rest", "url"
+    width: int = 0           # Image width in pixels (for token estimation)
+    height: int = 0          # Image height in pixels (for token estimation)
+
+    # Classification (set by classify_attachment)
+    content_type: str = "unknown"  # "image", "document", "text_file", "unsupported"
+```
+
+### Updated: `Message` Dataclass
+
+```python
+@dataclass
+class Message:
+    """A single message in a conversation."""
+    role: str  # "user" or "assistant"
+    content: str | list[dict[str, Any]]  # str for text-only, list for multimodal
+    attachments: list[Attachment] | None = None  # Metadata only (no base64 after compaction)
+    text_content: str = ""  # Plain text portion (always available for search/episodes/cognitive)
+```
+
+## Implementation
+
+### Phase 1: Core Attachment Pipeline
+
+#### 1A. Attachment Module — `nous/api/attachments.py`
+
+New module handling file classification, validation, security, and content block construction.
+
+```python
+"""Attachment processing for multimodal message support."""
+
+import base64
+import mimetypes
+import os
+import re
+
+# MIME type → Claude content block type mapping
+IMAGE_TYPES = {"image/jpeg", "image/png", "image/gif", "image/webp"}
+DOCUMENT_TYPES = {"application/pdf"}
+
+# Extensions that should be read as text
+TEXT_EXTENSIONS = {
+    ".py", ".js", ".ts", ".jsx", ".tsx", ".html", ".css",
+    ".c", ".cpp", ".h", ".java", ".go", ".rs", ".rb", ".php",
+    ".sh", ".sql", ".yaml", ".yml", ".toml", ".json", ".csv",
+    ".tsv", ".xml", ".txt", ".md", ".rst", ".log", ".env",
+    ".ini", ".cfg", ".dockerfile", ".gitignore", ".editorconfig",
+    "Makefile",
+}
+
+# Size limits
+MAX_IMAGE_SIZE = 20 * 1024 * 1024      # 20 MB
+MAX_DOCUMENT_SIZE = 32 * 1024 * 1024    # 32 MB
+MAX_TEXT_FILE_SIZE = 1 * 1024 * 1024    # 1 MB (text files injected into context)
+MAX_ATTACHMENTS_PER_MESSAGE = 5
+
+# Filename constraints
+MAX_FILENAME_LENGTH = 255
+FILENAME_SAFE_PATTERN = re.compile(r'[^\w\s\-\.\(\)]', re.UNICODE)
+
+
+def sanitize_filename(filename: str) -> str:
+    """Sanitize user-supplied filename. Strip path components, limit chars."""
+    # Strip path components (prevent traversal)
+    filename = os.path.basename(filename)
+    # Remove null bytes
+    filename = filename.replace('\x00', '')
+    # Replace unsafe characters
+    filename = FILENAME_SAFE_PATTERN.sub('_', filename)
+    # Truncate
+    filename = filename[:MAX_FILENAME_LENGTH]
+    return filename or "unnamed_file"
+
+
+def classify_attachment(filename: str, media_type: str) -> str:
+    """Classify attachment into: image, document, text_file, unsupported."""
+    if media_type in IMAGE_TYPES:
+        return "image"
+    if media_type in DOCUMENT_TYPES:
+        return "document"
+
+    # Check by extension for text files
+    ext = _get_extension(filename).lower()
+    if ext in TEXT_EXTENSIONS or media_type.startswith("text/"):
+        return "text_file"
+
+    return "unsupported"
+
+
+def validate_attachment(attachment: "Attachment") -> str | None:
+    """Validate attachment. Returns error string or None if valid."""
+    if attachment.content_type == "unsupported":
+        ext = _get_extension(attachment.filename)
+        return (
+            f"📎 I can't process {ext or attachment.media_type} files yet. "
+            f"I support images (JPEG, PNG, GIF, WebP), PDFs, and text/code files."
+        )
+
+    size_limits = {
+        "image": MAX_IMAGE_SIZE,
+        "document": MAX_DOCUMENT_SIZE,
+        "text_file": MAX_TEXT_FILE_SIZE,
+    }
+    limit = size_limits.get(attachment.content_type, 0)
+    if attachment.size_bytes > limit:
+        limit_mb = limit / 1024 / 1024
+        actual_mb = attachment.size_bytes / 1024 / 1024
+        return (
+            f"📎 {attachment.filename} is too large ({actual_mb:.1f} MB). "
+            f"Max for {attachment.content_type} is {limit_mb:.0f} MB. "
+            f"Try compressing or reducing resolution."
+        )
+    return None
+
+
+def validate_base64_size(data_base64: str) -> int:
+    """Calculate actual file size from base64 data. Don't trust client-declared size."""
+    # Base64: every 4 chars = 3 bytes, minus padding
+    padding = data_base64.count('=')
+    return (len(data_base64) * 3 // 4) - padding
+
+
+def build_content_blocks(
+    text: str,
+    attachments: list["Attachment"],
+) -> list[dict]:
+    """Build Claude API content blocks from text + attachments.
+
+    Returns a list suitable for the `content` field of a user message.
+    Images and documents come first (Claude recommends images before text),
+    then any text-file contents, then the user's text message.
+    """
+    blocks: list[dict] = []
+
+    for att in attachments:
+        if att.content_type == "image":
+            blocks.append({
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": att.media_type,
+                    "data": att.data_base64,
+                },
+            })
+
+        elif att.content_type == "document":
+            blocks.append({
+                "type": "document",
+                "source": {
+                    "type": "base64",
+                    "media_type": att.media_type,
+                    "data": att.data_base64,
+                },
+            })
+
+        elif att.content_type == "text_file":
+            # Decode base64 → UTF-8 text, inject as text block with filename header
+            try:
+                file_text = base64.b64decode(att.data_base64).decode("utf-8", errors="replace")
+                blocks.append({
+                    "type": "text",
+                    "text": f"--- File: {att.filename} ---\n{file_text}",
+                })
+            except Exception:
+                blocks.append({
+                    "type": "text",
+                    "text": f"[Could not decode file: {att.filename}]",
+                })
+
+    # User's text message always comes last
+    if text:
+        blocks.append({"type": "text", "text": text})
+
+    return blocks
+
+
+def compact_message_for_history(message: "Message") -> "Message":
+    """Replace heavy content blocks with metadata for conversation history.
+
+    MUST be called immediately after Claude API response, BEFORE _save_conversation().
+    Also clears attachment.data_base64 to allow GC of large strings.
+    """
+    if isinstance(message.content, str):
+        return message  # Already text-only
+
+    compacted_parts = []
+    for block in message.content:
+        if block.get("type") == "text":
+            compacted_parts.append(block)
+        elif block.get("type") == "image":
+            compacted_parts.append({
+                "type": "text",
+                "text": "[Image was sent and analyzed]",
+            })
+        elif block.get("type") == "document":
+            compacted_parts.append({
+                "type": "text",
+                "text": "[PDF document was sent and analyzed]",
+            })
+
+    # Simplify to string if only text remains
+    if len(compacted_parts) == 1:
+        content = compacted_parts[0].get("text", "")
+    else:
+        content = compacted_parts
+
+    # Clear base64 data from attachments to allow GC
+    if message.attachments:
+        for att in message.attachments:
+            att.data_base64 = ""
+
+    return Message(
+        role=message.role,
+        content=content,
+        attachments=message.attachments,  # Metadata only (base64 cleared)
+        text_content=message.text_content,
+    )
+
+
+def _get_extension(filename: str) -> str:
+    """Get file extension including dot, or empty string."""
+    _, ext = os.path.splitext(filename)
+    return ext
+```
+
+#### 1B. Update `Message` and `_format_messages` in Runner
+
+**`models.py` changes:**
+- `Message.content` type becomes `str | list[dict[str, Any]]`
+- Add `attachments: list[Attachment] | None = None` field
+- Add `text_content: str = ""` for plain-text extraction (used by episodes, search, cognitive layer)
+
+**`runner.py` changes:**
+
+`run_turn()` and `stream_chat()` gain an `attachments` parameter:
+
+```python
+async def run_turn(
+    self,
+    session_id: str,
+    user_message: str,
+    attachments: list[Attachment] | None = None,  # NEW
+    ...
+) -> tuple[str, TurnContext, dict[str, int]]:
+```
+
+Message construction (step 3) changes:
+
+```python
+# 3. Append user message
+if attachments:
+    valid_attachments = []
+    warnings = []
+    for att in attachments[:MAX_ATTACHMENTS_PER_MESSAGE]:
+        err = validate_attachment(att)
+        if err:
+            warnings.append(err)
+        else:
+            valid_attachments.append(att)
+
+    if valid_attachments:
+        content_blocks = build_content_blocks(user_message, valid_attachments)
+        msg = Message(
+            role="user",
+            content=content_blocks,
+            attachments=valid_attachments,
+            text_content=user_message,
+        )
+    else:
+        msg = Message(role="user", content=user_message, text_content=user_message)
+
+    if warnings:
+        warn_text = "\n".join(warnings)
+        user_message = f"{warn_text}\n\n{user_message}" if user_message else warn_text
+else:
+    msg = Message(role="user", content=user_message, text_content=user_message)
+
+conversation.messages.append(msg)
+```
+
+**After API response — critical compaction step:**
+
+```python
+# After Claude API call returns, compact multimodal message BEFORE anything else
+if attachments and valid_attachments:
+    # Find the user message we just sent (second-to-last in conversation)
+    user_msg_idx = len(conversation.messages) - 2  # -1 is assistant response
+    conversation.messages[user_msg_idx] = compact_message_for_history(
+        conversation.messages[user_msg_idx]
+    )
+    logger.info(f"Compacted multimodal message with {len(valid_attachments)} attachment(s)")
+```
+
+**Consumer migration** — update `recent_messages` extraction in both `run_turn` and `stream_chat`:
+
+```python
+recent_messages = [
+    m.text_content or (m.content if isinstance(m.content, str) else "")
+    for m in conversation.messages if m.role == "user"
+][-8:]
+```
+
+**Consumer migration** — update `_format_history_text()`:
+
+```python
+def _format_history_text(self, messages):
+    lines = []
+    for m in messages:
+        text = m.text_content if hasattr(m, 'text_content') and m.text_content else (
+            m.content if isinstance(m.content, str) else "[multimodal message]"
+        )
+        lines.append(f"{m.role}: {text}")
+    return "\n".join(lines)
+```
+
+`_format_messages()` already passes `m.content` directly — since content is now `str | list[dict]`, this works with Claude's API as-is. No changes needed.
+
+#### 1C. REST API Changes — `rest.py`
+
+Both `/chat` and `/chat/stream` accept an optional `attachments` array:
+
+```json
+{
+  "message": "What's in this image?",
+  "session_id": "abc-123",
+  "attachments": [
+    {
+      "filename": "screenshot.png",
+      "media_type": "image/png",
+      "data_base64": "iVBORw0KGgo...",
+      "size_bytes": 245000
+    }
+  ]
+}
+```
+
+Parsing in endpoint handlers (with security validation):
+
+```python
+raw_attachments = body.get("attachments") or []
+attachments = []
+for a in raw_attachments:
+    # Sanitize filename
+    filename = sanitize_filename(a.get("filename", "unnamed"))
+    media_type = a.get("media_type", "application/octet-stream")
+    data_base64 = a.get("data_base64", "")
+
+    # Calculate actual size from base64 (don't trust client-declared size)
+    actual_size = validate_base64_size(data_base64) if data_base64 else 0
+
+    att = Attachment(
+        filename=filename,
+        media_type=media_type,
+        data_base64=data_base64,
+        size_bytes=actual_size,  # Use calculated size, not client-declared
+        source="rest",
+        content_type=classify_attachment(filename, media_type),
+    )
+    attachments.append(att)
+```
+
+### Phase 2: Telegram Integration
+
+#### 2A. File Download Helper
+
+```python
+# In telegram_bot.py
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def download_telegram_file(bot, file_id: str) -> tuple[bytes, str]:
+    """Download a file from Telegram by file_id.
+
+    Returns (file_bytes, file_path).
+    Telegram files are available for 1 hour after the bot receives the message.
+    Telegram Bot API limit: files up to 20 MB only.
+
+    Raises:
+        TelegramError: on network/API failure
+        ValueError: on empty download
+    """
+    file_obj = await bot.get_file(file_id)
+    bio = io.BytesIO()
+    await file_obj.download_to_memory(bio)
+    file_bytes = bio.getvalue()
+
+    if not file_bytes:
+        raise ValueError(f"Empty file downloaded for file_id={file_id}")
+
+    return file_bytes, file_obj.file_path or ""
+```
+
+#### 2B. Update `_handle_update` to Process Attachments
+
+Current behavior — only processes `message.text`, ignores everything else.
+
+New behavior:
+
+```python
+async def _handle_update(self, update, context):
+    message = update.effective_message
+    if not message:
+        return
+
+    text = message.text or message.caption or ""
+    attachments: list[Attachment] = []
+
+    try:
+        # Photos (Telegram sends multiple sizes, pick largest)
+        if message.photo:
+            await message.chat.send_action(ChatAction.TYPING)
+            photo = message.photo[-1]  # Largest size
+            file_bytes, file_path = await download_telegram_file(context.bot, photo.file_id)
+            attachments.append(Attachment(
+                filename=sanitize_filename(f"photo_{photo.file_unique_id}.jpg"),
+                media_type="image/jpeg",
+                data_base64=base64.b64encode(file_bytes).decode(),
+                size_bytes=len(file_bytes),
+                source="telegram",
+                content_type="image",
+                width=photo.width,
+                height=photo.height,
+            ))
+
+        # Documents (PDF, images sent as files, code files, etc.)
+        if message.document:
+            await message.chat.send_action(ChatAction.TYPING)
+            doc = message.document
+            mime = doc.mime_type or mimetypes.guess_type(doc.file_name or "")[0] or "application/octet-stream"
+            file_bytes, _ = await download_telegram_file(context.bot, doc.file_id)
+            att = Attachment(
+                filename=sanitize_filename(doc.file_name or "document"),
+                media_type=mime,
+                data_base64=base64.b64encode(file_bytes).decode(),
+                size_bytes=len(file_bytes),
+                source="telegram",
+            )
+            att.content_type = classify_attachment(att.filename, att.media_type)
+            attachments.append(att)
+
+        # Stickers (WebP images — skip animated and video stickers)
+        if message.sticker and not message.sticker.is_animated and not message.sticker.is_video:
+            file_bytes, _ = await download_telegram_file(context.bot, message.sticker.file_id)
+            attachments.append(Attachment(
+                filename=sanitize_filename(f"sticker_{message.sticker.file_unique_id}.webp"),
+                media_type="image/webp",
+                data_base64=base64.b64encode(file_bytes).decode(),
+                size_bytes=len(file_bytes),
+                source="telegram",
+                content_type="image",
+            ))
+
+        # Voice messages — not supported, but give a helpful response
+        if message.voice or message.audio:
+            await message.reply_text(
+                "🎤 I can't process audio files yet. "
+                "Try sending text, images, PDFs, or code files instead."
+            )
+            if not text:
+                return
+
+    except Exception as e:
+        logger.error(f"Failed to download attachment: {e}", exc_info=True)
+        if not text:
+            await message.reply_text(
+                "⚠️ I couldn't download that file. "
+                "Please try again or send it in a different format."
+            )
+            return
+        # If there's text, continue without the attachment
+        logger.warning(f"Continuing with text only after attachment download failure")
+        attachments = []
+
+    # No text AND no attachments → nothing to process
+    if not text and not attachments:
+        return
+
+    # If only attachments, no text — set a default prompt
+    # NOTE: This is a tuning point. Current default is generic.
+    # Could be improved with type-aware defaults (e.g., "Review this code" for .py files)
+    if not text and attachments:
+        text = "What can you tell me about this?"
+
+    # Log attachment receipt (no base64 content)
+    if attachments:
+        att_summary = ", ".join(f"{a.filename} ({a.content_type})" for a in attachments)
+        logger.info(f"Processing message with attachments: {att_summary}")
+
+    # Pass to chat pipeline with attachments
+    await self._chat_streaming(message, text, attachments=attachments)
+```
+
+#### 2C. Update `_chat_streaming` and the REST call
+
+`_chat_streaming` gains an `attachments` parameter and passes it through to the API call:
+
+```python
+async def _chat_streaming(self, message, text, attachments=None):
+    # ... existing code ...
+    payload = {
+        "message": text,
+        "session_id": session_id,
+        "platform": "telegram",
+        "user_id": str(message.from_user.id),
+        "user_display_name": message.from_user.first_name,
+    }
+    if attachments:
+        payload["attachments"] = [
+            {
+                "filename": a.filename,
+                "media_type": a.media_type,
+                "data_base64": a.data_base64,
+                "size_bytes": a.size_bytes,
+            }
+            for a in attachments
+        ]
+    # ... POST to /chat/stream ...
+```
+
+### Phase 3: Token Estimation
+
+The `TokenEstimator` needs to handle multimodal content for accurate compaction decisions. **This must be implemented before Phase 4** to prevent false compaction triggers.
+
+```python
+def estimate_image_tokens(self, width: int = 0, height: int = 0) -> int:
+    """Estimate tokens for an image using Claude's formula.
+
+    Claude's actual formula: tokens = (width * height) / 750
+    If dimensions unknown, use conservative default of 1600 tokens.
+    """
+    if width > 0 and height > 0:
+        return max(1, (width * height) // 750)
+    return 1600  # Conservative default (~1100x1200 image)
+
+
+def estimate_message(self, message: dict) -> int:
+    """Estimate tokens for a single message, handling multimodal content."""
+    content = message.get("content", "")
+    if isinstance(content, str):
+        return self.estimate(content) + 4  # role overhead
+
+    total = 4  # role overhead
+    for block in content:
+        if block.get("type") == "text":
+            total += self.estimate(block.get("text", ""))
+        elif block.get("type") == "image":
+            # Use dimensions if available (stored in attachment metadata)
+            total += self.estimate_image_tokens()
+        elif block.get("type") == "document":
+            # PDFs: ~1500 tokens per page, assume average 5 pages if unknown
+            total += 7500
+    return total
+```
+
+### Phase 4: History Compaction Integration
+
+Ensure `compact_message_for_history()` is called in the critical path (see Blob Lifecycle above). The function lives in `attachments.py` (it's an attachment transformation, not a general compaction concern).
+
+Verify that the existing compaction pipeline in `compaction.py` handles the compacted format correctly — after compaction, messages contain only strings and `[Image was sent and analyzed]` placeholders, which the summarizer handles naturally.
+
+## File Size Limits
+
+- **Image** — 20 MB (Claude API limit)
+- **PDF** — 32 MB / 100 pages (Claude API limit)
+- **Text file** — 1 MB (context window protection — 1 MB ≈ 250K tokens)
+- **Per-message attachments** — 5 max (prevent abuse, keep context manageable)
+
+## Security
+
+### Filename Sanitization
+- Strip all path components (`os.path.basename`)
+- Remove null bytes
+- Replace unsafe characters (keep `\w`, `\s`, `-`, `.`, `(`, `)`)
+- Truncate to 255 characters
+- Apply at both Telegram download and REST ingestion
+
+### Size Validation
+- **Telegram:** Trust `len(file_bytes)` — we downloaded it ourselves
+- **REST:** Calculate actual size from base64 data (`len(data) * 3 / 4 - padding`). **Never trust client-declared `size_bytes`**
+- Validate against limits BEFORE building content blocks
+
+### Base64 Integrity
+- Validate base64 is decodable before sending to Claude
+- Validate MIME type via magic bytes when practical (future enhancement)
+
+### Logging Safety
+- **Never** log base64 content — truncate in all log messages
+- Log filename, type, size only
+- Ensure base64 data doesn't leak into episode summaries, fact storage, or decision records
+
+## Error Handling
+
+- **Unsupported type:** "📎 I can't process .docx files yet. I support images (JPEG, PNG, GIF, WebP), PDFs, and text/code files."
+- **Too large:** "📎 photo.jpg is too large (25.0 MB). Max for images is 20 MB. Try compressing or reducing resolution."
+- **Download failure (Telegram):** Log error, process text portion only, warn user: "⚠️ I couldn't download that file. Please try again or send it in a different format."
+- **Corrupted base64:** Skip attachment, warn user.
+- **Voice/audio message:** "🎤 I can't process audio files yet. Try sending text, images, PDFs, or code files instead."
+- **Telegram Bot API file limit:** Files >20 MB are rejected by Telegram before they reach us — no action needed.
+
+## Testing
+
+### Unit Tests — `tests/test_attachments.py`
+
+- `test_classify_attachment` — correct classification for all supported types
+- `test_classify_unsupported` — .docx, .mp3, .zip → "unsupported"
+- `test_validate_size_limits` — rejection at boundary for each type
+- `test_validate_base64_size` — actual size calculation matches expected
+- `test_sanitize_filename` — path traversal, null bytes, unicode, empty string
+- `test_build_content_blocks_image` — correct image block structure
+- `test_build_content_blocks_pdf` — correct document block structure
+- `test_build_content_blocks_text_file` — text file decoded and injected with header
+- `test_build_content_blocks_mixed` — multiple types in correct order
+- `test_build_content_blocks_text_only` — no attachments → single text block
+- `test_compact_message` — multimodal → metadata replacement, base64 cleared
+- `test_compact_message_roundtrip` — compacted message serializes/deserializes correctly
+- `test_compact_message_string_passthrough` — str content returns unchanged
+- `test_estimate_image_tokens` — with and without dimensions
+
+### Integration Tests
+
+- `test_run_turn_with_image` — end-to-end run_turn with a small test image
+- `test_run_turn_with_text_file` — text file contents reach Claude as text block
+- `test_stream_chat_with_attachment` — streaming works with attachments
+- `test_rest_chat_with_attachment` — REST endpoint accepts and processes attachments
+- `test_rest_attachment_size_validation` — client-declared size ignored, actual size used
+- `test_history_no_base64_after_compaction` — base64 data not present in conversation history after turn
+- `test_conversation_persistence_multimodal` — save/restore handles mixed content
+- `test_backward_compat_text_only` — existing text-only messages still work identically
+- `test_download_failure_graceful` — attachment download fails, text still processed
+- `test_token_estimation_multimodal` — image messages don't trigger false compaction
+
+### Manual Validation
+
+- Send photo on Telegram → Nous describes it
+- Send PDF on Telegram → Nous summarizes it
+- Send .py file on Telegram → Nous reviews the code
+- Send photo with caption → Nous uses both
+- Send unsupported .mp3 → Nous returns helpful error message
+- Send voice message → Nous returns helpful error message
+- Send >20 MB image → Telegram rejects before it reaches Nous
+- Send photo, then ask about it in next message → history shows "[Image was sent and analyzed]"
+
+## Implementation Order
+
+1. **`nous/api/attachments.py`** — New module: sanitize, classify, validate, build_content_blocks, compact (pure functions, fully testable in isolation)
+2. **`nous/api/models.py`** — Update `Message` dataclass, add `Attachment` dataclass
+3. **`tests/test_attachments.py`** — Full unit test suite for attachment module
+4. **`nous/api/compaction.py`** — `estimate_image_tokens()`, `estimate_message()` for multimodal (must precede runner changes)
+5. **`nous/api/runner.py`** — Update `run_turn`, `stream_chat`, consumer migration (recent_messages, _format_history_text), compaction call in critical path
+6. **`nous/api/rest.py`** — Accept attachments in `/chat` and `/chat/stream` with security validation
+7. **`nous/telegram_bot.py`** — File download helper + handler updates + error handling + typing indicators
+8. **Integration tests** — End-to-end validation across all paths
+
+## Known Limitations
+
+- **Telegram media groups** — When a user sends multiple photos as an album, Telegram delivers them as separate messages with the same `media_group_id`. Currently each is processed independently. Future: batch by `media_group_id` with a brief timeout.
+- **No rate limiting** — No per-user limit on file uploads. A user could send many large files rapidly. Future: add rate limiting per user per time window.
+- **MIME type trust** — We trust Telegram's declared MIME type. Future enhancement: validate via magic bytes.
+- **No Office doc support** — `.docx`, `.xlsx`, `.pptx` require external libraries. Out of scope for v1.
+- **No audio/video** — Would require Whisper or similar transcription service. Out of scope.
+
+## Migration
+
+No database schema changes required. Conversation history is JSON — the format change (`str` → `str | list`) is backward-compatible. Existing conversations with `str` content continue to work. New multimodal messages are compacted to string/simple-list format before persistence.
+
+## Future Extensions (Out of Scope)
+
+- **Office document conversion** (.docx → text via `python-docx`, .xlsx → CSV via `openpyxl`)
+- **Audio transcription** (voice messages → Whisper API → text)
+- **Image generation** (outbound: generate images via DALL-E/Stability and send back)
+- **URL preview** (auto-fetch and screenshot URLs in messages)
+- **Anthropic Files API** (upload once, reference by ID — revisit when OAT auth is supported)
+- **Media group batching** (collect album photos into single multimodal message)

--- a/docs/reviews/011.2-architecture-review.md
+++ b/docs/reviews/011.2-architecture-review.md
@@ -1,0 +1,104 @@
+# 011.2 Architecture & System Integration Review
+
+**Reviewer:** Nous (manual, in-conversation)
+**Date:** 2025-03-02
+**Scope:** How the multimodal spec integrates with existing Nous architecture
+
+---
+
+## Critical Findings
+
+### 1. Token Estimation is Blind to Multimodal Content (HIGH)
+
+`TokenEstimator.estimate_messages()` does:
+```python
+sum(self.estimate(m.get("content", "")) + 4 for m in messages)
+```
+
+If `content` becomes a `list[dict]` (multimodal blocks), `estimate()` falls through to `len(str(content)) * ratio`. This is **wildly wrong** for images:
+- Claude counts image tokens by pixel dimensions (formula: `tokens = (width * height) / 750`), not by base64 length
+- A 1MB JPEG (1024x768) costs ~1,049 tokens but its base64 is ~1.33MB → `estimate()` would report ~350,000 tokens
+- Result: compaction triggers falsely, every image message looks like it's blowing the context window
+
+**Fix needed:** `estimate_messages` must detect multimodal content blocks and estimate image tokens by dimensions (available from PIL or Telegram's `PhotoSize`), not string length. Text blocks within the list should be estimated normally.
+
+### 2. Base64 Blobs Will Persist to Database (HIGH)
+
+`_save_conversation()` does:
+```python
+{"role": m.role, "content": m.content}
+```
+
+If `content` is a multimodal list with base64 blobs, the **entire blob persists to the DB**. A single 5MB image = ~6.7MB of base64 in the conversation record. Multiple images per session → database balloons fast.
+
+The spec mentions "history compaction" (replacing blobs with metadata) but doesn't specify **when** this happens. It must happen:
+- **Immediately after the API response** — before the message enters `conversation.messages`
+- **NOT during compaction** — that's too late, blobs are already persisted
+
+**Fix needed:** Add explicit lifecycle: `user sends file → build multimodal content → send to Claude → receive response → strip blobs from the user message in conversation history → persist stripped version`
+
+### 3. Compaction Summarizer Will Receive Image Blobs (MEDIUM)
+
+If blobs aren't stripped early (per finding #2), the compaction system will:
+1. Feed base64-laden messages to the summarization LLM
+2. Waste massive tokens on re-processing already-seen images
+3. Potentially exceed the summarizer's own context window
+
+Already partially addressed by `_has_image_content()` in compaction.py, but only for tool results, not user messages.
+
+### 4. Photo-Without-Caption UX Gap (MEDIUM)
+
+Telegram handler currently uses `MessageHandler(filters.TEXT)`. Adding photo/document handlers is straightforward, but the spec doesn't address:
+- What if user sends a photo **without a caption**? What's the implicit prompt?
+- Should default to "Describe and analyze this image" or ask "What would you like me to do with this?"
+- This is a UX decision that affects how the content block is constructed
+
+### 5. Telegram Media Groups Not Addressed (LOW)
+
+When a user sends multiple photos at once (media group), Telegram delivers them as separate `Message` objects with the same `media_group_id`. The spec doesn't address:
+- Should they be batched into one API call?
+- Timeout-based grouping? (Wait 500ms for more photos in same group)
+- Or just process each independently?
+
+---
+
+## Positive Architectural Alignment
+
+### Already Compatible
+- `_format_messages` passes `m.content` directly → works for both `str` and `list[dict]` ✅
+- `_has_image_content()` already exists in compaction module → reusable ✅
+- `Message` dataclass in models.py is simple enough to extend without breaking ✅
+- REST API's `ChatRequest` can add optional `attachments` field without breaking existing clients ✅
+
+### Good Design Choices in Spec
+- **Base64 over Files API** — correct for OAT auth, stateless, one-shot pattern
+- **Separate `attachments.py` module** — keeps runner.py clean, pure functions are testable
+- **`text_content` property** — elegant way to give subsystems a string view without losing multimodal data
+- **Backward compatible** — str content still works everywhere
+
+---
+
+## Architectural Recommendations
+
+1. **Define blob lifecycle explicitly** — strip base64 from conversation history immediately after API response, before persistence
+2. **Extend `TokenEstimator`** — add `estimate_image_tokens(width, height)` method using Claude's formula
+3. **Pass dimensions through** — `Attachment` dataclass should include `width` and `height` (Telegram provides these for photos)
+4. **Default caption for bare photos** — define UX behavior in spec
+5. **Consider `media_group_id` batching** — even if deferred, note it as future work
+6. **Ensure cognitive layer uses `text_content`** — episode summarization, recall, and frame selection should never see base64
+7. **Add `attachment_metadata` to Message** — lightweight dict with filename, type, size (no blob) that persists to DB for context
+
+---
+
+## Integration Impact Matrix
+
+| Subsystem | Impact | Notes |
+|-----------|--------|-------|
+| `runner.py` | MEDIUM | `run_turn`/`stream_chat` gain `attachments` param, content building |
+| `models.py` | LOW | `Message.content` type union, optional `attachments` field |
+| `rest.py` | LOW | `ChatRequest` adds optional `attachments` array |
+| `telegram_bot.py` | MEDIUM | New handlers for photo/document/sticker |
+| `compaction.py` | MEDIUM | Token estimation, image-aware compaction |
+| `cognitive/` | LOW | Use `text_content` for all text operations |
+| Database | LOW | If blobs stripped early, no schema change needed |
+| A2A protocol | NONE | No multimodal in agent-to-agent yet |

--- a/docs/reviews/011.2-dx-implementation-review.md
+++ b/docs/reviews/011.2-dx-implementation-review.md
@@ -1,0 +1,263 @@
+# 011.2 Multimodal File Support — Developer Experience & Implementation Quality Review
+
+**Reviewer:** Nous (background task)  
+**Date:** 2025-03-02  
+**Spec:** `docs/implementation/011.2-multimodal-file-support.md`
+
+---
+
+## 1. Code Organization ⚠️ Needs Attention
+
+**What's good:**
+- `nous/api/attachments.py` as a dedicated module for pure attachment logic (classify, validate, build_content_blocks) is the right call. These are transport-agnostic functions that belong in the API layer.
+- Keeping Telegram download logic in `telegram_bot.py` is correct — the download is inherently Telegram-specific (`bot.get_file`, `download_to_memory`).
+
+**Issues:**
+- **The spec mentions `telegram_files.py` as an alternative** (line: "In telegram_bot.py or a new telegram_files.py") but doesn't commit to a decision. A developer will have to make a judgment call. The `download_telegram_file` function is small enough to stay in `telegram_bot.py` — recommend committing to that location explicitly.
+- **`compact_message_for_history()`** is defined in Phase 3 but the spec doesn't state WHERE it lives. It should live in `attachments.py` since it's an attachment-related transformation, not in `runner.py`. But it could also argue for `compaction.py`. This needs a decision.
+- **`classify_attachment()`** is called from both `rest.py` (Phase 1C) and `telegram_bot.py` (Phase 2B). The spec correctly has it in `attachments.py`, but should call out this cross-module dependency explicitly.
+
+**Suggestion:** Add a "Module Map" section showing which functions live where and who calls them.
+
+---
+
+## 2. Testability ⚠️ Needs Attention
+
+**What's good:**
+- The core functions (`classify_attachment`, `validate_attachment`, `build_content_blocks`) are pure functions with clear inputs/outputs — very easy to unit test.
+- The spec explicitly calls out `tests/test_attachments.py` in the build order.
+
+**Missing test cases:**
+- **No test cases specified for `compact_message_for_history()`** — this is a critical function that needs round-trip testing (multimodal → compacted → can Claude still see the history correctly?).
+- **No test for the `text_content` extraction path** — what happens when `Message.text_content` is empty vs. populated? This matters for episode summarization and search.
+- **No test for REST API deserialization** — malformed attachment JSON, missing required fields, base64 that isn't valid base64.
+- **No tests for Telegram handler branching** — photo-only, document-only, photo+caption, document+caption, sticker, unsupported type, multiple photos.
+- **Token estimator changes** aren't tested — the spec lists "Token estimator" as step 8 but doesn't specify what the multimodal estimation should do.
+- **Edge case: what happens when an old conversation (str content) is loaded and a new multimodal message is appended?** Backward compatibility test.
+
+**Integration test plan:**
+- The listed tests are realistic but incomplete. Missing: "Send photo, then follow up with text-only referencing the photo" (verifies history compaction preserves context). Also missing: "REST API multimodal end-to-end test" (not just Telegram).
+
+**Suggestion:** Add a test matrix table covering each function × each edge case.
+
+---
+
+## 3. Error Messages ❌ Has a Bug/Gap
+
+**What's good:**
+- The spec handles the happy path well and includes validation.
+
+**Issues:**
+- **The spec shows `validate_attachment()` returns error strings like:**
+  - `"File too large: {att.filename} ({mb:.1f} MB, max {MAX_FILE_SIZE_MB} MB)"`
+  - `"Unsupported file type: {att.media_type}"`
+  
+  These tell the user what **failed** but not what **to do**. 
+
+- **Better error messages:**
+  - `"📎 {att.filename} is too large ({mb:.1f} MB). Please send files under {MAX_FILE_SIZE_MB} MB. Tip: compress the image or send it at lower resolution."`
+  - `"📎 I can't process {att.media_type} files yet. I support images (JPEG, PNG, GIF, WebP) and documents (PDF). Try converting to PDF or taking a screenshot."`
+  
+- **The warnings are prepended to user_message with `⚠️` prefix** and passed to Claude as context. This is clever but has a UX issue: the warnings reach the user only AFTER Claude processes the whole turn. For a large file that was rejected, the user waits for the full LLM round-trip just to see the error. Consider returning validation errors immediately via a Telegram reply before calling the API.
+
+- **No error message for Telegram download failures.** If `download_telegram_file()` raises (network issue, file expired, file too large for Telegram's 20 MB bot limit), there's no try/except shown. The whole handler would crash silently.
+
+**Suggestion:** Add a `try/except` around the download, with a user-facing message: "❌ I couldn't download that file. Please try sending it again."
+
+---
+
+## 4. Default Prompt ⚠️ Needs Attention
+
+**Current:** `"What can you tell me about this?"`
+
+**Analysis:**
+- This is a reasonable generic default — Claude will naturally describe images, summarize PDFs, and review code.
+- However, it's suboptimal because Claude performs better with specific instructions.
+
+**Should it vary by file type? Yes, mildly:**
+- **Images:** "What can you tell me about this?" → works well, Claude naturally describes
+- **PDF documents:** "Please summarize this document." → more useful default
+- **Code files (.py, .js, .ts):** "Please review this code." → more useful default
+- **Data files (.csv, .json):** "What's in this data?" → more useful default
+
+**However**, varying by file type adds complexity and may surprise users. A better approach:
+
+**Suggestion:** Keep a single default but make it slightly more actionable: `"I've shared a file with you. Please analyze it."` — or even simpler: keep the current default but document it as a configuration point for future tuning. The current wording is fine for v1.
+
+---
+
+## 5. Message Dataclass Changes ❌ Has a Bug/Gap — CRITICAL
+
+This is the highest-risk area of the entire spec.
+
+**The change:** `Message.content: str` → `Message.content: str | list[dict[str, Any]]`
+
+**Consumers that WILL BREAK:**
+
+1. **`_format_history_text()` (runner.py:1321)**
+   ```python
+   lines.append(f"{role_label}: {msg.content}")
+   ```
+   If `msg.content` is `list[dict]`, this produces: `"User: [{'type': 'image', 'source': {'type': 'base64', ...}}]"` — a massive garbage string dumped into reflection context. **The spec does not address this.**
+
+2. **`_save_conversation()` (runner.py:1334)**
+   ```python
+   {"role": m.role, "content": m.content}
+   ```
+   If content is `list[dict]` with base64 image data, this serializes the FULL base64 into JSON stored in the database. A 5 MB image = ~6.7 MB base64 = ~6.7 MB in the conversation JSON. **The spec mentions compact_message_for_history() but doesn't show where/when it's called relative to _save_conversation().** Is compaction called before save? After the API call but before persistence? This ordering is ambiguous.
+
+3. **`recent_messages` extraction (runner.py:299, 617)**
+   ```python
+   recent_messages = [
+       m.content for m in conversation.messages if m.role == "user"
+   ][-8:]
+   ```
+   The spec shows a fix using `m.text_content`, but only in one place. There are TWO identical blocks (line 299 for `run_turn`, line 617 for `stream_chat`). The spec must update BOTH.
+
+4. **`_format_messages()` (runner.py:1309)**
+   ```python
+   return [{"role": m.role, "content": m.content} for m in conversation.messages]
+   ```
+   This one actually works as-is for the Claude API (Claude accepts `list[dict]` content blocks). BUT — if `compact_message_for_history()` has already replaced image blocks with text placeholders, then this would send placeholders to Claude on subsequent turns, not original images. This is actually probably the desired behavior (you don't want to re-send base64 images on every turn), but the spec doesn't explicitly discuss this trade-off.
+
+5. **`estimate_messages()` in compaction.py** — The spec lists "Token estimator" as step 8 but the compaction module currently uses `estimate()` which does `len(text) // 4` for strings. A `list[dict]` content block would go through `str(text)` first — producing a massive string from the base64 representation. This would wildly over-estimate token counts and might trigger premature compaction. **The spec acknowledges this needs work but doesn't provide the implementation.**
+
+**The spec's `text_content` field is the right idea** but the spec doesn't provide a comprehensive migration plan for all consumers.
+
+**Suggestion — REQUIRED before implementation:**
+Add an explicit table:
+
+| Consumer | File | Line | Current | Change Needed |
+|----------|------|------|---------|---------------|
+| `recent_messages` | runner.py | 299, 617 | `m.content` | `m.text_content or str(m.content)` |
+| `_format_history_text` | runner.py | 1321 | `msg.content` | `msg.text_content or str(msg.content)` |
+| `_format_messages` | runner.py | 1309 | `m.content` | No change (but must compact first) |
+| `_save_conversation` | runner.py | 1334 | `m.content` | Must compact before saving |
+| `estimate_messages` | compaction.py | ~line 70 | handles str | Must handle list[dict] |
+
+---
+
+## 6. Implementation Order ⚠️ Needs Attention
+
+**Current order:**
+1. `attachments.py` — pure functions
+2. `models.py` — Message changes
+3. `tests/test_attachments.py` — unit tests
+4. `runner.py` — run_turn, stream_chat, format_messages, history compaction
+5. `rest.py` — API endpoints
+6. `telegram_bot.py` — file download + handlers
+7. Integration tests
+8. Token estimator
+
+**Issues:**
+
+- **Step 4 is too big.** It bundles: (a) run_turn/stream_chat attachment parameter, (b) content block construction, (c) history compaction, (d) _format_history_text fix, (e) _save_conversation fix. These should be sub-steps. History compaction (Phase 3) is independently complex and should be its own step.
+
+- **Step 8 (token estimator) should come BEFORE step 4**, or at least be included in step 4. Without correct token estimation, compaction will misbehave on multimodal messages from the moment they're introduced. It's not a nice-to-have — it's load-bearing.
+
+- **Steps 5 and 6 ARE parallelizable** — REST API changes and Telegram bot changes are independent once runner.py (step 4) is done. The spec doesn't mention this.
+
+- **Hidden dependency:** `compact_message_for_history()` (Phase 3) MUST be implemented before `_save_conversation` can safely accept multimodal messages. If a developer implements steps 1-4 without compaction and sends an image, the full base64 will be stored in the DB. **The compaction must be included in step 4, not left as a separate phase.**
+
+**Suggested revised order:**
+1. `attachments.py` — pure functions + `compact_message_for_history()`
+2. `models.py` — Message changes
+3. `tests/test_attachments.py` — unit tests (including compaction tests)
+4. `compaction.py` — Token estimator for multimodal
+5. `runner.py` — run_turn, stream_chat, all consumer fixes, save/load with compaction
+6. `rest.py` — API endpoints (parallelizable with 7)
+7. `telegram_bot.py` — file download + handlers (parallelizable with 6)
+8. Integration tests
+
+---
+
+## 7. Missing Pieces ❌ Has Gaps
+
+**Not covered by the spec:**
+
+1. **Logging** — No mention of logging anywhere. At minimum:
+   - Log when attachments are received (filename, size, type) at INFO level
+   - Log validation rejections at WARNING level
+   - Log download failures at ERROR level
+   - Log base64 encoding timing for large files at DEBUG level
+
+2. **Telegram "typing" indicator** — Processing a photo involves: download (network I/O) → base64 encode → send to Claude → get response. This can easily take 5-10 seconds. The spec doesn't mention sending `ChatAction.TYPING` before processing. Current code may already do this for text, but the additional download delay makes it more important for attachments.
+
+3. **Progress feedback for large files** — A 20 MB PDF will take time to download and process. No mention of intermediate feedback ("📎 Processing your document...").
+
+4. **Concurrent attachments** — The spec shows processing photos, documents, and stickers sequentially. Multiple attachments could be downloaded in parallel with `asyncio.gather()`.
+
+5. **Memory/cleanup** — Base64 strings for large files can be 20+ MB in memory. The spec doesn't discuss when these are released. After `compact_message_for_history()` is called, the original `Attachment` objects with `data_base64` should be eligible for GC, but since they're stored on the `Message` object's `attachments` field, they'll persist until the conversation is garbage-collected. Consider clearing `data_base64` after compaction.
+
+6. **Rate limiting** — No mention of per-user rate limits on file uploads. A user could spam large images and burn through Claude API credits fast (images cost significantly more tokens than text).
+
+7. **Telegram's 20 MB bot download limit** — The spec sets `MAX_FILE_SIZE_MB = 20` which matches Telegram's limit, but doesn't note that Telegram will reject the download before our code even sees it. The error experience for this case is undefined.
+
+8. **File groups** — Telegram has "media groups" (multiple photos sent together as an album). These arrive as separate updates with a `media_group_id`. The spec doesn't handle grouping them into a single request. For v1 this is acceptable, but should be noted as a known limitation.
+
+9. **Animated stickers/video stickers** — The spec correctly excludes animated stickers (`not message.sticker.is_animated`) but doesn't handle video stickers (`message.sticker.is_video`). These should also be excluded.
+
+10. **Voice messages / video notes** — Listed as "future extensions" but the spec doesn't specify what happens when a user sends one NOW. Should return a helpful error: "🎤 I can't process voice messages yet. Please type your message or send a text file."
+
+---
+
+## 8. Spec Clarity ⚠️ Needs Attention
+
+**Clear and well-structured:**
+- The phased approach (Core → Telegram → History) is logical
+- Code samples are concrete and copy-paste-ready
+- The "What Claude Supports" section is a good reference
+
+**Ambiguous areas a developer would need to ask about:**
+
+1. **Where does `compact_message_for_history()` get called?** The function is defined but the call site isn't shown. Is it called:
+   - After each API call, before the response is appended?
+   - On the USER message, after the API call completes?
+   - Both?
+   - In `_save_conversation`?
+
+2. **What happens to the `attachments` field on `Message` after compaction?** Is it kept (for metadata) or cleared (for memory)?
+
+3. **The `content_type` field on `Attachment`** — is it set during construction or is it always derived from `classify_attachment()`? The REST API path has `content_type=classify_attachment(...)` at construction, but the Telegram path sets `att.content_type = classify_attachment(...)` after construction. Inconsistent — should be a `@property` or always set at construction.
+
+4. **The `source` field** (`"telegram"`, `"rest"`, `"a2a"`) — is it used anywhere? It's defined but never referenced in any logic. If it's for logging/metrics only, say so.
+
+5. **What Anthropic model version is assumed?** Claude 3.5 Sonnet has different multimodal capabilities than Claude 3 Opus or Haiku. The spec should note the minimum model version requirement.
+
+6. **The REST API `size_bytes` field** — is it trusted or verified? The spec shows `a.get("size_bytes", 0)` defaulting to 0 if not provided. But then `validate_attachment()` checks against `MAX_FILE_SIZE_BYTES`. If `size_bytes` is 0 (or spoofed), validation passes even for huge files. Should decode the base64 and check actual length, or at minimum check `len(a["data_base64"]) * 3 / 4`.
+
+---
+
+## 9. Dependency Check ✅ Solid (with caveat)
+
+**005.2 (Direct API Rewrite):** ✅ Complete and merged. The current codebase uses direct Anthropic API calls. The `_format_messages()`, `_extract_text()`, and streaming infrastructure that 011.2 depends on are all in place.
+
+**008.1 (Conversation Compaction):** ✅ Complete. `Conversation`, `Message` dataclass, `_save_conversation`, `_load_conversation`, `TokenEstimator` are all implemented.
+
+**Potential conflict:** 008.1's `TokenEstimator.estimate_messages()` operates on `list[dict]` with string `content` values. It does `content = m.get("content", "")` then `self.estimate(content)`. When content becomes `list[dict]` (multimodal), this silently produces incorrect estimates. Not a merge conflict, but a **runtime bug** that will appear as soon as multimodal messages enter the compaction pipeline.
+
+---
+
+## Summary Table
+
+| Area | Rating | Key Issue |
+|------|--------|-----------|
+| 1. Code Organization | ⚠️ | Uncommitted file locations, missing module map |
+| 2. Testability | ⚠️ | Missing test cases for compaction, backward compat, REST deserialization |
+| 3. Error Messages | ❌ | Don't tell user what to do; no download failure handling |
+| 4. Default Prompt | ⚠️ | Fine for v1, but document as a tuning point |
+| 5. Message Dataclass | ❌ | **CRITICAL** — 5 consumers of `.content` will break; incomplete migration plan |
+| 6. Implementation Order | ⚠️ | Step 4 too big; token estimator must come earlier; compaction can't be deferred |
+| 7. Missing Pieces | ❌ | No logging, no typing indicator, no memory cleanup, no rate limiting |
+| 8. Spec Clarity | ⚠️ | Compaction call site ambiguous; several inconsistencies |
+| 9. Dependencies | ✅ | Both deps complete; TokenEstimator runtime conflict noted |
+
+---
+
+## Top 3 Actions Before Implementation
+
+1. **Audit every consumer of `Message.content`** and add the migration table from Section 5. This prevents runtime bugs in history, reflection, persistence, and compaction. Non-negotiable.
+
+2. **Move `compact_message_for_history()` into the critical path** — it must be called before `_save_conversation()`, and the implementation order must reflect this. Without it, the first image sent will store megabytes of base64 in the database.
+
+3. **Add error handling and Telegram feedback** — wrap `download_telegram_file()` in try/except, add `ChatAction.TYPING`, and make error messages tell users what to do next.

--- a/docs/reviews/011.2-review-synthesis.md
+++ b/docs/reviews/011.2-review-synthesis.md
@@ -1,0 +1,90 @@
+# 011.2 Review Synthesis — All Three Angles
+
+**Reviews conducted:** Security & Privacy, DX & Implementation Quality, Architecture & System Integration
+**Date:** 2025-03-02
+
+---
+
+## Cross-Review Priority Matrix
+
+### 🔴 CRITICAL (Must fix before implementation)
+
+**1. Message.content Consumer Migration (DX + Architecture)**
+Five existing consumers of `Message.content` assume `str` type. When content becomes `str | list[dict]`, these break silently at runtime:
+- `recent_messages` extraction (runner.py lines 299, 617) — both locations
+- `_format_history_text()` (runner.py:1321) — dumps raw dicts into reflection
+- `_save_conversation()` (runner.py:1334) — persists full base64 blobs to DB
+- `estimate_messages()` (compaction.py) — wildly incorrect token counts for images
+
+**Resolution:** Added explicit consumer migration table with file/line/change for each. Added `text_content` property usage everywhere.
+
+**2. Blob Lifecycle Ambiguity (Architecture + Security)**
+The spec said "compact after API call" but never specified the exact call site or ordering relative to `_save_conversation()`. Without explicit ordering, base64 blobs will persist to the database.
+
+**Resolution:** Defined explicit lifecycle: `build blocks → send to Claude → receive response → compact user message → append assistant response → persist`. Compaction happens BEFORE persistence, BEFORE the next turn.
+
+**3. Token Estimation for Multimodal (Architecture + DX)**
+`TokenEstimator.estimate_messages()` uses string length for token estimation. Base64 image data would produce wildly incorrect counts (350K tokens for a 1MB image that actually costs ~1,049 tokens), causing false compaction triggers.
+
+**Resolution:** Moved Phase 4 (Token Estimator) to Step 4 in build order, before runner changes. Added `estimate_image_tokens(width, height)` using Claude's actual formula.
+
+### 🟡 HIGH (Should fix before implementation)
+
+**4. Security Hardening — Filename Injection (Security)**
+User-supplied filenames from Telegram are untrusted input. Path traversal, null bytes, shell metacharacters.
+
+**Resolution:** Added `sanitize_filename()` to attachments.py. Applied at download time.
+
+**5. REST API Size Trust (Security + DX)**
+`size_bytes` field from REST clients could be spoofed (including 0). Validation would pass for huge files.
+
+**Resolution:** Added actual base64 length validation: `actual_size = len(data_base64) * 3 / 4`. Don't trust client-declared size.
+
+**6. Error Messages Don't Guide Users (DX)**
+Current: "File too large: photo.jpg (25.0 MB, max 20 MB)"
+Better: "📎 photo.jpg is too large (25.0 MB). Please send files under 20 MB. Tip: compress the image or send at lower resolution."
+
+**Resolution:** Updated error templates to be actionable. Added unsupported type guidance.
+
+**7. No Download Error Handling (DX + Security)**
+`download_telegram_file()` has no try/except. Network failures, expired files, or Telegram 20MB limit would crash the handler silently.
+
+**Resolution:** Added try/except with user-facing error message and graceful fallback to text-only.
+
+### 🟢 MEDIUM (Include in v1)
+
+**8. Logging (DX)**
+No logging mentioned anywhere. Added INFO for attachments received, WARNING for rejections, ERROR for download failures. Base64 content truncated in all logs.
+
+**9. Telegram Typing Indicator (DX)**
+File processing adds 5-10s of latency. Added `ChatAction.TYPING` before download/processing.
+
+**10. Video Stickers (DX)**
+Spec excluded `is_animated` but missed `is_video`. Added exclusion.
+
+**11. Default Prompt Improvement (DX + Architecture)**
+"What can you tell me about this?" works but is generic. Kept for v1, documented as tuning point.
+
+**12. Memory Cleanup (DX)**
+After compaction, `Attachment.data_base64` should be cleared to allow GC of large strings. Added `att.data_base64 = ""` after compact.
+
+### 🔵 LOW (Future work, noted in spec)
+
+**13. Media Group Batching (Architecture)** — Telegram albums arrive as separate messages with `media_group_id`. Noted as known limitation.
+**14. Rate Limiting (Security)** — Per-user file upload limits. Noted as future work.
+**15. Unsupported Type Immediate Response (DX)** — Voice messages get a helpful error now, not silence.
+
+---
+
+## Changes Made to Spec
+
+1. Added **Module Map** showing function → file → callers
+2. Added **Consumer Migration Table** for all `Message.content` users
+3. Added **Blob Lifecycle** section with explicit ordering
+4. Added **Security** section: filename sanitization, size validation, base64 validation
+5. Reordered **Implementation Steps**: token estimator moved to step 4, compaction merged into critical path
+6. Added **Logging** section
+7. Updated **Error Messages** to be actionable
+8. Added missing **Test Cases**: compaction round-trip, backward compat, REST deserialization, download failure
+9. Added **Known Limitations** section
+10. Added explicit handling for video stickers, voice messages

--- a/docs/reviews/011.2-security-review.md
+++ b/docs/reviews/011.2-security-review.md
@@ -1,0 +1,51 @@
+# 011.2 Security & Privacy Review
+
+**Reviewer:** Subtask agent (38bb9148)
+**Date:** 2025-03-02
+**Scope:** Security attack surface, data handling, privacy implications
+
+---
+
+## Critical Findings
+
+### 1. Filename Injection (HIGH)
+- User-supplied filenames from Telegram documents are untrusted input
+- Could contain path traversal (`../../etc/passwd`), null bytes, or shell metacharacters
+- Must sanitize before any logging, storage, or processing
+
+### 2. File Size Trust (HIGH)
+- Telegram provides file size metadata but it shouldn't be trusted blindly
+- Must validate actual downloaded bytes against declared size
+- Enforce hard limits: 20MB images, 32MB PDFs, regardless of what Telegram metadata says
+
+### 3. Base64 Validation (MEDIUM)
+- After base64-encoding, validate the output is legitimate base64
+- Malformed content could cause downstream errors in Claude API
+- Validate MIME type matches actual file content (don't trust file extension alone)
+
+### 4. Memory/DoS Concerns (MEDIUM)
+- Base64 encoding increases payload size by ~33%
+- Multiple simultaneous file uploads could exhaust memory
+- Need per-request and per-user rate limits on file processing
+- Consider streaming download rather than loading entire file into memory
+
+### 5. Privacy — Blob Leakage (HIGH)
+- Base64 blobs must NOT leak into:
+  - Episode summaries
+  - Fact storage
+  - Decision records
+  - Log files (truncate in logging)
+- History compaction must strip blobs completely, not just summarize them
+
+## Positive Design Aspects
+- Base64 over Files API avoids external file state and third-party persistence
+- Stripping blobs from history after processing is the right pattern
+- No persistent file storage on Nous side reduces attack surface
+
+## Recommendations
+1. Sanitize all filenames — strip path components, limit characters, enforce max length
+2. Validate MIME type via magic bytes, not just extension
+3. Enforce strict size limits at download time (stream with byte counter)
+4. Add rate limiting: max N file messages per minute per user
+5. Ensure all logging of multimodal content truncates base64 data
+6. Add integration tests that verify blobs don't appear in persisted conversation history


### PR DESCRIPTION
## Summary
Adds implementation spec for multimodal file support — images, PDFs, and text files via Telegram and REST API.

## What's Included
- **docs/implementation/011.2-multimodal-file-support.md** — Full implementation spec (v2, post-review)
- **docs/reviews/011.2-security-review.md** — Security & privacy review
- **docs/reviews/011.2-dx-implementation-review.md** — Developer experience & implementation quality review
- **docs/reviews/011.2-architecture-review.md** — Architecture & system integration review
- **docs/reviews/011.2-review-synthesis.md** — Cross-review synthesis with prioritized findings

## Key Design Decisions
- **Base64 transport** over Anthropic Files API — OAT auth incompatibility (hard blocker), beta with no ZDR, vendor lock-in, unnecessary state for one-shot usage pattern
- **History compaction** — base64 blobs replaced with metadata after processing to prevent DB bloat
- **9-step critical path** defined for blob lifecycle (build -> send -> receive -> compact -> GC -> persist)
- **Backward compatible** — Message.content becomes str or list[dict], existing string usage preserved

## Critical Issues Found and Fixed in Review
1. **5 consumer sites** in runner.py/compaction.py assume content is string — migration table added
2. **Blob lifecycle ordering** was ambiguous — could persist base64 to DB without explicit ordering
3. **Token estimation** wrong for images — string length != image tokens, would trigger false compaction

## Supported File Types
- Images: JPEG, PNG, GIF, WebP (up to 20MB)
- PDFs: up to 32MB / 100 pages
- Text: .py, .js, .json, .md, .csv, .yaml, .sql, etc.
- Future: audio/video (needs Whisper), Office docs (needs python-docx/openpyxl)

## Build Order
1. Attachment module (pure functions, easy to test)
2. Message model updates
3. Token estimator fix
4. Runner + REST integration
5. Telegram bot handler