### PR TITLE
fix: handle thinking blocks in LLM handler responses

### DIFF
--- a/nous/handlers/episode_summarizer.py
+++ b/nous/handlers/episode_summarizer.py
@@ -159,7 +159,17 @@ class EpisodeSummarizer:
                 return None
 
             data = response.json()
-            text = data.get("content", [{}])[0].get("text", "")
+            # Find the text block — skip thinking blocks if present
+            text = ""
+            for block in data.get("content", []):
+                if block.get("type") == "text":
+                    text = block.get("text", "")
+                    break
+
+            if not text:
+                logger.warning("Summary LLM returned empty text (content blocks: %s)",
+                               [b.get("type") for b in data.get("content", [])])
+                return None
 
             return json.loads(text)
 

--- a/nous/handlers/fact_extractor.py
+++ b/nous/handlers/fact_extractor.py
@@ -189,7 +189,12 @@ class FactExtractor:
                 return []
 
             data = response.json()
-            text = data.get("content", [{}])[0].get("text", "")
+            # Find the text block — skip thinking blocks if present
+            text = ""
+            for block in data.get("content", []):
+                if block.get("type") == "text":
+                    text = block.get("text", "")
+                    break
             return json.loads(text)
 
         except (json.JSONDecodeError, httpx.TimeoutException):

--- a/nous/handlers/knowledge_extractor.py
+++ b/nous/handlers/knowledge_extractor.py
@@ -193,7 +193,12 @@ class KnowledgeExtractor:
                 return []
 
             data = response.json()
-            text = data.get("content", [{}])[0].get("text", "")
+            # Find the text block — skip thinking blocks if present
+            text = ""
+            for block in data.get("content", []):
+                if block.get("type") == "text":
+                    text = block.get("text", "")
+                    break
             return json.loads(text)
 
         except (json.JSONDecodeError, httpx.TimeoutException):

--- a/nous/handlers/sleep_handler.py
+++ b/nous/handlers/sleep_handler.py
@@ -241,7 +241,12 @@ class SleepHandler:
                 return
 
             data = response.json()
-            text = data.get("content", [{}])[0].get("text", "")
+            # Find the text block — skip thinking blocks if present
+            text = ""
+            for block in data.get("content", []):
+                if block.get("type") == "text":
+                    text = block.get("text", "")
+                    break
             reflection = json.loads(text)
 
             # Store reflection summary as a fact


### PR DESCRIPTION
## Problem

Episode summarizer (and 3 other handlers) fail silently with:
```
Summary generation failed: Expecting value: line 1 column 1 (char 0)
```

This is why 13 out of 15 recent episodes have no summary despite the summarizer running.

## Root Cause

All handlers extract text with:
```python
text = data.get("content", [{}])[0].get("text", "")
```

When the model returns thinking blocks (extended thinking / adaptive), `content[0]` is a thinking block with no `text` field → empty string → `json.loads("")` fails.

## Fix

Iterate content blocks to find `type=text`:
```python
for block in data.get("content", []):
    if block.get("type") == "text":
        text = block.get("text", "")
        break
```

Fixed in all 4 handlers: episode_summarizer, fact_extractor, knowledge_extractor, sleep_handler.

Added diagnostic logging when text is empty (logs block types for debugging).