### PR TITLE
docs: add INFO-level script logging to 012.3 run_python spec

### DIFF
--- a/docs/implementation/012.3-programmatic-tool-calling.md
+++ b/docs/implementation/012.3-programmatic-tool-calling.md
@@ -142,6 +142,13 @@ Env vars: `NOUS_PROGRAMMATIC_TOOLS_ENABLED=true`, `NOUS_PROGRAMMATIC_TOOLS_TIMEO
 
 ### Part 2: `run_python` tool (`nous/api/tools.py`)
 
+Add module-level logger (if not already present):
+
+```python
+import logging
+logger = logging.getLogger(__name__)
+```
+
 Add to `create_nous_tools()`:
 
 ```python
@@ -218,6 +225,7 @@ async def run_python(code: str) -> dict[str, Any]:
         exec(compile(code, "<nous_script>", "exec"), namespace)
 
     _timeout = settings.programmatic_tools_timeout
+    logger.info("run_python | %d chars\n%s", len(code), code)
     try:
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
             future = executor.submit(_run)


### PR DESCRIPTION
Adds `logger.info()` call before executor submit so every `run_python` script is captured at INFO level.

Logs: `run_python | <N> chars\n<script>`

Also adds `import logging` / `logger = logging.getLogger(__name__)` module-level note since the spec did not mention it.