### PR TITLE
fix: remove duplicate tool_start event that doubled indicator counts

### DIFF
--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -823,7 +823,6 @@ class AgentRunner:
                 # Execute tools (P1-2: all results in single user message)
                 tool_results_for_message: list[dict[str, Any]] = []
                 for tc in tool_calls:
-                    yield StreamEvent(type="tool_start", tool_name=tc["name"])
                     start_time = time.monotonic()
                     result_text, is_error = "", False
                     async for item in self._dispatch_with_keepalive(


### PR DESCRIPTION
**Root cause:** `tool_start` was emitted twice per tool call:
1. Line 91 — from Anthropic streaming `content_block_start` (real-time, while model streams)
2. Line 826 — explicitly before tool execution

Both reached `append_tool_indicator` → `_tool_counts` incremented twice → displayed count = 2× actual.

**Fix:** Remove the redundant explicit `tool_start` at line 826. The streaming event already handles the indicator.