### PR TITLE
F014: Frame Reasoning Scaffolds

### DIFF
--- a/docs/features/F014-reasoning-scaffolds.md
+++ b/docs/features/F014-reasoning-scaffolds.md
@@ -1,6 +1,6 @@
 # F014 — Frame Reasoning Scaffolds
 
-**Status:** Draft (v3 — revised after architecture review)  
+**Status:** Draft (v4 — approved with required revisions)  
 **Author:** Nous (with Tim)  
 **Created:** 2026-03-05  
 **Revised:** 2026-03-05  
@@ -48,10 +48,24 @@ Why pilot Decision first:
 
 ### Success Criteria (2-week measurement window)
 
+**Success (expand to next frame):**
 - Average reason count per decision increases (baseline: current avg)
 - Confidence calibration improves (fewer 0.95+ decisions that get marked as failures)
 - No increase in scaffold-related token costs > 15% per decision turn
 - Qualitative: decision descriptions become more structured without feeling formulaic
+
+**Failure (kill or redesign):**
+- Token cost increase > 25% with no measurable quality improvement
+- Scaffold steps are parroted mechanically without genuine reasoning (cargo cult)
+- Decision recording frequency drops (scaffold overhead discourages recording)
+- Tim reports the agent feels formulaic or robotic in decision conversations
+
+**Pre-pilot baseline task:** Before enabling scaffolds, run a query against the `decisions` table to capture:
+- Average reason count per decision (last 30 days)
+- Confidence distribution histogram (buckets: 0-0.5, 0.5-0.7, 0.7-0.85, 0.85-0.95, 0.95-1.0)
+- Decision-to-failure rate by confidence bucket
+- Average token usage per decision-frame turn
+Store as a fact in Heart for comparison at pilot end.
 
 ### File Structure
 
@@ -92,6 +106,12 @@ DECISION_SCAFFOLD_SHORT = (
 )
 
 
+import os
+
+# Kill switch — set NOUS_REASONING_SCAFFOLDS=false to disable all scaffolds
+SCAFFOLDS_ENABLED = os.getenv("NOUS_REASONING_SCAFFOLDS", "true").lower() in ("true", "1", "yes")
+
+
 def get_scaffold(frame_id: str, turn_in_frame: int, message_length: int) -> str | None:
     """Return the appropriate scaffold for a frame and turn.
 
@@ -103,6 +123,10 @@ def get_scaffold(frame_id: str, turn_in_frame: int, message_length: int) -> str 
     Returns:
         Scaffold string, or None if no scaffold applies.
     """
+    # Kill switch
+    if not SCAFFOLDS_ENABLED:
+        return None
+
     # Phase 1: Only Decision frame gets a scaffold
     if frame_id != "decision":
         return None
@@ -126,8 +150,8 @@ def _get_frame_instructions(self, turn_context: TurnContext) -> str:
     # Check for reasoning scaffold (replaces tool nudges for scaffolded frames)
     scaffold = get_scaffold(
         frame_id=frame_id,
-        turn_in_frame=turn_context.turn_in_frame,  # requires tracking
-        message_length=len(turn_context.user_message or ""),
+        turn_in_frame=turn_context.turn_in_frame,  # tracked in runner.py turn loop
+        message_length=turn_context.message_length,  # set by runner.py from user message
     )
     if scaffold:
         return scaffold
@@ -142,7 +166,21 @@ Key: scaffolds **replace** the existing `_get_frame_instructions()` return for t
 
 ### Turn Tracking
 
-Add `turn_in_frame: int` to TurnContext (or derive from conversation history). Resets when frame changes.
+Add two fields to `TurnContext` in `nous/nous/cognitive/schemas.py`:
+
+```python
+class TurnContext(BaseModel):
+    # ... existing fields ...
+    turn_in_frame: int = 1       # resets when frame changes
+    message_length: int = 0      # char length of user message (for complexity gate)
+```
+
+**Tracking site: `runner.py` turn loop.** The runner already owns the turn loop and has access to the user message. Before calling `_get_frame_instructions()`:
+- Set `turn_context.message_length = len(user_message)`
+- Track frame changes: if `current_frame != previous_frame`, reset `turn_in_frame` to 1; otherwise increment
+- This avoids passing raw user messages into TurnContext (only the length is needed for the complexity gate)
+
+**Config flag:** Add `NOUS_REASONING_SCAFFOLDS=true` to `.env` (kill switch, follows existing `NOUS_*_ENABLED` pattern).
 
 Token savings from compression:
 - Turn 1: ~280 tokens (full scaffold)
@@ -263,10 +301,11 @@ def get_scaffold(frame_id: str, turn_in_frame: int, message_length: int) -> str 
 RESEARCH_SUBTASK_SCAFFOLD = (
     "You are executing a research subtask. Follow this process:\n"
     "1. SCOPE — Define what you're researching and success criteria.\n"
-    "2. SEARCH — Use web_search with multiple query angles.\n"
-    "3. GATHER — Use web_fetch to read promising sources. Note conflicts.\n"
-    "4. SYNTHESIZE — Combine findings. Separate facts from inference.\n"
-    "5. DELIVER — Structured summary with key findings, sources, and confidence.\n"
+    "2. RECALL — Use recall_deep to check what is already known. Don't re-research existing knowledge.\n"
+    "3. SEARCH — Use web_search with multiple query angles for gaps not covered by memory.\n"
+    "4. GATHER — Use web_fetch to read promising sources. Note conflicts between sources and memory.\n"
+    "5. SYNTHESIZE — Combine memory + new findings. Separate facts from inference.\n"
+    "6. DELIVER — Structured summary with key findings, sources, and confidence.\n"
     "Deliver a clear, complete result. Do not ask questions."
 )
 
@@ -331,12 +370,12 @@ When Cognition Engine protocol ships:
 
 | File | Change |
 |------|--------|
-| `nous/nous/cognitive/scaffolds.py` | **NEW** — scaffold templates + `get_scaffold()` function |
-| `nous/nous/api/runner.py` | Modify `_get_frame_instructions()` to call `get_scaffold()` first |
+| `nous/nous/cognitive/scaffolds.py` | **NEW** — scaffold templates, `get_scaffold()` function, kill switch |
+| `nous/nous/api/runner.py` | Modify `_get_frame_instructions()` to call `get_scaffold()` first; track `turn_in_frame` + `message_length` in turn loop |
 | `nous/nous/api/tools.py` | Modify `build_subtask_prefix()` for research scaffold |
-| `nous/nous/cognitive/context.py` | Add `turn_in_frame` tracking to TurnContext |
+| `nous/nous/cognitive/schemas.py` | Add `turn_in_frame: int` and `message_length: int` fields to `TurnContext` |
+| `.env` | Add `NOUS_REASONING_SCAFFOLDS=true` config flag |
 | `nous/nous/heart/heart.py` | Phase 2 only — template storage/retrieval |
-| `nous/nous/cognitive/schemas.py` | Phase 2 only — template Pydantic models |
 
 ---
 
@@ -367,6 +406,15 @@ When Cognition Engine protocol ships:
 
 ## Revision History
 
+**v4 (2026-03-05) — Approved with required revisions (Round 2 review):**
+- **Kill switch re-added:** `NOUS_REASONING_SCAFFOLDS=true` env var with `SCAFFOLDS_ENABLED` gate in `get_scaffold()` (follows `NOUS_*_ENABLED` pattern; caught as regression from v2)
+- **TurnContext fixed:** `turn_context.user_message` reference replaced with `message_length: int` field (`user_message` doesn't exist on TurnContext)
+- **Affected files fixed:** `context.py` → `schemas.py` for TurnContext changes; added `.env` to affected files
+- **Turn tracking clarified:** `runner.py` is the tracking site; both `turn_in_frame` and `message_length` set there before `_get_frame_instructions()` call
+- **Research scaffold:** Added RECALL step (step 2) before SEARCH — check memory before hitting the web
+- **Failure criteria added:** Explicit kill/redesign conditions alongside success metrics
+- **Baseline metrics:** Promoted from open question to concrete pre-pilot task with specific queries
+
 **v3 (2026-03-05) — Post-architecture-review:**
 - **Rollout changed:** Decision frame pilot first (2 weeks), expand only after measurement
 - **Research scaffold:** Moved to `build_subtask_prefix()` in tools.py (not frame system)
@@ -394,4 +442,3 @@ When Cognition Engine protocol ships:
 1. Should scaffolds be visible in the agent's response, or purely internal (thinking block only)?
 2. Template inheritance — should subtasks inherit the parent's scaffold or get their own based on frame_type?
 3. How should scaffold compression handle frame switches mid-conversation? (Reset turn count per frame switch — proposed default)
-4. What's the baseline decision quality metric? Need to measure current avg reason count, confidence distribution, and failure rate before pilot starts.

--- a/docs/features/F014-reasoning-scaffolds.md
+++ b/docs/features/F014-reasoning-scaffolds.md
@@ -1,0 +1,297 @@
+# F014 — Frame Reasoning Scaffolds
+
+**Status:** Draft  
+**Author:** Nous (with Tim)  
+**Created:** 2026-03-05  
+**Depends on:** F003 (Frames), F002 (Brain/Decisions), F001 (Heart/Memory)  
+**Inspired by:** Paper #11 (Semi-Formal Reasoning Templates, arXiv 2603.01896v1)
+
+---
+
+## Problem
+
+Nous has 7 cognitive frames (task, question, decision, creative, conversation, debug, initiation) that control **tool availability** and **context budgets**, but they provide only generic prose instructions. There is no structured reasoning guidance — the agent decides *how* to think about each task ad hoc.
+
+Research (Paper #11, Kostka 2026) shows that semi-formal reasoning templates improve LLM accuracy by up to 30% on code analysis tasks. The key insight: **structured scaffolds constrain the reasoning path without constraining the conclusion**, reducing hallucination, improving consistency, and producing auditable deliberation traces.
+
+Currently:
+- Frame instructions in `runner.py::_get_frame_instructions()` are tool-use nudges, not reasoning scaffolds
+- `deliberation.py` has a basic `_should_deliberate()` gate but no structured deliberation process
+- Decision `record_decision` captures *what* was decided but not the structured *reasoning process*
+- No quality gates on memory operations (facts get stored without consistency checks)
+
+## Solution
+
+Add **Reasoning Scaffold Templates** to each frame — structured step-by-step thinking patterns that are injected into the system prompt alongside existing tool instructions. Templates are semi-formal: they define required reasoning phases without constraining the content of each phase.
+
+## Design Principles
+
+1. **Scaffolds guide, not constrain** — Templates define *what steps to take*, not *what to conclude*
+2. **Frame-native** — Each frame gets scaffolds matched to its cognitive purpose
+3. **Auditable** — Deliberation traces stored with decisions, enabling calibration analysis
+4. **Adaptive** — Templates can be skipped for trivial tasks (under a complexity threshold)
+5. **Extensible** — New templates can be added without code changes (DB-driven in Phase 3)
+
+---
+
+## Architecture
+
+### Phase 1: Static Scaffolds (Prompt Injection)
+
+Extend `_get_frame_instructions()` in `runner.py` to include reasoning scaffolds per frame.
+
+#### Frame Scaffolds
+
+**Decision Frame:**
+```
+REASONING SCAFFOLD — Decision Analysis:
+1. CONTEXT: State the decision and constraints
+2. RECALL: Search for similar past decisions (recall_deep)
+3. OPTIONS: Enumerate at least 2 alternatives
+4. TRADEOFFS: For each option, list pros/cons/risks
+5. EVIDENCE: Rate evidence strength (strong/moderate/weak/none) for each option
+6. CONFIDENCE: Score 0.0-1.0 — evidence FOR minus evidence AGAINST, not optimism
+7. DECIDE: Choose and record with record_decision
+```
+
+**Debug Frame:**
+```
+REASONING SCAFFOLD — Diagnostic Analysis:
+1. SYMPTOM: Describe the observed behavior precisely
+2. REPRODUCE: Can the issue be reproduced? Under what conditions?
+3. ISOLATE: Narrow scope — what works, what doesn't?
+4. HYPOTHESIZE: Generate at least 2 candidate root causes
+5. TEST: Design a test to distinguish between hypotheses
+6. VERIFY: Confirm the root cause with evidence
+7. FIX: Implement and verify the fix
+8. RECORD: Store root cause as fact, record decision if approach was chosen
+```
+
+**Task Frame:**
+```
+REASONING SCAFFOLD — Task Execution:
+1. UNDERSTAND: Restate the task and success criteria
+2. RECALL: Check memory for relevant context, past approaches, procedures
+3. PLAN: Break into steps if complex (>1 tool call likely)
+4. EXECUTE: Work through steps, checking results
+5. VERIFY: Does the output meet the success criteria?
+6. LEARN: Store any new facts discovered; record decisions if alternatives were chosen
+```
+
+**Research Frame (subtask):**
+```
+REASONING SCAFFOLD — Research Synthesis:
+1. SCOPE: Define the research question and boundaries
+2. GATHER: Search multiple sources (web_search, recall_deep)
+3. EVALUATE: Assess source quality and recency
+4. SYNTHESIZE: Identify patterns, contradictions, gaps across sources
+5. CONCLUDE: State findings with confidence levels
+6. STORE: Record key facts and cite sources
+```
+
+**Question Frame:**
+```
+REASONING SCAFFOLD — Knowledge Retrieval:
+1. CLASSIFY: What kind of question? (factual, opinion, procedural, temporal)
+2. RECALL: Search memory first (recall_deep, recall_recent)
+3. VERIFY: Is the recalled information current and reliable?
+4. SUPPLEMENT: If memory is insufficient, search web
+5. ANSWER: Respond with appropriate confidence qualifiers
+```
+
+**Creative Frame:**
+```
+REASONING SCAFFOLD — Creative Process:
+1. UNDERSTAND: What is being created and for whom?
+2. INSPIRE: Search for reference material and patterns
+3. GENERATE: Produce initial draft/concept
+4. EVALUATE: Does it meet the brief? What's missing?
+5. REFINE: Iterate on weak areas
+6. DELIVER: Present with rationale for key choices
+```
+
+**Conversation Frame:**
+Minimal scaffold — conversations should feel natural, not formulaic.
+```
+REASONING SCAFFOLD — Conversation:
+- If the user shares information, consider storing as fact
+- If a decision point arises, switch to decision reasoning
+- Proactively recall relevant context before responding
+```
+
+### Phase 2: Memory Quality Gates
+
+Add lightweight pre-commit checks before memory operations.
+
+#### Fact Quality Gate (before `learn_fact`)
+```
+Before storing a fact, verify:
+- ATOMIC: Does it contain exactly one piece of information?
+- NOVEL: Does it duplicate an existing fact? (recall_deep check)
+- CONFIDENT: Is the confidence level justified by evidence?
+- ATTRIBUTED: Is the source clear?
+```
+
+#### Decision Quality Gate (before `record_decision`)
+```
+Before recording a decision, verify:
+- ALTERNATIVES: Were at least 2 options considered?
+- EVIDENCE: Is there supporting evidence for the chosen option?
+- CALIBRATED: Does the confidence reflect uncertainty, not optimism?
+- DESCRIBED: Is the description a clean summary, not a stream-of-consciousness?
+```
+
+### Phase 3: DB-Driven Templates (Future)
+
+Move templates from hardcoded strings to a database table, enabling:
+- Runtime modification without code deploys
+- Per-domain template variants (e.g., "security decision" vs "architecture decision")  
+- Template versioning and A/B testing
+- User-customizable scaffolds
+
+#### Schema
+```sql
+CREATE TABLE reasoning_templates (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_id UUID NOT NULL REFERENCES agents(id),
+    frame_type VARCHAR(30) NOT NULL,
+    domain VARCHAR(100),  -- NULL = default for frame
+    template_name VARCHAR(200) NOT NULL,
+    steps JSONB NOT NULL,  -- ordered array of {name, instruction, required}
+    version INT NOT NULL DEFAULT 1,
+    active BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_reasoning_templates_lookup
+    ON reasoning_templates(agent_id, frame_type, domain)
+    WHERE active = true;
+```
+
+#### Step Schema (JSONB)
+```json
+[
+    {
+        "name": "CONTEXT",
+        "instruction": "State the decision and constraints",
+        "required": true
+    },
+    {
+        "name": "RECALL",
+        "instruction": "Search for similar past decisions",
+        "required": true
+    },
+    {
+        "name": "OPTIONS",
+        "instruction": "Enumerate at least 2 alternatives",
+        "required": true
+    }
+]
+```
+
+---
+
+## Implementation Plan
+
+### Phase 1 — Static Scaffolds (~3 hours)
+
+**1.1 — Extend `_get_frame_instructions()` in `runner.py`**
+- Add reasoning scaffold text to each frame's instruction block
+- Keep existing tool instructions; append scaffold after them
+- Gate behind a config flag `NOUS_REASONING_SCAFFOLDS=true` (default true)
+
+**1.2 — Extend `build_subtask_prefix()` in `tools.py`**
+- Subtasks should also receive scaffolds matching their `frame_type`
+- Extract scaffold text into a shared function used by both `_get_frame_instructions()` and `build_subtask_prefix()`
+
+**1.3 — Complexity Gate**
+- Add a simple heuristic: if user message < 20 chars and frame is `conversation`, skip scaffold
+- Prevents over-engineering simple greetings/acknowledgments
+
+### Phase 2 — Memory Quality Gates (~2 hours)
+
+**2.1 — Fact Quality Gate**
+- Add scaffold text to frames that encourage pre-commit checks before `learn_fact`
+- Not enforced programmatically in v1 — purely prompt-based guidance
+
+**2.2 — Decision Quality Gate**
+- Extend decision frame scaffold with explicit quality checklist
+- Log warning in `_check_safety_net()` if decision confidence > 0.9 (suspiciously high)
+
+### Phase 3 — DB-Driven Templates (~4 hours, future)
+
+**3.1 — Create `reasoning_templates` table**
+**3.2 — Seed with Phase 1 scaffolds**
+**3.3 — Modify `_get_frame_instructions()` to query DB**
+**3.4 — Add domain-specific template selection based on intent signals**
+
+---
+
+## Affected Files
+
+- `nous/api/runner.py` — Extend `_get_frame_instructions()` with scaffolds
+- `nous/api/tools.py` — Extend `build_subtask_prefix()` with scaffolds
+- `nous/cognitive/schemas.py` — Add `scaffold_enabled` to `FrameSelection` (Phase 1)
+- `nous/cognitive/deliberation.py` — Add confidence calibration warning (Phase 2)
+- `sql/migrations/` — New migration for `reasoning_templates` table (Phase 3)
+
+---
+
+## Token Budget Impact
+
+Each scaffold adds ~150-300 tokens to the system prompt. Current frame instructions are ~50-100 tokens each.
+
+**Estimated increase per frame:**
+- Decision: +250 tokens (most detailed scaffold)
+- Debug: +220 tokens
+- Task: +180 tokens
+- Research: +170 tokens
+- Question: +150 tokens
+- Creative: +160 tokens
+- Conversation: +80 tokens (minimal scaffold)
+
+**Mitigation:**
+- Complexity gate skips scaffolds for trivial interactions
+- Scaffolds are concise — step names + one-line instructions, not paragraphs
+- Net token cost is small vs. the quality improvement in reasoning
+
+---
+
+## Success Metrics
+
+1. **Decision quality** — Decisions recorded with ≥2 alternatives increase from ~30% to ~80%
+2. **Confidence calibration** — Mean absolute calibration error decreases (measured via outcome tracking)
+3. **Fact deduplication** — Duplicate fact rate drops by >50%
+4. **Debug resolution** — Root cause identification rate in debug frames improves
+5. **Deliberation traces** — >90% of decisions in decision frames follow the scaffold steps
+
+---
+
+## Research Connections
+
+- **Paper #11** (Semi-Formal Reasoning, arXiv 2603.01896) — Direct inspiration. Structured templates with natural language slots
+- **Paper #4** (SCL) — 5 cognitive phases map to scaffold steps (Cognition phase = our scaffold execution)
+- **Paper #5** (ACC) — Better structured reasoning produces better state for compression
+- **Paper #10** (ToM/IB) — Caution: scaffolds should be adaptive, not forced on simple tasks (weaker reasoning on trivial tasks wastes tokens)
+- **Paper #3** (Episodic Memory) — Scaffold traces become part of episodic memory, improving future recall
+
+---
+
+## CSTP / Cognition Engine Implications
+
+This feature has a natural extension path into the Cognition Engine / CSTP protocol:
+
+1. **Template serving** — CSTP could serve reasoning templates to connected agents based on decision category
+2. **Cross-agent calibration** — Scaffold traces enable comparing reasoning quality across different LLM backends
+3. **Template marketplace** — Domain-specific template packs (DevOps, Security, Architecture) as a product feature
+4. **Reasoning audit trail** — Every decision made through CSTP has a structured deliberation trace, not just a result
+
+---
+
+## Open Questions
+
+1. Should scaffolds be visible in the agent's response, or purely internal (thinking block only)?
+2. How aggressive should the complexity gate be? Risk of skipping scaffolds when they'd help vs. cluttering simple interactions
+3. Should Phase 2 quality gates be enforced programmatically (reject bad facts) or purely advisory (prompt guidance)?
+4. Template inheritance — should subtasks inherit the parent's scaffold or get their own based on frame_type?

--- a/docs/features/F014-reasoning-scaffolds.md
+++ b/docs/features/F014-reasoning-scaffolds.md
@@ -1,8 +1,9 @@
 # F014 — Frame Reasoning Scaffolds
 
-**Status:** Draft  
+**Status:** Draft (v2 — revised after review)  
 **Author:** Nous (with Tim)  
 **Created:** 2026-03-05  
+**Revised:** 2026-03-05  
 **Depends on:** F003 (Frames), F002 (Brain/Decisions), F001 (Heart/Memory)  
 **Inspired by:** Paper #11 (Semi-Formal Reasoning Templates, arXiv 2603.01896v1)
 
@@ -29,7 +30,7 @@ Add **Reasoning Scaffold Templates** to each frame — structured step-by-step t
 1. **Scaffolds guide, not constrain** — Templates define *what steps to take*, not *what to conclude*
 2. **Frame-native** — Each frame gets scaffolds matched to its cognitive purpose
 3. **Auditable** — Deliberation traces stored with decisions, enabling calibration analysis
-4. **Adaptive** — Templates can be skipped for trivial tasks (under a complexity threshold)
+4. **Adaptive** — Templates compress after first turn and skip for trivial interactions in appropriate frames
 5. **Extensible** — New templates can be added without code changes (DB-driven in Phase 3)
 
 ---
@@ -40,6 +41,14 @@ Add **Reasoning Scaffold Templates** to each frame — structured step-by-step t
 
 Extend `_get_frame_instructions()` in `runner.py` to include reasoning scaffolds per frame.
 
+#### Scaffold Compression (Turn-Aware Injection)
+
+To manage token costs over multi-turn conversations:
+- **Turn 1 in frame:** Inject full scaffold (150-300 tokens)
+- **Turn 2+ in frame:** Inject 1-line compressed reminder (e.g., "Follow the decision scaffold: CONTEXT → RECALL → OPTIONS → TRADEOFFS → EVIDENCE → CONFIDENCE → DECIDE")
+
+This requires tracking turn count per frame in `TurnContext`. The frame's turn counter resets when the frame changes.
+
 #### Frame Scaffolds
 
 **Decision Frame:**
@@ -47,7 +56,7 @@ Extend `_get_frame_instructions()` in `runner.py` to include reasoning scaffolds
 REASONING SCAFFOLD — Decision Analysis:
 1. CONTEXT: State the decision and constraints
 2. RECALL: Search for similar past decisions (recall_deep)
-3. OPTIONS: Enumerate at least 2 alternatives
+3. OPTIONS: Enumerate alternatives if viable ones exist. If there is only one reasonable option, explicitly state why alternatives were considered and rejected.
 4. TRADEOFFS: For each option, list pros/cons/risks
 5. EVIDENCE: Rate evidence strength (strong/moderate/weak/none) for each option
 6. CONFIDENCE: Score 0.0-1.0 — evidence FOR minus evidence AGAINST, not optimism
@@ -78,17 +87,6 @@ REASONING SCAFFOLD — Task Execution:
 6. LEARN: Store any new facts discovered; record decisions if alternatives were chosen
 ```
 
-**Research Frame (subtask):**
-```
-REASONING SCAFFOLD — Research Synthesis:
-1. SCOPE: Define the research question and boundaries
-2. GATHER: Search multiple sources (web_search, recall_deep)
-3. EVALUATE: Assess source quality and recency
-4. SYNTHESIZE: Identify patterns, contradictions, gaps across sources
-5. CONCLUDE: State findings with confidence levels
-6. STORE: Record key facts and cite sources
-```
-
 **Question Frame:**
 ```
 REASONING SCAFFOLD — Knowledge Retrieval:
@@ -111,35 +109,41 @@ REASONING SCAFFOLD — Creative Process:
 ```
 
 **Conversation Frame:**
-Minimal scaffold — conversations should feel natural, not formulaic.
+No scaffold. Conversations should feel natural, not formulaic. The existing frame instructions are sufficient. Fact storage should happen organically when the user explicitly shares information — not as a prompted checklist.
+
+**Initiation Frame:**
+No scaffold. Onboarding is a guided flow with its own structure.
+
+#### Research Subtask Scaffold
+
+Research is not a main-conversation frame — it's a subtask mode. This scaffold is injected via `build_subtask_prefix()` when `frame_type="research"` is passed to `spawn_task`.
+
 ```
-REASONING SCAFFOLD — Conversation:
-- If the user shares information, consider storing as fact
-- If a decision point arises, switch to decision reasoning
-- Proactively recall relevant context before responding
+REASONING SCAFFOLD — Research Synthesis:
+1. SCOPE: Define the research question and boundaries
+2. GATHER: Search multiple sources (web_search, recall_deep)
+3. EVALUATE: Assess source quality and recency
+4. SYNTHESIZE: Identify patterns, contradictions, gaps across sources
+5. CONCLUDE: State findings with confidence levels
+6. STORE: Record key facts and cite sources
 ```
 
-### Phase 2: Memory Quality Gates
+### Phase 2: Enhanced Brain Quality Checks
 
-Add lightweight pre-commit checks before memory operations.
+Instead of adding parallel prompt-based quality gates, **integrate quality checks into existing Brain validation flow**. This avoids conflicting enforcement layers.
 
-#### Fact Quality Gate (before `learn_fact`)
-```
-Before storing a fact, verify:
-- ATOMIC: Does it contain exactly one piece of information?
-- NOVEL: Does it duplicate an existing fact? (recall_deep check)
-- CONFIDENT: Is the confidence level justified by evidence?
-- ATTRIBUTED: Is the source clear?
-```
+#### Enhanced `_should_deliberate()` in `deliberation.py`
+- Before recording a decision, check if the scaffold's reasoning steps were followed
+- Flag decisions with confidence > 0.9 for extra scrutiny (suspiciously high)
+- Verify that alternatives were considered (if Decision scaffold was active)
 
-#### Decision Quality Gate (before `record_decision`)
-```
-Before recording a decision, verify:
-- ALTERNATIVES: Were at least 2 options considered?
-- EVIDENCE: Is there supporting evidence for the chosen option?
-- CALIBRATED: Does the confidence reflect uncertainty, not optimism?
-- DESCRIBED: Is the description a clean summary, not a stream-of-consciousness?
-```
+#### Enhanced `learn_fact` validation in Heart
+- Extend existing fact storage logic with lightweight checks:
+  - **ATOMIC:** Does the fact contain a single piece of information?
+  - **NOVEL:** Quick `recall_deep` check for potential duplicates before committing
+  - **ATTRIBUTED:** Is a source specified?
+- These are **programmatic checks in the storage layer**, not prompt injection
+- Non-blocking in v1: log warnings for quality issues but still store the fact
 
 ### Phase 3: DB-Driven Templates (Future)
 
@@ -153,7 +157,7 @@ Move templates from hardcoded strings to a database table, enabling:
 ```sql
 CREATE TABLE reasoning_templates (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    agent_id UUID NOT NULL REFERENCES agents(id),
+    agent_name VARCHAR(100) NOT NULL,  -- agent identifier (no agents table yet)
     frame_type VARCHAR(30) NOT NULL,
     domain VARCHAR(100),  -- NULL = default for frame
     template_name VARCHAR(200) NOT NULL,
@@ -165,9 +169,18 @@ CREATE TABLE reasoning_templates (
 );
 
 CREATE INDEX idx_reasoning_templates_lookup
-    ON reasoning_templates(agent_id, frame_type, domain)
+    ON reasoning_templates(agent_name, frame_type, domain)
     WHERE active = true;
 ```
+
+**Domain values** (initial set, aligned with `record_decision` categories):
+- `architecture`
+- `security`
+- `performance`
+- `integration`
+- `process`
+- `memory`
+- `debugging`
 
 #### Step Schema (JSONB)
 ```json
@@ -184,7 +197,7 @@ CREATE INDEX idx_reasoning_templates_lookup
     },
     {
         "name": "OPTIONS",
-        "instruction": "Enumerate at least 2 alternatives",
+        "instruction": "Enumerate alternatives if viable ones exist",
         "required": true
     }
 ]
@@ -194,77 +207,105 @@ CREATE INDEX idx_reasoning_templates_lookup
 
 ## Implementation Plan
 
-### Phase 1 — Static Scaffolds (~3 hours)
+### Phase 1 — Static Scaffolds (~4 hours)
 
-**1.1 — Extend `_get_frame_instructions()` in `runner.py`**
-- Add reasoning scaffold text to each frame's instruction block
+**1.1 — Scaffold Text Module**
+- Create shared scaffold definitions (used by both `_get_frame_instructions()` and `build_subtask_prefix()`)
+- Each scaffold is a simple string constant
+
+**1.2 — Extend `_get_frame_instructions()` in `runner.py`**
+- Append reasoning scaffold text to each frame's instruction block (except conversation + initiation)
 - Keep existing tool instructions; append scaffold after them
 - Gate behind a config flag `NOUS_REASONING_SCAFFOLDS=true` (default true)
 
-**1.2 — Extend `build_subtask_prefix()` in `tools.py`**
-- Subtasks should also receive scaffolds matching their `frame_type`
-- Extract scaffold text into a shared function used by both `_get_frame_instructions()` and `build_subtask_prefix()`
+**1.3 — Turn-Aware Scaffold Compression**
+- Add `frame_turn_count` to `TurnContext`
+- Increment when frame stays the same across turns; reset on frame change
+- Turn 1: full scaffold injection
+- Turn 2+: compressed 1-line reminder with step names only
 
-**1.3 — Complexity Gate**
-- Add a simple heuristic: if user message < 20 chars and frame is `conversation`, skip scaffold
-- Prevents over-engineering simple greetings/acknowledgments
+**1.4 — Extend `build_subtask_prefix()` in `tools.py`**
+- Inject Research scaffold when `frame_type="research"`
+- Inject frame-appropriate scaffold for other subtask frame types
 
-### Phase 2 — Memory Quality Gates (~2 hours)
+**1.5 — Complexity Gate**
+- Skip scaffold injection when ALL of:
+  - Frame is `conversation` or `initiation`
+  - User message < 20 chars
+- All other frames (task, debug, decision, question, creative) **always** get scaffolds regardless of message length
+- Rationale: if the frame classifier assigned a structured frame, the task needs structured reasoning even if the prompt is short
 
-**2.1 — Fact Quality Gate**
-- Add scaffold text to frames that encourage pre-commit checks before `learn_fact`
-- Not enforced programmatically in v1 — purely prompt-based guidance
+### Phase 2 — Enhanced Brain Quality Checks (~2 hours)
 
-**2.2 — Decision Quality Gate**
-- Extend decision frame scaffold with explicit quality checklist
-- Log warning in `_check_safety_net()` if decision confidence > 0.9 (suspiciously high)
+**2.1 — Extend `_should_deliberate()` in `deliberation.py`**
+- Use scaffold-informed criteria for deliberation triggers
+- Add confidence calibration warning for confidence > 0.9
+
+**2.2 — Extend fact storage validation in Heart**
+- Programmatic checks (atomic, novel, attributed) in the storage layer
+- Log warnings for quality issues in v1, don't block storage
 
 ### Phase 3 — DB-Driven Templates (~4 hours, future)
 
 **3.1 — Create `reasoning_templates` table**
 **3.2 — Seed with Phase 1 scaffolds**
-**3.3 — Modify `_get_frame_instructions()` to query DB**
+**3.3 — Modify `_get_frame_instructions()` to query DB (with cache)**
 **3.4 — Add domain-specific template selection based on intent signals**
 
 ---
 
 ## Affected Files
 
-- `nous/api/runner.py` — Extend `_get_frame_instructions()` with scaffolds
+- `nous/api/runner.py` — Extend `_get_frame_instructions()` with scaffolds + turn-aware compression
 - `nous/api/tools.py` — Extend `build_subtask_prefix()` with scaffolds
-- `nous/cognitive/schemas.py` — Add `scaffold_enabled` to `FrameSelection` (Phase 1)
-- `nous/cognitive/deliberation.py` — Add confidence calibration warning (Phase 2)
+- `nous/cognitive/schemas.py` — Add `frame_turn_count` to `TurnContext`
+- `nous/cognitive/deliberation.py` — Enhanced deliberation criteria (Phase 2)
+- `nous/memory/heart.py` — Fact quality checks in storage layer (Phase 2)
 - `sql/migrations/` — New migration for `reasoning_templates` table (Phase 3)
 
 ---
 
 ## Token Budget Impact
 
-Each scaffold adds ~150-300 tokens to the system prompt. Current frame instructions are ~50-100 tokens each.
+Each scaffold adds ~150-300 tokens to the system prompt on **first turn only**. Subsequent turns get a compressed 1-line reminder (~30-50 tokens).
 
-**Estimated increase per frame:**
-- Decision: +250 tokens (most detailed scaffold)
+**First-turn cost per frame:**
+- Decision: +250 tokens
 - Debug: +220 tokens
 - Task: +180 tokens
-- Research: +170 tokens
 - Question: +150 tokens
 - Creative: +160 tokens
-- Conversation: +80 tokens (minimal scaffold)
+- Conversation: +0 tokens (no scaffold)
+- Initiation: +0 tokens (no scaffold)
+- Research (subtask): +170 tokens
+
+**Multi-turn example (5-turn debug session):**
+- Without compression: 5 × 220 = 1,100 tokens
+- With compression: 220 + (4 × 40) = 380 tokens (65% reduction)
 
 **Mitigation:**
-- Complexity gate skips scaffolds for trivial interactions
+- Turn-aware compression reduces repetition cost dramatically
+- Complexity gate skips scaffolds for trivial conversations
 - Scaffolds are concise — step names + one-line instructions, not paragraphs
-- Net token cost is small vs. the quality improvement in reasoning
+
+---
+
+## Interaction with `run_python`
+
+Scaffolds guide **high-level reasoning and tool selection**, including what recall queries to batch in `run_python`. They do NOT inject into the Python execution environment itself.
+
+Example: A Decision scaffold step "RECALL: Search for similar past decisions" may cause the agent to write a `run_python` script that calls `recall_deep()` with relevant queries. The scaffold influenced *what* to search for, but the Python code itself runs in its normal sandboxed context.
 
 ---
 
 ## Success Metrics
 
-1. **Decision quality** — Decisions recorded with ≥2 alternatives increase from ~30% to ~80%
+1. **Decision quality** — Decisions with documented alternatives increase from ~30% to ~70%+
 2. **Confidence calibration** — Mean absolute calibration error decreases (measured via outcome tracking)
 3. **Fact deduplication** — Duplicate fact rate drops by >50%
 4. **Debug resolution** — Root cause identification rate in debug frames improves
 5. **Deliberation traces** — >90% of decisions in decision frames follow the scaffold steps
+6. **Token efficiency** — Multi-turn scaffold cost stays under 15% of total system prompt tokens
 
 ---
 
@@ -273,7 +314,7 @@ Each scaffold adds ~150-300 tokens to the system prompt. Current frame instructi
 - **Paper #11** (Semi-Formal Reasoning, arXiv 2603.01896) — Direct inspiration. Structured templates with natural language slots
 - **Paper #4** (SCL) — 5 cognitive phases map to scaffold steps (Cognition phase = our scaffold execution)
 - **Paper #5** (ACC) — Better structured reasoning produces better state for compression
-- **Paper #10** (ToM/IB) — Caution: scaffolds should be adaptive, not forced on simple tasks (weaker reasoning on trivial tasks wastes tokens)
+- **Paper #10** (ToM/IB) — Caution: scaffolds should be adaptive, not forced on simple tasks. Model capability is dominant factor — scaffolds amplify strengths but can confuse weak models
 - **Paper #3** (Episodic Memory) — Scaffold traces become part of episodic memory, improving future recall
 
 ---
@@ -289,9 +330,26 @@ This feature has a natural extension path into the Cognition Engine / CSTP proto
 
 ---
 
+## Revision History
+
+**v2 (2026-03-05) — Post-review updates:**
+- Dropped conversation scaffold entirely — conversations should feel natural
+- Dropped initiation scaffold — has its own guided flow
+- Renamed "Research Frame" to "Research Subtask Scaffold" — injected via `build_subtask_prefix()`, not frame system
+- Softened OPTIONS step from "at least 2 alternatives" to "enumerate if viable, explain why if not"
+- Added turn-aware scaffold compression (full on turn 1, 1-line reminder on turn 2+)
+- Merged Phase 2 into existing Brain validation flow — no parallel prompt-based quality gates
+- Fixed complexity gate: skip only in conversation + initiation frames, all structured frames always get scaffolds
+- Fixed Phase 3 schema: removed `agents(id)` FK reference (table doesn't exist), defined concrete domain values
+- Added `run_python` interaction section
+- Added token efficiency metric
+- Updated affected files list (added `heart.py`, `schemas.py`)
+
+---
+
 ## Open Questions
 
 1. Should scaffolds be visible in the agent's response, or purely internal (thinking block only)?
-2. How aggressive should the complexity gate be? Risk of skipping scaffolds when they'd help vs. cluttering simple interactions
-3. Should Phase 2 quality gates be enforced programmatically (reject bad facts) or purely advisory (prompt guidance)?
-4. Template inheritance — should subtasks inherit the parent's scaffold or get their own based on frame_type?
+2. Template inheritance — should subtasks inherit the parent's scaffold or get their own based on frame_type?
+3. Should Phase 2 fact quality checks become blocking (reject bad facts) after a validation period, or remain advisory permanently?
+4. How should scaffold compression handle frame switches mid-conversation? (e.g., conversation → decision → conversation — does decision get full scaffold again?)

--- a/docs/features/F014-reasoning-scaffolds.md
+++ b/docs/features/F014-reasoning-scaffolds.md
@@ -1,6 +1,6 @@
 # F014 — Frame Reasoning Scaffolds
 
-**Status:** Draft (v2 — revised after review)  
+**Status:** Draft (v3 — revised after architecture review)  
 **Author:** Nous (with Tim)  
 **Created:** 2026-03-05  
 **Revised:** 2026-03-05  
@@ -11,339 +11,381 @@
 
 ## Problem
 
-Nous has 7 cognitive frames (task, question, decision, creative, conversation, debug, initiation) that control **tool availability** and **context budgets**, but they provide only generic prose instructions. There is no structured reasoning guidance — the agent decides *how* to think about each task ad hoc.
+Nous has 7 cognitive frames (task, question, decision, creative, conversation, debug, initiation) that control **tool availability** and **context budgets**, but they provide only generic tool-use nudges. There is no structured reasoning guidance — the agent decides *how* to think about each task ad hoc.
 
 Research (Paper #11, Kostka 2026) shows that semi-formal reasoning templates improve LLM accuracy by up to 30% on code analysis tasks. The key insight: **structured scaffolds constrain the reasoning path without constraining the conclusion**, reducing hallucination, improving consistency, and producing auditable deliberation traces.
 
 Currently:
 - Frame instructions in `runner.py::_get_frame_instructions()` are tool-use nudges, not reasoning scaffolds
-- `deliberation.py` has a basic `_should_deliberate()` gate but no structured deliberation process
-- Decision `record_decision` captures *what* was decided but not the structured *reasoning process*
-- No quality gates on memory operations (facts get stored without consistency checks)
+- `deliberation.py` has a basic `_should_deliberate()` gate and `_validate_decision_quality()` but no structured deliberation process
+- `record_decision` captures *what* was decided but not the structured *reasoning process*
 
 ## Solution
 
-Add **Reasoning Scaffold Templates** to each frame — structured step-by-step thinking patterns that are injected into the system prompt alongside existing tool instructions. Templates are semi-formal: they define required reasoning phases without constraining the content of each phase.
+Add **Reasoning Scaffold Templates** — structured step-by-step thinking patterns that **replace** existing frame instructions (not layer on top). Pilot with Decision frame first, measure, then expand.
 
-## Design Principles
+### Design Principles (from Paper #11)
 
-1. **Scaffolds guide, not constrain** — Templates define *what steps to take*, not *what to conclude*
-2. **Frame-native** — Each frame gets scaffolds matched to its cognitive purpose
-3. **Auditable** — Deliberation traces stored with decisions, enabling calibration analysis
-4. **Adaptive** — Templates compress after first turn and skip for trivial interactions in appropriate frames
-5. **Extensible** — New templates can be added without code changes (DB-driven in Phase 3)
+1. **Guide process, not conclusions** — scaffolds tell you *what steps to take*, never *what to decide*
+2. **Frame-native** — each scaffold matches its frame's cognitive purpose
+3. **Token-efficient** — 150-300 tokens per scaffold with turn-aware compression
+4. **Auditable** — scaffold steps create traceable deliberation artifacts
+5. **Additive, not duplicative** — scaffolds REPLACE existing tool nudges, merging tool guidance into scaffold steps
 
 ---
 
-## Architecture
+## Phase 1 — Decision Frame Pilot (~2h)
 
-### Phase 1: Static Scaffolds (Prompt Injection)
+### Rollout Strategy
 
-Extend `_get_frame_instructions()` in `runner.py` to include reasoning scaffolds per frame.
+**Decision frame only** for 2 weeks. Measure before expanding.
 
-#### Scaffold Compression (Turn-Aware Injection)
+Why pilot Decision first:
+- Highest-stakes frame — bad decisions are expensive
+- Most measurable — `decisions` table tracks confidence, reasons, categories, stakes
+- Already has deliberation infrastructure (`_should_deliberate()`, `_validate_decision_quality()`)
+- Richest existing instructions — most to merge/replace
 
-To manage token costs over multi-turn conversations:
-- **Turn 1 in frame:** Inject full scaffold (150-300 tokens)
-- **Turn 2+ in frame:** Inject 1-line compressed reminder (e.g., "Follow the decision scaffold: CONTEXT → RECALL → OPTIONS → TRADEOFFS → EVIDENCE → CONFIDENCE → DECIDE")
+### Success Criteria (2-week measurement window)
 
-This requires tracking turn count per frame in `TurnContext`. The frame's turn counter resets when the frame changes.
+- Average reason count per decision increases (baseline: current avg)
+- Confidence calibration improves (fewer 0.95+ decisions that get marked as failures)
+- No increase in scaffold-related token costs > 15% per decision turn
+- Qualitative: decision descriptions become more structured without feeling formulaic
 
-#### Frame Scaffolds
+### File Structure
 
-**Decision Frame:**
-```
-REASONING SCAFFOLD — Decision Analysis:
-1. CONTEXT: State the decision and constraints
-2. RECALL: Search for similar past decisions (recall_deep)
-3. OPTIONS: Enumerate alternatives if viable ones exist. If there is only one reasonable option, explicitly state why alternatives were considered and rejected.
-4. TRADEOFFS: For each option, list pros/cons/risks
-5. EVIDENCE: Rate evidence strength (strong/moderate/weak/none) for each option
-6. CONFIDENCE: Score 0.0-1.0 — evidence FOR minus evidence AGAINST, not optimism
-7. DECIDE: Choose and record with record_decision
-```
+Create `nous/nous/cognitive/scaffolds.py` — standalone module, imported by `runner.py`.
 
-**Debug Frame:**
-```
-REASONING SCAFFOLD — Diagnostic Analysis:
-1. SYMPTOM: Describe the observed behavior precisely
-2. REPRODUCE: Can the issue be reproduced? Under what conditions?
-3. ISOLATE: Narrow scope — what works, what doesn't?
-4. HYPOTHESIZE: Generate at least 2 candidate root causes
-5. TEST: Design a test to distinguish between hypotheses
-6. VERIFY: Confirm the root cause with evidence
-7. FIX: Implement and verify the fix
-8. RECORD: Store root cause as fact, record decision if approach was chosen
-```
+```python
+# nous/nous/cognitive/scaffolds.py
+"""Reasoning scaffold templates for cognitive frames.
 
-**Task Frame:**
-```
-REASONING SCAFFOLD — Task Execution:
-1. UNDERSTAND: Restate the task and success criteria
-2. RECALL: Check memory for relevant context, past approaches, procedures
-3. PLAN: Break into steps if complex (>1 tool call likely)
-4. EXECUTE: Work through steps, checking results
-5. VERIFY: Does the output meet the success criteria?
-6. LEARN: Store any new facts discovered; record decisions if alternatives were chosen
-```
+Each scaffold provides structured step-by-step reasoning guidance.
+Scaffolds REPLACE frame tool-nudge instructions (not layered on top).
+Phase 1: Decision frame only. Expand after measurement.
+"""
 
-**Question Frame:**
-```
-REASONING SCAFFOLD — Knowledge Retrieval:
-1. CLASSIFY: What kind of question? (factual, opinion, procedural, temporal)
-2. RECALL: Search memory first (recall_deep, recall_recent)
-3. VERIFY: Is the recalled information current and reliable?
-4. SUPPLEMENT: If memory is insufficient, search web
-5. ANSWER: Respond with appropriate confidence qualifiers
-```
+# Full scaffold — injected on turn 1 of a frame
+DECISION_SCAFFOLD = """## Reasoning Scaffold — Decision Frame
 
-**Creative Frame:**
-```
-REASONING SCAFFOLD — Creative Process:
-1. UNDERSTAND: What is being created and for whom?
-2. INSPIRE: Search for reference material and patterns
-3. GENERATE: Produce initial draft/concept
-4. EVALUATE: Does it meet the brief? What's missing?
-5. REFINE: Iterate on weak areas
-6. DELIVER: Present with rationale for key choices
-```
+Follow these steps. You may skip steps that don't apply, but don't skip RECALL or CALIBRATE.
 
-**Conversation Frame:**
-No scaffold. Conversations should feel natural, not formulaic. The existing frame instructions are sufficient. Fact storage should happen organically when the user explicitly shares information — not as a prompted checklist.
+1. **CONTEXT** — State what needs to be decided and why now.
+2. **RECALL** — Search memory for similar past decisions. Note what worked and what didn't.
+   → Use `recall_deep` to find relevant prior decisions.
+3. **CONSTRAINTS** — List hard constraints (time, resources, compatibility, censors).
+4. **OPTIONS** — Enumerate viable alternatives. If only one reasonable option exists, state why others were rejected.
+5. **TRADEOFFS** — For each option: pros, cons, risks, reversibility.
+   → Use `web_search` and `web_fetch` to research options if needed.
+6. **EVIDENCE** — What data supports each option? Flag gaps where you're guessing.
+7. **CALIBRATE** — Set confidence honestly. What would change your mind? What's your uncertainty?
+8. **DECIDE** — Record with `record_decision`. Include category, stakes, confidence, and structured reasons.
 
-**Initiation Frame:**
-No scaffold. Onboarding is a guided flow with its own structure.
+Do NOT record status reports, routine completions, or greetings as decisions."""
 
-#### Research Subtask Scaffold
+# Compressed reminder — injected on turn 2+ within same frame
+DECISION_SCAFFOLD_SHORT = (
+    "Continue following the Decision scaffold: "
+    "CONTEXT → RECALL → CONSTRAINTS → OPTIONS → TRADEOFFS → EVIDENCE → CALIBRATE → DECIDE. "
+    "Use `record_decision` for real decisions only."
+)
 
-Research is not a main-conversation frame — it's a subtask mode. This scaffold is injected via `build_subtask_prefix()` when `frame_type="research"` is passed to `spawn_task`.
 
-```
-REASONING SCAFFOLD — Research Synthesis:
-1. SCOPE: Define the research question and boundaries
-2. GATHER: Search multiple sources (web_search, recall_deep)
-3. EVALUATE: Assess source quality and recency
-4. SYNTHESIZE: Identify patterns, contradictions, gaps across sources
-5. CONCLUDE: State findings with confidence levels
-6. STORE: Record key facts and cite sources
+def get_scaffold(frame_id: str, turn_in_frame: int, message_length: int) -> str | None:
+    """Return the appropriate scaffold for a frame and turn.
+
+    Args:
+        frame_id: The active cognitive frame identifier.
+        turn_in_frame: Which turn within this frame (1-indexed).
+        message_length: Character length of the user's message.
+
+    Returns:
+        Scaffold string, or None if no scaffold applies.
+    """
+    # Phase 1: Only Decision frame gets a scaffold
+    if frame_id != "decision":
+        return None
+
+    # Turn-aware compression
+    if turn_in_frame <= 1:
+        return DECISION_SCAFFOLD
+    else:
+        return DECISION_SCAFFOLD_SHORT
 ```
 
-### Phase 2: Enhanced Brain Quality Checks
+### Integration Point — `runner.py::_get_frame_instructions()`
 
-Instead of adding parallel prompt-based quality gates, **integrate quality checks into existing Brain validation flow**. This avoids conflicting enforcement layers.
+```python
+# In _get_frame_instructions():
+from nous.cognitive.scaffolds import get_scaffold
 
-#### Enhanced `_should_deliberate()` in `deliberation.py`
-- Before recording a decision, check if the scaffold's reasoning steps were followed
-- Flag decisions with confidence > 0.9 for extra scrutiny (suspiciously high)
-- Verify that alternatives were considered (if Decision scaffold was active)
+def _get_frame_instructions(self, turn_context: TurnContext) -> str:
+    frame_id = turn_context.frame.frame_id
 
-#### Enhanced `learn_fact` validation in Heart
-- Extend existing fact storage logic with lightweight checks:
-  - **ATOMIC:** Does the fact contain a single piece of information?
-  - **NOVEL:** Quick `recall_deep` check for potential duplicates before committing
-  - **ATTRIBUTED:** Is a source specified?
-- These are **programmatic checks in the storage layer**, not prompt injection
-- Non-blocking in v1: log warnings for quality issues but still store the fact
+    # Check for reasoning scaffold (replaces tool nudges for scaffolded frames)
+    scaffold = get_scaffold(
+        frame_id=frame_id,
+        turn_in_frame=turn_context.turn_in_frame,  # requires tracking
+        message_length=len(turn_context.user_message or ""),
+    )
+    if scaffold:
+        return scaffold
 
-### Phase 3: DB-Driven Templates (Future)
+    # Fallback to existing tool nudges for non-scaffolded frames
+    if frame_id == "task":
+        return "## Tool Instructions\n\n..."  # existing
+    # ... etc
+```
 
-Move templates from hardcoded strings to a database table, enabling:
-- Runtime modification without code deploys
-- Per-domain template variants (e.g., "security decision" vs "architecture decision")  
-- Template versioning and A/B testing
-- User-customizable scaffolds
+Key: scaffolds **replace** the existing `_get_frame_instructions()` return for their frame. No layering. The tool guidance ("Use `recall_deep`", "Use `record_decision`") is merged INTO the scaffold steps.
 
-#### Schema
+### Turn Tracking
+
+Add `turn_in_frame: int` to TurnContext (or derive from conversation history). Resets when frame changes.
+
+Token savings from compression:
+- Turn 1: ~280 tokens (full scaffold)
+- Turn 2+: ~45 tokens (compressed)
+- 5-turn decision session: ~460 tokens total vs ~1,400 if full scaffold every turn (67% savings)
+
+---
+
+## Phase 1.5 — Expand to Other Frames (after 2-week pilot succeeds)
+
+Only proceed if Decision frame pilot meets success criteria.
+
+### Debug Frame Scaffold
+
+```python
+DEBUG_SCAFFOLD = """## Reasoning Scaffold — Debug Frame
+
+1. **SYMPTOM** — What's the observable problem? Error messages, unexpected behavior, log output.
+2. **REPRODUCE** — Can you trigger it reliably? What are the exact steps?
+3. **ISOLATE** — Narrow the search space. Which component, file, function?
+   → Use `bash` and `read_file` for investigation.
+4. **HYPOTHESIZE** — What could cause this? List 2-3 candidates ranked by likelihood.
+   → Use `recall_deep` to check for similar past bugs.
+5. **TEST** — Design a test for each hypothesis. Run it.
+   → Use `web_search` and `web_fetch` to look up error messages or docs.
+6. **VERIFY** — Confirm the root cause. Don't fix symptoms.
+7. **FIX** — Implement the fix. Explain why it addresses the root cause.
+8. **RECORD** — Store root cause with `learn_fact`. Record meaningful debugging decisions with `record_decision` (root cause identified, fix approach chosen). Do NOT record routine debug steps.
+
+Do NOT record routine status observations as decisions."""
+
+DEBUG_SCAFFOLD_SHORT = (
+    "Continue following the Debug scaffold: "
+    "SYMPTOM → REPRODUCE → ISOLATE → HYPOTHESIZE → TEST → VERIFY → FIX → RECORD. "
+    "Store root causes with `learn_fact`."
+)
+```
+
+### Task Frame Scaffold
+
+```python
+TASK_SCAFFOLD = """## Reasoning Scaffold — Task Frame
+
+1. **UNDERSTAND** — What's being asked? Restate the goal in your own terms.
+2. **PLAN** — Break into steps. Identify dependencies and order.
+   → Use `recall_deep` for relevant past work.
+3. **EXECUTE** — Work through each step. Use all available tools.
+4. **VERIFY** — Check your work. Does the output match the goal?
+5. **REPORT** — Summarize what was done and any follow-ups needed.
+   → Store important outcomes with `learn_fact`."""
+
+TASK_SCAFFOLD_SHORT = (
+    "Continue following the Task scaffold: "
+    "UNDERSTAND → PLAN → EXECUTE → VERIFY → REPORT."
+)
+```
+
+### Question Frame Scaffold
+
+```python
+QUESTION_SCAFFOLD = """## Reasoning Scaffold — Question Frame
+
+1. **RECALL** — Search memory first. What do you already know?
+   → Use `recall_deep` to search for relevant knowledge.
+2. **ASSESS** — Is memory sufficient, or do you need external info?
+   → Use `web_search` and `web_fetch` for current events or topics not in memory.
+3. **SYNTHESIZE** — Combine sources. Flag confidence level and gaps.
+4. **ANSWER** — Respond clearly. Cite sources when possible."""
+
+QUESTION_SCAFFOLD_SHORT = (
+    "Continue following the Question scaffold: "
+    "RECALL → ASSESS → SYNTHESIZE → ANSWER."
+)
+```
+
+### Complexity Gate (Phase 1.5)
+
+Add complexity sensing for lighter frames:
+
+```python
+# Frames that ALWAYS get scaffolds regardless of message length
+_ALWAYS_SCAFFOLD = {"decision", "debug", "task"}
+
+# Frames that skip scaffolds for very short messages
+_COMPLEXITY_GATED = {"question"}
+
+# Frames that NEVER get scaffolds
+_NEVER_SCAFFOLD = {"conversation", "creative", "initiation"}
+
+def get_scaffold(frame_id: str, turn_in_frame: int, message_length: int) -> str | None:
+    if frame_id in _NEVER_SCAFFOLD:
+        return None
+
+    if frame_id in _COMPLEXITY_GATED and message_length < 30:
+        return None
+
+    if frame_id in _ALWAYS_SCAFFOLD or frame_id in _COMPLEXITY_GATED:
+        # return appropriate scaffold based on frame_id and turn
+        ...
+```
+
+### Frames NOT scaffolded (rationale)
+
+- **Conversation** — should feel natural, not transactional. Existing minimal nudge is sufficient.
+- **Creative** — scaffolds constrain creative thinking. Keep it open.
+- **Initiation** — has its own guided flow (store_identity, complete_initiation).
+
+---
+
+## Research Subtask Scaffold (separate from frame system)
+
+"Research" is NOT a frame in FRAME_TOOLS. Research runs as subtasks via `spawn_task(frame_type="research")`.
+
+### Injection Point — `build_subtask_prefix()` in `nous/nous/api/tools.py`
+
+```python
+# In build_subtask_prefix():
+RESEARCH_SUBTASK_SCAFFOLD = (
+    "You are executing a research subtask. Follow this process:\n"
+    "1. SCOPE — Define what you're researching and success criteria.\n"
+    "2. SEARCH — Use web_search with multiple query angles.\n"
+    "3. GATHER — Use web_fetch to read promising sources. Note conflicts.\n"
+    "4. SYNTHESIZE — Combine findings. Separate facts from inference.\n"
+    "5. DELIVER — Structured summary with key findings, sources, and confidence.\n"
+    "Deliver a clear, complete result. Do not ask questions."
+)
+
+def build_subtask_prefix(task: str, frame_type: str | None = None) -> str:
+    if frame_type == "research":
+        return f"{RESEARCH_SUBTASK_SCAFFOLD}\n\nTask: {task}"
+
+    # existing logic for other frame types
+    base = "You are executing a background subtask.\n..."
+    ...
+```
+
+---
+
+## Phase 2 — DB-Driven Templates (future, ~4h)
+
+**Phase 2 scope is narrower than v2 spec.** No scaffold compliance checking — that creates perverse incentives (performing steps for appearance rather than genuine reasoning). The existing `_validate_decision_quality()` in `deliberation.py` handles structural quality.
+
+Phase 2 is about **extensibility without code changes**:
+
+### Schema
+
 ```sql
 CREATE TABLE reasoning_templates (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    agent_name VARCHAR(100) NOT NULL,  -- agent identifier (no agents table yet)
-    frame_type VARCHAR(30) NOT NULL,
-    domain VARCHAR(100),  -- NULL = default for frame
-    template_name VARCHAR(200) NOT NULL,
-    steps JSONB NOT NULL,  -- ordered array of {name, instruction, required}
-    version INT NOT NULL DEFAULT 1,
-    active BOOLEAN NOT NULL DEFAULT true,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    frame_id VARCHAR(30) NOT NULL,              -- 'decision', 'debug', etc.
+    domain VARCHAR(50),                          -- 'architecture', 'security', 'performance', 'integration', 'process', 'memory', 'debugging'
+    name VARCHAR(100) NOT NULL,
+    steps JSONB NOT NULL,                        -- [{"name": "CONTEXT", "instruction": "...", "tool_hint": "recall_deep"}]
+    compressed TEXT NOT NULL,                    -- 1-line reminder version
+    is_default BOOLEAN DEFAULT false,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now()
 );
 
-CREATE INDEX idx_reasoning_templates_lookup
-    ON reasoning_templates(agent_name, frame_type, domain)
-    WHERE active = true;
+-- Concrete domain values (aligned with record_decision categories):
+-- architecture, security, performance, integration, process, memory, debugging
+-- NULL domain = default template for that frame
 ```
 
-**Domain values** (initial set, aligned with `record_decision` categories):
-- `architecture`
-- `security`
-- `performance`
-- `integration`
-- `process`
-- `memory`
-- `debugging`
+### Lookup logic
 
-#### Step Schema (JSONB)
-```json
-[
-    {
-        "name": "CONTEXT",
-        "instruction": "State the decision and constraints",
-        "required": true
-    },
-    {
-        "name": "RECALL",
-        "instruction": "Search for similar past decisions",
-        "required": true
-    },
-    {
-        "name": "OPTIONS",
-        "instruction": "Enumerate alternatives if viable ones exist",
-        "required": true
-    }
-]
+```python
+def get_scaffold(frame_id, turn_in_frame, message_length, domain=None):
+    # 1. Check DB for domain-specific template
+    # 2. Fall back to DB default template (domain=NULL)
+    # 3. Fall back to hardcoded static scaffolds
+    ...
 ```
 
----
+### CSTP Extension (future)
 
-## Implementation Plan
-
-### Phase 1 — Static Scaffolds (~4 hours)
-
-**1.1 — Scaffold Text Module**
-- Create shared scaffold definitions (used by both `_get_frame_instructions()` and `build_subtask_prefix()`)
-- Each scaffold is a simple string constant
-
-**1.2 — Extend `_get_frame_instructions()` in `runner.py`**
-- Append reasoning scaffold text to each frame's instruction block (except conversation + initiation)
-- Keep existing tool instructions; append scaffold after them
-- Gate behind a config flag `NOUS_REASONING_SCAFFOLDS=true` (default true)
-
-**1.3 — Turn-Aware Scaffold Compression**
-- Add `frame_turn_count` to `TurnContext`
-- Increment when frame stays the same across turns; reset on frame change
-- Turn 1: full scaffold injection
-- Turn 2+: compressed 1-line reminder with step names only
-
-**1.4 — Extend `build_subtask_prefix()` in `tools.py`**
-- Inject Research scaffold when `frame_type="research"`
-- Inject frame-appropriate scaffold for other subtask frame types
-
-**1.5 — Complexity Gate**
-- Skip scaffold injection when ALL of:
-  - Frame is `conversation` or `initiation`
-  - User message < 20 chars
-- All other frames (task, debug, decision, question, creative) **always** get scaffolds regardless of message length
-- Rationale: if the frame classifier assigned a structured frame, the task needs structured reasoning even if the prompt is short
-
-### Phase 2 — Enhanced Brain Quality Checks (~2 hours)
-
-**2.1 — Extend `_should_deliberate()` in `deliberation.py`**
-- Use scaffold-informed criteria for deliberation triggers
-- Add confidence calibration warning for confidence > 0.9
-
-**2.2 — Extend fact storage validation in Heart**
-- Programmatic checks (atomic, novel, attributed) in the storage layer
-- Log warnings for quality issues in v1, don't block storage
-
-### Phase 3 — DB-Driven Templates (~4 hours, future)
-
-**3.1 — Create `reasoning_templates` table**
-**3.2 — Seed with Phase 1 scaffolds**
-**3.3 — Modify `_get_frame_instructions()` to query DB (with cache)**
-**3.4 — Add domain-specific template selection based on intent signals**
+When Cognition Engine protocol ships:
+- Templates served to connected agents via CSTP
+- Agent declares frame/domain → receives appropriate scaffold
+- Reasoning traces stored with decision artifacts
+- Domain template library as productizable feature
 
 ---
 
 ## Affected Files
 
-- `nous/api/runner.py` — Extend `_get_frame_instructions()` with scaffolds + turn-aware compression
-- `nous/api/tools.py` — Extend `build_subtask_prefix()` with scaffolds
-- `nous/cognitive/schemas.py` — Add `frame_turn_count` to `TurnContext`
-- `nous/cognitive/deliberation.py` — Enhanced deliberation criteria (Phase 2)
-- `nous/memory/heart.py` — Fact quality checks in storage layer (Phase 2)
-- `sql/migrations/` — New migration for `reasoning_templates` table (Phase 3)
+| File | Change |
+|------|--------|
+| `nous/nous/cognitive/scaffolds.py` | **NEW** — scaffold templates + `get_scaffold()` function |
+| `nous/nous/api/runner.py` | Modify `_get_frame_instructions()` to call `get_scaffold()` first |
+| `nous/nous/api/tools.py` | Modify `build_subtask_prefix()` for research scaffold |
+| `nous/nous/cognitive/context.py` | Add `turn_in_frame` tracking to TurnContext |
+| `nous/nous/heart/heart.py` | Phase 2 only — template storage/retrieval |
+| `nous/nous/cognitive/schemas.py` | Phase 2 only — template Pydantic models |
 
 ---
 
-## Token Budget Impact
+## What This Spec Does NOT Do
 
-Each scaffold adds ~150-300 tokens to the system prompt on **first turn only**. Subsequent turns get a compressed 1-line reminder (~30-50 tokens).
-
-**First-turn cost per frame:**
-- Decision: +250 tokens
-- Debug: +220 tokens
-- Task: +180 tokens
-- Question: +150 tokens
-- Creative: +160 tokens
-- Conversation: +0 tokens (no scaffold)
-- Initiation: +0 tokens (no scaffold)
-- Research (subtask): +170 tokens
-
-**Multi-turn example (5-turn debug session):**
-- Without compression: 5 × 220 = 1,100 tokens
-- With compression: 220 + (4 × 40) = 380 tokens (65% reduction)
-
-**Mitigation:**
-- Turn-aware compression reduces repetition cost dramatically
-- Complexity gate skips scaffolds for trivial conversations
-- Scaffolds are concise — step names + one-line instructions, not paragraphs
+- **No scaffold compliance checking** — verifying "did you follow step 3?" creates perverse incentives. Removed per review.
+- **No conversation/creative/initiation scaffolds** — these frames don't benefit from structured reasoning.
+- **No automatic expansion** — each frame gets scaffolds only after the previous frame's pilot shows measurable improvement.
+- **No modifications to `record_decision` schema** — scaffolds improve the reasoning *input*, the decision schema captures the *output* unchanged.
 
 ---
 
-## Interaction with `run_python`
+## Token Budget
 
-Scaffolds guide **high-level reasoning and tool selection**, including what recall queries to batch in `run_python`. They do NOT inject into the Python execution environment itself.
+### Phase 1 (Decision only)
+- Turn 1: ~280 tokens (full scaffold)
+- Turn 2+: ~45 tokens (compressed)
+- 5-turn decision session: ~460 tokens total
+- vs no compression: ~1,400 tokens (67% savings)
+- vs current tool nudges: ~150 tokens/turn → scaffolds add ~130 tokens on turn 1, save on subsequent turns
 
-Example: A Decision scaffold step "RECALL: Search for similar past decisions" may cause the agent to write a `run_python` script that calls `recall_deep()` with relevant queries. The scaffold influenced *what* to search for, but the Python code itself runs in its normal sandboxed context.
-
----
-
-## Success Metrics
-
-1. **Decision quality** — Decisions with documented alternatives increase from ~30% to ~70%+
-2. **Confidence calibration** — Mean absolute calibration error decreases (measured via outcome tracking)
-3. **Fact deduplication** — Duplicate fact rate drops by >50%
-4. **Debug resolution** — Root cause identification rate in debug frames improves
-5. **Deliberation traces** — >90% of decisions in decision frames follow the scaffold steps
-6. **Token efficiency** — Multi-turn scaffold cost stays under 15% of total system prompt tokens
-
----
-
-## Research Connections
-
-- **Paper #11** (Semi-Formal Reasoning, arXiv 2603.01896) — Direct inspiration. Structured templates with natural language slots
-- **Paper #4** (SCL) — 5 cognitive phases map to scaffold steps (Cognition phase = our scaffold execution)
-- **Paper #5** (ACC) — Better structured reasoning produces better state for compression
-- **Paper #10** (ToM/IB) — Caution: scaffolds should be adaptive, not forced on simple tasks. Model capability is dominant factor — scaffolds amplify strengths but can confuse weak models
-- **Paper #3** (Episodic Memory) — Scaffold traces become part of episodic memory, improving future recall
-
----
-
-## CSTP / Cognition Engine Implications
-
-This feature has a natural extension path into the Cognition Engine / CSTP protocol:
-
-1. **Template serving** — CSTP could serve reasoning templates to connected agents based on decision category
-2. **Cross-agent calibration** — Scaffold traces enable comparing reasoning quality across different LLM backends
-3. **Template marketplace** — Domain-specific template packs (DevOps, Security, Architecture) as a product feature
-4. **Reasoning audit trail** — Every decision made through CSTP has a structured deliberation trace, not just a result
+### Phase 1.5 (All scaffolded frames)
+- Each scaffold: 150-280 tokens (turn 1), 30-50 tokens (turn 2+)
+- Worst case (decision): +130 tokens on turn 1 vs current nudges
+- Best case (question): ~120 tokens, similar to current nudges
 
 ---
 
 ## Revision History
 
+**v3 (2026-03-05) — Post-architecture-review:**
+- **Rollout changed:** Decision frame pilot first (2 weeks), expand only after measurement
+- **Research scaffold:** Moved to `build_subtask_prefix()` in tools.py (not frame system)
+- **Tool nudge merge:** Scaffolds REPLACE `_get_frame_instructions()` output, not layer on top
+- **File path fixed:** `nous/nous/heart/heart.py` (was `nous/memory/heart.py`)
+- **scaffolds.py:** Extracted to `nous/nous/cognitive/scaffolds.py` from day 1
+- **Complexity gate:** Added intra-frame sensing (question frame skips for < 30 char messages)
+- **Phase 2 compliance checking removed:** Creates perverse incentives, existing `_validate_decision_quality()` is sufficient
+- **Success criteria added:** Measurable metrics for pilot evaluation
+
 **v2 (2026-03-05) — Post-review updates:**
-- Dropped conversation scaffold entirely — conversations should feel natural
-- Dropped initiation scaffold — has its own guided flow
-- Renamed "Research Frame" to "Research Subtask Scaffold" — injected via `build_subtask_prefix()`, not frame system
-- Softened OPTIONS step from "at least 2 alternatives" to "enumerate if viable, explain why if not"
-- Added turn-aware scaffold compression (full on turn 1, 1-line reminder on turn 2+)
-- Merged Phase 2 into existing Brain validation flow — no parallel prompt-based quality gates
-- Fixed complexity gate: skip only in conversation + initiation frames, all structured frames always get scaffolds
-- Fixed Phase 3 schema: removed `agents(id)` FK reference (table doesn't exist), defined concrete domain values
-- Added `run_python` interaction section
-- Added token efficiency metric
-- Updated affected files list (added `heart.py`, `schemas.py`)
+- Dropped conversation and initiation scaffolds
+- Renamed Research Frame → Research Subtask Scaffold
+- Softened OPTIONS step from "at least 2 alternatives" to "enumerate if viable"
+- Added turn-aware scaffold compression
+- Merged Phase 2 into existing Brain validation flow
+- Fixed complexity gate, Phase 3 schema, added run_python interaction section
+
+**v1 (2026-03-05) — Initial draft**
 
 ---
 
@@ -351,5 +393,5 @@ This feature has a natural extension path into the Cognition Engine / CSTP proto
 
 1. Should scaffolds be visible in the agent's response, or purely internal (thinking block only)?
 2. Template inheritance — should subtasks inherit the parent's scaffold or get their own based on frame_type?
-3. Should Phase 2 fact quality checks become blocking (reject bad facts) after a validation period, or remain advisory permanently?
-4. How should scaffold compression handle frame switches mid-conversation? (e.g., conversation → decision → conversation — does decision get full scaffold again?)
+3. How should scaffold compression handle frame switches mid-conversation? (Reset turn count per frame switch — proposed default)
+4. What's the baseline decision quality metric? Need to measure current avg reason count, confidence distribution, and failure rate before pilot starts.


### PR DESCRIPTION
## Summary
Add structured reasoning templates (semi-formal scaffolds) to each of Nous cognitive frames.

## Motivation
Paper #11 showed structured reasoning templates improve accuracy by up to 30%. Each frame should supply a reasoning scaffold — not telling the agent what to conclude, but what steps to take.

## Phases
- **Phase 1** — Static Scaffolds (~3h): 7 frame-specific templates + complexity gate
- **Phase 2** — Memory Quality Gates (~2h): Pre-commit checks on learn_fact and record_decision
- **Phase 3** — DB-Driven Templates (~4h): reasoning_templates table, domain-specific variants

## CSTP Extension
- Template serving to connected agents
- Reasoning audit trails
- Domain template marketplace

## Research Basis
Papers #10, #11 from the LLM agent memory/cognition collection

## Files
- docs/features/F014-reasoning-scaffolds.md (+297 lines)