### PR TITLE
feat: Exa.ai search integration with automatic failover

### DIFF
--- a/nous/api/web_tools.py
+++ b/nous/api/web_tools.py
@@ -122,12 +122,21 @@ async def _web_search(
     try:
         # Check API key
         if not _settings.brave_search_api_key:
-            return _mcp_response("Error: BRAVE_SEARCH_API_KEY not configured. Set this environment variable to enable web search.")
+            # Try Exa as fallback
+            exa_result = await _exa_search(query, count, _settings=_settings, _http=_http)
+            if exa_result:
+                return exa_result
+            return _mcp_response("Error: No search provider configured. Set BRAVE_SEARCH_API_KEY or EXA_API_KEY.")
 
         # Check rate limit
         rate_error = _check_rate_limit(_settings)
         if rate_error:
-            return _mcp_response(f"Rate limit: {rate_error}")
+            # Try Exa as fallback
+            logger.info("Brave rate limit hit, trying Exa fallback")
+            exa_result = await _exa_search(query, count, _settings=_settings, _http=_http)
+            if exa_result:
+                return exa_result
+            return _mcp_response(f"Rate limit: {rate_error} (Exa fallback also unavailable)")
 
         count = min(count, 10)
 
@@ -150,6 +159,10 @@ async def _web_search(
         )
 
         if response.status_code != 200:
+            logger.warning("Brave search failed (HTTP %d), trying Exa fallback", response.status_code)
+            exa_result = await _exa_search(query, count, _settings=_settings, _http=_http)
+            if exa_result:
+                return exa_result
             return _mcp_response(f"Search failed (HTTP {response.status_code}). Check BRAVE_SEARCH_API_KEY if 401.")
 
         data = response.json()
@@ -174,12 +187,295 @@ async def _web_search(
         return _mcp_response("\n".join(lines))
 
     except httpx.TimeoutException:
-        return _mcp_response("Web search timed out. Try again.")
+        logger.warning("Brave search timed out, trying Exa fallback")
+        exa_result = await _exa_search(query, count, _settings=_settings, _http=_http)
+        if exa_result:
+            return exa_result
+        return _mcp_response("Web search timed out on all providers. Try again.")
     except httpx.ConnectError as e:
-        return _mcp_response(f"Could not connect to search service: {e}")
+        logger.warning("Brave connect error, trying Exa fallback: %s", e)
+        exa_result = await _exa_search(query, count, _settings=_settings, _http=_http)
+        if exa_result:
+            return exa_result
+        return _mcp_response(f"Could not connect to any search service: {e}")
     except Exception as e:
         logger.exception("web_search error")
+        exa_result = await _exa_search(query, count, _settings=_settings, _http=_http)
+        if exa_result:
+            return exa_result
         return _mcp_response(f"Search error: {e}")
+
+
+
+
+async def _exa_search(
+    query: str,
+    count: int = 5,
+    *,
+    search_type: str = "auto",
+    content_mode: str = "text",
+    max_text_chars: int = 3000,
+    include_domains: list[str] | None = None,
+    exclude_domains: list[str] | None = None,
+    output_schema: dict[str, Any] | None = None,
+    category: str | None = None,
+    max_age_hours: int | None = None,
+    _settings: Settings,
+    _http: httpx.AsyncClient,
+) -> dict[str, Any] | None:
+    """Search via Exa API (fallback + research provider).
+
+    Supports all Exa search types, content modes, and category indexes:
+    - search_type: "auto" (balanced), "fast" (quick), "deep" (research, 4-12s),
+                   "deep-reasoning" (complex multi-step)
+    - content_mode: "text" (full content) or "highlights" (key excerpts)
+    - output_schema: structured output schema for deep/deep-reasoning types
+    - include_domains / exclude_domains: domain filtering
+      (can be combined: include broad domain, exclude specific subdomain)
+    - category: search dedicated indexes — "people", "company", "news",
+                "research paper", "tweet". Omit for general web search.
+    - max_age_hours: content freshness control for livecrawl.
+        24 = livecrawl if cache > 24h old
+        1 = near real-time
+        0 = always livecrawl (ignore cache)
+        -1 = never livecrawl (cache only, fastest)
+        None = default (livecrawl as fallback if no cache)
+
+    Returns formatted results dict, or None if Exa is not configured or fails.
+    """
+    if not _settings.exa_api_key:
+        return None
+
+    try:
+        # Build payload
+        payload: dict[str, Any] = {
+            "query": query,
+            "type": search_type,
+            "numResults": min(count, 10),
+        }
+
+        # Content configuration — text or highlights, not both
+        if content_mode == "highlights":
+            payload["contents"] = {
+                "highlights": {"maxCharacters": min(max_text_chars, 4000)}
+            }
+        else:
+            payload["contents"] = {
+                "text": {"maxCharacters": min(max_text_chars, 20000)}
+            }
+
+        # Domain filtering (can combine: include broad domain, exclude subdomain)
+        if include_domains:
+            payload["includeDomains"] = include_domains
+        if exclude_domains:
+            payload["excludeDomains"] = exclude_domains
+
+        # Category filter — searches dedicated indexes
+        # Valid: "people", "company", "news", "research paper", "tweet"
+        if category:
+            payload["category"] = category
+
+        # Content freshness / livecrawl control
+        if max_age_hours is not None:
+            payload["maxAgeHours"] = max_age_hours
+
+        # Structured output (deep and deep-reasoning only)
+        if output_schema and search_type in ("deep", "deep-reasoning"):
+            payload["outputSchema"] = output_schema
+
+        # Adjust timeout for deep searches (they take 4-12s)
+        timeout = 30 if search_type in ("deep", "deep-reasoning") else 15
+
+        response = await _http.post(
+            "https://api.exa.ai/search",
+            json=payload,
+            headers={
+                "x-api-key": _settings.exa_api_key,
+                "Content-Type": "application/json",
+            },
+            timeout=timeout,
+        )
+
+        if response.status_code != 200:
+            logger.warning("Exa search failed (HTTP %d): %s", response.status_code, response.text[:200])
+            return None
+
+        data = response.json()
+
+        # Handle structured output response (deep search with schema)
+        if output_schema and "output" in data:
+            output = data["output"]
+            lines = [f"Structured results for: {query}  [via Exa {search_type}]\n"]
+            import json as json_mod
+            lines.append(json_mod.dumps(output.get("content", {}), indent=2))
+            grounding = output.get("grounding", [])
+            if grounding:
+                lines.append("\nGrounding/Citations:")
+                for g in grounding[:10]:
+                    field = g.get("field", "")
+                    confidence = g.get("confidence", "")
+                    citations = g.get("citations", [])
+                    cite_urls = ", ".join(c.get("url", "") for c in citations[:3])
+                    lines.append(f"  {field} ({confidence}): {cite_urls}")
+            return _mcp_response("\n".join(lines))
+
+        # Standard results
+        results = data.get("results", [])
+
+        if not results:
+            return _mcp_response(f"No results found for: {query}")
+
+        lines = [f"Search results for: {query}  [via Exa {search_type}]\n"]
+        for i, r in enumerate(results[:count], 1):
+            title = r.get("title", "No title")
+            url = r.get("url", "")
+
+            # Extract content based on mode
+            if content_mode == "highlights":
+                highlights = r.get("highlights", [])
+                snippet = " ... ".join(highlights)[:500].strip() if highlights else ""
+            else:
+                snippet = r.get("text", "")[:500].strip()
+
+            lines.append(f"{i}. {title}")
+            lines.append(f"   URL: {url}")
+            if snippet:
+                lines.append(f"   {snippet}\n")
+            else:
+                lines.append("")
+
+        return _mcp_response("\n".join(lines))
+
+    except httpx.TimeoutException:
+        logger.warning("Exa search timed out for query: %s (type=%s)", query, search_type)
+        return None
+    except Exception as e:
+        logger.warning("Exa search error: %s", e)
+        return None
+
+
+
+async def _exa_get_contents(
+    urls: list[str],
+    *,
+    content_mode: str = "text",
+    max_text_chars: int = 3000,
+    _settings: Settings,
+    _http: httpx.AsyncClient,
+) -> dict[str, Any] | None:
+    """Get contents for known URLs via Exa /contents endpoint.
+
+    Useful when you already have URLs and want to extract clean content
+    without searching. Supports text or highlights mode.
+
+    Returns formatted results dict, or None if Exa is not configured or fails.
+    """
+    if not _settings.exa_api_key:
+        return None
+
+    try:
+        payload: dict[str, Any] = {"urls": urls}
+
+        if content_mode == "highlights":
+            payload["highlights"] = {"maxCharacters": min(max_text_chars, 4000)}
+        else:
+            payload["text"] = {"maxCharacters": min(max_text_chars, 20000)}
+
+        response = await _http.post(
+            "https://api.exa.ai/contents",
+            json=payload,
+            headers={
+                "x-api-key": _settings.exa_api_key,
+                "Content-Type": "application/json",
+            },
+            timeout=15,
+        )
+
+        if response.status_code != 200:
+            logger.warning("Exa contents failed (HTTP %d): %s", response.status_code, response.text[:200])
+            return None
+
+        data = response.json()
+        results = data.get("results", [])
+
+        if not results:
+            return _mcp_response("No content extracted from provided URLs")
+
+        lines = ["Content extracted via Exa:\n"]
+        for i, r in enumerate(results, 1):
+            title = r.get("title", "No title")
+            url = r.get("url", "")
+            if content_mode == "highlights":
+                highlights = r.get("highlights", [])
+                content_text = " ... ".join(highlights)[:500].strip() if highlights else ""
+            else:
+                content_text = r.get("text", "")[:500].strip()
+
+            lines.append(f"{i}. {title}")
+            lines.append(f"   URL: {url}")
+            if content_text:
+                lines.append(f"   {content_text}\n")
+
+        return _mcp_response("\n".join(lines))
+
+    except Exception as e:
+        logger.warning("Exa contents error: %s", e)
+        return None
+
+
+async def _exa_answer(
+    query: str,
+    *,
+    _settings: Settings,
+    _http: httpx.AsyncClient,
+) -> dict[str, Any] | None:
+    """Q&A with citations from web search via Exa /answer endpoint.
+
+    Returns a direct answer to the query with source citations.
+    Useful for factual questions where you want a synthesized answer
+    rather than a list of search results.
+
+    Returns formatted answer dict, or None if Exa is not configured or fails.
+    """
+    if not _settings.exa_api_key:
+        return None
+
+    try:
+        payload: dict[str, Any] = {"query": query}
+
+        response = await _http.post(
+            "https://api.exa.ai/answer",
+            json=payload,
+            headers={
+                "x-api-key": _settings.exa_api_key,
+                "Content-Type": "application/json",
+            },
+            timeout=30,
+        )
+
+        if response.status_code != 200:
+            logger.warning("Exa answer failed (HTTP %d): %s", response.status_code, response.text[:200])
+            return None
+
+        data = response.json()
+        answer = data.get("answer", "")
+        citations = data.get("citations", [])
+
+        lines = [f"Answer for: {query}  [via Exa Answer]\n"]
+        lines.append(answer)
+
+        if citations:
+            lines.append("\nSources:")
+            for c in citations[:10]:
+                title = c.get("title", "")
+                url = c.get("url", "")
+                lines.append(f"  • {title}: {url}")
+
+        return _mcp_response("\n".join(lines))
+
+    except Exception as e:
+        logger.warning("Exa answer error: %s", e)
+        return None
 
 
 async def _web_fetch(

--- a/skills/exa/SKILL.md
+++ b/skills/exa/SKILL.md
@@ -1,0 +1,227 @@
+# Exa Search — Skill Reference
+
+## Overview
+Exa is a neural/semantic web search API. Used as fallback when Brave hits rate limits, and directly for deep research, structured data extraction, category-specific searches, and Q&A with citations.
+
+**Free tier:** 1,000 queries/month
+**API key env:** `EXA_API_KEY`
+**Docs:** https://docs.exa.ai
+
+## Internal Functions
+
+### `_exa_search()` — Main search
+```python
+await _exa_search(
+    query="your query",
+    count=10,                          # max results
+    search_type="auto",                # "auto" | "fast" | "deep" | "deep-reasoning"
+    content_mode="text",               # "text" (full) | "highlights" (excerpts)
+    max_text_chars=3000,               # content character limit
+    include_domains=["arxiv.org"],     # optional domain filter
+    exclude_domains=["pinterest.com"], # optional domain exclusion
+    output_schema={...},               # structured output (deep/deep-reasoning only)
+    category="news",                   # optional category index
+    max_age_hours=24,                  # optional freshness control
+    _settings=settings,
+    _http=http_client,
+)
+```
+
+### `_exa_get_contents()` — Extract content from known URLs
+```python
+await _exa_get_contents(
+    urls=["https://example.com/article"],
+    content_mode="text",               # "text" | "highlights"
+    max_text_chars=3000,
+    _settings=settings,
+    _http=http_client,
+)
+```
+
+### `_exa_answer()` — Q&A with citations
+```python
+await _exa_answer(
+    query="What is the current state of AI safety research?",
+    _settings=settings,
+    _http=http_client,
+)
+```
+Returns a synthesized answer with source citations. Best for factual questions.
+
+## Search Types
+
+| Type | Speed | Best For |
+|------|-------|----------|
+| `fast` | Fastest | Real-time apps, quick lookups |
+| `auto` | Medium | Most queries — balanced relevance & speed |
+| `deep` | 4-12s | Research, enrichment, thorough results |
+| `deep-reasoning` | Slowest | Complex multi-step reasoning tasks |
+
+**Tip:** `deep` and `deep-reasoning` support structured outputs via `output_schema`.
+
+## Content Modes
+
+| Mode | Config | Best For |
+|------|--------|----------|
+| `text` | Full page content (up to 20K chars) | RAG, full articles, code docs |
+| `highlights` | Key excerpts (up to 4K chars) | Summaries, Q&A, general research |
+
+**Warning:** `text` mode with high `max_text_chars` increases token consumption significantly. Use `highlights` when full content isn't needed.
+
+## Category Indexes
+
+Search dedicated content indexes. Each returns only that content type.
+**Omit category for general web search.** Categories can be restrictive — if results are sparse, try without.
+
+### `"people"` — Find people by role/expertise
+```python
+_exa_search("software engineer distributed systems", category="people")
+```
+- Use SINGULAR form ("engineer" not "engineers")
+- Describe what they work on
+- No date/text filters supported
+
+### `"company"` — Find companies by industry/attributes
+```python
+_exa_search("AI startup healthcare", category="company")
+```
+- Use SINGULAR form
+- Simple entity queries
+- Returns company objects, not articles
+
+### `"news"` — News articles
+```python
+_exa_search("OpenAI announcements", category="news", max_age_hours=24)
+```
+- Use `max_age_hours=0` for breaking news (forces livecrawl)
+
+### `"research paper"` — Academic papers
+```python
+_exa_search("transformer architecture improvements", category="research paper")
+```
+- Includes arxiv.org, paperswithcode.com, and academic sources
+- Use `type="auto"` for most queries
+
+### `"tweet"` — Twitter/X posts
+```python
+_exa_search("AI safety discussion", category="tweet")
+```
+- Good for real-time discussions and public sentiment
+
+## Content Freshness (`max_age_hours`)
+
+Controls livecrawl behavior for cached content:
+
+| Value | Behavior | Best For |
+|-------|----------|----------|
+| `24` | Livecrawl if cache > 24h old | Daily-fresh content |
+| `1` | Livecrawl if cache > 1h old | Near real-time data |
+| `0` | Always livecrawl (ignore cache) | Real-time, breaking news |
+| `-1` | Never livecrawl (cache only) | Max speed, historical/static content |
+| `None` (omit) | Default — livecrawl as fallback | Recommended for most queries |
+
+**Note:** Livecrawl isn't necessary for historical/educational queries where cached data is sufficient.
+
+## Domain Filtering
+
+```python
+_exa_search(
+    "query",
+    include_domains=["vercel.com"],
+    exclude_domains=["community.vercel.com"],  # exclude subdomain of included domain
+)
+```
+- `includeDomains` and `excludeDomains` CAN be used together
+- Common pattern: include broad domain, exclude specific subdomain
+- Usually not needed — Exa's neural search finds relevant results without filtering
+
+## Structured Outputs (Deep Search)
+
+Only available with `deep` and `deep-reasoning` search types.
+
+```python
+result = await _exa_search(
+    "articles about GPUs",
+    search_type="deep",
+    output_schema={
+        "type": "object",
+        "description": "Companies mentioned in articles",
+        "required": ["companies"],
+        "properties": {
+            "companies": {
+                "type": "array",
+                "description": "List of companies mentioned",
+                "items": {
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {
+                        "name": {"type": "string", "description": "Name of the company"},
+                        "description": {"type": "string", "description": "Short description"}
+                    }
+                }
+            }
+        }
+    },
+    content_mode="highlights",
+)
+```
+
+**Response includes:**
+- `output.content` — structured JSON matching your schema
+- `output.grounding` — field-level citations with source URLs and confidence scores
+
+**Schema controls:** `type`, `description`, `required`, `properties`, `items`
+
+**When to use:**
+- Enrichment workflows (company info, people data, product details)
+- Data pipelines (structured data without parsing free text)
+- Grounded facts (every field comes with citations and confidence)
+
+## Fallback Chain
+
+Brave (primary) -> Exa (automatic fallback on rate limit, HTTP error, timeout, or missing key)
+
+The fallback is transparent — `web_search` tool tries Brave first, falls back to Exa automatically.
+
+## MCP Server (for Claude Code)
+
+```bash
+claude mcp add --transport http exa https://mcp.exa.ai/mcp?exaApiKey=YOUR_KEY
+```
+
+Enable all tools:
+```
+https://mcp.exa.ai/mcp?exaApiKey=YOUR_KEY&tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa,company_research_exa,people_search_exa,deep_researcher_start,deep_researcher_check
+```
+
+## Troubleshooting
+
+**Need structured data from search?**
+1. Use `type="deep"` or `type="deep-reasoning"` with `output_schema`
+2. Define the fields you need — Exa returns grounded JSON with field-level citations
+
+**Results not relevant?**
+1. Try `type="auto"` — most balanced, has fallback mechanisms
+2. Try `type="deep"` — runs multiple query variations and ranks combined results
+3. Refine query — use singular form, be specific
+4. Check category matches your use case
+
+**Results too slow?**
+1. Use `type="fast"`
+2. Reduce `num_results`
+3. Skip contents if you only need URLs
+
+**No results?**
+1. Remove filters (date, domain restrictions)
+2. Simplify query
+3. Try `type="auto"` — has fallback mechanisms
+
+**High token cost?**
+- Switch from `text` to `highlights` mode
+- Reduce `max_text_chars`
+
+## Resources
+
+- **Docs:** https://exa.ai/docs
+- **Dashboard:** https://dashboard.exa.ai
+- **API Status:** https://status.exa.ai


### PR DESCRIPTION
## Summary
Integrates Exa.ai as a fallback search provider, giving Nous 3,000 queries/month (Brave 2,000 + Exa 1,000) with automatic failover.

## Changes

### `nous/api/web_tools.py` (+300 lines)
- **`_exa_search()`** — full-featured search
  - 4 search types: `auto`, `fast`, `deep`, `deep-reasoning`
  - 5 category indexes: `people`, `company`, `news`, `research paper`, `tweet`
  - Structured outputs via `output_schema` (deep/deep-reasoning only)
  - Domain filtering (`include_domains` / `exclude_domains`, composable)
  - Freshness control via `max_age_hours` (0=livecrawl, -1=cache only)
  - Content modes: `text` (full, 20K chars) or `highlights` (excerpts, 4K)
  - Smart timeouts: 30s for deep/deep-reasoning, 15s for auto/fast
- **`_exa_get_contents()`** — extract content from known URLs without searching
- **`_exa_answer()`** — Q&A endpoint returning synthesized answers with citations
- **Automatic failover chain:** Brave → Exa on rate limit, HTTP error, timeout, or missing key

### `skills/exa/SKILL.md` (new, 227 lines)
Complete skill reference covering all endpoints, parameters, categories, structured outputs, freshness control, domain filtering, troubleshooting, and resources.

## Configuration
- Reads `EXA_API_KEY` from environment / `.env`
- No code changes needed to existing search callers — failover is transparent

## Testing
- ✅ `/search` with category filter — returns results
- ✅ `/contents` URL extraction — returns page content  
- ✅ `/answer` Q&A — returns synthesized answer with citations
- ✅ Failover from Brave → Exa verified
- ✅ Branch rebased cleanly on origin/main