### PR TITLE
fix: drop original graph_edges_relation_check in migration 016

### DIFF
--- a/sql/migrations/016_graph_edges_polymorphic.sql
+++ b/sql/migrations/016_graph_edges_polymorphic.sql
@@ -35,8 +35,9 @@ ALTER TABLE brain.graph_edges
         target_type IN ('decision', 'fact', 'episode', 'procedure')
     );
 
--- 7. Extend relation check constraint
+-- 7. Extend relation check constraint (drop both old names)
 ALTER TABLE brain.graph_edges DROP CONSTRAINT IF EXISTS ck_edges_relation;
+ALTER TABLE brain.graph_edges DROP CONSTRAINT IF EXISTS graph_edges_relation_check;
 ALTER TABLE brain.graph_edges
     ADD CONSTRAINT ck_edges_relation CHECK (
         relation IN (


### PR DESCRIPTION
Migration 016 extended the relation check constraint but only dropped `ck_edges_relation`. The original constraint from `init.sql` is named `graph_edges_relation_check` and was blocking inserts of new relation types (`evidence_for`, `discussed_in`, `extracted_from`).

Fix: add `DROP CONSTRAINT IF EXISTS graph_edges_relation_check` before the new constraint is added.