### PR TITLE
F019 v3: Three-tier brand architecture — Cognition Engines → Nous → Verdicto

### DIFF
--- a/docs/features/F019-nous-website.md
+++ b/docs/features/F019-nous-website.md
@@ -1,10 +1,20 @@
-# F019 — Nous Website (v2 — Review-Updated)
+# F019 — Website & Brand Architecture (v3 — Brand Restructure)
 
 > **Status:** Planned
 > **Priority:** P2
 > **Depends on:** ~~F018 (Agent Identity)~~ — removed as hard dependency (see §Dependency Note)
-> **Estimated effort:** ~2–3 days design + ~3–4 days build (Phase 1) — see §Effort Estimates
-> **Domain:** `mem-brain.ai` *(resolved — matches INDEX.md)*
+> **Estimated effort:** ~2–3 days design + ~3–4 days build (Phase 1)
+> **Last updated:** March 9, 2026
+
+## Changelog (v3)
+
+- 🏗️ **Major: Three-tier brand architecture adopted** — Cognition Engines (company) → Nous (OSS) → Verdicto (enterprise)
+- 🌐 Domain reassigned: `mem-brain.ai` → redirect to `cognition-engines.ai`; primary enterprise site is now `verdicto.ai`
+- 🏷️ Tagline finalized: _"Verdicto — Enterprise AI that remembers, decides, and learns. Built on Nous. Powered by Cognition Engines."_
+- 📄 `/cognition-engines` bridge page redesigned for three-tier brand hierarchy
+- 🎯 Positioning updated to reflect enterprise (Verdicto) vs open-source (Nous) split
+- 📋 Domain mapping table added
+- 🔁 Supersedes v2 decision to use `mem-brain.ai` as primary domain
 
 ## Changelog (v2)
 
@@ -13,7 +23,7 @@
 - 🔀 Reordered homepage: Quick Start moves to position 3, Concepts Grid moved to /concepts
 - 📊 Flagged stale stats — added build-time stats pipeline requirement
 - 📈 Moved analytics from Phase 3 → Phase 1
-- 🏠 Resolved domain to `mem-brain.ai` (was conflicting with INDEX.md)
+- 🏠 Resolved domain to `mem-brain.ai` (was conflicting with INDEX.md) — **superseded in v3**
 - 🚀 Added "What to Build Next" adoption section
 - 📱 Added responsive design and accessibility specs
 - 🔍 Added SEO implementation details
@@ -23,44 +33,89 @@
 
 ---
 
+## Brand Architecture
+
+### Three-Tier Hierarchy
+
+```
+Cognition Engines          ← The company / umbrella brand
+├── Nous                   ← Open-source cognitive agent framework
+│   └── Membrain           ← Neuromorphic memory substrate (sub-project)
+└── Verdicto               ← Enterprise product
+```
+
+**Tagline:**
+> _Verdicto — Enterprise AI that remembers, decides, and learns._
+> _Built on Nous. Powered by Cognition Engines._
+
+### Domain Mapping
+
+| Domain | Role | Traffic | Action |
+|--------|------|---------|--------|
+| `cognition-engines.ai` | Company site, blog, research, articles | 2.21k visits | **Primary brand — keep building** |
+| `verdicto.ai` | Enterprise product site, docs, API, pricing | 0 visits | **Build as enterprise product home** |
+| `nous-agent.ai` | OSS project | 0 visits | **Redirect to GitHub repo or OSS docs** |
+| `mem-brain.ai` | Legacy | 0 visits | **Redirect to cognition-engines.ai** |
+| `decision-memory.ai` | Reserved | 522 visits | **Parked — potential content play** |
+
+### Brand Positioning
+
+**Cognition Engines** — The vision, the research, the thought leadership.
+- Home for Tim's LinkedIn article series
+- Company identity for external communications
+- Audience: industry peers, CTOs, AI leaders
+
+**Nous** — The open-source framework. Free, Apache 2.0, community-driven.
+- Audience: developers, researchers, agent builders
+- Lives on GitHub (`tfatykhov/membrain`)
+- The nerdy Greek name works perfectly for the OSS crowd
+
+**Verdicto** — The enterprise product. Managed, supported, compliance-ready.
+- Audience: enterprise teams, VPs of Engineering, procurement departments
+- Latin root: "verdictum" = a true saying / a judgment
+- Pronounceable, memorable, unique in search, communicates value instantly
+- Features beyond OSS: audit trails, compliance, SSO, managed memory, SLA
+
+### Pattern Reference
+
+This follows the proven open-source-to-enterprise playbook:
+- **Elastic** → Elasticsearch (OSS) / Elastic Cloud (enterprise)
+- **HashiCorp** → Terraform (OSS) / Terraform Cloud (enterprise)
+- **Databricks** → Apache Spark (OSS) / Databricks (enterprise)
+- **Grafana Labs** → Grafana (OSS) / Grafana Cloud (enterprise)
+- **Neo4j** → Neo4j Community (OSS) / Neo4j Aura (enterprise)
+
+---
+
 ## Problem
 
 Nous is a serious open-source framework with a genuinely novel foundation — Minsky's Society of Mind as a first-class architecture. But its only public front door right now is a GitHub README.
 
 A README serves people who already found you. A website converts curious passers-by into actual adopters. For an open-source framework targeting developer adoption, that gap matters enormously.
 
+With the Verdicto enterprise brand, we now also need a distinct enterprise presence that speaks to decision-makers, not just developers.
+
 The risk of waiting: other frameworks (LangChain, CrewAI, AutoGen) continue to dominate discovery simply because they have polished public presence — not because they're architecturally stronger.
 
 ## Goal
 
-A fast, minimal, developer-first website that:
+**Two websites, one ecosystem:**
 
-1. Communicates what Nous is in under 10 seconds
-2. Earns credibility with technical developers through honest depth
-3. Provides a clear path from curiosity → running agent → building with it
-4. Cross-links with `cognition-engines.ai` as the companion decision layer
+1. **cognition-engines.ai** — Company site with blog, research, and brand story. Links to both Nous and Verdicto.
+2. **verdicto.ai** — Enterprise product site: what it does, how it's different, how to evaluate/buy it.
+
+The Nous OSS project lives on GitHub with a solid README + docs. `nous-agent.ai` redirects there.
 
 ## Audience
 
-**Primary:** Software engineers building AI agents who are frustrated with the shallowness of current frameworks (LangChain-style prompt plumbing). They want something architecturally honest.
+**Nous (OSS):**
+- Software engineers building AI agents who are frustrated with the shallowness of current frameworks (LangChain-style prompt plumbing). They want something architecturally honest.
 
-**Secondary:** Technical leads and CTOs evaluating frameworks for team adoption. They need to understand the "why" quickly, trust the architecture, and hand it off to their devs.
+**Verdicto (Enterprise):**
+- Technical leads and CTOs evaluating agent platforms for enterprise deployment. They need to understand the "why" quickly, trust the architecture, see compliance/security story, and bring it to procurement.
 
-## Positioning
-
-**One-liner:**
-> *"An AI agent framework that thinks, learns, and grows — grounded in Minsky's Society of Mind."*
-
-**What Nous is NOT:**
-- Not another prompt-chaining library
-- Not a thin wrapper around OpenAI
-- Not a cloud service you pay for
-
-**What Nous IS:**
-- An opinionated open-source framework
-- Grounded in 40 years of cognitive science (Minsky, 1986)
-- Embeds decision memory, structured recall, self-monitoring, and calibration as first-class concepts
-- Runs entirely in your infrastructure
+**Cognition Engines (Company):**
+- Industry peers, AI practitioners, potential partners. Following Tim's thought leadership and research.
 
 ---
 
@@ -76,17 +131,37 @@ F018 is a runtime architecture feature — it replaces the static `NOUS_IDENTITY
 
 ## Site Architecture
 
+### cognition-engines.ai
+
 ```
-/                   → Homepage (hero + quick start + why + architecture + CTA)
-/docs               → Documentation (mirrors /docs in repo)
-/concepts           → Deep dives: K-Lines, Censors, Calibration, Frames, B-Brain
-/concepts/{name}    → Individual concept pages
-/blog               → Posts (Phase 2)
-/cognition-engines  → Bridge page — relationship to cognition-engines.ai
-/404                → Custom 404 with search + navigation help
+/                   → Company homepage (vision + links to Nous & Verdicto)
+/blog               → Articles (LinkedIn cross-posts + originals)
+/research           → Research summaries, paper reviews
+/about              → Tim's background, company story
 ```
 
-**Repo location:** Website lives in the Nous monorepo at `/website/`. Rationale: keeps content co-located with code, single PR workflow, and build-time stats can read from the same repo. Deployment is decoupled via Vercel's path-based build triggers.
+### verdicto.ai
+
+```
+/                   → Product homepage (hero + value props + how it works + CTA)
+/features           → Enterprise features breakdown
+/architecture       → Technical deep dive (Minsky foundation, memory layers, decision intelligence)
+/docs               → Enterprise documentation
+/pricing            → Pricing/contact (Phase 2)
+/concepts           → Deep dives: K-Lines, Censors, Calibration, Frames, B-Brain
+/concepts/{name}    → Individual concept pages
+/404                → Custom 404
+```
+
+### nous-agent.ai
+```
+/  → Redirect to github.com/tfatykhov/membrain
+```
+
+### mem-brain.ai
+```
+/  → Redirect to cognition-engines.ai
+```
 
 ---
 
@@ -108,14 +183,16 @@ F018 is a runtime architecture feature — it replaces the static `NOUS_IDENTITY
 
 **Rationale:** Dark theme signals "developer tool." Violet accent differentiates from the sea of blue developer sites. Teal secondary provides warmth without competing.
 
+**Note:** Verdicto may adopt a slightly warmer/more professional variant of this palette for enterprise positioning. Design exploration needed in Phase 1.
+
 ### Typography
 
 | Role | Font | Weight | Size |
 |------|------|--------|------|
-| Headings | `Space Groto` (Google Fonts) | 700 | 2.5rem / 2rem / 1.5rem |
+| Headings | `Space Grotesk` (Google Fonts) | 700 | 2.5rem / 2rem / 1.5rem |
 | Body | `Inter` (Google Fonts) | 400/500 | 1rem (16px) |
 | Code / mono | `JetBrains Mono` (Google Fonts) | 400 | 0.875rem |
-| Hero tagline | `Space Groto` | 700 | 3.5rem (desktop) / 2rem (mobile) |
+| Hero tagline | `Space Grotesk` | 700 | 3.5rem (desktop) / 2rem (mobile) |
 
 **Rationale:** Space Grotesk conveys technical precision with personality. Inter is the developer standard — familiar and highly readable. JetBrains Mono for code blocks signals seriousness to devs.
 
@@ -157,40 +234,36 @@ F018 is a runtime architecture feature — it replaces the static `NOUS_IDENTITY
 
 ## Page Designs
 
-### 1. Homepage
+### verdicto.ai Homepage
 
-**Conversion funnel:** Hook → Prove It Works → Try It → Understand Why → Go Deeper
+**Conversion funnel:** Hook → Prove It Works → Differentiate → Try It → Go Deeper
 
 #### Section 1: Hero
 
 ```
 ┌─────────────────────────────────────────────────────┐
 │                                                     │
-│   [Nous project image — "Minds from Mindless Stuff"]│
+│   Verdicto                                          │
 │                                                     │
-│   AI agents that think, learn, and grow.            │
+│   Enterprise AI that remembers, decides, and learns.│
 │                                                     │
-│   Nous is an open-source agent framework grounded   │
-│   in Minsky's Society of Mind — with structured     │
-│   memory, decision intelligence, and self-monitoring│
-│   built in from the start.                         │
+│   Built on 40 years of cognitive science. Verdicto  │
+│   gives your AI agents structured memory, decision  │
+│   intelligence, and self-monitoring — so they get   │
+│   smarter with every interaction.                   │
 │                                                     │
-│   [Get Started →]          [GitHub ↗]               │
+│   [Request Demo →]       [View Architecture ↗]      │
 │                                                     │
-│   v0.x.x · Apache 2.0 · {lines} lines · {tests} tests │
+│   Built on Nous · Powered by Cognition Engines      │
 └─────────────────────────────────────────────────────┘
 ```
 
-**Changes from v1:**
-- Stats are now dynamic — pulled at build time (see §Build-Time Stats)
-- Terminal animation or short code snippet embedded in hero background (subtle, non-distracting)
-
 ---
 
-#### Section 2: "Why Nous?" (3 columns — tightened)
+#### Section 2: "Why Verdicto?" (3 columns)
 
 **Column 1: Structured Memory**
-> Current agents store text and hope for the best. Nous gives agents four memory layers — from fast working memory to persistent decision intelligence — so they actually learn from experience.
+> Current agents store text and hope for the best. Verdicto gives agents four memory layers — from fast working memory to persistent decision intelligence — so they actually learn from experience.
 
 **Column 2: Decision Intelligence**
 > Every significant decision is recorded with reasoning, confidence, and outcome. Your agent tracks its own calibration. When it faces the same situation again, it knows what worked.
@@ -200,47 +273,22 @@ F018 is a runtime architecture feature — it replaces the static `NOUS_IDENTITY
 >
 > ¹ [Deep dive into the concepts →](/concepts)
 
-**Changes from v1:**
-- Removed insider jargon (K-Lines, B-Brains, chapter numbers) from homepage
-- Capability-first language — what it *does*, not what it's *called*
-- Minsky citation kept but as footnote link to /concepts, not inline
+---
+
+#### Section 3: Enterprise Value Props
+
+**Column 1: Cost Reduction**
+> After 10 conversations per user, Verdicto's memory architecture costs 26% less than long-context alternatives. The savings compound with every interaction.
+
+**Column 2: Compliance & Audit**
+> Full decision audit trail. Every judgment your agent makes is traceable — reasoning, confidence, outcome. Built for regulated industries.
+
+**Column 3: Your Infrastructure**
+> Runs entirely in your environment. No data leaves your perimeter. No vendor lock-in. Built on open-source Nous, so you can inspect every line.
 
 ---
 
-#### Section 3: Quick Start ⬆️ MOVED UP
-
-Show the minimum viable code to get a Nous agent running.
-
-```bash
-# Clone and start (requires Docker)
-git clone https://github.com/tfatykhov/nous
-cd nous
-cp .env.example .env  # add your ANTHROPIC_API_KEY
-docker compose up
-```
-
-```bash
-# Talk to your agent
-curl -X POST http://localhost:8000/chat \
-  -H "Content-Type: application/json" \
-  -d '{"message": "Hello — what do you remember about me?"}'
-```
-
-> Your agent is now running with structured memory, decision recording, and self-monitoring. Everything it learns persists across sessions.
-
-**Prerequisites callout (honest about requirements):**
-> 📋 You'll need: Docker, an Anthropic API key ([get one here](https://console.anthropic.com)), and ~10 minutes.
-
-**[Read the full quickstart docs →]** · **[Try the playground →]** *(Phase 2)*
-
-**Changes from v1:**
-- Moved from position 6 → position 3 (critical for conversion)
-- Added honest prerequisites callout (Docker, API key, realistic time)
-- Added playground link placeholder for Phase 2
-
----
-
-#### Section 4: The Nous Loop (simplified)
+#### Section 4: The Cognitive Loop (simplified)
 
 Visual treatment of the 7-step cognitive cycle. Rendered as a clean circular/linear SVG diagram with hover/click to expand.
 
@@ -258,51 +306,81 @@ One-line descriptions:
 - **Monitor** — Did the action match the intent? Were there surprises?
 - **Learn** — Update memory, calibration, and guardrails for next time
 
-**Changes from v1:**
-- Moved from position 3 → position 4 (after Quick Start)
-- Removed table format — now a visual diagram with progressive disclosure
-- Removed Minsky jargon from labels (B-Brain → "self-monitoring layer")
+---
+
+#### Section 5: Open Source Foundation
+
+```
+┌─────────────────────────────────────────────────────┐
+│   Built on Nous — the open-source cognitive agent   │
+│   framework with {lines} lines of Python,           │
+│   {tests} tests, and an Apache 2.0 license.         │
+│                                                     │
+│   [View on GitHub →]    [Read the Research →]        │
+│                                                     │
+│   Verdicto adds enterprise features on top:         │
+│   managed deployment, SLA, SSO, audit trails,       │
+│   compliance tooling, and dedicated support.         │
+└─────────────────────────────────────────────────────┘
+```
 
 ---
 
-#### Section 5: Stats Bar ⬆️ MOVED UP
+#### Section 6: CTA
 
 ```
-{lines} lines of Python · {tests} tests · {tables} Postgres tables · {endpoints} REST endpoints · v{version}
+┌─────────────────────────────────────────────────────┐
+│   Ready to give your AI agents real memory?         │
+│                                                     │
+│   [Request Demo →]    [Read the Docs →]             │
+│                                                     │
+│   Or start with the open-source framework:          │
+│   git clone https://github.com/tfatykhov/membrain  │
+└─────────────────────────────────────────────────────┘
 ```
-
-**All stats are build-time dynamic** — pulled from the repo at deploy. See §Build-Time Stats.
-
----
-
-#### Section 6: What to Build Next 🆕
-
-> **Got it running? Here's where to go:**
->
-> 🔧 **[Build a Custom Agent →]** — Give your agent a unique identity, tools, and knowledge base
-> 📖 **[Explore the Concepts →]** — Understand the cognitive architecture under the hood
-> 🤝 **[Join the Community →]** — GitHub Discussions for questions, ideas, and show-and-tell
-> 🔄 **[Coming from LangChain? →]** — Key differences and migration patterns *(Phase 2)*
-
-**Rationale:** The original spec had no adoption path. Developers who completed Quick Start had nowhere to go. This section bridges "I tried it" → "I'm building with it."
 
 ---
 
 #### Section 7: Footer
 
-- GitHub link + star button
-- Community link (GitHub Discussions — Phase 1; Discord considered for Phase 2)
-- Cognition Engines link (one line: "Nous uses Cognition Engines for decision intelligence")
-- Apache 2.0 license note
+- GitHub link + star button (Nous OSS)
+- Cognition Engines link
+- Apache 2.0 license note (for Nous OSS core)
+- Enterprise contact / support link
 - *"Built on Minsky and too much coffee ☕"*
-
-**Changes from v1:**
-- Cognition Engines moved from its own section → footer link (new visitors don't need the internal project structure)
-- Community link added to Phase 1
 
 ---
 
-### 2. /concepts Landing Page
+### cognition-engines.ai Homepage
+
+```
+┌─────────────────────────────────────────────────────┐
+│   Cognition Engines                                 │
+│                                                     │
+│   Building AI that thinks, not just predicts.       │
+│                                                     │
+│   We research and build cognitive architectures     │
+│   for AI agents — grounded in Minsky's Society of   │
+│   Mind and validated against the latest research.   │
+│                                                     │
+│   ┌──────────────┐    ┌──────────────┐              │
+│   │ Nous (OSS)   │    │ Verdicto     │              │
+│   │ The framework│    │ Enterprise   │              │
+│   │ [GitHub →]   │    │ [Learn More]│              │
+│   └──────────────┘    └──────────────┘              │
+│                                                     │
+│   Latest Articles                                   │
+│   ────────────────                                  │
+│   • Your AI Agent Has Amnesia...                    │
+│   • Stop Renting AI...                              │
+│   • The Silent Risk...                              │
+│   • AI agents make hundreds of decisions...         │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+### /concepts Pages (on verdicto.ai)
 
 Grid of cards, one per core Minsky concept. Each card shows:
 - Concept name (capability-first label)
@@ -318,12 +396,7 @@ Cards:
 - **Parallel Reasoning (Bundles)** — Multiple reasons are stronger than one chain of thought
 - **Papert's Principle** — Understanding by debugging — how agents learn from their own failures
 
-**Changes from v1:**
-- Moved from homepage → dedicated /concepts page (unclutters conversion funnel)
-- Added capability-first labels alongside Minsky terms
-- Chapter numbers removed from cards (available on deep-dive pages)
-
-### 3. /concepts/{name} Pages
+### /concepts/{name} Pages
 
 One page per core concept. Template:
 
@@ -338,10 +411,10 @@ One page per core concept. Template:
 ## Minsky's Original Insight
 [Quote + brief context from the book]
 
-## How Nous Implements It
+## How Verdicto Implements It
 [Code snippet or diagram showing the actual implementation]
 
-## Why It Matters for Agents
+## Why It Matters for Enterprise Agents
 [Practical consequence — what breaks without this, what it enables]
 
 ## Try It
@@ -357,19 +430,7 @@ Pages to build:
 - `/concepts/parallel-bundles` — Parallel Reasoning
 - `/concepts/paperts-principle` — Papert's Principle
 
-### 4. /cognition-engines Bridge Page
-
-Explains the relationship for developers who find one project and wonder about the other.
-
-Content:
-- What Cognition Engines is (standalone decision server, MCP integration)
-- What Nous is (full agent framework, embedded Brain)
-- How they relate (same philosophy, independent codebases)
-- When to use which:
-  - **Cognition Engines:** You have an existing agent stack and want to add decision intelligence via MCP
-  - **Nous:** You're building a new agent from scratch and want the full cognitive architecture
-
-### 5. /404 Page 🆕
+### /404 Page
 
 ```
 # Wrong K-Line Activated
@@ -383,9 +444,9 @@ On-brand, helpful, not annoying.
 
 ---
 
-## Build-Time Stats Pipeline 🆕
+## Build-Time Stats Pipeline
 
-Stats displayed on the site must be current at deploy time. Stale stats (the v1 spec said 11,800 lines; repo currently has 38,000+) undermine credibility.
+Stats displayed on the site must be current at deploy time. Stale stats undermine credibility.
 
 **Implementation:**
 ```javascript
@@ -405,7 +466,7 @@ Stats are injected into the Astro build via a custom integration. No manual upda
 
 ---
 
-## SEO Implementation 🆕
+## SEO Implementation
 
 ### Technical SEO
 - `sitemap.xml` — auto-generated by `@astrojs/sitemap`
@@ -415,14 +476,20 @@ Stats are injected into the Astro build via a custom integration. No manual upda
 - Open Graph + Twitter Card meta on all pages
 
 ### OG Image
-- Default: 1200×630, dark background, Nous logo + tagline
+- Default: 1200×630, dark background, Verdicto logo + tagline
 - Per-concept pages: concept name + one-line description
 - Generated at build time via `@vercel/og` or Satori
 
 ### Target Keywords
-- Primary: "AI agent framework", "Society of Mind agent", "Minsky AI framework"
-- Secondary: "agent memory architecture", "decision intelligence AI", "cognitive AI agent"
-- Long-tail: "alternative to LangChain", "AI agent structured memory", "agent calibration framework"
+
+**verdicto.ai:**
+- Primary: "enterprise AI agent", "AI agent memory", "AI decision intelligence"
+- Secondary: "agent memory architecture", "cognitive AI platform", "enterprise AI compliance"
+- Long-tail: "AI agent that learns from decisions", "alternative to LangChain enterprise", "Minsky Society of Mind AI"
+
+**cognition-engines.ai:**
+- Primary: "cognitive AI research", "AI agent architecture", "Society of Mind framework"
+- Secondary: "AI agent memory research", "LLM agent cognition"
 
 ---
 
@@ -443,18 +510,19 @@ Stats are injected into the Astro build via a custom integration. No manual upda
 ### Hosting
 - **Vercel** (free tier, instant deploys from GitHub)
 - Build trigger: changes to `/website/**` path only
-- Domain: `mem-brain.ai` — HTTPS via Vercel automatically
+- Domains: `verdicto.ai` and `cognition-engines.ai` — HTTPS via Vercel automatically
 - Preview deploys on PRs for content review
 
 ### Assets Needed
 
-- [ ] `docs/nous-project-image.png` — already exists, use in hero
+- [ ] Verdicto logo and wordmark
+- [ ] Cognition Engines logo and wordmark
 - [ ] Architecture diagram — render existing mermaid as SVG (build-time or manual export)
 - [ ] Memory layers diagram — render existing mermaid as SVG
 - [ ] Loop diagram — custom SVG of the 7-step cycle (circular layout preferred)
 - [ ] Minsky portrait or book cover — **check MIT Press licensing first; have a Plan B** (abstract geometric alternative)
-- [ ] OG image template (1200×630)
-- [ ] Favicon (SVG preferred for crisp rendering at all sizes)
+- [ ] OG image templates (1200×630) for both sites
+- [ ] Favicons for both sites (SVG preferred for crisp rendering at all sizes)
 
 ---
 
@@ -462,90 +530,98 @@ Stats are injected into the Astro build via a custom integration. No manual upda
 
 1. **Show, don't tell** — code snippets over adjectives
 2. **Credit the source** — Minsky gets cited, not vaguely referenced
-3. **Capability first, jargon second** — Lead with what it does ("structured recall"), follow with what it's called ("K-Lines"). On the homepage, capabilities only. On /concepts, full Minsky terminology.
-4. **Honest about status** — v0.x, actively built, not "production ready for everyone"
-5. **Developer voice** — no marketing speak. "Nous gives agents structured memory" not "unlock the power of next-generation AI"
-6. **Short paragraphs** — developers skim. Every paragraph should survive being skipped.
-
-### Content Authorship 🆕
-- **Homepage copy:** Exists in this spec, needs copyedit pass before build
-- **7 concept pages:** Tim (or Nous drafts, Tim reviews). ~500 words each. Estimate: 1 day total
-- **Launch blog post:** Tim. Should explain the Minsky connection and why this framework exists. Good for HN/dev.to. Estimate: 2–3 hours
+3. **Capability first, jargon second** — Lead with what it does ("structured recall"), follow with what it's called ("K-Lines"). On product pages, capabilities only. On /concepts, full Minsky terminology.
+4. **Honest about status** — actively built, enterprise-ready features clearly distinguished from roadmap
+5. **Two voices:**
+   - **Nous (OSS):** Developer voice — "Nous gives agents structured memory" not "unlock the power of next-generation AI"
+   - **Verdicto (Enterprise):** Professional but still technical — "Verdicto reduces inference costs 26% after 10 user sessions" not "leverage synergies"
+6. **Short paragraphs** — developers and executives both skim. Every paragraph should survive being skipped.
 
 ---
 
 ## Launch Sequence
 
-### Phase 0.5 — Landing Page (optional, ~2–3 hours) 🆕
-- [ ] Hero + tagline + GitHub link + stats bar + footer
-- [ ] Domain live with HTTPS
-- [ ] Gets a URL testable immediately while full Phase 1 is built
+### Phase 0.5 — Landing Pages (~1 day)
+- [ ] `verdicto.ai`: Hero + tagline + "Coming Soon" + email capture
+- [ ] `cognition-engines.ai`: Hero + article links + Nous/Verdicto cards
+- [ ] Domain redirects: `mem-brain.ai` → CE, `nous-agent.ai` → GitHub
+- [ ] All domains live with HTTPS
 
-### Phase 1 — MVP (~2–3 days build)
-- [ ] Full homepage (all 7 sections per this spec)
+### Phase 1 — MVP (~2–3 days build per site)
+- [ ] `verdicto.ai` full homepage (all 7 sections per this spec)
+- [ ] `cognition-engines.ai` full homepage + blog (article cross-posts)
 - [ ] Design system implemented (colors, typography, components)
 - [ ] Build-time stats pipeline
-- [ ] Analytics installed (Plausible — privacy-respecting, 5-minute setup) ⬆️ MOVED FROM PHASE 3
-- [ ] Community link active (GitHub Discussions)
-- [ ] SEO basics (sitemap, robots.txt, OG image, JSON-LD)
-- [ ] 404 page
-- [ ] Domain purchased and DNS configured
+- [ ] Analytics installed (Plausible — privacy-respecting, 5-minute setup)
+- [ ] SEO basics (sitemap, robots.txt, OG images, JSON-LD)
+- [ ] 404 pages for both sites
 
 ### Phase 2 — Content Complete (~3–4 days)
-- [ ] `/concepts` landing page + all 7 concept deep-dive pages
-- [ ] `/docs` (mirror or integrate GitHub docs via MDX)
-- [ ] `/cognition-engines` bridge page
+- [ ] `/concepts` landing page + all 7 concept deep-dive pages (on verdicto.ai)
+- [ ] `/docs` — enterprise documentation
+- [ ] `/architecture` — technical deep dive
 - [ ] Per-page OG images
-- [ ] Launch blog post
-- [ ] Playground or hosted demo exploration (research spike: can we offer a sandbox without requiring user's API key?)
+- [ ] Launch blog post on cognition-engines.ai
+- [ ] Playground or hosted demo exploration
 
 ### Phase 3 — Growth
-- [ ] `/blog` — ongoing posts, Minsky deep dives, build log
-- [ ] Community growth (Discord if GitHub Discussions outgrows itself)
+- [ ] `/blog` on cognition-engines.ai — ongoing posts, Minsky deep dives, build log
+- [ ] `/pricing` on verdicto.ai — pricing model, contact form
+- [ ] Community growth (GitHub Discussions → Discord if needed)
 - [ ] Video: 90-second demo (agent running, showing memory, decisions, calibration)
 - [ ] "Coming from LangChain/CrewAI" migration guide
 - [ ] Newsletter signup (if warranted by traffic)
+- [ ] Case studies / testimonials
 
 ---
 
-## Effort Estimates (Revised) 🆕
+## Effort Estimates (Revised)
 
 | Phase | Design | Build | Content | Total |
 |-------|--------|-------|---------|-------|
-| Phase 0.5 | 0 | 2–3h | 0 | ~3h |
-| Phase 1 | 4–6h | 12–16h | 2–3h (copyedit) | ~2–3 days |
-| Phase 2 | 2–3h | 8–12h | 8–10h (7 concept pages + blog) | ~3–4 days |
+| Phase 0.5 | 2h | 4h | 1h | ~1 day |
+| Phase 1 | 6–8h | 20–24h | 4–6h | ~4–5 days |
+| Phase 2 | 2–3h | 8–12h | 8–10h | ~3–4 days |
 | Phase 3 | Ongoing | Ongoing | Ongoing | Ongoing |
 
-**Note:** Original estimate was "~1 day design + ~2 days build" which significantly underestimated the design system work, responsive implementation, stats pipeline, and SEO setup. Revised estimates include realistic buffer for iteration.
+**Note:** Effort increased from v2 due to now building two sites instead of one. Shared design system mitigates some duplication. Phase 0.5 landing pages can be live within a day.
 
 ---
 
 ## Success Metrics
 
-- **GitHub stars** — primary signal for developer interest
-- **Quick Start completion rate** — tracked via analytics (page view: homepage → docs/quickstart)
-- **Time on site** — proxy for content quality (target: > 2 min average)
-- **Inbound issues/PRs** — quality signal (are people actually using it?)
-- **Search visibility** — track rankings for target keywords monthly
-- **Referral sources** — which channels (HN, dev.to, Twitter, organic) drive adoption?
+**Nous (OSS):**
+- GitHub stars — primary signal for developer interest
+- Inbound issues/PRs — quality signal (are people actually using it?)
+
+**Verdicto (Enterprise):**
+- Demo requests — primary conversion metric
+- Time on site — proxy for content quality (target: > 2 min average)
+- Search visibility — track rankings for target keywords monthly
+
+**Cognition Engines (Brand):**
+- Article engagement — LinkedIn reactions, comments, shares
+- Referral sources — which channels (HN, dev.to, Twitter, LinkedIn, organic) drive awareness?
+- Cross-site navigation — are CE readers clicking through to Verdicto?
 
 ---
 
 ## Resolved Questions ✅
 
-1. **Domain name** → `mem-brain.ai` (matches INDEX.md, decision recorded)
-2. **F018 dependency** → Removed as hard blocker (messaging exists in this spec)
-3. **Repo location** → In-repo at `/website/`, decoupled deploys via Vercel path triggers
-4. **Analytics timing** → Phase 1 (Plausible, 5-minute setup, don't lose early data)
-5. **Community from day one** → GitHub Discussions in Phase 1, Discord evaluated in Phase 3
+1. **Brand architecture** → Three-tier: Cognition Engines (company) → Nous (OSS) → Verdicto (enterprise). Decision recorded March 9, 2026.
+2. **Domain mapping** → `cognition-engines.ai` (company), `verdicto.ai` (enterprise product), `nous-agent.ai` (redirect to GitHub), `mem-brain.ai` (redirect to CE), `decision-memory.ai` (parked)
+3. **F018 dependency** → Removed as hard blocker (messaging exists in this spec)
+4. **Repo location** → In-repo at `/website/`, decoupled deploys via Vercel path triggers
+5. **Analytics timing** → Phase 1 (Plausible, 5-minute setup, don't lose early data)
+6. **Community from day one** → GitHub Discussions in Phase 1, Discord evaluated in Phase 3
+7. **Tagline** → _"Verdicto — Enterprise AI that remembers, decides, and learns. Built on Nous. Powered by Cognition Engines."_
 
 ## Open Questions (Remaining)
 
-1. **Docs hosting** — Embedded in site (MDX) or link to GitHub? Embedded is better UX but more maintenance. Decision needed before Phase 2.
-2. **Video** — 90-second demo could be very effective for HN/dev.to launch. Worth the effort before Phase 2 launch?
-3. **Should cognition-engines.ai and mem-brain.ai visually relate?** — Shared design language signals ecosystem. But each has different audiences.
+1. **Verdicto visual identity** — Does it share the Nous dark theme or get a slightly warmer/more professional variant? Needs design exploration.
+2. **Docs hosting** — Embedded in site (MDX) or link to GitHub? Embedded is better UX but more maintenance. Decision needed before Phase 2.
+3. **Video** — 90-second demo could be very effective for launch. Worth the effort before Phase 2?
 4. **Minsky portrait licensing** — MIT Press permission needed. If denied, Plan B: abstract geometric art inspired by Society of Mind diagrams.
 5. **Playground/sandbox** — Can we offer a hosted demo without requiring the user's API key? Options: pre-recorded demo, shared sandbox with rate limiting, or WebContainer-based local runtime. Research spike in Phase 2.
-6. **Cookie consent / GDPR** — Plausible is cookieless and GDPR-compliant by default. Confirm no consent banner needed.
-7. **Internationalization** — Consciously deferred. English only for foreseeable future. Note: keep content in MDX files (not hardcoded) to make future i18n possible.
+6. **Verdicto pricing model** — Freemium? Per-seat? Usage-based? Deferred to Phase 3 but needs research before then.
+7. **Logo design** — Need logos for both Verdicto and Cognition Engines. Budget for professional design or DIY?


### PR DESCRIPTION
## Summary

Major brand restructure for the project:

**Three-tier hierarchy:**
- **Cognition Engines** — company/umbrella brand (cognition-engines.ai)
- **Nous** — open-source cognitive agent framework (GitHub)
- **Verdicto** — enterprise product (verdicto.ai)

**Tagline:** _Verdicto — Enterprise AI that remembers, decides, and learns. Built on Nous. Powered by Cognition Engines._

## Changes
- F019 spec updated from v2 → v3
- Complete domain mapping (5 domains)
- Separate site architectures for verdicto.ai and cognition-engines.ai
- Enterprise value props (cost reduction, compliance, self-hosted)
- Updated SEO keywords, success metrics, effort estimates
- Supersedes earlier mem-brain.ai domain decision

## Pattern
Follows proven OSS-to-enterprise playbook (Elastic, HashiCorp, Databricks, Grafana Labs, Neo4j).