### PR TITLE
docs(F011): v2 spec — learn_skill tool, marketplace support, no filesystem scanner

### DIFF
--- a/docs/features/F011-skill-discovery.md
+++ b/docs/features/F011-skill-discovery.md
@@ -2,13 +2,14 @@
 
 > **Status:** Planned
 > **Priority:** P1
-> **Depends on:** F003 (Cognitive Layer), F002 (Heart — Procedures)
+> **Depends on:** F003 (Cognitive Layer), F002 (Heart — Procedures), F012 (K-Line Learning)
 > **Estimated effort:** ~4-6 hours
+> **Spec version:** v2 — revised 2026-03-09 (simplified acquisition model)
 
 ## Problem
 
 Nous has skills (code-review, serper, web tools) stored as files in the workspace, but:
-- **No indexing** — skills aren't registered anywhere the cognitive loop can find them
+- **No registration** — skills aren't in the procedure registry the cognitive loop can search
 - **No auto-activation** — the agent must manually recall skill existence from facts
 - **No matching** — there's no mechanism to match incoming tasks to relevant skills
 - **No loading** — skill context (instructions, tool paths, patterns) isn't injected into working memory
@@ -17,15 +18,19 @@ Currently, skill awareness depends entirely on facts learned via `learn_fact`. I
 
 ## Solution
 
-Use the existing **Procedure** system in Heart as the skill registry. Procedures already have:
-- `name`, `domain`, `description`
-- `goals` (upper fringe — what it's for)
-- `core_patterns`, `core_tools`, `core_concepts` (middle — transferable knowledge)
-- `implementation_notes` (lower fringe — specific details)
-- `activation_count`, `success_count`, `failure_count` (effectiveness tracking)
-- `tags` and `embedding` for semantic search
+Use the existing **Procedure** system in Heart as the skill registry — it already has everything needed. The missing piece is a single acquisition path: a `learn_skill` tool that parses a SKILL.md file from **any source** (URL, marketplace, local path, raw markdown) and registers it as a durable procedure in the DB.
 
-Skills are procedures that come from the filesystem rather than being learned from experience.
+**Key insight:** Once registered, a skill lives in `heart.procedures` (Postgres). It doesn't need to be on disk to survive restarts. The filesystem was never the right source of truth — the DB is.
+
+### What changes from v1 spec
+
+| v1 (original) | v2 (this spec) |
+|---------------|----------------|
+| Filesystem scanner runs on every startup | One-time bootstrap only (empty DB) |
+| Skills coupled to deployed files | Skills live in DB, source-independent |
+| No marketplace support | URL/marketplace first-class |
+| Restart required to add new skill | Add skills mid-conversation |
+| Separate indexer module | Single `learn_skill` tool + parser |
 
 ## Architecture
 
@@ -41,128 +46,193 @@ graph TD
     D3 --> E[Working Memory]
     E --> F[DELIBERATE]
     F --> G[ACT — with skill context]
+
+    subgraph Acquisition
+        URL["URL / Marketplace"] --> LST[learn_skill tool]
+        Local["Local SKILL.md"] --> LST
+        Raw["Raw markdown"] --> LST
+        LST --> Parser[SkillParser]
+        Parser --> DB[(heart.procedures)]
+    end
+
+    DB --> D3
 ```
 
-### Skill Discovery happens at the RECALL stage
+### Skill Discovery at RECALL (unchanged from v1)
 
-This is the natural fit because:
 1. **FRAME** has already classified the task type (task, decision, debug, conversation, creative)
-2. **RECALL** is where we search all memory types — adding procedures/skills is a natural extension
-3. Skills load into **Working Memory** as items with high relevance
-4. The **Context Engine** already has a procedures budget slot (priority 7)
-
-### Registration Flow
-
-```mermaid
-sequenceDiagram
-    participant FS as Filesystem
-    participant Idx as Skill Indexer
-    participant DB as Heart.Procedures
-    participant CL as Cognitive Layer
-
-    Note over FS: skills/serper/SKILL.md
-    Note over FS: skills/code-review/SKILL.md
-
-    FS->>Idx: Scan workspace/skills/
-    Idx->>Idx: Parse SKILL.md (name, description, tools, triggers)
-    Idx->>DB: store_procedure() for each skill
-    Note over DB: Procedures table with embeddings
-
-    Note over CL: During RECALL stage
-    CL->>DB: search_procedures(query=user_input, frame=current_frame)
-    DB-->>CL: Matched skills (by embedding similarity + frame domain)
-    CL->>CL: Load into working memory + context
-```
+2. **RECALL** searches all memory types — procedures/skills are a natural extension
+3. Matched skills load into **Working Memory** as high-relevance items
+4. **Context Engine** already has a procedures budget slot at priority 7 — just needs data
 
 ## Design
 
 ### 1. Skill Manifest (SKILL.md frontmatter)
 
-Skills already have `SKILL.md` files. Add structured frontmatter:
+Add structured YAML frontmatter to SKILL.md files. This is the machine-readable contract:
 
 ```yaml
 ---
 name: serper-search
 description: Google search via Serper.dev API
-domain: research          # maps to procedure domain
-triggers:                 # keywords/phrases that should activate this skill
+domain: research
+triggers:
   - web search
   - google
   - find online
   - research
   - look up
-frames:                   # which cognitive frames auto-activate this skill
+frames:
   - task
   - debug
-tools:                    # tools this skill provides/enhances
+tools:
   - web_search
   - web_fetch
-requires:                 # dependencies
+requires:
   - SERPER_API_KEY
+source_url: https://clawhub.com/skills/serper    # optional, for marketplace skills
+version: "1.0"                                    # optional
 ---
 ```
 
-### 2. Skill Indexer (`nous/skills/indexer.py`)
+Fields:
+- `name` — unique skill identifier (used for dedup)
+- `description` — one-line summary, used as embedding seed
+- `domain` — procedure domain (research, debugging, code-review, etc.)
+- `triggers` — phrases that should activate this skill at RECALL
+- `frames` — cognitive frames that boost this skill (+0.2 score)
+- `tools` — tools this skill provides or enhances
+- `requires` — environment variables that must be set (missing = `active=False`)
+- `source_url` — where it came from (marketplace URL, GitHub raw link, etc.)
+- `version` — optional version string for update tracking
 
-New module that:
-- Scans `NOUS_WORKSPACE_DIR/skills/` on startup
-- Parses SKILL.md frontmatter
-- Creates/updates procedure records in Heart via `store_procedure()`
-- Generates embeddings from description + triggers for semantic matching
-- Re-indexes on `skill_added` / `skill_removed` events
+### 2. `learn_skill` Tool
+
+The primary acquisition path. Exposed to the model like `learn_fact`.
 
 ```python
-class SkillIndexer:
-    """Index workspace skills as procedures in Heart."""
+async def learn_skill(
+    source: str,          # URL, local path, or "inline"
+    content: str | None,  # raw markdown if source="inline"
+) -> dict:
+    """
+    Register a skill from a URL, local path, or raw markdown.
 
-    async def index_all(self, workspace_dir: str) -> list[ProcedureDetail]:
-        """Scan skills directory and register as procedures."""
-        skills_dir = Path(workspace_dir) / "skills"
-        if not skills_dir.exists():
-            return []
+    Examples:
+      learn_skill(source="https://clawhub.com/skills/serper/SKILL.md")
+      learn_skill(source="skills/code-review/SKILL.md")
+      learn_skill(source="inline", content="---\\nname: my-skill\\n...\\n---\\n# My Skill...")
+    """
+```
 
-        results = []
-        for skill_dir in skills_dir.iterdir():
-            if not skill_dir.is_dir():
-                continue
-            skill_md = skill_dir / "SKILL.md"
-            if not skill_md.exists():
-                continue
+**Behaviour:**
+1. Fetch content (web_fetch for URLs, read_file for local paths, use `content` directly for inline)
+2. Parse SKILL.md frontmatter → `SkillManifest`
+3. Check `requires` env vars → set `active=False` if any missing, log warning
+4. Dedup: search existing procedures by name — update if found, create if not
+5. Call `heart.store_procedure()` → durable in DB with embedding
+6. Return `{name, id, active, message}`
 
-            manifest = self._parse_manifest(skill_md)
-            procedure = await self._register_skill(manifest)
-            results.append(procedure)
+**Tool schema:**
+```json
+{
+  "type": "object",
+  "properties": {
+    "source": {
+      "type": "string",
+      "description": "URL, local file path relative to workspace, or 'inline' for raw content"
+    },
+    "content": {
+      "type": "string",
+      "description": "Raw SKILL.md markdown when source is 'inline'"
+    }
+  },
+  "required": ["source"]
+}
+```
 
-        return results
+### 3. SkillParser (`nous/skills/parser.py`)
 
-    def _parse_manifest(self, path: Path) -> SkillManifest:
-        """Parse SKILL.md frontmatter into SkillManifest."""
+Single module. No scanner, no file watcher — just parsing logic.
+
+```python
+@dataclass
+class SkillManifest:
+    name: str
+    description: str
+    domain: str
+    triggers: list[str]
+    frames: list[str]
+    tools: list[str]
+    requires: list[str]
+    source_url: str | None
+    version: str | None
+    raw_content: str           # full SKILL.md text after frontmatter
+    first_section: str         # first H2 block — used in working memory compact format
+
+class SkillParser:
+    def parse(self, markdown: str, source_hint: str | None = None) -> SkillManifest:
+        """Parse SKILL.md markdown into SkillManifest. Raises ValueError if frontmatter missing."""
         ...
 
-    async def _register_skill(self, manifest: SkillManifest) -> ProcedureDetail:
-        """Create or update procedure from skill manifest."""
-        input = ProcedureInput(
+    def to_procedure_input(self, manifest: SkillManifest) -> ProcedureInput:
+        """Convert SkillManifest to ProcedureInput for heart.store_procedure()."""
+        return ProcedureInput(
             name=manifest.name,
             domain=manifest.domain,
             description=manifest.description,
-            goals=manifest.triggers,          # upper fringe = when to activate
-            core_tools=manifest.tools,        # middle = what tools it provides
-            core_patterns=manifest.triggers,  # middle = activation patterns
-            implementation_notes=[str(manifest.path)],  # lower fringe = where to find it
-            tags=["skill", "filesystem"] + manifest.frames,
+            goals=manifest.triggers,              # upper fringe — when to activate
+            core_tools=manifest.tools,            # middle — what tools it uses
+            core_patterns=manifest.triggers,      # middle — activation patterns
+            core_concepts=[manifest.domain],      # middle — domain concepts
+            implementation_notes=[               # lower fringe — source + version
+                manifest.source_url or "local",
+                f"version:{manifest.version}" if manifest.version else "",
+            ],
+            tags=["skill"] + manifest.frames,
         )
-        return await self._heart.store_procedure(input)
 ```
 
-### 3. Cognitive Layer Integration (RECALL stage)
+### 4. Bootstrap (fresh install only)
 
-In `CognitiveLayer.pre_turn()`, after frame selection:
+On startup, if `heart.procedures` has zero rows with tag `skill`:
+
+```python
+async def bootstrap_local_skills(workspace_dir: str, heart: Heart) -> int:
+    """
+    One-time bootstrap: register local SKILL.md files when DB is empty.
+    Runs once, never again (DB becomes source of truth after this).
+    """
+    skills_dir = Path(workspace_dir) / "skills"
+    if not skills_dir.exists():
+        return 0
+
+    count = await heart.count_procedures(tags=["skill"])
+    if count > 0:
+        return 0  # already bootstrapped — don't re-scan
+
+    registered = 0
+    for skill_dir in skills_dir.iterdir():
+        skill_md = skill_dir / "SKILL.md"
+        if skill_md.exists():
+            await _register_from_path(skill_md, heart)
+            registered += 1
+
+    logger.info(f"Bootstrapped {registered} local skills into procedures DB")
+    return registered
+```
+
+Called once in `main.py` during startup. After that, the filesystem is irrelevant — skills are in the DB.
+
+### 5. Cognitive Layer Integration (RECALL stage)
+
+In `CognitiveLayer.pre_turn()`, after frame selection — this is the part the plumbing already supports:
 
 ```python
 # During RECALL — search procedures/skills by input + frame
 procedures = await self._heart.search_procedures(
     query=user_input,
-    domain=frame.frame_id,  # frame-based filtering
+    domain=frame.frame_id,
     limit=3,
 )
 
@@ -179,99 +249,27 @@ for proc in procedures:
     )
 ```
 
-### 4. Context Engine (procedures budget)
+The `recalled_procedure_ids` plumbing in `layer.py` already exists (lines 274, 312, 407, 520–522). This stage just needs data.
 
-The context engine already has a procedures slot at priority 7. Currently unused because no procedures exist. Once skills are indexed as procedures, they'll automatically flow into context:
+### 6. Two-Pass RECALL: Merge & Ranking
+
+**Pass 1:** Semantic search — embedding similarity to user input → `(skill_id, semantic_score)`
+
+**Pass 2:** Frame-domain boost — procedures where `domain` or `tags` match current frame → `+0.2`
 
 ```python
-# context.py — already implemented, just needs data
-# 7. Procedures (F11: skills auto-surfaced here)
-if budget.procedures > 0 and "procedure" not in skip_types:
-    procedures = await self._heart.search_procedures(...)
-    ...
-```
-
-### 5. Frame-Based Auto-Activation
-
-Map frames to skill domains:
-
-| Frame | Auto-activate skills with domain |
-|-------|----------------------------------|
-| task | Any matching domain |
-| debug | debugging, code-review |
-| decision | architecture, process |
-| conversation | (none — lightweight) |
-| creative | writing, design |
-
-Skills with matching `frames` in their manifest are boosted in recall.
-
-### 6. Effectiveness Tracking
-
-When a skill is activated and the turn succeeds/fails:
-- `success_count++` or `failure_count++` via `record_procedure_outcome()`
-- Skills with low effectiveness get deprioritized in recall
-- Links to episodes via `episode_procedures` table (currently empty)
-
-## Database Impact
-
-**No new tables.** Uses existing:
-- `heart.procedures` — skill registry (currently 0 rows)
-- `heart.episode_procedures` — skill-episode links (currently 0 rows)
-- `heart.working_memory.items` — loaded skill context (currently always empty)
-
-All three tables are built and waiting for data.
-
-## Files Changed
-
-| File | Change |
-|------|--------|
-| `nous/skills/__init__.py` | New package |
-| `nous/skills/indexer.py` | Skill indexer (~150 lines) |
-| `nous/skills/manifest.py` | SKILL.md parser (~60 lines) |
-| `nous/cognitive/layer.py` | Add procedure search to RECALL stage |
-| `nous/main.py` | Run skill indexer on startup |
-| `tests/test_skill_indexer.py` | Tests (~200 lines) |
-
-**Estimated:** ~410 lines new code, ~50 lines modified
-
-## Relationship to Other Features
-
-- **F002 Heart (Procedures)** — Skills ARE procedures. Same storage, same API.
-- **F003 Cognitive Layer** — Skill discovery slots into the existing RECALL stage.
-- **F005 Context Engine** — Procedures budget already allocated at priority 7.
-- **F008 Memory Lifecycle** — Skills from filesystem are "permanent" (re-indexed on startup). Learned procedures from experience follow normal lifecycle.
-- **v0.2.0 F011 K-Line Learning** — Learned procedures complement filesystem skills. Over time, Nous discovers its own "skills" from repeated patterns.
-
-## Two-Pass RECALL: Merge & Ranking
-
-Skill discovery uses a two-pass RECALL with merged scoring:
-
-### Pass 1: Semantic Search
-Query procedures by embedding similarity to user input. Returns `(skill_id, semantic_score)`.
-
-### Pass 2: Frame-Domain Filter
-Query procedures where `domain` matches current frame or `tags` contain the frame ID. Returns `(skill_id, domain_match=true)`.
-
-### Merge Strategy
-```python
-# Combine scores, deduplicate by name
 combined = {}
 for skill_id, score in semantic_results:
     combined[skill_id] = score
-for skill_id, _ in domain_results:
-    combined[skill_id] = combined.get(skill_id, 0.0) + 0.2  # frame boost
+for skill_id in frame_matched:
+    combined[skill_id] = combined.get(skill_id, 0.0) + 0.2
 
-# Sort by score, take top 3
 top_skills = sorted(combined.items(), key=lambda x: -x[1])[:3]
 ```
 
-- Frame-domain match adds `+0.2` score boost
-- Deduplicate by skill `name`
-- Top K=3 (fits within procedures context budget)
+### 7. Working Memory Content Format
 
-## Working Memory Content Format
-
-When a skill loads into working memory, use a **compact format** — not full SKILL.md:
+Compact format — not full SKILL.md:
 
 ```
 [Skill: serper-search]
@@ -282,53 +280,96 @@ Triggers: web search, google, find online, research
 {first H2 section from SKILL.md — the "when to use" prose}
 ```
 
-Full SKILL.md stays on disk, fetchable via `read_file` if the agent needs implementation details. This keeps 3 simultaneous skills within ~300-400 tokens total.
+Full SKILL.md stays in `implementation_notes` (source URL or local path), fetchable via `read_file` or `web_fetch` if the agent needs implementation details. Keeps 3 simultaneous skills within ~300–400 tokens total.
 
-## Monitor Stage: Effectiveness Wiring
+### 8. Effectiveness Tracking
 
-The MONITOR stage (post-turn) evaluates skill effectiveness:
+Post-turn, procedures that appeared in context get reinforced:
 
 ```python
-# In CognitiveLayer.post_turn(), after outcome assessment
-for skill_id in turn_context.activated_skills:
+for skill_id in turn_context.recalled_procedure_ids:
     if turn_succeeded:
         await self._heart.record_procedure_outcome(skill_id, success=True)
     elif turn_failed:
         await self._heart.record_procedure_outcome(skill_id, success=False)
 ```
 
-This wires into the existing `success_count` / `failure_count` columns. Skills with `failure_count / (success_count + failure_count) > 0.6` after 5+ activations get a `-0.1` score penalty in RECALL.
+Skills with `failure_count / (success_count + failure_count) > 0.6` after 5+ activations get `-0.1` score penalty in RECALL. This feeds F012's weak review — skills that underperform get LLM-reviewed and potentially retired.
 
-## Re-indexing Strategy
-
-**v1: Startup-only.** SkillIndexer runs once on application start. New skills added mid-session require a restart.
-
-**Future options (not in v1):**
-- Manual trigger via `/index-skills` Telegram command
-- File watcher (fsnotify) on the skills directory
-- Event-driven: `skill_added` bus event triggers re-index
-
-This is an explicit design constraint, not an oversight.
-
-## `requires` Field Semantics
-
-The `requires` field lists **environment variables** that must be set for the skill to function:
+### 9. `requires` Field Semantics
 
 ```yaml
 requires:
   - SERPER_API_KEY
-  - BRAVE_SEARCH_API_KEY
 ```
 
-At index time, SkillIndexer checks `os.environ` for each required var:
-- **All present** → procedure stored with `active=True`
-- **Any missing** → procedure stored with `active=False`, logged as warning
-- Inactive procedures are excluded from RECALL search
+At registration time, `SkillParser` checks `os.environ` for each required var:
+- **All present** → `active=True`
+- **Any missing** → `active=True` but logged as warning (don't block registration — env may differ per deployment)
 
-This prevents the agent from loading a skill into working memory, attempting to use it, and failing because a required API key is missing.
+At RECALL time, inactive procedures are excluded. This prevents the agent from loading a skill, attempting to use it, and failing on a missing API key.
 
-## Open Questions
+> **v2 change:** Registration doesn't fail on missing env vars (v1 set `active=False`). Skills are registered regardless — the env check at RECALL time is the gate. This way, a skill installed from a marketplace works across deployments regardless of which keys are configured where.
 
-1. Should the agent be able to create new skill files from learned procedures (the reverse flow)?
-2. How to handle skill conflicts (two skills claim the same domain/triggers)?
-3. Should effectiveness penalties decay over time (skill improved but old failures drag it down)?
+## Marketplace Flow
+
+With this architecture, acquiring a skill from ClaWHub or any URL is a single conversation turn:
+
+```
+User: "Learn the serper search skill from clawhub.com"
+Nous: [calls learn_skill(source="https://clawhub.com/skills/serper/SKILL.md")]
+      → fetches, parses, registers
+      → "Learned serper-search skill. It will auto-activate on web search tasks."
+```
+
+No restart. No file deployment. No admin action. Available immediately on the next RECALL.
+
+## F011 + F012 Unified Picture
+
+Both pathways write to the same `heart.procedures` table. RECALL can't distinguish source:
+
+| Source | Tag | Who creates it |
+|--------|-----|----------------|
+| `learn_skill` tool (URL/marketplace) | `skill`, `marketplace` | User or Nous |
+| `learn_skill` tool (local SKILL.md) | `skill`, `local` | Bootstrap or user |
+| F012 decision clustering | `auto:decision_cluster` | Nous (sleep) |
+| F012 episode lessons | `auto:episode_lesson` | Nous (sleep) |
+| F012 monitor recovery | `auto:monitor_recovery` | Nous (real-time) |
+
+At RECALL time, all are treated identically. Nous builds its own skill library from experience; users extend it from the marketplace. Same storage, same search, same auto-surfacing.
+
+## Database Impact
+
+**No new tables.** Uses existing:
+- `heart.procedures` — skill registry
+- `heart.episode_procedures` — skill-episode links
+- `heart.working_memory.items` — loaded skill context
+
+All three are built and waiting for data.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `nous/skills/__init__.py` | New package |
+| `nous/skills/parser.py` | SkillParser + SkillManifest (~120 lines) |
+| `nous/api/tools.py` | Add `learn_skill` tool + schema (~80 lines) |
+| `nous/cognitive/layer.py` | Wire procedure RECALL (~30 lines) |
+| `nous/main.py` | Bootstrap call on startup (~15 lines) |
+| `tests/test_skill_parser.py` | Tests (~150 lines) |
+
+**Estimated:** ~395 lines new code, ~45 lines modified. Slightly simpler than v1.
+
+## Relationship to Other Features
+
+- **F002 Heart (Procedures)** — Skills ARE procedures. Same storage, same API.
+- **F003 Cognitive Layer** — Skill discovery slots into the existing RECALL stage. Plumbing already present.
+- **F005 Context Engine** — Procedures budget slot already allocated at priority 7.
+- **F012 K-Line Learning** — Auto-learned procedures complement acquired skills. Same registry, unified RECALL.
+- **F008 Memory Lifecycle** — Skills from `learn_skill` are permanent (no TTL). Weak review (F012) can retire them if ineffective.
+
+## Open Questions (v1 → resolved in v2)
+
+1. ~~Should the agent create new skill files from learned procedures?~~ → **Resolved:** F012 writes to DB directly. No filesystem round-trip needed.
+2. **Skill conflicts** (two skills claim the same domain/triggers) — dedup by `name` at registration. Duplicate names update the existing record rather than creating a new one. Domain/trigger overlap is fine — ranking handles it.
+3. **Effectiveness decay** — penalties should decay after 30 days of inactivity (aligns with F012 weak review staleness window). Not blocking for v1.

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -94,7 +94,7 @@ All shipped implementation specs with PR references:
 |---------|------|----------|-------------|
 | #38 | _is_informational() Phase 2 | P1 | Partially addressed by PR #76 (delete instead of abandon). Further tuning possible. |
 | #52 | Topic-Aware Recall v2 | P1 | Spike merged (#75). Full 008.2 spec exists if spike proves insufficient. |
-| F011 | [Skill Discovery](F011-skill-discovery.md) | P1 | Index workspace skills as procedures, auto-surface in RECALL based on task/frame. |
+| F011 | [Skill Discovery](F011-skill-discovery.md) | P1 | `learn_skill` tool acquires skills from URL/marketplace/local — registered as procedures, auto-surface in RECALL. No filesystem scanner. |
 | 010.1 | Health Dashboard | P1 | Enrich GET /status with episode outcome breakdown, fact health, decision stats. |
 
 ### Phase 3 — Growth


### PR DESCRIPTION
## F011 Skill Discovery — v2 Spec

Revised architecture based on design discussion 2026-03-09.

### What changed from v1

| v1 (original) | v2 (this PR) |
|---|---|
| Filesystem scanner on every startup | One-time bootstrap only (empty DB) |
| Skills coupled to deployed files | Skills live in DB, source-independent |
| No marketplace support | URL/marketplace first-class |
| Restart required to add new skill | Add skills mid-conversation |
| Separate indexer module | Single `learn_skill` tool + parser |

### Core insight

Once a skill is registered, it lives in `heart.procedures` (Postgres). The filesystem was never the right source of truth — the DB is. The filesystem scanner adds complexity (restart coupling, stale duplicates, redeploy fragility) with no real benefit once you have a `learn_skill` tool.

### New primary path

`learn_skill(source)` tool — accepts URL, local path, or raw markdown. Works in a conversation turn. No restart needed. Marketplace skills and local skills use identical code paths.

### F011 + F012 unified

Both auto-learned procedures (F012) and acquired skills (F011) write to `heart.procedures`. RECALL treats them identically. Nous builds its own skill library from experience; users extend it from the marketplace.

### Files
- `docs/features/F011-skill-discovery.md` — full v2 spec
- `docs/features/INDEX.md` — updated description

⚡ Emerson