### PR TITLE
feat(f022): fact-to-fact related_to edges

### DIFF
--- a/nous/brain/graph_linker.py
+++ b/nous/brain/graph_linker.py
@@ -120,6 +120,75 @@ class GraphLinker:
 
         return edges
 
+    async def link_fact_to_facts(
+        self,
+        fact_id: UUID,
+        fact_content: str,
+        session: AsyncSession,
+    ) -> list[GraphEdgeInfo]:
+        """Find and link a new fact to similar existing facts via embedding similarity."""
+        if not self.embedder or not self.settings.cross_type_linking_enabled:
+            return []
+
+        template_text = common_template_text("fact", fact_content)
+        try:
+            fact_embedding = await self.embedder.embed(template_text)
+        except Exception:
+            logger.warning("Failed to embed fact %s for fact-to-fact linking", fact_id)
+            return []
+
+        embedding_str = "[" + ",".join(str(float(v)) for v in fact_embedding) + "]"
+
+        sql = text("""
+            SELECT id, content,
+                   1 - (embedding <=> CAST(:embedding AS vector)) AS similarity
+            FROM heart.facts
+            WHERE agent_id = :agent_id
+              AND active = true
+              AND id != :fact_id
+              AND embedding IS NOT NULL
+              AND 1 - (embedding <=> CAST(:embedding AS vector)) >= :threshold
+            ORDER BY embedding <=> CAST(:embedding AS vector)
+            LIMIT 5
+        """)
+        result = await session.execute(sql, {
+            "embedding": embedding_str,
+            "agent_id": self.agent_id,
+            "fact_id": fact_id,
+            "threshold": self.settings.cross_type_same_threshold * 0.9,
+        })
+        candidates = result.all()
+
+        edges = []
+        for row in candidates:
+            if row.similarity >= self.settings.cross_type_same_threshold:
+                stmt = (
+                    pg_insert(GraphEdge)
+                    .values(
+                        source_id=fact_id,
+                        target_id=row.id,
+                        source_type="fact",
+                        target_type="fact",
+                        agent_id=self.agent_id,
+                        relation="related_to",
+                        weight=float(row.similarity),
+                        auto_linked=True,
+                    )
+                    .on_conflict_do_nothing(index_elements=["source_id", "target_id", "relation"])
+                )
+                await session.execute(stmt)
+                edges.append(GraphEdgeInfo(
+                    source_id=fact_id,
+                    target_id=row.id,
+                    source_type="fact",
+                    target_type="fact",
+                    relation="related_to",
+                    weight=float(row.similarity),
+                    auto_linked=True,
+                ))
+
+        return edges
+
     async def link_episode_deterministic(
         self,
         episode_id: UUID,

--- a/nous/handlers/fact_graph_linker.py
+++ b/nous/handlers/fact_graph_linker.py
@@ -1,9 +1,9 @@
 """Fact Graph Linker — cross-type linking on fact creation.
 
 Listens to: fact_learned (in-process EventBus)
-Calls: GraphLinker.link_fact_to_decisions()
+Calls: GraphLinker.link_fact_to_decisions() and GraphLinker.link_fact_to_facts()
 
-F022 Phase 2: Wires the missing fact->decision cross-type edge creation.
+F022 Phase 2: Wires fact->decision and fact->fact auto-linking.
 """
 
 from __future__ import annotations
@@ -55,18 +55,24 @@ class FactGraphLinker:
 
         try:
             async with self._graph_linker.db.session() as link_session:
-                edges = await self._graph_linker.link_fact_to_decisions(
+                decision_edges = await self._graph_linker.link_fact_to_decisions(
                     fact_id=fact_id,
                     fact_content=fact_content,
                     session=link_session,
                 )
-                if edges:
+                fact_edges = await self._graph_linker.link_fact_to_facts(
+                    fact_id=fact_id,
+                    fact_content=fact_content,
+                    session=link_session,
+                )
+                all_edges = decision_edges + fact_edges
+                if all_edges:
                     await link_session.commit()
                     logger.debug(
-                        "F022: Linked fact %s to %d decisions via cross-type embedding",
-                        fact_id, len(edges),
+                        "F022: Linked fact %s to %d decisions + %d facts",
+                        fact_id, len(decision_edges), len(fact_edges),
                     )
         except asyncio.CancelledError:
             raise  # Let the EventBus handle cancellation for clean shutdown
         except Exception:
-            logger.debug("F022 fact->decision graph linking failed for fact %s", fact_id_str)
+            logger.debug("F022 fact graph linking failed for fact %s", fact_id_str)

--- a/tests/test_fact_graph_linker.py
+++ b/tests/test_fact_graph_linker.py
@@ -1,4 +1,4 @@
-"""Tests for F022 Phase 2 gap fix: fact-to-decision auto-linking."""
+"""Tests for F022 Phase 2: fact-to-decision and fact-to-fact auto-linking."""
 
 from __future__ import annotations
 
@@ -183,8 +183,8 @@ class TestFactGraphLinker:
         graph_linker.db.session.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_calls_link_fact_to_decisions(self):
-        """Should call graph_linker.link_fact_to_decisions with correct args."""
+    async def test_calls_link_fact_to_decisions_and_facts(self):
+        """Should call both link_fact_to_decisions and link_fact_to_facts."""
         graph_linker = AsyncMock(spec=GraphLinker)
         mock_session = AsyncMock()
         mock_cm = AsyncMock()
@@ -194,7 +194,7 @@ class TestFactGraphLinker:
         graph_linker.db.session.return_value = mock_cm
 
         fact_id = uuid4()
-        edge = GraphEdgeInfo(
+        decision_edge = GraphEdgeInfo(
             source_id=fact_id,
             target_id=uuid4(),
             source_type="fact",
@@ -203,7 +203,17 @@ class TestFactGraphLinker:
             weight=0.85,
             auto_linked=True,
         )
-        graph_linker.link_fact_to_decisions = AsyncMock(return_value=[edge])
+        fact_edge = GraphEdgeInfo(
+            source_id=fact_id,
+            target_id=uuid4(),
+            source_type="fact",
+            target_type="fact",
+            relation="related_to",
+            weight=0.92,
+            auto_linked=True,
+        )
+        graph_linker.link_fact_to_decisions = AsyncMock(return_value=[decision_edge])
+        graph_linker.link_fact_to_facts = AsyncMock(return_value=[fact_edge])
 
         handler, _, _ = self._make_handler(graph_linker=graph_linker)
         event = _make_event(fact_id=fact_id, content="PostgreSQL uses MVCC")
@@ -215,11 +225,44 @@ class TestFactGraphLinker:
             fact_content="PostgreSQL uses MVCC",
             session=mock_session,
         )
+        graph_linker.link_fact_to_facts.assert_called_once_with(
+            fact_id=fact_id,
+            fact_content="PostgreSQL uses MVCC",
+            session=mock_session,
+        )
+        mock_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_commits_when_only_fact_edges(self):
+        """Should commit when only link_fact_to_facts returns edges."""
+        graph_linker = AsyncMock(spec=GraphLinker)
+        mock_session = AsyncMock()
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        graph_linker.db = MagicMock()
+        graph_linker.db.session.return_value = mock_cm
+
+        fact_edge = GraphEdgeInfo(
+            source_id=uuid4(),
+            target_id=uuid4(),
+            source_type="fact",
+            target_type="fact",
+            relation="related_to",
+            weight=0.93,
+            auto_linked=True,
+        )
+        graph_linker.link_fact_to_decisions = AsyncMock(return_value=[])
+        graph_linker.link_fact_to_facts = AsyncMock(return_value=[fact_edge])
+
+        handler, _, _ = self._make_handler(graph_linker=graph_linker)
+        await handler.handle(_make_event())
+
         mock_session.commit.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_no_commit_when_no_edges(self):
-        """Should not commit when link_fact_to_decisions returns empty list."""
+        """Should not commit when both linking methods return empty lists."""
         graph_linker = AsyncMock(spec=GraphLinker)
         mock_session = AsyncMock()
         mock_cm = AsyncMock()
@@ -228,6 +271,7 @@ class TestFactGraphLinker:
         graph_linker.db = MagicMock()
         graph_linker.db.session.return_value = mock_cm
         graph_linker.link_fact_to_decisions = AsyncMock(return_value=[])
+        graph_linker.link_fact_to_facts = AsyncMock(return_value=[])
 
         handler, _, _ = self._make_handler(graph_linker=graph_linker)
         await handler.handle(_make_event())
@@ -245,6 +289,26 @@ class TestFactGraphLinker:
         graph_linker.db = MagicMock()
         graph_linker.db.session.return_value = mock_cm
         graph_linker.link_fact_to_decisions = AsyncMock(
+            side_effect=Exception("embedding service down")
+        )
+
+        handler, _, _ = self._make_handler(graph_linker=graph_linker)
+
+        # Should NOT raise
+        await handler.handle(_make_event())
+
+    @pytest.mark.asyncio
+    async def test_error_in_fact_to_facts_isolated(self):
+        """link_fact_to_facts failure should not propagate."""
+        graph_linker = AsyncMock(spec=GraphLinker)
+        mock_session = AsyncMock()
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        graph_linker.db = MagicMock()
+        graph_linker.db.session.return_value = mock_cm
+        graph_linker.link_fact_to_decisions = AsyncMock(return_value=[])
+        graph_linker.link_fact_to_facts = AsyncMock(
             side_effect=Exception("embedding service down")
         )
 


### PR DESCRIPTION
## Summary
- Add `link_fact_to_facts()` to `GraphLinker` — queries `heart.facts` by cosine similarity, creates `related_to` edges for facts above `cross_type_same_threshold` (0.90)
- Wire into `FactGraphLinker` handler alongside existing fact-to-decision linking
- Add 3 new unit tests (combined linking, fact-only commit, error isolation)

## Details
The `cross_type_same_threshold` config setting (0.90) already existed but had no consumer. This completes the missing fact→fact edge type that was part of the original F022 design.

No schema changes — `related_to` relation and `fact`/`fact` type pair already valid in `brain.graph_edges`.

## Test plan
- [x] All 12 unit tests pass (`tests/test_fact_graph_linker.py` + `tests/test_graph_linker.py`)
- [ ] Integration test with Postgres (needs docker-compose)

🤖 Generated with [Claude Code](https://claude.com/claude-code)