### PR TITLE
fix: enable pool_pre_ping to discard dead DB connections

### DIFF
--- a/nous/storage/database.py
+++ b/nous/storage/database.py
@@ -19,6 +19,7 @@ class Database:
             settings.db_url,
             pool_size=settings.db_pool_size,
             max_overflow=settings.db_max_overflow,
+            pool_pre_ping=True,
             echo=settings.log_level == "debug",
         )
         self.session_factory = async_sessionmaker(self.engine, class_=AsyncSession, expire_on_commit=False)


### PR DESCRIPTION
## Summary
- Enable `pool_pre_ping=True` on the SQLAlchemy async engine
- Prevents `InterfaceError: connection is closed` crashes when cancelled requests leave dead connections in the pool
- The subtask worker was crashing on dequeue because it got a dead connection

## Test plan
- [x] One-line change, no logic changes
- [ ] Deploy and verify subtask worker no longer crashes after request cancellations

🤖 Generated with [Claude Code](https://claude.com/claude-code)