### PR TITLE
chore: update default models to claude-sonnet-4-6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,7 +219,7 @@ DB connection vars are **unprefixed** (shared with docker-compose). All others u
 | `NOUS_IDENTITY_PROMPT` | Built-in default | **Agent identity.** First section of every system prompt. How Nous knows who it is, what tools it has, and how to behave. Override to customize. |
 | `NOUS_AGENT_ID` | `nous-default` | Agent identifier |
 | `NOUS_AGENT_NAME` | `Nous` | Agent display name |
-| `NOUS_MODEL` | `claude-sonnet-4-5-20250514` | LLM model for chat |
+| `NOUS_MODEL` | `claude-sonnet-4-6` | LLM model for chat |
 | `NOUS_MAX_TURNS` | `10` | Max tool loop iterations |
 | `NOUS_MCP_ENABLED` | `true` | Enable MCP server |
 | `NOUS_LOG_LEVEL` | `info` | Log level |
@@ -229,7 +229,7 @@ DB connection vars are **unprefixed** (shared with docker-compose). All others u
 | `NOUS_EPISODE_SUMMARY_ENABLED` | `true` | Enable episode summarization handler |
 | `NOUS_FACT_EXTRACTION_ENABLED` | `true` | Enable fact extraction handler |
 | `NOUS_SLEEP_ENABLED` | `true` | Enable sleep/reflection handler |
-| `NOUS_BACKGROUND_MODEL` | `claude-sonnet-4-5-20250514` | Model for background LLM tasks |
+| `NOUS_BACKGROUND_MODEL` | `claude-sonnet-4-6` | Model for background LLM tasks |
 | `NOUS_SESSION_TIMEOUT` | `1800` | Session idle timeout in seconds |
 | `NOUS_SLEEP_TIMEOUT` | `7200` | Sleep mode timeout in seconds |
 | `NOUS_SLEEP_CHECK_INTERVAL` | `60` | Sleep check interval in seconds |

--- a/nous/cognitive/schemas.py
+++ b/nous/cognitive/schemas.py
@@ -17,6 +17,7 @@ MODEL_CONTEXT_WINDOWS: dict[str, int] = {
     "claude-opus-4-6": 1_000_000,
     "claude-sonnet-4-5": 200_000,
     "claude-opus-4-5": 200_000,
+    "claude-haiku-4-5": 200_000,
     "gpt-4o": 128_000,
     "gpt-4-turbo": 128_000,
 }

--- a/nous/config.py
+++ b/nous/config.py
@@ -85,7 +85,7 @@ class Settings(BaseSettings):
         validation_alias="GITHUB_TOKEN",
     )
     background_model: str = Field(
-        default="claude-sonnet-4-5-20250514",
+        default="claude-sonnet-4-6",
         validation_alias="NOUS_BACKGROUND_MODEL",
     )
     session_idle_timeout: int = Field(
@@ -105,7 +105,7 @@ class Settings(BaseSettings):
     mcp_enabled: bool = True
 
     # LLM
-    model: str = "claude-sonnet-4-5-20250514"
+    model: str = "claude-sonnet-4-6"
     max_tokens: int = 4096
 
     # Extended thinking


### PR DESCRIPTION
## Summary
- Update default `model` and `background_model` from legacy `claude-sonnet-4-5-20250514` to `claude-sonnet-4-6`
- Add `claude-haiku-4-5` (200k) to context window map — used by contradiction detection model
- Update CLAUDE.md defaults

Sonnet 4.5 is now a legacy model per Anthropic docs. Sonnet 4.6 brings 1M context (up from 200k), better performance, and lower latency.

## Test plan
- [x] Config defaults updated
- [x] Context window map covers all models we use
- [ ] Deploy and verify API calls use new model

🤖 Generated with [Claude Code](https://claude.com/claude-code)