### PR TITLE
fix: always retry on retryable status codes, log all retry headers

### DIFF
--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -71,12 +71,22 @@ class StreamEvent:
 
 
 def _should_retry(status_code: int, headers: httpx.Headers) -> bool:
-    """Decide whether to retry based on x-should-retry header and status code."""
+    """Always retry on retryable status codes. Log x-should-retry header if present."""
     should = headers.get("x-should-retry")
+    is_retryable = status_code in (408, 409, 429) or status_code >= 500
+
     if should is not None:
-        return should.lower() == "true"
-    # Default: retry on 408, 409, 429, and any 5xx
-    return status_code in (408, 409, 429) or status_code >= 500
+        if should.lower() == "true":
+            logger.info("x-should-retry: true (status %d)", status_code)
+            return True
+        else:
+            # Log but ignore — we always retry on retryable status codes
+            logger.info(
+                "x-should-retry: false (status %d) — retrying anyway per policy",
+                status_code,
+            )
+
+    return is_retryable
 
 
 def _retry_delay(attempt: int, response: httpx.Response | None = None) -> float:
@@ -89,22 +99,33 @@ def _retry_delay(attempt: int, response: httpx.Response | None = None) -> float:
     from email.utils import parsedate_to_datetime
 
     if response is not None:
-        # 1. retry-after-ms (milliseconds)
         retry_ms = response.headers.get("retry-after-ms")
+        retry_after = response.headers.get("retry-after")
+        should_retry = response.headers.get("x-should-retry")
+
+        logger.info(
+            "Retry headers: x-should-retry=%s, retry-after-ms=%s, retry-after=%s",
+            should_retry,
+            retry_ms,
+            retry_after,
+        )
+
+        # 1. retry-after-ms (milliseconds)
         if retry_ms is not None:
             try:
                 delay = float(retry_ms) / 1000.0
                 if 0 <= delay <= _HEADER_DELAY_MAX:
+                    logger.info("Using retry-after-ms: %.3fs", delay)
                     return delay
             except (ValueError, OverflowError):
                 pass
 
         # 2. Retry-After (seconds or HTTP date)
-        retry_after = response.headers.get("retry-after")
         if retry_after is not None:
             try:
                 delay = float(retry_after)
                 if 0 <= delay <= _HEADER_DELAY_MAX:
+                    logger.info("Using Retry-After: %.1fs", delay)
                     return delay
             except ValueError:
                 # Try parsing as HTTP date
@@ -113,6 +134,7 @@ def _retry_delay(attempt: int, response: httpx.Response | None = None) -> float:
                     target = parsedate_to_datetime(retry_after)
                     delay = (target - datetime.now(timezone.utc)).total_seconds()
                     if 0 <= delay <= _HEADER_DELAY_MAX:
+                        logger.info("Using Retry-After (date): %.1fs", delay)
                         return delay
                 except (ValueError, TypeError):
                     pass


### PR DESCRIPTION
## Summary
- `x-should-retry: false` no longer prevents retry on retryable statuses — logged but overridden
- `x-should-retry: true` still forces retry on any status code
- All three retry headers logged at INFO on every retry for diagnostics:
  `x-should-retry`, `retry-after-ms`, `retry-after`

## Test plan
- [x] `_should_retry(500, {"x-should-retry": "false"})` returns True
- [x] `_should_retry(400, {"x-should-retry": "false"})` returns False
- [x] `_should_retry(200, {"x-should-retry": "true"})` returns True
- [ ] Deploy and verify retry headers visible in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)