### PR TITLE
fix: tune httpx connection pool limits

### DIFF
--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -327,8 +327,8 @@ class AgentRunner:
             pool=10.0,
         )
         limits = httpx.Limits(
-            max_connections=10,
-            max_keepalive_connections=5,
+            max_connections=5,       # 1 active stream + 2 subtask + 2 buffer
+            max_keepalive_connections=2,  # 1 warm connection ready, no idle hoarding
         )
 
         self._http = httpx.AsyncClient(


### PR DESCRIPTION
## Summary
- `max_connections`: 10 → 5 (1 active stream + 2 subtask + 2 buffer)
- `max_keepalive_connections`: 5 → 2 (1 warm connection ready, no idle hoarding)
- With HTTP/2 multiplexing, fewer connections needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)