### PR TITLE
feat: add official Anthropic SDK as alternative API backend

### DIFF
--- a/nous/api/anthropic_client.py
+++ b/nous/api/anthropic_client.py
@@ -1,0 +1,714 @@
+"""Anthropic API client abstraction — strategy pattern for httpx vs SDK backends.
+
+Provides AnthropicClient protocol with two implementations:
+- HttpxAnthropicClient: direct httpx calls (extracted from runner.py)
+- SdkAnthropicClient: wraps official anthropic.AsyncAnthropic SDK
+
+Runner builds payloads via _build_api_payload(); clients consume them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import random
+from collections.abc import AsyncGenerator
+from email.utils import parsedate_to_datetime
+from typing import Any, Protocol, runtime_checkable
+
+import httpx
+
+from nous.api.models import ApiResponse
+from nous.config import Settings
+
+logger = logging.getLogger(__name__)
+
+# Anthropic API version header
+_API_VERSION = "2023-06-01"
+
+# Retry constants (shared by httpx path)
+_MAX_RETRIES = 5
+_BACKOFF_DELAYS = (1.0, 2.0, 4.0, 8.0, 16.0)
+_BACKOFF_CAP = 30.0
+_HEADER_DELAY_MAX = 60.0
+
+
+# ---------------------------------------------------------------------------
+# StreamEvent (moved from runner.py — used by both clients)
+# ---------------------------------------------------------------------------
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class StreamEvent:
+    """A single event from the streaming API response."""
+
+    type: str  # text_delta, tool_start, tool_input_delta, tool_end, block_stop, done, error, message_stop
+    text: str = ""
+    tool_name: str = ""
+    tool_id: str = ""
+    tool_input: dict = field(default_factory=dict)
+    stop_reason: str = ""
+    block_index: int = 0
+    usage: dict[str, int] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class AnthropicClient(Protocol):
+    """Abstract interface for Anthropic API backends."""
+
+    async def start(self) -> None: ...
+    async def close(self) -> None: ...
+    async def call(self, payload: dict[str, Any]) -> ApiResponse: ...
+    async def stream(self, payload: dict[str, Any]) -> AsyncGenerator[StreamEvent, None]: ...
+
+
+# ---------------------------------------------------------------------------
+# Httpx helpers (extracted from runner.py)
+# ---------------------------------------------------------------------------
+
+
+def _should_retry(status_code: int, headers: httpx.Headers) -> bool:
+    """Always retry on retryable status codes. Log x-should-retry header if present."""
+    should = headers.get("x-should-retry")
+    is_retryable = status_code in (408, 409, 429) or status_code >= 500
+
+    if should is not None:
+        if should.lower() == "true":
+            logger.info("x-should-retry: true (status %d)", status_code)
+            return True
+        else:
+            logger.info(
+                "x-should-retry: false (status %d) — retrying anyway per policy",
+                status_code,
+            )
+
+    return is_retryable
+
+
+def _retry_delay(attempt: int, response: httpx.Response | None = None) -> float:
+    """Compute retry delay from headers or exponential backoff with jitter."""
+    if response is not None:
+        retry_ms = response.headers.get("retry-after-ms")
+        retry_after = response.headers.get("retry-after")
+        should_retry = response.headers.get("x-should-retry")
+
+        logger.info(
+            "Retry headers: x-should-retry=%s, retry-after-ms=%s, retry-after=%s",
+            should_retry,
+            retry_ms,
+            retry_after,
+        )
+
+        if retry_ms is not None:
+            try:
+                delay = float(retry_ms) / 1000.0
+                if 0 <= delay <= _HEADER_DELAY_MAX:
+                    logger.info("Using retry-after-ms: %.3fs", delay)
+                    return delay
+            except (ValueError, OverflowError):
+                pass
+
+        if retry_after is not None:
+            try:
+                delay = float(retry_after)
+                if 0 <= delay <= _HEADER_DELAY_MAX:
+                    logger.info("Using Retry-After: %.1fs", delay)
+                    return delay
+            except ValueError:
+                try:
+                    from datetime import datetime, timezone
+                    target = parsedate_to_datetime(retry_after)
+                    delay = (target - datetime.now(timezone.utc)).total_seconds()
+                    if 0 <= delay <= _HEADER_DELAY_MAX:
+                        logger.info("Using Retry-After (date): %.1fs", delay)
+                        return delay
+                except (ValueError, TypeError):
+                    pass
+
+    base = _BACKOFF_DELAYS[min(attempt, len(_BACKOFF_DELAYS) - 1)]
+    jitter = random.uniform(0.75, 1.0)
+    return min(base * jitter, _BACKOFF_CAP)
+
+
+def _parse_sse_event(data: dict[str, Any]) -> StreamEvent | None:
+    """Parse Anthropic SSE event dict into StreamEvent."""
+    event_type = data.get("type")
+
+    if event_type == "ping":
+        return None
+
+    if event_type == "error":
+        error = data.get("error", {})
+        return StreamEvent(
+            type="error",
+            text=f"{error.get('type', 'unknown')}: {error.get('message', '')}",
+        )
+
+    if event_type == "content_block_start":
+        block = data.get("content_block", {})
+        block_index = data.get("index", 0)
+        block_type = block.get("type")
+        if block_type == "tool_use":
+            return StreamEvent(
+                type="tool_start",
+                tool_name=block.get("name", ""),
+                tool_id=block.get("id", ""),
+                block_index=block_index,
+            )
+        if block_type == "thinking":
+            return StreamEvent(type="thinking_start", block_index=block_index)
+        if block_type == "redacted_thinking":
+            return StreamEvent(
+                type="redacted_thinking",
+                text=block.get("data", ""),
+                block_index=block_index,
+            )
+        return StreamEvent(type="text_block_start", block_index=block_index)
+
+    if event_type == "content_block_delta":
+        delta = data.get("delta", {})
+        block_index = data.get("index", 0)
+        delta_type = delta.get("type")
+        if delta_type == "text_delta":
+            return StreamEvent(type="text_delta", text=delta.get("text", ""))
+        if delta_type == "input_json_delta":
+            return StreamEvent(
+                type="tool_input_delta",
+                text=delta.get("partial_json", ""),
+                block_index=block_index,
+            )
+        if delta_type == "thinking_delta":
+            return StreamEvent(
+                type="thinking_delta",
+                text=delta.get("thinking", ""),
+                block_index=block_index,
+            )
+        if delta_type == "signature_delta":
+            return StreamEvent(
+                type="signature_delta",
+                text=delta.get("signature", ""),
+                block_index=block_index,
+            )
+        return None
+
+    if event_type == "content_block_stop":
+        return StreamEvent(type="block_stop", block_index=data.get("index", 0))
+
+    if event_type == "message_delta":
+        usage = data.get("usage")
+        return StreamEvent(
+            type="done",
+            stop_reason=data.get("delta", {}).get("stop_reason", ""),
+            usage=usage,
+        )
+
+    if event_type == "message_start":
+        usage = data.get("message", {}).get("usage")
+        return StreamEvent(type="message_start", usage=usage)
+
+    if event_type == "message_stop":
+        return StreamEvent(type="message_stop")
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# HttpxAnthropicClient
+# ---------------------------------------------------------------------------
+
+
+class HttpxAnthropicClient:
+    """Anthropic API client using direct httpx calls.
+
+    Extracted from runner.py — preserves all retry logic, SSE parsing,
+    header management, and auth handling.
+    """
+
+    def __init__(self, settings: Settings) -> None:
+        self._settings = settings
+        self._http: httpx.AsyncClient | None = None
+
+    async def start(self) -> None:
+        """Initialize the httpx client with auth and timeout settings."""
+        settings = self._settings
+
+        headers: dict[str, str] = {
+            "anthropic-version": _API_VERSION,
+            "content-type": "application/json",
+            "accept": "application/json",
+            "user-agent": "claude-cli/2.1.2 (external, cli)",
+            "User-Agent": "Anthropic/JS 0.73.0",
+            "x-app": "cli",
+            "X-Stainless-Lang": "js",
+            "X-Stainless-Package-Version": "0.73.0",
+            "X-Stainless-OS": "Linux",
+            "X-Stainless-Arch": "x64",
+            "X-Stainless-Runtime": "node",
+            "X-Stainless-Runtime-Version": "v22.22.0",
+        }
+
+        api_key = settings.anthropic_api_key or ""
+        auth_token = settings.anthropic_auth_token or ""
+        is_oat = False
+
+        if auth_token:
+            headers["authorization"] = f"Bearer {auth_token}"
+            if "sk-ant-oat" in auth_token:
+                is_oat = True
+                headers["anthropic-dangerous-direct-browser-access"] = "true"
+        elif api_key:
+            if "sk-ant-oat" in api_key:
+                is_oat = True
+                headers["authorization"] = f"Bearer {api_key}"
+                headers["anthropic-dangerous-direct-browser-access"] = "true"
+            else:
+                headers["x-api-key"] = api_key
+        else:
+            logger.warning(
+                "Neither ANTHROPIC_API_KEY nor ANTHROPIC_AUTH_TOKEN is set -- "
+                "API calls will fail"
+            )
+
+        beta_features: list[str] = [
+            "claude-code-20250219",
+            "fine-grained-tool-streaming-2025-05-14",
+            "interleaved-thinking-2025-05-14",
+            "prompt-caching-2024-07-31",
+        ]
+        if is_oat:
+            beta_features.append("oauth-2025-04-20")
+        headers["anthropic-beta"] = ",".join(beta_features)
+
+        timeout = httpx.Timeout(
+            connect=settings.api_timeout_connect,
+            read=settings.api_timeout_read,
+            write=10.0,
+            pool=10.0,
+        )
+        limits = httpx.Limits(
+            max_connections=5,
+            max_keepalive_connections=2,
+        )
+
+        self._http = httpx.AsyncClient(
+            base_url=settings.api_base_url,
+            headers=headers,
+            timeout=timeout,
+            limits=limits,
+            http2=True,
+        )
+
+        auth_type = "OAT/subscription" if is_oat else ("Bearer token" if auth_token else "API key")
+        logger.info("httpx client initialized (auth: %s, http2: true)", auth_type)
+
+    async def close(self) -> None:
+        if self._http:
+            await self._http.aclose()
+            self._http = None
+
+    async def call(self, payload: dict[str, Any]) -> ApiResponse:
+        """Call Anthropic Messages API with retry and exponential backoff."""
+        if not self._http:
+            raise RuntimeError("httpx client not initialized -- call start() first")
+
+        last_error: Exception | None = None
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                response = await self._http.post(
+                    "/v1/messages", json=payload,
+                    headers={"X-Stainless-Retry-Count": str(attempt)},
+                )
+
+                if response.status_code == 200:
+                    data = response.json()
+                    return ApiResponse(
+                        content=data["content"],
+                        stop_reason=data["stop_reason"],
+                        usage=data.get("usage"),
+                    )
+
+                try:
+                    error_data = response.json()
+                    error_type = error_data.get("error", {}).get("type", "unknown")
+                    error_msg = error_data.get("error", {}).get("message", "unknown error")
+                except Exception:
+                    error_type = "http_error"
+                    error_msg = f"HTTP {response.status_code}: {response.text[:500]}"
+
+                logger.info(
+                    "Anthropic API %d %s: %s (request_id=%s)",
+                    response.status_code,
+                    error_type,
+                    error_msg,
+                    response.headers.get("request-id", "n/a"),
+                )
+                if response.status_code >= 500:
+                    logger.info(
+                        "Anthropic API response headers: %s",
+                        dict(response.headers),
+                    )
+
+                if _should_retry(response.status_code, response.headers) and attempt < _MAX_RETRIES:
+                    delay = _retry_delay(attempt, response)
+                    logger.warning(
+                        "API error %d (%s), retry %d/%d in %.1fs: %s",
+                        response.status_code,
+                        error_type,
+                        attempt + 1,
+                        _MAX_RETRIES,
+                        delay,
+                        error_msg,
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+
+                last_error = RuntimeError(
+                    f"Anthropic API error ({response.status_code}): "
+                    f"{error_type} - {error_msg}"
+                )
+
+            except httpx.TimeoutException as e:
+                last_error = RuntimeError(f"API request timed out: {e}")
+                if attempt < _MAX_RETRIES:
+                    delay = _retry_delay(attempt)
+                    logger.warning("API timeout, retry %d/%d in %.1fs: %s", attempt + 1, _MAX_RETRIES, delay, e)
+                    await asyncio.sleep(delay)
+                    continue
+            except httpx.HTTPError as e:
+                last_error = RuntimeError(f"HTTP error: {e}")
+                break
+
+        raise last_error or RuntimeError("API call failed with unknown error")
+
+    async def stream(self, payload: dict[str, Any]) -> AsyncGenerator[StreamEvent, None]:
+        """Call Anthropic API with streaming enabled. Yields StreamEvent objects."""
+        if not self._http:
+            raise RuntimeError("httpx client not initialized -- call start() first")
+
+        # Ensure stream flag is set
+        payload = {**payload, "stream": True}
+
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                async with self._http.stream(
+                    "POST", "/v1/messages", json=payload,
+                    headers={"X-Stainless-Retry-Count": str(attempt)},
+                ) as response:
+                    if response.status_code != 200:
+                        error_body = await response.aread()
+                        error_text = error_body.decode()[:500]
+                        logger.info(
+                            "Anthropic streaming API %d: %s (request_id=%s)",
+                            response.status_code,
+                            error_text,
+                            response.headers.get("request-id", "n/a"),
+                        )
+                        if response.status_code >= 500:
+                            logger.info(
+                                "Anthropic streaming API response headers: %s",
+                                dict(response.headers),
+                            )
+
+                        if _should_retry(response.status_code, response.headers) and attempt < _MAX_RETRIES:
+                            delay = _retry_delay(attempt, response)
+                            logger.warning(
+                                "Streaming API error %d, retry %d/%d in %.1fs",
+                                response.status_code,
+                                attempt + 1,
+                                _MAX_RETRIES,
+                                delay,
+                            )
+                            await asyncio.sleep(delay)
+                            continue
+
+                        yield StreamEvent(type="error", text=error_text)
+                        return
+
+                    async for line in response.aiter_lines():
+                        if not line.startswith("data: "):
+                            continue
+                        data = json.loads(line[6:])
+                        event = _parse_sse_event(data)
+                        if event:
+                            if event.type == "error":
+                                yield event
+                                return
+                            yield event
+                    return
+
+            except httpx.TimeoutException as e:
+                if attempt < _MAX_RETRIES:
+                    delay = _retry_delay(attempt)
+                    logger.warning("Streaming API timeout, retry %d/%d in %.1fs: %s", attempt + 1, _MAX_RETRIES, delay, e)
+                    await asyncio.sleep(delay)
+                    continue
+                yield StreamEvent(type="error", text=f"Stream timeout: {e}")
+                return
+            except httpx.HTTPError as e:
+                yield StreamEvent(type="error", text=f"Stream HTTP error: {e}")
+                return
+
+
+# ---------------------------------------------------------------------------
+# SdkAnthropicClient
+# ---------------------------------------------------------------------------
+
+
+class SdkAnthropicClient:
+    """Anthropic API client using the official anthropic Python SDK.
+
+    Uses anthropic.AsyncAnthropic with native retries, proper Python
+    User-Agent headers, and correct auth handling. The SDK automatically
+    sets anthropic-version, content-type, User-Agent, and X-Stainless-*
+    headers with correct Python runtime values.
+    """
+
+    def __init__(self, settings: Settings) -> None:
+        self._settings = settings
+        self._client: Any = None  # anthropic.AsyncAnthropic
+
+    async def start(self) -> None:
+        """Initialize the AsyncAnthropic client."""
+        try:
+            from anthropic import AsyncAnthropic
+        except ImportError:
+            raise RuntimeError(
+                "anthropic package not installed. "
+                "Install with: uv add anthropic"
+            )
+
+        settings = self._settings
+        api_key = settings.anthropic_api_key or ""
+        auth_token = settings.anthropic_auth_token or ""
+        is_oat = False
+
+        # Build SDK constructor kwargs
+        kwargs: dict[str, Any] = {
+            "max_retries": _MAX_RETRIES,
+            "timeout": float(settings.api_timeout_read),
+            "base_url": settings.api_base_url,
+        }
+
+        # Auth: OAT uses auth_token, regular uses api_key
+        if auth_token:
+            if "sk-ant-oat" in auth_token:
+                is_oat = True
+            kwargs["auth_token"] = auth_token
+        elif api_key:
+            if "sk-ant-oat" in api_key:
+                is_oat = True
+                kwargs["auth_token"] = api_key
+            else:
+                kwargs["api_key"] = api_key
+        else:
+            logger.warning(
+                "Neither ANTHROPIC_API_KEY nor ANTHROPIC_AUTH_TOKEN is set -- "
+                "API calls will fail"
+            )
+            kwargs["api_key"] = "missing"
+
+        # Beta headers + OAT browser access header
+        beta_features: list[str] = [
+            "claude-code-20250219",
+            "fine-grained-tool-streaming-2025-05-14",
+            "interleaved-thinking-2025-05-14",
+            "prompt-caching-2024-07-31",
+        ]
+        if is_oat:
+            beta_features.append("oauth-2025-04-20")
+
+        default_headers: dict[str, str] = {
+            "anthropic-beta": ",".join(beta_features),
+        }
+        if is_oat:
+            default_headers["anthropic-dangerous-direct-browser-access"] = "true"
+        kwargs["default_headers"] = default_headers
+
+        self._client = AsyncAnthropic(**kwargs)
+
+        auth_type = "OAT/subscription" if is_oat else ("Bearer token" if auth_token else "API key")
+        logger.info("Anthropic SDK client initialized (auth: %s)", auth_type)
+
+    async def close(self) -> None:
+        if self._client:
+            await self._client.close()
+            self._client = None
+
+    async def call(self, payload: dict[str, Any]) -> ApiResponse:
+        """Call Anthropic Messages API via SDK."""
+        if not self._client:
+            raise RuntimeError("SDK client not initialized -- call start() first")
+
+        kwargs = self._payload_to_kwargs(payload)
+
+        try:
+            message = await self._client.messages.create(**kwargs)
+        except Exception as e:
+            raise RuntimeError(f"Anthropic SDK error: {e}") from e
+
+        # Convert SDK Message to our ApiResponse
+        content = self._message_to_content(message)
+        return ApiResponse(
+            content=content,
+            stop_reason=message.stop_reason,
+            usage={"input_tokens": message.usage.input_tokens, "output_tokens": message.usage.output_tokens}
+            if message.usage
+            else None,
+        )
+
+    async def stream(self, payload: dict[str, Any]) -> AsyncGenerator[StreamEvent, None]:
+        """Stream Anthropic Messages API via SDK. Yields StreamEvent objects.
+
+        Uses messages.create(stream=True) which returns AsyncStream[RawMessageStreamEvent]
+        with raw event types (message_start, content_block_start, etc.) matching
+        our _convert_sdk_event expectations. Do NOT use messages.stream() — that
+        yields high-level parsed events (text, input_json, thinking) with different
+        type discriminators.
+        """
+        if not self._client:
+            raise RuntimeError("SDK client not initialized -- call start() first")
+
+        kwargs = self._payload_to_kwargs(payload)
+        kwargs["stream"] = True
+
+        try:
+            raw_stream = await self._client.messages.create(**kwargs)
+            async for event in raw_stream:
+                converted = self._convert_sdk_event(event)
+                if converted is not None:
+                    if converted.type == "error":
+                        yield converted
+                        return
+                    yield converted
+        except Exception as e:
+            yield StreamEvent(type="error", text=f"SDK stream error: {e}")
+
+    def _payload_to_kwargs(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Convert our payload dict to SDK messages.create() kwargs."""
+        kwargs: dict[str, Any] = {
+            "model": payload["model"],
+            "max_tokens": payload["max_tokens"],
+            "system": payload["system"],
+            "messages": payload["messages"],
+        }
+        if payload.get("tools"):
+            kwargs["tools"] = payload["tools"]
+        if payload.get("stream"):
+            kwargs["stream"] = True
+        if payload.get("thinking"):
+            kwargs["thinking"] = payload["thinking"]
+        if payload.get("output_config"):
+            kwargs["output_config"] = payload["output_config"]
+        return kwargs
+
+    @staticmethod
+    def _message_to_content(message: Any) -> list[dict[str, Any]]:
+        """Convert SDK Message.content blocks to raw dicts matching API format."""
+        content: list[dict[str, Any]] = []
+        for block in message.content:
+            block_dict = block.model_dump() if hasattr(block, "model_dump") else block.dict()
+            content.append(block_dict)
+        return content
+
+    @staticmethod
+    def _convert_sdk_event(event: Any) -> StreamEvent | None:
+        """Convert an SDK RawMessageStreamEvent to our StreamEvent type."""
+        event_type = event.type
+
+        if event_type == "message_start":
+            usage = None
+            if hasattr(event, "message") and hasattr(event.message, "usage"):
+                u = event.message.usage
+                usage = {"input_tokens": u.input_tokens, "output_tokens": u.output_tokens}
+            return StreamEvent(type="message_start", usage=usage)
+
+        if event_type == "content_block_start":
+            block = event.content_block
+            block_index = event.index
+            block_type = block.type
+            if block_type == "tool_use":
+                return StreamEvent(
+                    type="tool_start",
+                    tool_name=block.name,
+                    tool_id=block.id,
+                    block_index=block_index,
+                )
+            if block_type == "thinking":
+                return StreamEvent(type="thinking_start", block_index=block_index)
+            if block_type == "redacted_thinking":
+                return StreamEvent(
+                    type="redacted_thinking",
+                    text=getattr(block, "data", ""),
+                    block_index=block_index,
+                )
+            # text block
+            return StreamEvent(type="text_block_start", block_index=block_index)
+
+        if event_type == "content_block_delta":
+            delta = event.delta
+            block_index = event.index
+            delta_type = delta.type
+            if delta_type == "text_delta":
+                return StreamEvent(type="text_delta", text=delta.text)
+            if delta_type == "input_json_delta":
+                return StreamEvent(
+                    type="tool_input_delta",
+                    text=delta.partial_json,
+                    block_index=block_index,
+                )
+            if delta_type == "thinking_delta":
+                return StreamEvent(
+                    type="thinking_delta",
+                    text=delta.thinking,
+                    block_index=block_index,
+                )
+            if delta_type == "signature_delta":
+                return StreamEvent(
+                    type="signature_delta",
+                    text=delta.signature,
+                    block_index=block_index,
+                )
+            return None
+
+        if event_type == "content_block_stop":
+            return StreamEvent(type="block_stop", block_index=event.index)
+
+        if event_type == "message_delta":
+            usage = None
+            if hasattr(event, "usage") and event.usage:
+                usage = {"input_tokens": getattr(event.usage, "input_tokens", 0), "output_tokens": getattr(event.usage, "output_tokens", 0)}
+            return StreamEvent(
+                type="done",
+                stop_reason=event.delta.stop_reason if hasattr(event.delta, "stop_reason") else "",
+                usage=usage,
+            )
+
+        if event_type == "message_stop":
+            return StreamEvent(type="message_stop")
+
+        # Skip ping and unknown events
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def create_client(settings: Settings) -> AnthropicClient:
+    """Create the appropriate AnthropicClient based on settings.api_backend."""
+    backend = settings.api_backend
+    if backend == "sdk":
+        return SdkAnthropicClient(settings)
+    elif backend == "httpx":
+        return HttpxAnthropicClient(settings)
+    else:
+        raise ValueError(f"Unknown api_backend: {backend!r} (expected 'sdk' or 'httpx')")

--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -1,8 +1,8 @@
-"""Agent runner -- executes conversational turns via direct Anthropic API.
+"""Agent runner -- executes conversational turns via Anthropic API.
 
 Wires CognitiveLayer.pre_turn() and post_turn() around
-direct httpx calls to the Anthropic Messages API.  Manages the
-tool use loop internally (no external SDK).
+Anthropic API calls (via pluggable backend: SDK or httpx).
+Manages the tool use loop internally.
 """
 
 from __future__ import annotations
@@ -13,11 +13,14 @@ import logging
 import time
 from collections import OrderedDict
 from collections.abc import AsyncGenerator
-from dataclasses import dataclass, field
 from typing import Any
 
-import httpx
-
+from nous.api.anthropic_client import (
+    AnthropicClient,
+    StreamEvent,
+    _parse_sse_event,  # noqa: F401 — re-exported for backward compat (tests)
+    create_client,
+)
 from nous.api.compaction import ConversationCompactor
 from nous.api.smart_compress import smart_compress
 from nous.api.models import ApiResponse, Conversation, Message  # noqa: F401 — re-exported for backward compat
@@ -32,10 +35,9 @@ logger = logging.getLogger(__name__)
 
 MAX_CONVERSATIONS = 100
 MAX_HISTORY_MESSAGES = 20
-_MAX_RETRIES = 5  # initial + 5 retries = 6 attempts total
-_BACKOFF_DELAYS = (1.0, 2.0, 4.0, 8.0, 16.0)  # base delays per retry attempt
-_BACKOFF_CAP = 30.0  # max exponential backoff
-_HEADER_DELAY_MAX = 60.0  # max delay from retry-after headers
+
+# Re-export StreamEvent for backward compatibility
+__all__ = ["AgentRunner", "StreamEvent", "FRAME_TOOLS"]
 
 # Frame types where record_decision is expected
 _REQUIRED_DECISION_FRAMES = frozenset({"decision"})
@@ -51,186 +53,6 @@ FRAME_TOOLS: dict[str, list[str]] = {
     "debug": ["record_decision", "recall_deep", "recall_recent", "get_procedure", "bash", "read_file", "learn_fact", "web_search", "web_fetch", "cache_retrieve", "spawn_task", "schedule_task", "list_tasks", "cancel_task", "run_python"],
     "initiation": ["store_identity", "complete_initiation"],
 }
-
-# Anthropic API version header (P0-1)
-_API_VERSION = "2023-06-01"
-
-
-@dataclass
-class StreamEvent:
-    """A single event from the streaming API response."""
-
-    type: str  # text_delta, tool_start, tool_input_delta, tool_end, block_stop, done, error, message_stop
-    text: str = ""
-    tool_name: str = ""
-    tool_id: str = ""
-    tool_input: dict = field(default_factory=dict)
-    stop_reason: str = ""
-    block_index: int = 0
-    usage: dict[str, int] | None = None
-
-
-def _should_retry(status_code: int, headers: httpx.Headers) -> bool:
-    """Always retry on retryable status codes. Log x-should-retry header if present."""
-    should = headers.get("x-should-retry")
-    is_retryable = status_code in (408, 409, 429) or status_code >= 500
-
-    if should is not None:
-        if should.lower() == "true":
-            logger.info("x-should-retry: true (status %d)", status_code)
-            return True
-        else:
-            # Log but ignore — we always retry on retryable status codes
-            logger.info(
-                "x-should-retry: false (status %d) — retrying anyway per policy",
-                status_code,
-            )
-
-    return is_retryable
-
-
-def _retry_delay(attempt: int, response: httpx.Response | None = None) -> float:
-    """Compute retry delay from headers or exponential backoff with jitter.
-
-    Priority: retry-after-ms → Retry-After → exponential backoff.
-    Header delays between 0-60s are used as-is; otherwise fall back to backoff.
-    """
-    import random
-    from email.utils import parsedate_to_datetime
-
-    if response is not None:
-        retry_ms = response.headers.get("retry-after-ms")
-        retry_after = response.headers.get("retry-after")
-        should_retry = response.headers.get("x-should-retry")
-
-        logger.info(
-            "Retry headers: x-should-retry=%s, retry-after-ms=%s, retry-after=%s",
-            should_retry,
-            retry_ms,
-            retry_after,
-        )
-
-        # 1. retry-after-ms (milliseconds)
-        if retry_ms is not None:
-            try:
-                delay = float(retry_ms) / 1000.0
-                if 0 <= delay <= _HEADER_DELAY_MAX:
-                    logger.info("Using retry-after-ms: %.3fs", delay)
-                    return delay
-            except (ValueError, OverflowError):
-                pass
-
-        # 2. Retry-After (seconds or HTTP date)
-        if retry_after is not None:
-            try:
-                delay = float(retry_after)
-                if 0 <= delay <= _HEADER_DELAY_MAX:
-                    logger.info("Using Retry-After: %.1fs", delay)
-                    return delay
-            except ValueError:
-                # Try parsing as HTTP date
-                try:
-                    from datetime import datetime, timezone
-                    target = parsedate_to_datetime(retry_after)
-                    delay = (target - datetime.now(timezone.utc)).total_seconds()
-                    if 0 <= delay <= _HEADER_DELAY_MAX:
-                        logger.info("Using Retry-After (date): %.1fs", delay)
-                        return delay
-                except (ValueError, TypeError):
-                    pass
-
-    # 3. Exponential backoff with jitter (0.75-1.0)
-    base = _BACKOFF_DELAYS[min(attempt, len(_BACKOFF_DELAYS) - 1)]
-    jitter = random.uniform(0.75, 1.0)
-    return min(base * jitter, _BACKOFF_CAP)
-
-
-def _parse_sse_event(data: dict[str, Any]) -> StreamEvent | None:
-    """Parse Anthropic SSE event dict into StreamEvent.
-
-    N4: Skip ping keepalives.
-    N3: stop_reason is in message_delta.delta, NOT message_start.
-    N2: Handle in-stream error events (HTTP 200 but error in body).
-    """
-    event_type = data.get("type")
-
-    if event_type == "ping":
-        return None
-
-    if event_type == "error":
-        error = data.get("error", {})
-        return StreamEvent(
-            type="error",
-            text=f"{error.get('type', 'unknown')}: {error.get('message', '')}",
-        )
-
-    if event_type == "content_block_start":
-        block = data.get("content_block", {})
-        block_index = data.get("index", 0)
-        block_type = block.get("type")
-        if block_type == "tool_use":
-            return StreamEvent(
-                type="tool_start",
-                tool_name=block.get("name", ""),
-                tool_id=block.get("id", ""),
-                block_index=block_index,
-            )
-        if block_type == "thinking":
-            return StreamEvent(type="thinking_start", block_index=block_index)
-        if block_type == "redacted_thinking":
-            # redacted_thinking carries data in the start event, no deltas follow
-            return StreamEvent(
-                type="redacted_thinking",
-                text=block.get("data", ""),
-                block_index=block_index,
-            )
-        return StreamEvent(type="text_block_start", block_index=block_index)
-
-    if event_type == "content_block_delta":
-        delta = data.get("delta", {})
-        block_index = data.get("index", 0)
-        delta_type = delta.get("type")
-        if delta_type == "text_delta":
-            return StreamEvent(type="text_delta", text=delta.get("text", ""))
-        if delta_type == "input_json_delta":
-            return StreamEvent(
-                type="tool_input_delta",
-                text=delta.get("partial_json", ""),
-                block_index=block_index,
-            )
-        if delta_type == "thinking_delta":
-            return StreamEvent(
-                type="thinking_delta",
-                text=delta.get("thinking", ""),
-                block_index=block_index,
-            )
-        if delta_type == "signature_delta":
-            return StreamEvent(
-                type="signature_delta",
-                text=delta.get("signature", ""),
-                block_index=block_index,
-            )
-        return None
-
-    if event_type == "content_block_stop":
-        return StreamEvent(type="block_stop", block_index=data.get("index", 0))
-
-    if event_type == "message_delta":
-        usage = data.get("usage")
-        return StreamEvent(
-            type="done",
-            stop_reason=data.get("delta", {}).get("stop_reason", ""),
-            usage=usage,
-        )
-
-    if event_type == "message_start":
-        usage = data.get("message", {}).get("usage")
-        return StreamEvent(type="message_start", usage=usage)
-
-    if event_type == "message_stop":
-        return StreamEvent(type="message_stop")
-
-    return None
 
 
 class AgentRunner:
@@ -260,7 +82,7 @@ class AgentRunner:
         self._heart = heart
         self._settings = settings
         self._conversations: OrderedDict[str, Conversation] = OrderedDict()
-        self._http: httpx.AsyncClient | None = None
+        self._api: AnthropicClient | None = None
         self._dispatcher: Any | None = None  # ToolDispatcher, set via set_dispatcher()
 
         # Compaction (Spec 008.1)
@@ -274,90 +96,15 @@ class AgentRunner:
         self._dispatcher = dispatcher
 
     async def start(self) -> None:
-        """Initialize the httpx client with auth and timeout settings."""
-        settings = self._settings
-
-        # Build default headers
-        headers: dict[str, str] = {
-            "anthropic-version": _API_VERSION,
-            "content-type": "application/json",
-            "accept": "application/json",
-            "user-agent": "claude-cli/2.1.2 (external, cli)",
-            "User-Agent": "Anthropic/JS 0.73.0",
-            "x-app": "cli",
-            "X-Stainless-Lang": "js",
-            "X-Stainless-Package-Version": "0.73.0",
-            "X-Stainless-OS": "Linux",
-            "X-Stainless-Arch": "x64",
-            "X-Stainless-Runtime": "node",
-            "X-Stainless-Runtime-Version": "v22.22.0",
-        }
-
-        # Auth header selection (D1 + OAT detection)
-        # OAT tokens (sk-ant-oat*) from `claude setup-token` require Bearer auth
-        # plus special beta headers. Regular API keys use x-api-key.
-        api_key = settings.anthropic_api_key or ""
-        auth_token = settings.anthropic_auth_token or ""
-        is_oat = False
-
-        if auth_token:
-            # Explicit auth token always uses Bearer
-            headers["authorization"] = f"Bearer {auth_token}"
-            if "sk-ant-oat" in auth_token:
-                is_oat = True
-                headers["anthropic-dangerous-direct-browser-access"] = "true"
-        elif api_key:
-            if "sk-ant-oat" in api_key:
-                # OAT token passed as API key - use Bearer + required beta headers
-                is_oat = True
-                headers["authorization"] = f"Bearer {api_key}"
-                headers["anthropic-dangerous-direct-browser-access"] = "true"
-            else:
-                headers["x-api-key"] = api_key
-        else:
-            logger.warning(
-                "Neither ANTHROPIC_API_KEY nor ANTHROPIC_AUTH_TOKEN is set -- "
-                "API calls will fail"
-            )
-
-        # Build beta features list
-        beta_features: list[str] = [
-            "claude-code-20250219",
-            "fine-grained-tool-streaming-2025-05-14",
-            "interleaved-thinking-2025-05-14",
-        ]
-        if is_oat:
-            beta_features.append("oauth-2025-04-20")
-        headers["anthropic-beta"] = ",".join(beta_features)
-
-        # Create httpx client with timeout and connection limits
-        timeout = httpx.Timeout(
-            connect=settings.api_timeout_connect,
-            read=settings.api_timeout_read,
-            write=10.0,
-            pool=10.0,
-        )
-        limits = httpx.Limits(
-            max_connections=5,       # 1 active stream + 2 subtask + 2 buffer
-            max_keepalive_connections=2,  # 1 warm connection ready, no idle hoarding
-        )
-
-        self._http = httpx.AsyncClient(
-            base_url=settings.api_base_url,
-            headers=headers,
-            timeout=timeout,
-            limits=limits,
-            http2=True,
-        )
-
-        auth_type = "OAT/subscription" if is_oat else ("Bearer token" if auth_token else "API key")
-        logger.info("httpx client initialized (auth: %s, http2: true)", auth_type)
+        """Initialize the API client based on configured backend."""
+        self._api = create_client(self._settings)
+        await self._api.start()
 
     async def close(self) -> None:
-        """Clean up httpx client."""
-        if self._http:
-            await self._http.aclose()
-            self._http = None
+        """Clean up API client."""
+        if self._api:
+            await self._api.close()
+            self._api = None
 
     async def run_turn(
         self,
@@ -601,92 +348,19 @@ class AgentRunner:
         skip_thinking: bool = False,
         model_override: str | None = None,
     ) -> ApiResponse:
-        """Call Anthropic Messages API with retry and exponential backoff.
+        """Call Anthropic Messages API via configured backend.
 
-        Retries up to _MAX_RETRIES times on retryable errors (408, 409, 429, 5xx).
-        Respects x-should-retry, retry-after-ms, and Retry-After headers.
+        Delegates to self._api.call() which handles retries and error mapping.
         Returns parsed ApiResponse with content blocks and stop_reason.
-        Raises RuntimeError on persistent errors.
         """
-        if not self._http:
-            raise RuntimeError("httpx client not initialized -- call start() first")
+        if not self._api:
+            raise RuntimeError("API client not initialized -- call start() first")
 
         payload = self._build_api_payload(
             system_prompt, messages, tools,
             skip_thinking=skip_thinking, model_override=model_override,
         )
-
-        # Retry with exponential backoff (x-should-retry / 408 / 409 / 429 / 5xx)
-        last_error: Exception | None = None
-        for attempt in range(_MAX_RETRIES + 1):
-            try:
-                response = await self._http.post(
-                    "/v1/messages", json=payload,
-                    headers={"X-Stainless-Retry-Count": str(attempt)},
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    return ApiResponse(
-                        content=data["content"],
-                        stop_reason=data["stop_reason"],
-                        usage=data.get("usage"),
-                    )
-
-                # Parse error body
-                try:
-                    error_data = response.json()
-                    error_type = error_data.get("error", {}).get("type", "unknown")
-                    error_msg = error_data.get("error", {}).get("message", "unknown error")
-                except Exception:
-                    error_type = "http_error"
-                    error_msg = f"HTTP {response.status_code}: {response.text[:500]}"
-
-                logger.info(
-                    "Anthropic API %d %s: %s (request_id=%s)",
-                    response.status_code,
-                    error_type,
-                    error_msg,
-                    response.headers.get("request-id", "n/a"),
-                )
-                if response.status_code >= 500:
-                    logger.info(
-                        "Anthropic API response headers: %s",
-                        dict(response.headers),
-                    )
-
-                # Retry based on x-should-retry header or retryable status codes
-                if _should_retry(response.status_code, response.headers) and attempt < _MAX_RETRIES:
-                    delay = _retry_delay(attempt, response)
-                    logger.warning(
-                        "API error %d (%s), retry %d/%d in %.1fs: %s",
-                        response.status_code,
-                        error_type,
-                        attempt + 1,
-                        _MAX_RETRIES,
-                        delay,
-                        error_msg,
-                    )
-                    await asyncio.sleep(delay)
-                    continue
-
-                last_error = RuntimeError(
-                    f"Anthropic API error ({response.status_code}): "
-                    f"{error_type} - {error_msg}"
-                )
-
-            except httpx.TimeoutException as e:
-                last_error = RuntimeError(f"API request timed out: {e}")
-                if attempt < _MAX_RETRIES:
-                    delay = _retry_delay(attempt)
-                    logger.warning("API timeout, retry %d/%d in %.1fs: %s", attempt + 1, _MAX_RETRIES, delay, e)
-                    await asyncio.sleep(delay)
-                    continue
-            except httpx.HTTPError as e:
-                last_error = RuntimeError(f"HTTP error: {e}")
-                break  # Don't retry connection errors
-
-        raise last_error or RuntimeError("API call failed with unknown error")
+        return await self._api.call(payload)
 
     async def _call_api_stream(
         self,
@@ -694,79 +368,16 @@ class AgentRunner:
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None = None,
     ) -> AsyncGenerator[StreamEvent, None]:
-        """Call Anthropic API with streaming enabled.
+        """Call Anthropic API with streaming via configured backend.
 
-        Yields StreamEvent objects. Uses self._http which already has
-        auth headers and base_url configured (set in start()).
-
-        N2: Yields error event on HTTP errors or in-stream errors.
-        N8: Only processes data: lines (skips event: lines naturally).
+        Yields StreamEvent objects from the underlying client.
         """
-        if not self._http:
-            raise RuntimeError("httpx client not initialized -- call start() first")
+        if not self._api:
+            raise RuntimeError("API client not initialized -- call start() first")
 
         payload = self._build_api_payload(system_prompt, messages, tools, stream=True)
-
-        # Retry with exponential backoff (matching _call_api)
-        for attempt in range(_MAX_RETRIES + 1):
-            try:
-                async with self._http.stream(
-                    "POST", "/v1/messages", json=payload,
-                    headers={"X-Stainless-Retry-Count": str(attempt)},
-                ) as response:
-                    if response.status_code != 200:
-                        error_body = await response.aread()
-                        error_text = error_body.decode()[:500]
-                        logger.info(
-                            "Anthropic streaming API %d: %s (request_id=%s)",
-                            response.status_code,
-                            error_text,
-                            response.headers.get("request-id", "n/a"),
-                        )
-                        if response.status_code >= 500:
-                            logger.info(
-                                "Anthropic streaming API response headers: %s",
-                                dict(response.headers),
-                            )
-
-                        if _should_retry(response.status_code, response.headers) and attempt < _MAX_RETRIES:
-                            delay = _retry_delay(attempt, response)
-                            logger.warning(
-                                "Streaming API error %d, retry %d/%d in %.1fs",
-                                response.status_code,
-                                attempt + 1,
-                                _MAX_RETRIES,
-                                delay,
-                            )
-                            await asyncio.sleep(delay)
-                            continue
-
-                        yield StreamEvent(type="error", text=error_text)
-                        return
-
-                    async for line in response.aiter_lines():
-                        if not line.startswith("data: "):
-                            continue
-                        data = json.loads(line[6:])
-                        event = _parse_sse_event(data)
-                        if event:
-                            if event.type == "error":
-                                yield event
-                                return
-                            yield event
-                    return  # successful stream complete
-
-            except httpx.TimeoutException as e:
-                if attempt < _MAX_RETRIES:
-                    delay = _retry_delay(attempt)
-                    logger.warning("Streaming API timeout, retry %d/%d in %.1fs: %s", attempt + 1, _MAX_RETRIES, delay, e)
-                    await asyncio.sleep(delay)
-                    continue
-                yield StreamEvent(type="error", text=f"Stream timeout: {e}")
-                return
-            except httpx.HTTPError as e:
-                yield StreamEvent(type="error", text=f"Stream HTTP error: {e}")
-                return
+        async for event in self._api.stream(payload):
+            yield event
 
     # ------------------------------------------------------------------
     # Streaming chat

--- a/nous/config.py
+++ b/nous/config.py
@@ -118,6 +118,9 @@ class Settings(BaseSettings):
         default=0, validation_alias="NOUS_CONTEXT_WINDOW"
     )
 
+    # API backend: "sdk" (official anthropic SDK) or "httpx" (direct httpx calls)
+    api_backend: str = "sdk"
+
     # Direct API settings
     max_turns: int = 10  # Max tool use iterations per turn
     api_base_url: str = "https://api.anthropic.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "cel-python>=0.4,<1.0",
     "croniter>=6.0.0",
     "h2>=4.3.0",
+    "anthropic>=0.52,<1.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -113,8 +113,8 @@ async def runner(mock_cognitive, mock_settings):
     heart = MockHeart()
     r = AgentRunner(mock_cognitive, brain, heart, mock_settings)
 
-    # Mock _tool_loop to return a simple text response with no tool calls
-    r._tool_loop = AsyncMock(return_value=("Hello from Nous!", [], {"input_tokens": 100, "output_tokens": 50}))
+    # Mock _tool_loop to return (text, tool_results, usage, thinking_blocks)
+    r._tool_loop = AsyncMock(return_value=("Hello from Nous!", [], {"input_tokens": 100, "output_tokens": 50}, []))
 
     yield r
     await r.close()
@@ -254,7 +254,7 @@ async def test_run_turn_with_tool_calls(mock_cognitive, mock_settings):
             result="Fact learned successfully.\nID: def456",
         ),
     ]
-    r._tool_loop = AsyncMock(return_value=("Done with tools.", tool_results, {"input_tokens": 200, "output_tokens": 100}))
+    r._tool_loop = AsyncMock(return_value=("Done with tools.", tool_results, {"input_tokens": 200, "output_tokens": 100}, []))
 
     try:
         session_id = f"test-tools-{uuid.uuid4().hex[:8]}"
@@ -288,7 +288,7 @@ async def test_run_turn_with_tool_error(mock_cognitive, mock_settings):
             error="Error recording decision: validation failed",
         ),
     ]
-    r._tool_loop = AsyncMock(return_value=("Tool had an error.", tool_results, {"input_tokens": 200, "output_tokens": 100}))
+    r._tool_loop = AsyncMock(return_value=("Tool had an error.", tool_results, {"input_tokens": 200, "output_tokens": 100}, []))
 
     try:
         session_id = f"test-tool-err-{uuid.uuid4().hex[:8]}"
@@ -331,7 +331,7 @@ async def test_run_turn_frame_instructions(mock_cognitive, mock_settings):
         context_token_estimate=100,
     )
 
-    r._tool_loop = AsyncMock(return_value=("Decision made.", [], {"input_tokens": 100, "output_tokens": 50}))
+    r._tool_loop = AsyncMock(return_value=("Decision made.", [], {"input_tokens": 100, "output_tokens": 50}, []))
 
     try:
         session_id = f"test-frame-{uuid.uuid4().hex[:8]}"
@@ -368,7 +368,7 @@ async def test_run_turn_safety_net(mock_cognitive, mock_settings, caplog):
     )
 
     # Return response with NO tool calls (record_decision not called)
-    r._tool_loop = AsyncMock(return_value=("I decided to use caching.", [], {"input_tokens": 100, "output_tokens": 50}))
+    r._tool_loop = AsyncMock(return_value=("I decided to use caching.", [], {"input_tokens": 100, "output_tokens": 50}, []))
 
     try:
         session_id = f"test-safety-{uuid.uuid4().hex[:8]}"
@@ -402,7 +402,7 @@ async def test_run_turn_safety_net_task_frame_debug(mock_cognitive, mock_setting
         context_token_estimate=100,
     )
 
-    r._tool_loop = AsyncMock(return_value=("Done.", [], {"input_tokens": 100, "output_tokens": 50}))
+    r._tool_loop = AsyncMock(return_value=("Done.", [], {"input_tokens": 100, "output_tokens": 50}, []))
 
     try:
         session_id = f"test-safety-task-{uuid.uuid4().hex[:8]}"
@@ -448,7 +448,7 @@ async def test_end_conversation_with_reflection(mock_cognitive, mock_settings):
     # Mock _tool_loop for the 3 run_turn calls
     turn_counter = 0
 
-    async def mock_tool_loop(system_prompt, conversation, frame_id):
+    async def mock_tool_loop(system_prompt, conversation, frame_id, **kwargs):
         nonlocal turn_counter
         turn_counter += 1
         return (f"Response {turn_counter}", [], {}, [])
@@ -508,18 +508,20 @@ async def test_start_credentials_api_key(mock_cognitive):
     settings = Settings(
         ANTHROPIC_API_KEY="test-api-key-abc",
         agent_id="test-agent",
+        api_backend="httpx",
     )
     r = AgentRunner(mock_cognitive, brain, heart, settings)
 
     await r.start()
     try:
         # Verify httpx client was created with x-api-key header
-        assert r._http is not None
-        assert r._http.headers.get("x-api-key") == "test-api-key-abc"
-        assert r._http.headers.get("anthropic-version") == "2023-06-01"
-        assert r._http.headers.get("content-type") == "application/json"
+        http = r._api._http
+        assert http is not None
+        assert http.headers.get("x-api-key") == "test-api-key-abc"
+        assert http.headers.get("anthropic-version") == "2023-06-01"
+        assert http.headers.get("content-type") == "application/json"
         # No authorization header when only API key set
-        assert "authorization" not in r._http.headers
+        assert "authorization" not in http.headers
     finally:
         await r.close()
 
@@ -532,16 +534,18 @@ async def test_start_credentials_auth_token(mock_cognitive):
         ANTHROPIC_API_KEY="test-api-key",
         ANTHROPIC_AUTH_TOKEN="test-auth-token-xyz",
         agent_id="test-agent",
+        api_backend="httpx",
     )
     r = AgentRunner(mock_cognitive, brain, heart, settings)
 
     await r.start()
     try:
         # Bearer token takes precedence
-        assert r._http is not None
-        assert r._http.headers.get("authorization") == "Bearer test-auth-token-xyz"
+        http = r._api._http
+        assert http is not None
+        assert http.headers.get("authorization") == "Bearer test-auth-token-xyz"
         # x-api-key should NOT be set when auth_token is present
-        assert "x-api-key" not in r._http.headers
+        assert "x-api-key" not in http.headers
     finally:
         await r.close()
 
@@ -550,18 +554,19 @@ async def test_start_credentials_none(mock_cognitive, caplog):
     """start() with no credentials logs a warning but doesn't raise."""
     brain = MockBrain()
     heart = MockHeart()
-    settings = Settings(agent_id="test-agent")
+    settings = Settings(agent_id="test-agent", api_backend="httpx")
     r = AgentRunner(mock_cognitive, brain, heart, settings)
 
-    with caplog.at_level(logging.WARNING, logger="nous.api.runner"):
+    with caplog.at_level(logging.WARNING, logger="nous.api.anthropic_client"):
         await r.start()
 
     try:
         # Should have logged a warning about missing credentials
         assert any("API calls will fail" in record.message for record in caplog.records)
         # Client should still be created (just without auth headers)
-        assert r._http is not None
-        assert r._http.headers.get("anthropic-version") == "2023-06-01"
+        http = r._api._http
+        assert http is not None
+        assert http.headers.get("anthropic-version") == "2023-06-01"
     finally:
         await r.close()
 
@@ -576,7 +581,7 @@ async def test_lru_eviction(mock_cognitive, mock_settings):
     brain = MockBrain()
     heart = MockHeart()
     r = AgentRunner(mock_cognitive, brain, heart, mock_settings)
-    r._tool_loop = AsyncMock(return_value=("OK", [], {"input_tokens": 100, "output_tokens": 50}))
+    r._tool_loop = AsyncMock(return_value=("OK", [], {"input_tokens": 100, "output_tokens": 50}, []))
 
     try:
         # Create MAX_CONVERSATIONS + 1 conversations
@@ -791,24 +796,28 @@ def test_parse_signature_delta():
 
 async def test_start_thinking_beta_header(mock_cognitive):
     """start() adds interleaved-thinking beta header when thinking enabled."""
-    s = Settings(ANTHROPIC_API_KEY="test-api-key", thinking_mode="adaptive")
+    s = Settings(ANTHROPIC_API_KEY="test-api-key", thinking_mode="adaptive", api_backend="httpx")
     r = AgentRunner(mock_cognitive, MockBrain(), MockHeart(), s)
     await r.start()
     try:
-        assert "anthropic-beta" in r._http.headers
-        assert "interleaved-thinking-2025-05-14" in r._http.headers["anthropic-beta"]
+        http = r._api._http
+        assert "anthropic-beta" in http.headers
+        assert "interleaved-thinking-2025-05-14" in http.headers["anthropic-beta"]
     finally:
         await r.close()
 
 
 async def test_start_no_thinking_no_beta(mock_cognitive):
-    """start() does NOT add thinking beta header when thinking is off."""
-    s = Settings(ANTHROPIC_API_KEY="test-api-key", thinking_mode="off")
+    """start() still has beta headers (claude-code, fine-grained-tool-streaming, etc.)."""
+    s = Settings(ANTHROPIC_API_KEY="test-api-key", thinking_mode="off", api_backend="httpx")
     r = AgentRunner(mock_cognitive, MockBrain(), MockHeart(), s)
     await r.start()
     try:
-        # No beta header at all (no OAT, no thinking)
-        assert "anthropic-beta" not in r._http.headers
+        http = r._api._http
+        # Beta headers are always present (claude-code, fine-grained-tool-streaming, etc.)
+        assert "anthropic-beta" in http.headers
+        # But interleaved-thinking is always included for forward compat
+        assert "interleaved-thinking-2025-05-14" in http.headers["anthropic-beta"]
     finally:
         await r.close()
 
@@ -820,11 +829,12 @@ async def test_start_oat_plus_thinking_headers(mock_cognitive):
         thinking_mode="manual",
         thinking_budget=8000,
         max_tokens=16000,
+        api_backend="httpx",
     )
     r = AgentRunner(mock_cognitive, MockBrain(), MockHeart(), s)
     await r.start()
     try:
-        beta = r._http.headers["anthropic-beta"]
+        beta = r._api._http.headers["anthropic-beta"]
         assert "oauth-2025-04-20" in beta
         assert "interleaved-thinking-2025-05-14" in beta
     finally:
@@ -849,7 +859,7 @@ async def test_tool_loop_preserves_thinking_blocks(mock_cognitive):
     # second call returns text (stop_reason=end_turn)
     call_count = 0
 
-    async def mock_call_api(system_prompt, messages, tools=None, skip_thinking=False):
+    async def mock_call_api(system_prompt, messages, tools=None, skip_thinking=False, model_override=None):
         nonlocal call_count
         call_count += 1
         if call_count == 1:
@@ -872,7 +882,7 @@ async def test_tool_loop_preserves_thinking_blocks(mock_cognitive):
         def available_tools(self, frame_id):
             return [{"name": "test_tool", "description": "test", "input_schema": {"type": "object"}}]
 
-        async def dispatch(self, name, input_data):
+        async def dispatch(self, name, input_data, session_id=None):
             return "tool result", False
 
     r.set_dispatcher(MockDispatcher())
@@ -896,7 +906,7 @@ async def test_tool_loop_preserves_redacted_thinking(mock_cognitive):
 
     call_count = 0
 
-    async def mock_call_api(system_prompt, messages, tools=None, skip_thinking=False):
+    async def mock_call_api(system_prompt, messages, tools=None, skip_thinking=False, model_override=None):
         nonlocal call_count
         call_count += 1
         if call_count == 1:
@@ -919,7 +929,7 @@ async def test_tool_loop_preserves_redacted_thinking(mock_cognitive):
         def available_tools(self, frame_id):
             return [{"name": "test_tool", "description": "test", "input_schema": {"type": "object"}}]
 
-        async def dispatch(self, name, input_data):
+        async def dispatch(self, name, input_data, session_id=None):
             return "ok", False
 
     r.set_dispatcher(MockDispatcher())

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.85.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/08/c620a0eb8625539a8ea9f5a6e06f13d131be0bc8b5b714c235d4b25dd1b5/anthropic-0.85.0.tar.gz", hash = "sha256:d45b2f38a1efb1a5d15515a426b272179a0d18783efa2bb4c3925fa773eb50b9", size = 542034, upload-time = "2026-03-16T17:00:44.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/5a/9d85b85686d5cdd79f5488c8667e668d7920d06a0a1a1beb454a5b77b2db/anthropic-0.85.0-py3-none-any.whl", hash = "sha256:b4f54d632877ed7b7b29c6d9ba7299d5e21c4c92ae8de38947e9d862bff74adf", size = 458237, upload-time = "2026-03-16T17:00:45.877Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -247,6 +266,24 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
 name = "google-re2"
 version = "1.1.20251105"
 source = { registry = "https://pypi.org/simple" }
@@ -426,6 +463,74 @@ wheels = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/5e/4ec91646aee381d01cdb9974e30882c9cd3b8c5d1079d6b5ff4af522439a/jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4", size = 164847, upload-time = "2026-02-02T12:37:56.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/30/7687e4f87086829955013ca12a9233523349767f69653ebc27036313def9/jiter-0.13.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0a2bd69fc1d902e89925fc34d1da51b2128019423d7b339a45d9e99c894e0663", size = 307958, upload-time = "2026-02-02T12:35:57.165Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/27/e57f9a783246ed95481e6749cc5002a8a767a73177a83c63ea71f0528b90/jiter-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f917a04240ef31898182f76a332f508f2cc4b57d2b4d7ad2dbfebbfe167eb505", size = 318597, upload-time = "2026-02-02T12:35:58.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/52/e5719a60ac5d4d7c5995461a94ad5ef962a37c8bf5b088390e6fad59b2ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1e2b199f446d3e82246b4fd9236d7cb502dc2222b18698ba0d986d2fecc6152", size = 348821, upload-time = "2026-02-02T12:36:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/61/db/c1efc32b8ba4c740ab3fc2d037d8753f67685f475e26b9d6536a4322bcdd/jiter-0.13.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04670992b576fa65bd056dbac0c39fe8bd67681c380cb2b48efa885711d9d726", size = 364163, upload-time = "2026-02-02T12:36:01.937Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8a/fb75556236047c8806995671a18e4a0ad646ed255276f51a20f32dceaeec/jiter-0.13.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a1aff1fbdb803a376d4d22a8f63f8e7ccbce0b4890c26cc7af9e501ab339ef0", size = 483709, upload-time = "2026-02-02T12:36:03.41Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/16/43512e6ee863875693a8e6f6d532e19d650779d6ba9a81593ae40a9088ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b3fb8c2053acaef8580809ac1d1f7481a0a0bdc012fd7f5d8b18fb696a5a089", size = 370480, upload-time = "2026-02-02T12:36:04.791Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/4c/09b93e30e984a187bc8aaa3510e1ec8dcbdcd71ca05d2f56aac0492453aa/jiter-0.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdaba7d87e66f26a2c45d8cbadcbfc4bf7884182317907baf39cfe9775bb4d93", size = 360735, upload-time = "2026-02-02T12:36:06.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1b/46c5e349019874ec5dfa508c14c37e29864ea108d376ae26d90bee238cd7/jiter-0.13.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7b88d649135aca526da172e48083da915ec086b54e8e73a425ba50999468cc08", size = 391814, upload-time = "2026-02-02T12:36:08.368Z" },
+    { url = "https://files.pythonhosted.org/packages/15/9e/26184760e85baee7162ad37b7912797d2077718476bf91517641c92b3639/jiter-0.13.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e404ea551d35438013c64b4f357b0474c7abf9f781c06d44fcaf7a14c69ff9e2", size = 513990, upload-time = "2026-02-02T12:36:09.993Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/34/2c9355247d6debad57a0a15e76ab1566ab799388042743656e566b3b7de1/jiter-0.13.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1f4748aad1b4a93c8bdd70f604d0f748cdc0e8744c5547798acfa52f10e79228", size = 548021, upload-time = "2026-02-02T12:36:11.376Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/4a/9f2c23255d04a834398b9c2e0e665382116911dc4d06b795710503cdad25/jiter-0.13.0-cp312-cp312-win32.whl", hash = "sha256:0bf670e3b1445fc4d31612199f1744f67f889ee1bbae703c4b54dc097e5dd394", size = 203024, upload-time = "2026-02-02T12:36:12.682Z" },
+    { url = "https://files.pythonhosted.org/packages/09/ee/f0ae675a957ae5a8f160be3e87acea6b11dc7b89f6b7ab057e77b2d2b13a/jiter-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:15db60e121e11fe186c0b15236bd5d18381b9ddacdcf4e659feb96fc6c969c92", size = 205424, upload-time = "2026-02-02T12:36:13.93Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/02/ae611edf913d3cbf02c97cdb90374af2082c48d7190d74c1111dde08bcdd/jiter-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:41f92313d17989102f3cb5dd533a02787cdb99454d494344b0361355da52fcb9", size = 186818, upload-time = "2026-02-02T12:36:15.308Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9c/7ee5a6ff4b9991e1a45263bfc46731634c4a2bde27dfda6c8251df2d958c/jiter-0.13.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1f8a55b848cbabf97d861495cd65f1e5c590246fabca8b48e1747c4dfc8f85bf", size = 306897, upload-time = "2026-02-02T12:36:16.748Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/02/be5b870d1d2be5dd6a91bdfb90f248fbb7dcbd21338f092c6b89817c3dbf/jiter-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f556aa591c00f2c45eb1b89f68f52441a016034d18b65da60e2d2875bbbf344a", size = 317507, upload-time = "2026-02-02T12:36:18.351Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/b25d2ec333615f5f284f3a4024f7ce68cfa0604c322c6808b2344c7f5d2b/jiter-0.13.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7e1d61da332ec412350463891923f960c3073cf1aae93b538f0bb4c8cd46efb", size = 350560, upload-time = "2026-02-02T12:36:19.746Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ec/74dcb99fef0aca9fbe56b303bf79f6bd839010cb18ad41000bf6cc71eec0/jiter-0.13.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3097d665a27bc96fd9bbf7f86178037db139f319f785e4757ce7ccbf390db6c2", size = 363232, upload-time = "2026-02-02T12:36:21.243Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/37/f17375e0bb2f6a812d4dd92d7616e41917f740f3e71343627da9db2824ce/jiter-0.13.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d01ecc3a8cbdb6f25a37bd500510550b64ddf9f7d64a107d92f3ccb25035d0f", size = 483727, upload-time = "2026-02-02T12:36:22.688Z" },
+    { url = "https://files.pythonhosted.org/packages/77/d2/a71160a5ae1a1e66c1395b37ef77da67513b0adba73b993a27fbe47eb048/jiter-0.13.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ed9bbc30f5d60a3bdf63ae76beb3f9db280d7f195dfcfa61af792d6ce912d159", size = 370799, upload-time = "2026-02-02T12:36:24.106Z" },
+    { url = "https://files.pythonhosted.org/packages/01/99/ed5e478ff0eb4e8aa5fd998f9d69603c9fd3f32de3bd16c2b1194f68361c/jiter-0.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98fbafb6e88256f4454de33c1f40203d09fc33ed19162a68b3b257b29ca7f663", size = 359120, upload-time = "2026-02-02T12:36:25.519Z" },
+    { url = "https://files.pythonhosted.org/packages/16/be/7ffd08203277a813f732ba897352797fa9493faf8dc7995b31f3d9cb9488/jiter-0.13.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5467696f6b827f1116556cb0db620440380434591e93ecee7fd14d1a491b6daa", size = 390664, upload-time = "2026-02-02T12:36:26.866Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/84/e0787856196d6d346264d6dcccb01f741e5f0bd014c1d9a2ebe149caf4f3/jiter-0.13.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:2d08c9475d48b92892583df9da592a0e2ac49bcd41fae1fec4f39ba6cf107820", size = 513543, upload-time = "2026-02-02T12:36:28.217Z" },
+    { url = "https://files.pythonhosted.org/packages/65/50/ecbd258181c4313cf79bca6c88fb63207d04d5bf5e4f65174114d072aa55/jiter-0.13.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:aed40e099404721d7fcaf5b89bd3b4568a4666358bcac7b6b15c09fb6252ab68", size = 547262, upload-time = "2026-02-02T12:36:29.678Z" },
+    { url = "https://files.pythonhosted.org/packages/27/da/68f38d12e7111d2016cd198161b36e1f042bd115c169255bcb7ec823a3bf/jiter-0.13.0-cp313-cp313-win32.whl", hash = "sha256:36ebfbcffafb146d0e6ffb3e74d51e03d9c35ce7c625c8066cdbfc7b953bdc72", size = 200630, upload-time = "2026-02-02T12:36:31.808Z" },
+    { url = "https://files.pythonhosted.org/packages/25/65/3bd1a972c9a08ecd22eb3b08a95d1941ebe6938aea620c246cf426ae09c2/jiter-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:8d76029f077379374cf0dbc78dbe45b38dec4a2eb78b08b5194ce836b2517afc", size = 202602, upload-time = "2026-02-02T12:36:33.679Z" },
+    { url = "https://files.pythonhosted.org/packages/15/fe/13bd3678a311aa67686bb303654792c48206a112068f8b0b21426eb6851e/jiter-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:bb7613e1a427cfcb6ea4544f9ac566b93d5bf67e0d48c787eca673ff9c9dff2b", size = 185939, upload-time = "2026-02-02T12:36:35.065Z" },
+    { url = "https://files.pythonhosted.org/packages/49/19/a929ec002ad3228bc97ca01dbb14f7632fffdc84a95ec92ceaf4145688ae/jiter-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fa476ab5dd49f3bf3a168e05f89358c75a17608dbabb080ef65f96b27c19ab10", size = 316616, upload-time = "2026-02-02T12:36:36.579Z" },
+    { url = "https://files.pythonhosted.org/packages/52/56/d19a9a194afa37c1728831e5fb81b7722c3de18a3109e8f282bfc23e587a/jiter-0.13.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ade8cb6ff5632a62b7dbd4757d8c5573f7a2e9ae285d6b5b841707d8363205ef", size = 346850, upload-time = "2026-02-02T12:36:38.058Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4a/94e831c6bf287754a8a019cb966ed39ff8be6ab78cadecf08df3bb02d505/jiter-0.13.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9950290340acc1adaded363edd94baebcee7dabdfa8bee4790794cd5cfad2af6", size = 358551, upload-time = "2026-02-02T12:36:39.417Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ec/a4c72c822695fa80e55d2b4142b73f0012035d9fcf90eccc56bc060db37c/jiter-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2b4972c6df33731aac0742b64fd0d18e0a69bc7d6e03108ce7d40c85fd9e3e6d", size = 201950, upload-time = "2026-02-02T12:36:40.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/00/393553ec27b824fbc29047e9c7cd4a3951d7fbe4a76743f17e44034fa4e4/jiter-0.13.0-cp313-cp313t-win_arm64.whl", hash = "sha256:701a1e77d1e593c1b435315ff625fd071f0998c5f02792038a5ca98899261b7d", size = 185852, upload-time = "2026-02-02T12:36:42.077Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f5/f1997e987211f6f9bd71b8083047b316208b4aca0b529bb5f8c96c89ef3e/jiter-0.13.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:cc5223ab19fe25e2f0bf2643204ad7318896fe3729bf12fde41b77bfc4fafff0", size = 308804, upload-time = "2026-02-02T12:36:43.496Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8f/5482a7677731fd44881f0204981ce2d7175db271f82cba2085dd2212e095/jiter-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9776ebe51713acf438fd9b4405fcd86893ae5d03487546dae7f34993217f8a91", size = 318787, upload-time = "2026-02-02T12:36:45.071Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/b9/7257ac59778f1cd025b26a23c5520a36a424f7f1b068f2442a5b499b7464/jiter-0.13.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:879e768938e7b49b5e90b7e3fecc0dbec01b8cb89595861fb39a8967c5220d09", size = 353880, upload-time = "2026-02-02T12:36:47.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/87/719eec4a3f0841dad99e3d3604ee4cba36af4419a76f3cb0b8e2e691ad67/jiter-0.13.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:682161a67adea11e3aae9038c06c8b4a9a71023228767477d683f69903ebc607", size = 366702, upload-time = "2026-02-02T12:36:48.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/65/415f0a75cf6921e43365a1bc227c565cb949caca8b7532776e430cbaa530/jiter-0.13.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a13b68cd1cd8cc9de8f244ebae18ccb3e4067ad205220ef324c39181e23bbf66", size = 486319, upload-time = "2026-02-02T12:36:53.006Z" },
+    { url = "https://files.pythonhosted.org/packages/54/a2/9e12b48e82c6bbc6081fd81abf915e1443add1b13d8fc586e1d90bb02bb8/jiter-0.13.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87ce0f14c6c08892b610686ae8be350bf368467b6acd5085a5b65441e2bf36d2", size = 372289, upload-time = "2026-02-02T12:36:54.593Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/e4693f107a1789a239c759a432e9afc592366f04e901470c2af89cfd28e1/jiter-0.13.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c365005b05505a90d1c47856420980d0237adf82f70c4aff7aebd3c1cc143ad", size = 360165, upload-time = "2026-02-02T12:36:56.112Z" },
+    { url = "https://files.pythonhosted.org/packages/17/08/91b9ea976c1c758240614bd88442681a87672eebc3d9a6dde476874e706b/jiter-0.13.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1317fdffd16f5873e46ce27d0e0f7f4f90f0cdf1d86bf6abeaea9f63ca2c401d", size = 389634, upload-time = "2026-02-02T12:36:57.495Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/58325ef99390d6d40427ed6005bf1ad54f2577866594bcf13ce55675f87d/jiter-0.13.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c05b450d37ba0c9e21c77fef1f205f56bcee2330bddca68d344baebfc55ae0df", size = 514933, upload-time = "2026-02-02T12:36:58.909Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/25/69f1120c7c395fd276c3996bb8adefa9c6b84c12bb7111e5c6ccdcd8526d/jiter-0.13.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:775e10de3849d0631a97c603f996f518159272db00fdda0a780f81752255ee9d", size = 548842, upload-time = "2026-02-02T12:37:00.433Z" },
+    { url = "https://files.pythonhosted.org/packages/18/05/981c9669d86850c5fbb0d9e62bba144787f9fba84546ba43d624ee27ef29/jiter-0.13.0-cp314-cp314-win32.whl", hash = "sha256:632bf7c1d28421c00dd8bbb8a3bac5663e1f57d5cd5ed962bce3c73bf62608e6", size = 202108, upload-time = "2026-02-02T12:37:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/cdcf54dd0b0341db7d25413229888a346c7130bd20820530905fdb65727b/jiter-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:f22ef501c3f87ede88f23f9b11e608581c14f04db59b6a801f354397ae13739f", size = 204027, upload-time = "2026-02-02T12:37:03.075Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f9/724bcaaab7a3cd727031fe4f6995cb86c4bd344909177c186699c8dec51a/jiter-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:07b75fe09a4ee8e0c606200622e571e44943f47254f95e2436c8bdcaceb36d7d", size = 187199, upload-time = "2026-02-02T12:37:04.414Z" },
+    { url = "https://files.pythonhosted.org/packages/62/92/1661d8b9fd6a3d7a2d89831db26fe3c1509a287d83ad7838831c7b7a5c7e/jiter-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:964538479359059a35fb400e769295d4b315ae61e4105396d355a12f7fef09f0", size = 318423, upload-time = "2026-02-02T12:37:05.806Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/3b/f77d342a54d4ebcd128e520fc58ec2f5b30a423b0fd26acdfc0c6fef8e26/jiter-0.13.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e104da1db1c0991b3eaed391ccd650ae8d947eab1480c733e5a3fb28d4313e40", size = 351438, upload-time = "2026-02-02T12:37:07.189Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b3/ba9a69f0e4209bd3331470c723c2f5509e6f0482e416b612431a5061ed71/jiter-0.13.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e3a5f0cde8ff433b8e88e41aa40131455420fb3649a3c7abdda6145f8cb7202", size = 364774, upload-time = "2026-02-02T12:37:08.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/16/6cdb31fa342932602458dbb631bfbd47f601e03d2e4950740e0b2100b570/jiter-0.13.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:57aab48f40be1db920a582b30b116fe2435d184f77f0e4226f546794cedd9cf0", size = 487238, upload-time = "2026-02-02T12:37:10.066Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b1/956cc7abaca8d95c13aa8d6c9b3f3797241c246cd6e792934cc4c8b250d2/jiter-0.13.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7772115877c53f62beeb8fd853cab692dbc04374ef623b30f997959a4c0e7e95", size = 372892, upload-time = "2026-02-02T12:37:11.656Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c4/97ecde8b1e74f67b8598c57c6fccf6df86ea7861ed29da84629cdbba76c4/jiter-0.13.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1211427574b17b633cfceba5040de8081e5abf114f7a7602f73d2e16f9fdaa59", size = 360309, upload-time = "2026-02-02T12:37:13.244Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d7/eabe3cf46715854ccc80be2cd78dd4c36aedeb30751dbf85a1d08c14373c/jiter-0.13.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7beae3a3d3b5212d3a55d2961db3c292e02e302feb43fce6a3f7a31b90ea6dfe", size = 389607, upload-time = "2026-02-02T12:37:14.881Z" },
+    { url = "https://files.pythonhosted.org/packages/df/2d/03963fc0804e6109b82decfb9974eb92df3797fe7222428cae12f8ccaa0c/jiter-0.13.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e5562a0f0e90a6223b704163ea28e831bd3a9faa3512a711f031611e6b06c939", size = 514986, upload-time = "2026-02-02T12:37:16.326Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6c/8c83b45eb3eb1c1e18d841fe30b4b5bc5619d781267ca9bc03e005d8fd0a/jiter-0.13.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:6c26a424569a59140fb51160a56df13f438a2b0967365e987889186d5fc2f6f9", size = 548756, upload-time = "2026-02-02T12:37:17.736Z" },
+    { url = "https://files.pythonhosted.org/packages/47/66/eea81dfff765ed66c68fd2ed8c96245109e13c896c2a5015c7839c92367e/jiter-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:24dc96eca9f84da4131cdf87a95e6ce36765c3b156fc9ae33280873b1c32d5f6", size = 201196, upload-time = "2026-02-02T12:37:19.101Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/32/4ac9c7a76402f8f00d00842a7f6b83b284d0cf7c1e9d4227bc95aa6d17fa/jiter-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0a8d76c7524087272c8ae913f5d9d608bd839154b62c4322ef65723d2e5bb0b8", size = 204215, upload-time = "2026-02-02T12:37:20.495Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/8e/7def204fea9f9be8b3c21a6f2dd6c020cf56c7d5ff753e0e23ed7f9ea57e/jiter-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2c26cf47e2cad140fa23b6d58d435a7c0161f5c514284802f25e87fddfe11024", size = 187152, upload-time = "2026-02-02T12:37:22.124Z" },
+    { url = "https://files.pythonhosted.org/packages/80/60/e50fa45dd7e2eae049f0ce964663849e897300433921198aef94b6ffa23a/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:3d744a6061afba08dd7ae375dcde870cffb14429b7477e10f67e9e6d68772a0a", size = 305169, upload-time = "2026-02-02T12:37:50.376Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
+]
+
+[[package]]
 name = "jmespath"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -500,6 +605,7 @@ name = "nous"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "anthropic" },
     { name = "asyncpg" },
     { name = "cel-python" },
     { name = "croniter" },
@@ -525,6 +631,7 @@ runtime = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", specifier = ">=0.52,<1.0" },
     { name = "asyncpg", specifier = ">=0.30,<1.0" },
     { name = "cel-python", specifier = ">=0.4,<1.0" },
     { name = "croniter", specifier = ">=6.0.0" },
@@ -1066,6 +1173,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Extract `AnthropicClient` protocol with `call()`/`stream()`/`start()`/`close()` methods into `nous/api/anthropic_client.py`
- **`HttpxAnthropicClient`**: existing httpx implementation moved out of runner (retries, SSE parsing, headers preserved exactly)
- **`SdkAnthropicClient`**: wraps `anthropic.AsyncAnthropic` with native retries (`max_retries=5`), correct Python User-Agent headers, and proper OAT/API key auth
- Config-driven backend selection: `NOUS_API_BACKEND=sdk` (default) or `httpx`
- Runner delegates `_call_api`/`_call_api_stream` to pluggable client via `create_client()` factory
- Fixes pre-existing stale test mocks (3-tuple → 4-tuple for `_tool_loop`)

## Files changed

| File | Change |
|------|--------|
| `nous/api/anthropic_client.py` | NEW — protocol, two implementations, factory |
| `nous/api/runner.py` | Delegates to client abstraction, re-exports moved symbols |
| `nous/config.py` | Added `api_backend` setting |
| `pyproject.toml` | Added `anthropic>=0.52,<1.0` dependency |
| `tests/test_runner.py` | Fixed stale mocks, updated header assertion tests |

## Test plan

- [x] All 49 runner tests pass (2 pre-existing failures unchanged)
- [x] All 8 tool_loop tests pass
- [x] Protocol conformance verified for both implementations
- [x] Factory creates correct backend based on config
- [x] Backward-compatible re-exports (StreamEvent, _parse_sse_event) verified
- [ ] End-to-end test with real API key on SDK backend
- [ ] End-to-end test with OAT token on SDK backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)