### PR TITLE
feat: wire programmatic censor checks into turn pipeline

### DIFF
--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -155,6 +155,14 @@ class AgentRunner:
         # 3. Append user message
         conversation.messages.append(Message(role="user", content=user_message))
 
+        # 3b. Censor block check — skip LLM if input was blocked
+        if turn_context.censor_blocked:
+            response_text = turn_context.censor_block_reason or "I can't process that request."
+            conversation.messages.append(Message(role="assistant", content=response_text))
+            turn_result = TurnResult(response_text=response_text)
+            await self._cognitive.post_turn(_agent_id, session_id, turn_result, turn_context)
+            return response_text, usage
+
         # 4-6. Build system prompt and run tool loop
         response_text = ""
         tool_results: list[ToolResult] = []
@@ -450,6 +458,16 @@ class AgentRunner:
         )
 
         conversation.messages.append(Message(role="user", content=user_message))
+
+        # Censor block check — yield block message and return
+        if turn_context.censor_blocked:
+            block_msg = turn_context.censor_block_reason or "I can't process that request."
+            conversation.messages.append(Message(role="assistant", content=block_msg))
+            turn_result = TurnResult(response_text=block_msg)
+            await self._cognitive.post_turn(_agent_id, session_id, turn_result, turn_context)
+            yield StreamEvent(type="text", text=block_msg)
+            yield StreamEvent(type="done")
+            return
 
         system_prompt = self._build_system_prompt(turn_context, platform=platform)
         if system_prompt_prefix:

--- a/nous/cognitive/layer.py
+++ b/nous/cognitive/layer.py
@@ -418,11 +418,40 @@ class CognitiveLayer:
         except Exception:
             pass
 
+        # Programmatic censor check on user input (#160 follow-up).
+        # This complements the prompt-based censors (soft) with actual
+        # pattern matching (hard). check_censors() increments
+        # activation_count as a side effect.
+        censor_blocked = False
+        censor_block_reason: str | None = None
+        try:
+            matches = await self._heart.check_censors(user_input, session=session)
+            for match in matches:
+                if match.action == "block":
+                    censor_blocked = True
+                    censor_block_reason = (
+                        f"Blocked by censor: {match.reason or match.trigger_pattern}"
+                    )
+                    logger.warning(
+                        "Censor BLOCK on user input (session=%s, censor=%s): %s",
+                        session_id, match.id, match.trigger_pattern,
+                    )
+                    break  # One block is enough
+                elif match.action == "warn":
+                    logger.info(
+                        "Censor WARN on user input (session=%s, censor=%s): %s",
+                        session_id, match.id, match.trigger_pattern,
+                    )
+        except Exception:
+            logger.debug("Censor check failed during pre_turn")
+
         return TurnContext(
             system_prompt=system_prompt,
             frame=frame,
             decision_id=decision_id,
             active_censors=active_censors,
+            censor_blocked=censor_blocked,
+            censor_block_reason=censor_block_reason,
             context_token_estimate=context_token_estimate,
             recalled_decision_ids=recalled_decision_ids,
             recalled_fact_ids=recalled_fact_ids,
@@ -579,6 +608,28 @@ class CognitiveLayer:
                     await self._heart.record_procedure_outcome(pid, proc_outcome, session=session)
                 except Exception:
                     logger.debug("Failed to reinforce procedure %s", proc_id_str)
+
+        # Post-turn censor check on model output (#160 follow-up).
+        # Catches credential leaks, blocked content in model responses.
+        # Only logs — doesn't block (response already sent in streaming).
+        # Increments activation_count for monitoring/escalation.
+        try:
+            output_matches = await self._heart.check_censors(
+                turn_result.response_text, session=session,
+            )
+            for match in output_matches:
+                if match.action == "block":
+                    logger.warning(
+                        "Censor BLOCK on model output (session=%s, censor=%s): %s",
+                        session_id, match.id, match.trigger_pattern,
+                    )
+                elif match.action == "warn":
+                    logger.info(
+                        "Censor WARN on model output (session=%s, censor=%s): %s",
+                        session_id, match.id, match.trigger_pattern,
+                    )
+        except Exception:
+            logger.debug("Censor check failed during post_turn")
 
         # 5. Update session metadata for significance tracking (005.5)
         meta = self._session_metadata.setdefault(session_id, SessionMetadata())

--- a/nous/cognitive/schemas.py
+++ b/nous/cognitive/schemas.py
@@ -183,6 +183,8 @@ class TurnContext(BaseModel):
     frame: FrameSelection
     decision_id: str | None = None  # Set if frame is 'decision' or 'task'
     active_censors: list[str] = Field(default_factory=list)
+    censor_blocked: bool = False  # Set if a block censor matched user input
+    censor_block_reason: str | None = None  # Reason for the block
     context_token_estimate: int = 0
     recalled_decision_ids: list[str] = Field(default_factory=list)
     recalled_fact_ids: list[str] = Field(default_factory=list)


### PR DESCRIPTION
## Problem

16 censors in the DB, **zero ever triggered**. `activation_count = 0` for all. The `check()` method exists with full semantic + keyword matching, auto-escalation, and side effects — but it was never called. Censors only worked as prompt text injected into system prompt, relying on Claude to self-censor.

## Fix

Wire `heart.check_censors()` into the cognitive layer at two points:

### Pre-turn (user input)
- Calls `check_censors(user_input)` after context build
- **Block**: Sets `censor_blocked=True` on TurnContext → runner skips LLM call, returns block reason
- **Warn**: Logs at INFO level, continues normally
- Handles both `run_turn` (sync) and `stream_chat` (streaming) paths

### Post-turn (model output)
- Calls `check_censors(response_text)` after assessment
- **Log only** — response may already be streamed, so can't block
- Increments `activation_count` for monitoring and auto-escalation
- Catches credential leaks, blocked content in responses

## Changes

| File | Change |
|------|--------|
| `cognitive/schemas.py` | Add `censor_blocked` + `censor_block_reason` to TurnContext |
| `cognitive/layer.py` | Add pre-turn and post-turn censor checks |
| `api/runner.py` | Handle `censor_blocked` in both sync and streaming paths |

## Impact

- `activation_count` will start incrementing (dashboard visibility)
- Auto-escalation (warn → block after threshold) will actually work
- False positive tracking becomes meaningful
- Block censors will actually block (previously relied on Claude obeying prompt instructions)
- Belt and suspenders: prompt-based (soft) + programmatic (hard)

## Safety

- Pre-turn block is conservative: returns block reason, still calls `post_turn` for cleanup
- Post-turn is log-only (can't unsend a streamed response)
- `check_censors()` failures are caught and logged at debug level — never breaks the turn

⚡ Emerson