### PR TITLE
fix(sleep): fix reflect phase list crash and generalize _http attribute error

### DIFF
--- a/nous/handlers/procedure_learner.py
+++ b/nous/handlers/procedure_learner.py
@@ -221,7 +221,7 @@ class ProcedureLearner:
 
     async def _learn_from_decisions(self, max_new: int) -> int:
         """Fetch reviewed successful decisions, cluster, extract procedures."""
-        if not self._embeddings or not self._http:
+        if not self._embeddings or not self._llm:
             return 0
 
         try:
@@ -338,7 +338,7 @@ class ProcedureLearner:
 
     async def _learn_from_episodes(self, max_new: int) -> int:
         """Collect lessons from completed episodes, cluster, extract procedures."""
-        if not self._embeddings or not self._http:
+        if not self._embeddings or not self._llm:
             return 0
 
         try:
@@ -419,7 +419,7 @@ class ProcedureLearner:
 
     async def _review_weak_procedures(self) -> int:
         """Find and review auto-learned procedures with low effectiveness or stale activation."""
-        if not self._http:
+        if not self._llm:
             return 0
 
         try:

--- a/nous/handlers/sleep_handler.py
+++ b/nous/handlers/sleep_handler.py
@@ -272,6 +272,9 @@ class SleepHandler:
                 return True
 
             reflection = parse_llm_json(text)
+            if not isinstance(reflection, dict):
+                logger.warning("Reflection LLM returned %s instead of dict, skipping", type(reflection).__name__)
+                return True
 
             # Store structured facts from LLM (preferred path)
             structured_facts = reflection.get("facts", [])


### PR DESCRIPTION
## Summary

Fixes the two bugs revealed by the `exc_info=True` tracebacks added in #175:

1. **Reflect phase** — `parse_llm_json()` sometimes returns a `list` instead of a `dict`, causing `AttributeError: 'list' object has no attribute 'get'`. Added type guard to skip gracefully.

2. **Generalize phase** — `ProcedureLearner` checks `self._http` but the attribute was renamed to `self._llm` in `__init__`. All 3 stale `self._http` references updated to `self._llm`.

## Test plan

- [x] 30 sleep handler tests pass
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)