### PR TITLE
feat: dynamic vector weight config + runtime API (F025 prep)

### DIFF
--- a/nous/api/rest.py
+++ b/nous/api/rest.py
@@ -806,6 +806,71 @@ def create_app(
         return JSONResponse({"status": "started", "message": "Sleep cycle triggered"})
 
     # ------------------------------------------------------------------
+    # Admin: runtime config endpoints (F025 prep)
+    # ------------------------------------------------------------------
+
+    async def get_search_weights(request: Request) -> JSONResponse:
+        """GET /admin/search-weights — current vector/keyword weight + source."""
+        from nous.runtime_config import RuntimeConfig
+
+        rc = RuntimeConfig.get()
+        vw = rc.get_vector_weight(settings)
+        source = rc.get_vector_weight_source(settings)
+        return JSONResponse({
+            "vector_weight": vw,
+            "keyword_weight": round(1.0 - vw, 4),
+            "source": source,
+        })
+
+    async def set_search_weights(request: Request) -> JSONResponse:
+        """POST /admin/search-weights — update vector weight at runtime."""
+        from nous.runtime_config import RuntimeConfig
+
+        try:
+            body = await request.json()
+        except Exception:
+            return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+
+        raw = body.get("vector_weight")
+        if raw is None:
+            return JSONResponse({"error": "Missing required field: vector_weight"}, status_code=400)
+
+        try:
+            vw = float(raw)
+        except (TypeError, ValueError):
+            return JSONResponse({"error": "vector_weight must be a number"}, status_code=400)
+
+        if not (0.0 <= vw <= 1.0):
+            return JSONResponse(
+                {"error": "vector_weight must be between 0.0 and 1.0"},
+                status_code=400,
+            )
+
+        rc = RuntimeConfig.get()
+        old_vw = rc.get_vector_weight(settings)
+        old_source = rc.get_vector_weight_source(settings)
+        rc.set_vector_weight(vw)
+
+        # Persist to DB
+        try:
+            async with database.session() as session:
+                await rc.persist_to_db(session, "vector_weight", vw)
+        except Exception as e:
+            logger.error("Failed to persist vector_weight: %s", e)
+            # In-memory override still applies for this process
+
+        logger.info(
+            "vector_weight updated to %.4f (was %.4f, source: %s)",
+            vw, old_vw, old_source,
+        )
+
+        return JSONResponse({
+            "vector_weight": vw,
+            "keyword_weight": round(1.0 - vw, 4),
+            "source": "runtime_override",
+        })
+
+    # ------------------------------------------------------------------
     # F021: Dashboard endpoints (route registration in Task 10)
     # ------------------------------------------------------------------
 
@@ -959,6 +1024,9 @@ def create_app(
         Route("/schedules/{id}", deactivate_schedule, methods=["DELETE"]),
         Route("/health", health),
         Route("/sleep/trigger", trigger_sleep, methods=["POST"]),
+        # Admin API endpoints (F025 prep)
+        Route("/admin/search-weights", get_search_weights),
+        Route("/admin/search-weights", set_search_weights, methods=["POST"]),
         # Dashboard API endpoints (F021) — MUST be before static Mount
         Route("/dashboard/graph", dashboard_graph),
         Route("/dashboard/calibration", dashboard_calibration),

--- a/nous/cognitive/layer.py
+++ b/nous/cognitive/layer.py
@@ -956,8 +956,8 @@ class CognitiveLayer:
         original episode.
 
         R-P1-2: Uses direct cosine similarity via EmbeddingProvider, NOT
-        hybrid_search (which returns 0.7*vector + 0.3*keyword combined scores
-        that max at ~0.79 for perfect vector match — making 0.85 unreachable).
+        hybrid_search (which returns vector*w + keyword*(1-w) combined scores
+        that max at ~0.79 at default weight — making 0.85 unreachable).
 
         R-P1-3: Filters to episodes started within last 48 hours to avoid
         matching ancient episodes about similar topics.

--- a/nous/config.py
+++ b/nous/config.py
@@ -37,6 +37,9 @@ class Settings(BaseSettings):
     # Anti-hallucination (F016 Phase 0)
     anti_hallucination_prompt: bool = True
 
+    # F025 prep: hybrid search vector weight (keyword_weight = 1 - vector_weight)
+    vector_weight: float = 0.7
+
     # F017: Relevance floor
     relevance_floor_enabled: bool = True
 

--- a/nous/heart/facts.py
+++ b/nous/heart/facts.py
@@ -811,7 +811,17 @@ class FactManager:
         category: str | None,
         session: AsyncSession,
     ) -> list[FactSummary]:
-        """Search all facts including inactive (no active filter)."""
+        """Search all facts including inactive (no active filter).
+
+        Uses same weight resolution as hybrid_search() but does NOT
+        call it — intentionally omits the active=true filter so
+        superseded/inactive facts are included.
+        """
+        from nous.heart.search import _resolve_vector_weight
+
+        vw = _resolve_vector_weight()
+        kw = 1.0 - vw
+
         params: dict = {
             "agent_id": self.agent_id,
             "query_text": query,
@@ -826,11 +836,11 @@ class FactManager:
             params["query_embedding"] = "[" + ",".join(str(float(v)) for v in embedding) + "]"
             sql = text(f"""
                 SELECT t.id,
-                    (COALESCE(1 - (t.embedding <=> CAST(:query_embedding AS vector)), 0) * 0.7
+                    (COALESCE(1 - (t.embedding <=> CAST(:query_embedding AS vector)), 0) * {vw}
                      + COALESCE(
                          ts_rank_cd(t.search_tsv, plainto_tsquery('english', :query_text))
                          / (1.0 + ts_rank_cd(t.search_tsv, plainto_tsquery('english', :query_text))),
-                       0) * 0.3
+                       0) * {kw}
                     ) AS combined_score
                 FROM heart.facts t
                 WHERE t.agent_id = :agent_id {filter_extra}

--- a/nous/heart/heart.py
+++ b/nous/heart/heart.py
@@ -678,10 +678,11 @@ class Heart:
     ) -> list[RecallResult]:
         """Search across ALL memory types, return ranked results.
 
-        Results carry their original hybrid search scores (0.7*vector +
-        0.3*keyword for episodes/facts/procedures via hybrid_search(),
-        cosine similarity for censors). Since most sub-searches use the
-        same scoring formula, scores are directly comparable.
+        Results carry their original hybrid search scores (configurable
+        vector/keyword weighting via hybrid_search(); default 0.7/0.3,
+        overridable at runtime). Censors use cosine similarity. Since
+        most sub-searches use the same scoring formula, scores are
+        directly comparable.
         """
         if session is None:
             async with self.db.session() as session:
@@ -733,9 +734,9 @@ class Heart:
                 results_list.append(exc)
 
         # Use original search scores instead of RRF positional scores.
-        # Episodes, facts, and procedures use hybrid_search() (0.7*vector
-        # + 0.3*keyword). Censors use cosine similarity. Scores are
-        # comparable enough for meaningful cross-type ranking.
+        # Episodes, facts, and procedures use hybrid_search() (configurable
+        # vector/keyword weight; default 0.7/0.3). Censors use cosine
+        # similarity. Scores are comparable enough for cross-type ranking.
         merged: list[RecallResult] = []
 
         for memory_type, raw_results in zip(keys, results_list):

--- a/nous/heart/search.py
+++ b/nous/heart/search.py
@@ -13,6 +13,18 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
+def _resolve_vector_weight() -> float:
+    """Resolve vector_weight from runtime config > settings > default 0.7."""
+    from nous.config import Settings
+    from nous.runtime_config import RuntimeConfig
+
+    try:
+        settings = Settings()
+    except Exception:
+        return 0.7
+    return RuntimeConfig.get().get_vector_weight(settings)
+
+
 async def hybrid_search(
     session: AsyncSession,
     table: str,
@@ -22,7 +34,7 @@ async def hybrid_search(
     extra_where: str = "",
     extra_params: dict | None = None,
     limit: int = 10,
-    vector_weight: float = 0.7,
+    vector_weight: float | None = None,
 ) -> list[tuple[UUID, float]]:
     """Hybrid vector + keyword search over a Heart table.
 
@@ -30,6 +42,12 @@ async def hybrid_search(
     1. Vector similarity via cosine distance on embedding column
     2. Keyword relevance via ts_rank_cd on search_tsv column
     3. Combined score = vector_weight * vector_score + (1 - vector_weight) * keyword_score
+
+    Weight resolution order:
+    1. Explicit vector_weight param (highest priority)
+    2. Runtime override (set via /admin/search-weights API)
+    3. NOUS_VECTOR_WEIGHT env var / config default
+    4. Fallback: 0.7
 
     Args:
         session: Active SQLAlchemy async session.
@@ -42,10 +60,14 @@ async def hybrid_search(
         extra_params: Additional parameters for extra_where bindings.
         limit: Maximum number of results to return.
         vector_weight: Weight for vector score (keyword weight = 1 - vector_weight).
+            None = resolve from runtime config / settings / default.
 
     Returns:
         List of (id, combined_score) ordered by score DESC.
     """
+    if vector_weight is None:
+        vector_weight = _resolve_vector_weight()
+
     params: dict = {
         "agent_id": agent_id,
         "query_text": query_text,

--- a/nous/main.py
+++ b/nous/main.py
@@ -50,6 +50,12 @@ async def create_components(settings: Settings) -> dict:
     await database.connect()  # F1: connect() not initialize()
     await run_migrations(database.engine)  # Apply pending SQL migrations
 
+    # Load runtime config overrides from DB (must be after migrations)
+    from nous.runtime_config import RuntimeConfig
+    runtime_cfg = RuntimeConfig.get()
+    async with database.session() as cfg_session:
+        await runtime_cfg.load_from_db(cfg_session)
+
     embedding_provider = None
     if settings.openai_api_key:
         embedding_provider = EmbeddingProvider(

--- a/nous/runtime_config.py
+++ b/nous/runtime_config.py
@@ -1,0 +1,98 @@
+"""Mutable runtime configuration — loaded from DB, updated via API.
+
+Settings (pydantic-settings) is immutable after startup and handles env vars /
+defaults.  RuntimeConfig holds live overrides that can change at runtime via
+the /admin API.  Resolution order for each knob:
+
+  1. Explicit caller parameter (per-call override)
+  2. Runtime override set via API  (stored here + persisted to nous_system.config)
+  3. Env var / Settings default
+  4. Hardcoded fallback
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+# Keys used in nous_system.config table
+_KEY_VECTOR_WEIGHT = "vector_weight"
+
+
+class RuntimeConfig:
+    """Singleton holding runtime-mutable configuration."""
+
+    _instance: RuntimeConfig | None = None
+
+    def __init__(self) -> None:
+        self._overrides: dict[str, Any] = {}
+
+    @classmethod
+    def get(cls) -> RuntimeConfig:
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def reset(cls) -> None:
+        """Reset singleton (for tests)."""
+        cls._instance = None
+
+    # -- Vector weight --------------------------------------------------------
+
+    def get_vector_weight(self, settings: Any) -> float:
+        """Resolve vector_weight: runtime override > env/settings > default."""
+        if _KEY_VECTOR_WEIGHT in self._overrides:
+            return float(self._overrides[_KEY_VECTOR_WEIGHT])
+        return float(settings.vector_weight)
+
+    def get_vector_weight_source(self, settings: Any) -> str:
+        """Return the source of the current effective vector_weight."""
+        if _KEY_VECTOR_WEIGHT in self._overrides:
+            return "runtime_override"
+        if "vector_weight" in settings.model_fields_set:
+            return "env_var"
+        return "default"
+
+    def set_vector_weight(self, value: float) -> None:
+        """Set runtime override (call persist_to_db separately)."""
+        self._overrides[_KEY_VECTOR_WEIGHT] = value
+
+    def clear_vector_weight(self) -> None:
+        """Remove runtime override, falling back to settings."""
+        self._overrides.pop(_KEY_VECTOR_WEIGHT, None)
+
+    # -- DB persistence -------------------------------------------------------
+
+    async def load_from_db(self, session: AsyncSession) -> None:
+        """Load all persisted overrides from nous_system.config."""
+        try:
+            result = await session.execute(
+                text("SELECT key, value FROM nous_system.config")
+            )
+            for row in result:
+                key, value = row[0], row[1]
+                if key == _KEY_VECTOR_WEIGHT and value is not None:
+                    w = float(value)
+                    if 0.0 <= w <= 1.0:
+                        self._overrides[key] = w
+                        logger.info("Loaded runtime override: %s = %s", key, w)
+        except Exception:
+            logger.debug("nous_system.config table not available yet (normal on first run)")
+
+    async def persist_to_db(self, session: AsyncSession, key: str, value: Any) -> None:
+        """Upsert a config value to nous_system.config."""
+        await session.execute(
+            text("""
+                INSERT INTO nous_system.config (key, value)
+                VALUES (:key, CAST(:value AS jsonb))
+                ON CONFLICT (key) DO UPDATE SET value = CAST(:value AS jsonb)
+            """),
+            {"key": key, "value": str(value)},
+        )
+        await session.commit()

--- a/sql/migrations/021_config_table.sql
+++ b/sql/migrations/021_config_table.sql
@@ -1,0 +1,12 @@
+-- 021: Runtime config key-value store (F025 prep)
+-- General-purpose runtime configuration table.  Agent-scoped overrides
+-- belong in nous_system.agents.config JSONB, not here.
+
+CREATE TABLE IF NOT EXISTS nous_system.config (
+    key   VARCHAR PRIMARY KEY,
+    value JSONB NOT NULL,
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TRIGGER set_updated_at BEFORE UPDATE ON nous_system.config
+    FOR EACH ROW EXECUTE FUNCTION update_timestamp();


### PR DESCRIPTION
## Summary

- Consolidates hardcoded 0.7/0.3 vector/keyword search weights into a single configurable value
- Adds `NOUS_VECTOR_WEIGHT` env var via `Settings.vector_weight`
- Creates `RuntimeConfig` singleton for mutable runtime overrides (Settings stays immutable)
- Adds `nous_system.config` key-value table (migration 021) for persistence
- Adds `GET/POST /admin/search-weights` REST endpoints for runtime tuning
- Weight resolution order: caller param > runtime override > env var > default 0.7

## Changes

| File | Change |
|------|--------|
| `nous/config.py` | Add `vector_weight: float = 0.7` field |
| `nous/runtime_config.py` | **New** — RuntimeConfig singleton with DB persistence |
| `sql/migrations/021_config_table.sql` | **New** — `nous_system.config` table + trigger |
| `nous/heart/search.py` | `hybrid_search()` signature → `float | None = None`, resolve from config |
| `nous/heart/facts.py` | Replace hardcoded 0.7/0.3 in `_search_all()` with config values |
| `nous/api/rest.py` | Add `GET/POST /admin/search-weights` endpoints |
| `nous/main.py` | Load runtime config from DB after migrations |
| `nous/heart/heart.py` | Update docstrings |
| `nous/cognitive/layer.py` | Update docstrings |

## Design decisions (from 3-agent review)

- **RuntimeConfig vs mutating Settings**: Settings is frozen pydantic — runtime overrides live in a separate mutable singleton
- **facts.py option (b)**: `_search_all()` intentionally omits `active=true` filter, so it reads from config directly instead of routing through `hybrid_search()`
- **None sentinel**: `hybrid_search(vector_weight=None)` makes resolution order unambiguous
- **Config table is global**: Agent-scoped overrides belong in `agents.config` JSONB, not here

## Test plan

- [x] `RuntimeConfig` import, set/clear/resolve verified
- [x] `_resolve_vector_weight()` returns correct default
- [x] `rest.py` imports compile correctly
- [x] Existing test suite passes (26 unit tests, DB tests need Postgres)
- [x] Grep confirms no remaining hardcoded weights in SQL
- [ ] Integration test: POST weight change persists and is returned by GET
- [ ] Integration test: Weight change affects search ranking

🤖 Generated with [Claude Code](https://claude.com/claude-code)