### PR TITLE
fix: procedure learning broken — sleep cycle creates 0 procedures (#188)

### DIFF
--- a/docs/plans/2026-03-23-fix-procedure-learning.md
+++ b/docs/plans/2026-03-23-fix-procedure-learning.md
@@ -1,0 +1,472 @@
+# Fix Procedure Learning (Issue #188) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix 4 bugs preventing procedure learning during sleep cycles — decision pathway returns 0 reviewed decisions, stats under-report, episode pathway has no visibility, and `_list_decisions` doesn't map `reviewed_at`.
+
+**Architecture:** 5 targeted changes across 3 files. No new files. All tests use mocks (no DB needed). Existing test patterns in `test_procedure_learner.py` and `test_sleep_handler.py` provide the mock infrastructure.
+
+**Tech Stack:** Python 3.12+, pytest, pytest-asyncio, unittest.mock (AsyncMock, MagicMock)
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `nous/brain/brain.py` | Modify line ~201 | Add `reviewed_at` to `_list_decisions` inline mapper |
+| `nous/handlers/procedure_learner.py` | Modify lines ~229-234 | Pass DB filters + add diagnostic logging |
+| `nous/handlers/sleep_handler.py` | Modify line ~360 | Count both decision + episode pathways in stats |
+| `tests/test_procedure_learner.py` | Modify | Add regression tests for bugs 1, 1B, 4 |
+| `tests/test_sleep_handler.py` | Modify | Add regression test for bug 2 |
+
+---
+
+### Task 1: Fix `reviewed_at` mapping in `brain.py` `_list_decisions`
+
+**Files:**
+- Modify: `nous/brain/brain.py:191-204`
+- Test: `tests/test_procedure_learner.py` (indirect — existing test `test_decision_cluster_creates_procedure` sets `reviewed_at` on mocked summaries)
+
+This is the hidden fourth bug. The `_list_decisions` inline mapper constructs `DecisionSummary` without `reviewed_at`, so any Python-side filter on that field sees `None`. The separate `_decision_to_summary()` helper at line 1354 does include it, but `_list_decisions` doesn't use it.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_procedure_learner.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_list_decisions_reviewed_at_must_be_populated():
+    """Regression: _list_decisions must populate reviewed_at in DecisionSummary.
+
+    Bug: brain.py _list_decisions inline mapper omitted reviewed_at,
+    causing procedure_learner's Python filter to see None for all decisions.
+    Issue #188, Gap 1.
+    """
+    # This test verifies the contract: when list_decisions returns summaries
+    # with reviewed_at set, the procedure_learner filter works.
+    learner, brain, heart, embeddings, http = _build_learner()
+
+    # Simulate what happens when list_decisions correctly populates reviewed_at
+    summaries_with_reviewed = [_make_decision_summary(reviewed_at=_RECENT) for _ in range(3)]
+    brain.list_decisions.return_value = (summaries_with_reviewed, 3)
+
+    # Verify the filter passes (reviewed_at is not None)
+    for s in summaries_with_reviewed:
+        assert s.reviewed_at is not None, "reviewed_at must be populated by list_decisions"
+
+    # Simulate what happens when reviewed_at is None (the bug)
+    summaries_without_reviewed = [_make_decision_summary(reviewed_at=None) for _ in range(3)]
+    # These would all be filtered out by the learner's filter
+    filtered = [d for d in summaries_without_reviewed if d.outcome in ("success", "partial") and d.reviewed_at is not None]
+    assert len(filtered) == 0, "Without reviewed_at, filter rejects all"
+```
+
+- [ ] **Step 2: Run test to verify it passes (this is a contract test, not a failure test)**
+
+Run: `uv run pytest tests/test_procedure_learner.py::test_list_decisions_reviewed_at_must_be_populated -v`
+
+- [ ] **Step 3: Fix the mapper in brain.py**
+
+In `nous/brain/brain.py`, find the inline `DecisionSummary` construction in `_list_decisions` (around line 191-204). Add `reviewed_at=d.reviewed_at`:
+
+```python
+        summaries = [
+            DecisionSummary(
+                id=d.id,
+                description=d.description,
+                confidence=d.confidence,
+                category=d.category,
+                stakes=d.stakes,
+                outcome=d.outcome or "pending",
+                pattern=d.pattern,
+                tags=tags_by_id.get(d.id, []),
+                reviewed_at=d.reviewed_at,  # <-- ADD THIS LINE
+                created_at=d.created_at,
+            )
+            for d in decisions
+        ]
+```
+
+- [ ] **Step 4: Verify no existing tests break**
+
+Run: `uv run pytest tests/test_procedure_learner.py tests/test_sleep_handler.py -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add nous/brain/brain.py tests/test_procedure_learner.py
+git commit -m "fix: populate reviewed_at in _list_decisions inline mapper (#188)"
+```
+
+---
+
+### Task 2: Fix decision pathway DB query in `procedure_learner.py`
+
+**Files:**
+- Modify: `nous/handlers/procedure_learner.py:229-234`
+- Test: `tests/test_procedure_learner.py`
+
+Bug 1: `list_decisions(limit=100)` with no filters returns 100 most recent (all pending). The 124 reviewed successful decisions are older and outside the window.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_procedure_learner.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_decision_pathway_passes_db_filters():
+    """Regression: list_decisions must be called with outcome and reviewed filters.
+
+    Bug: list_decisions(limit=100) with no filters returned 100 most recent
+    decisions (all pending), missing the 124 reviewed successful ones.
+    Issue #188, Bug 1.
+    """
+    learner, brain, heart, embeddings, http = _build_learner()
+
+    # Return empty so we don't need to set up the full pipeline
+    brain.list_decisions.return_value = ([], 0)
+    heart.list_episodes.return_value = []
+    heart.search_procedures.return_value = []
+
+    await learner.run_sleep_learning()
+
+    # Verify list_decisions was called with the right filters
+    brain.list_decisions.assert_called_once()
+    call_kwargs = brain.list_decisions.call_args
+    # Check positional or keyword args contain outcome and reviewed filters
+    _, kwargs = call_kwargs
+    assert kwargs.get("outcome") == "success" or (len(call_kwargs.args) > 0 and "success" in str(call_kwargs)), \
+        "list_decisions must filter outcome='success'"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_procedure_learner.py::test_decision_pathway_passes_db_filters -v`
+Expected: FAIL — current code calls `list_decisions(limit=100)` without outcome/reviewed.
+
+- [ ] **Step 3: Fix the query and remove redundant Python filter**
+
+In `nous/handlers/procedure_learner.py`, replace lines 228-234:
+
+```python
+        try:
+            # Fetch reviewed successful decisions — pass filters to DB
+            # to avoid the window problem where 100 most recent are all pending.
+            # Issue #188 Bug 1: was list_decisions(limit=100) with no filters.
+            decisions_success, _ = await self._brain.list_decisions(
+                limit=50, outcome="success", reviewed=True
+            )
+            decisions_partial, _ = await self._brain.list_decisions(
+                limit=50, outcome="partial", reviewed=True
+            )
+            successful = list(decisions_success) + list(decisions_partial)
+            logger.info(
+                "Decision pathway: %d success + %d partial = %d reviewed decisions",
+                len(decisions_success), len(decisions_partial), len(successful),
+            )
+            if len(successful) < self._settings.procedure_cluster_min_size:
+                logger.info("Decision pathway: too few reviewed decisions (%d < %d)",
+                            len(successful), self._settings.procedure_cluster_min_size)
+                return 0
+```
+
+- [ ] **Step 4: Update the test to match new call pattern**
+
+Update the test to verify the new call pattern:
+
+```python
+@pytest.mark.asyncio
+async def test_decision_pathway_passes_db_filters():
+    """Regression: list_decisions must be called with outcome and reviewed filters.
+
+    Bug: list_decisions(limit=100) with no filters returned 100 most recent
+    decisions (all pending), missing the 124 reviewed successful ones.
+    Issue #188, Bug 1.
+    """
+    learner, brain, heart, embeddings, http = _build_learner()
+
+    brain.list_decisions.return_value = ([], 0)
+    heart.list_episodes.return_value = []
+    heart.search_procedures.return_value = []
+
+    await learner.run_sleep_learning()
+
+    # Must be called twice: once for "success", once for "partial"
+    assert brain.list_decisions.call_count == 2
+    calls = brain.list_decisions.call_args_list
+
+    # First call: outcome="success", reviewed=True
+    _, kwargs0 = calls[0]
+    assert kwargs0["outcome"] == "success"
+    assert kwargs0["reviewed"] is True
+
+    # Second call: outcome="partial", reviewed=True
+    _, kwargs1 = calls[1]
+    assert kwargs1["outcome"] == "partial"
+    assert kwargs1["reviewed"] is True
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_procedure_learner.py -v`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add nous/handlers/procedure_learner.py tests/test_procedure_learner.py
+git commit -m "fix: pass outcome/reviewed filters to list_decisions in procedure learner (#188)"
+```
+
+---
+
+### Task 3: Fix sleep stats under-reporting in `sleep_handler.py`
+
+**Files:**
+- Modify: `nous/handlers/sleep_handler.py:360`
+- Test: `tests/test_sleep_handler.py`
+
+Bug 2: Only counts `decisions_learned`, ignores `episodes_learned`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_sleep_handler.py`:
+
+```python
+class TestProcedureStatsCountBothPathways:
+    """Bug 2 regression: procedures_created must include both decision and episode pathways."""
+
+    @pytest.mark.asyncio
+    async def test_procedures_created_includes_episodes(self):
+        """Regression: sleep_stats must count episodes_learned + decisions_learned.
+
+        Bug: Only counted decisions_learned, ignored episodes_learned.
+        Issue #188, Bug 2.
+        """
+        handler, brain, heart, bus, _ = _make_sleep_handler()
+        handler._phase_review_decisions = AsyncMock(return_value=True)
+        handler._phase_prune = AsyncMock(return_value=True)
+        handler._phase_compress = AsyncMock(return_value=True)
+        handler._phase_reflect = AsyncMock(return_value=True)
+
+        # Procedure learner returns both decision and episode learned counts
+        handler._procedure_learner = AsyncMock()
+        handler._procedure_learner.run_sleep_learning = AsyncMock(
+            return_value={"decisions_learned": 2, "episodes_learned": 3, "weak_reviewed": 1}
+        )
+
+        await handler._run_sleep(_make_event("sleep_started"))
+
+        emitted = bus.emit.call_args[0][0]
+        # Must be 2 + 3 = 5, not just 2
+        assert emitted.data["procedures_created"] == 5
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_sleep_handler.py::TestProcedureStatsCountBothPathways -v`
+Expected: FAIL — current code returns 2, not 5.
+
+- [ ] **Step 3: Fix the stats line**
+
+In `nous/handlers/sleep_handler.py`, replace line 360:
+
+```python
+                sleep_stats["procedures_created"] += stats.get("decisions_learned", 0) + stats.get("episodes_learned", 0)
+```
+
+- [ ] **Step 4: Update existing test that will break**
+
+The existing `test_generalize_increments_procedures_created` (line 284-294) sets `decisions_learned=3, episodes_learned=1` and asserts `procedures_created == 3`. After the fix, the actual value is `3 + 1 = 4`. Update the assertion:
+
+In `tests/test_sleep_handler.py`, find `test_generalize_increments_procedures_created` and change:
+
+```python
+        assert sleep_stats["procedures_created"] == 3
+```
+
+to:
+
+```python
+        # After fix: counts both decisions_learned (3) + episodes_learned (1) = 4
+        assert sleep_stats["procedures_created"] == 4
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_sleep_handler.py -v`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add nous/handlers/sleep_handler.py tests/test_sleep_handler.py
+git commit -m "fix: count both decision and episode pathways in sleep stats (#188)"
+```
+
+---
+
+### Task 4: Add diagnostic logging to episode pathway
+
+**Files:**
+- Modify: `nous/handlers/procedure_learner.py:339-414`
+- Test: `tests/test_procedure_learner.py`
+
+Bug 3 visibility: Episode pathway has no logging to show where it drops to zero.
+
+- [ ] **Step 1: Write the test**
+
+Add to `tests/test_procedure_learner.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_episode_pathway_logs_diagnostics(caplog):
+    """Episode pathway must log diagnostic info at each stage.
+
+    Issue #188, Bug 3: Episode pathway fails silently.
+    """
+    import logging
+    learner, brain, heart, embeddings, http = _build_learner()
+
+    brain.list_decisions.return_value = ([], 0)
+
+    # 3 episodes but only 1 has success outcome
+    ep_success = _make_episode_summary(outcome="success")
+    ep_failure = _make_episode_summary(outcome="failure")
+    ep_ongoing = _make_episode_summary(outcome="ongoing")
+    heart.list_episodes.return_value = [ep_success, ep_failure, ep_ongoing]
+
+    heart.get_episode.return_value = _make_episode_detail(
+        ep_success, lessons=["Single lesson"]
+    )
+
+    heart.search_procedures.return_value = []
+
+    with caplog.at_level(logging.INFO, logger="nous.handlers.procedure_learner"):
+        await learner.run_sleep_learning()
+
+    # Should log specific episode pathway diagnostics
+    assert "Episode pathway" in caplog.text
+    assert "episodes fetched" in caplog.text or "lessons collected" in caplog.text
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_procedure_learner.py::test_episode_pathway_logs_diagnostics -v`
+Expected: FAIL — current code has no "Episode pathway" log messages.
+
+- [ ] **Step 3: Add logging to episode pathway**
+
+In `nous/handlers/procedure_learner.py`, in `_learn_from_episodes()`, add logging after key stages. Replace lines 344-361:
+
+```python
+        try:
+            # Fetch completed/resolved episodes
+            episodes_summary = await self._heart.list_episodes(limit=50)
+            logger.info("Episode pathway: %d episodes fetched", len(episodes_summary))
+
+            # Collect lessons from completed episodes (need full details)
+            all_lessons: list[str] = []
+            skipped_outcome = 0
+            skipped_no_lessons = 0
+            for ep_summary in episodes_summary:
+                if ep_summary.outcome not in ("success", "partial"):
+                    skipped_outcome += 1
+                    continue
+                try:
+                    ep_detail = await self._heart.get_episode(ep_summary.id)
+                    if ep_detail.lessons_learned:
+                        all_lessons.extend(ep_detail.lessons_learned)
+                    else:
+                        skipped_no_lessons += 1
+                except (ValueError, Exception):
+                    continue
+
+            logger.info(
+                "Episode pathway: %d lessons collected (%d skipped: %d wrong outcome, %d no lessons)",
+                len(all_lessons), skipped_outcome + skipped_no_lessons,
+                skipped_outcome, skipped_no_lessons,
+            )
+
+            if len(all_lessons) < self._settings.procedure_cluster_min_size:
+                logger.info("Episode pathway: too few lessons (%d < %d)",
+                            len(all_lessons), self._settings.procedure_cluster_min_size)
+                return 0
+```
+
+Also add logging after clustering (around line 371):
+
+```python
+            logger.info(
+                "Episode pathway: %d clusters found from %d embeddings (threshold=%.2f, min_size=%d)",
+                len(clusters), len(embeddings),
+                self._settings.procedure_episode_similarity,
+                self._settings.procedure_cluster_min_size,
+            )
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_procedure_learner.py -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add nous/handlers/procedure_learner.py tests/test_procedure_learner.py
+git commit -m "fix: add diagnostic logging to procedure learner pathways (#188)"
+```
+
+---
+
+### Task 5: Update existing tests for new call pattern
+
+**Files:**
+- Modify: `tests/test_procedure_learner.py`
+- Modify: `tests/test_sleep_handler.py` (assertion already updated in Task 3)
+
+The existing test `test_decision_cluster_creates_procedure` sets up `brain.list_decisions.return_value` with pre-filtered summaries. After Task 2, `list_decisions` is called twice (success + partial). Update the mock setup.
+
+- [ ] **Step 1: Update existing test mock setup**
+
+In `tests/test_procedure_learner.py`, update `test_decision_cluster_creates_procedure`:
+
+```python
+@pytest.mark.asyncio
+async def test_decision_cluster_creates_procedure():
+    """3+ similar successful reviewed decisions -> 1 procedure."""
+    learner, brain, heart, embeddings, http = _build_learner()
+
+    # Set up 3 successful reviewed decisions
+    summaries = [_make_decision_summary() for _ in range(3)]
+    # list_decisions now called twice: success returns 3, partial returns 0
+    brain.list_decisions.side_effect = [(summaries, 3), ([], 0)]
+
+    # ... rest unchanged ...
+```
+
+Update ALL tests that set `brain.list_decisions.return_value` to use `side_effect` with two returns (one for success call, one for partial call). Affected tests:
+
+- `test_decision_cluster_creates_procedure` — change to `side_effect = [(summaries, 3), ([], 0)]`
+- `test_small_cluster_rejected` — change to `side_effect = [(summaries, 2), ([], 0)]`
+- `test_recency_gate` — change to `side_effect = [(summaries, 3), ([], 0)]`
+- `test_dedup_skips_similar_existing` — change to `side_effect = [(summaries, 3), ([], 0)]`
+- `test_max_cap_enforcement` — change to `side_effect = [(summaries, 6), ([], 0)]`
+
+Tests that use `return_value = ([], 0)` should change to `side_effect = [([], 0), ([], 0)]`:
+
+- `test_episode_lesson_clustering`
+- `test_too_few_episodes`
+- `test_weak_review_retires`
+- `test_disabled_learning_returns_empty` — no change needed (assert_not_called)
+- `test_no_embeddings_returns_zero` — change to `side_effect = [([], 0), ([], 0)]`
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `uv run pytest tests/test_procedure_learner.py tests/test_sleep_handler.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_procedure_learner.py tests/test_sleep_handler.py
+git commit -m "test: update procedure learner tests for dual-query pattern (#188)"
+```

--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -198,6 +198,7 @@ class Brain:
                 outcome=d.outcome or "pending",
                 pattern=d.pattern,
                 tags=tags_by_id.get(d.id, []),
+                reviewed_at=d.reviewed_at,
                 created_at=d.created_at,
             )
             for d in decisions

--- a/nous/handlers/procedure_learner.py
+++ b/nous/handlers/procedure_learner.py
@@ -225,14 +225,25 @@ class ProcedureLearner:
             return 0
 
         try:
-            # Fetch recent reviewed successful decisions
-            decisions, _ = await self._brain.list_decisions(limit=100)
-            # Filter: reviewed + successful/partial outcome
-            successful = [
-                d for d in decisions
-                if d.outcome in ("success", "partial") and d.reviewed_at is not None
-            ]
+            # Fetch reviewed successful decisions — pass filters to DB
+            # to avoid the window problem where 100 most recent are all pending.
+            # Issue #188 Bug 1: was list_decisions(limit=100) with no filters.
+            decisions_success, _ = await self._brain.list_decisions(
+                limit=50, outcome="success", reviewed=True
+            )
+            decisions_partial, _ = await self._brain.list_decisions(
+                limit=50, outcome="partial", reviewed=True
+            )
+            successful = list(decisions_success) + list(decisions_partial)
+            logger.info(
+                "Decision pathway: %d success + %d partial = %d reviewed decisions",
+                len(decisions_success), len(decisions_partial), len(successful),
+            )
             if len(successful) < self._settings.procedure_cluster_min_size:
+                logger.info(
+                    "Decision pathway: too few reviewed decisions (%d < %d)",
+                    len(successful), self._settings.procedure_cluster_min_size,
+                )
                 return 0
 
             # Get full details for bridge function text
@@ -344,20 +355,36 @@ class ProcedureLearner:
         try:
             # Fetch completed/resolved episodes
             episodes_summary = await self._heart.list_episodes(limit=50)
+            logger.info("Episode pathway: %d episodes fetched", len(episodes_summary))
 
             # Collect lessons from completed episodes (need full details)
             all_lessons: list[str] = []
+            skipped_outcome = 0
+            skipped_no_lessons = 0
             for ep_summary in episodes_summary:
                 if ep_summary.outcome not in ("success", "partial"):
+                    skipped_outcome += 1
                     continue
                 try:
                     ep_detail = await self._heart.get_episode(ep_summary.id)
                     if ep_detail.lessons_learned:
                         all_lessons.extend(ep_detail.lessons_learned)
+                    else:
+                        skipped_no_lessons += 1
                 except (ValueError, Exception):
                     continue
 
+            logger.info(
+                "Episode pathway: %d lessons collected (%d skipped: %d wrong outcome, %d no lessons)",
+                len(all_lessons), skipped_outcome + skipped_no_lessons,
+                skipped_outcome, skipped_no_lessons,
+            )
+
             if len(all_lessons) < self._settings.procedure_cluster_min_size:
+                logger.info(
+                    "Episode pathway: too few lessons (%d < %d)",
+                    len(all_lessons), self._settings.procedure_cluster_min_size,
+                )
                 return 0
 
             # Embed lessons
@@ -368,6 +395,12 @@ class ProcedureLearner:
                 embeddings,
                 threshold=self._settings.procedure_episode_similarity,
                 min_size=self._settings.procedure_cluster_min_size,
+            )
+            logger.info(
+                "Episode pathway: %d clusters found from %d embeddings (threshold=%.2f, min_size=%d)",
+                len(clusters), len(embeddings),
+                self._settings.procedure_episode_similarity,
+                self._settings.procedure_cluster_min_size,
             )
 
             created = 0

--- a/nous/handlers/sleep_handler.py
+++ b/nous/handlers/sleep_handler.py
@@ -357,7 +357,7 @@ class SleepHandler:
         if self._procedure_learner:
             try:
                 stats = await self._procedure_learner.run_sleep_learning()
-                sleep_stats["procedures_created"] += stats.get("decisions_learned", 0)
+                sleep_stats["procedures_created"] += stats.get("decisions_learned", 0) + stats.get("episodes_learned", 0)
                 logger.info(
                     "Sleep generalize: %d decisions, %d episodes, %d reviewed",
                     stats.get("decisions_learned", 0),

--- a/tests/test_procedure_learner.py
+++ b/tests/test_procedure_learner.py
@@ -11,7 +11,6 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
-import httpx
 import pytest
 
 from nous.brain.schemas import BridgeInfo, DecisionDetail, DecisionSummary
@@ -202,16 +201,14 @@ def _dissimilar_embedding(base: list[float]) -> list[float]:
     return [x / norm for x in raw] if norm > 0 else raw
 
 
-def _mock_llm_response(data: dict) -> httpx.Response:
-    """Create a mock httpx.Response with LLM JSON output."""
-    return httpx.Response(
-        200,
-        json={
-            "content": [
-                {"type": "text", "text": json.dumps(data)},
-            ]
-        },
-    )
+def _mock_llm_response(data: dict) -> MagicMock:
+    """Create a mock LLM response matching call_background_llm's expected format.
+
+    call_background_llm accesses response.content (list of dicts with type/text).
+    """
+    response = MagicMock()
+    response.content = [{"type": "text", "text": json.dumps(data)}]
+    return response
 
 
 def _llm_procedure_data(name: str = "Async DB Pattern") -> dict:
@@ -285,20 +282,22 @@ def _build_learner(settings: Settings | None = None):
     brain = AsyncMock()
     heart = AsyncMock()
     embeddings = AsyncMock()
-    http = AsyncMock(spec=httpx.AsyncClient)
+    # No spec= constraint — LLMClient protocol uses .call() which isn't on httpx.AsyncClient
+    llm_client = AsyncMock()
     s = settings or _make_settings()
-    learner = ProcedureLearner(brain, heart, embeddings, s, http)
-    return learner, brain, heart, embeddings, http
+    learner = ProcedureLearner(brain, heart, embeddings, s, llm_client)
+    return learner, brain, heart, embeddings, llm_client
 
 
 @pytest.mark.asyncio
 async def test_decision_cluster_creates_procedure():
     """3+ similar successful reviewed decisions -> 1 procedure."""
-    learner, brain, heart, embeddings, http = _build_learner()
+    learner, brain, heart, embeddings, llm_client = _build_learner()
 
     # Set up 3 successful reviewed decisions
     summaries = [_make_decision_summary() for _ in range(3)]
-    brain.list_decisions.return_value = (summaries, 3)
+    # list_decisions called twice: outcome="success" then outcome="partial"
+    brain.list_decisions.side_effect = [(summaries, 3), ([], 0)]
 
     # Each decision has bridge function
     details = [_make_decision_detail(s) for s in summaries]
@@ -313,7 +312,7 @@ async def test_decision_cluster_creates_procedure():
     ]
 
     # LLM returns procedure data
-    http.post.return_value = _mock_llm_response(_llm_procedure_data())
+    llm_client.call.return_value = _mock_llm_response(_llm_procedure_data())
 
     # No duplicate
     heart.search_procedures.return_value = []
@@ -333,10 +332,10 @@ async def test_decision_cluster_creates_procedure():
 @pytest.mark.asyncio
 async def test_small_cluster_rejected():
     """Only 2 successful decisions -> no cluster, no procedure."""
-    learner, brain, heart, embeddings, http = _build_learner()
+    learner, brain, heart, embeddings, llm_client = _build_learner()
 
     summaries = [_make_decision_summary() for _ in range(2)]
-    brain.list_decisions.return_value = (summaries, 2)
+    brain.list_decisions.side_effect = [(summaries, 2), ([], 0)]
 
     details = [_make_decision_detail(s) for s in summaries]
     brain.get.side_effect = details
@@ -353,7 +352,7 @@ async def test_small_cluster_rejected():
 @pytest.mark.asyncio
 async def test_success_rate_gate():
     """Cluster where <70% are successful -> excluded."""
-    learner, brain, heart, embeddings, http = _build_learner()
+    learner, brain, heart, embeddings, llm_client = _build_learner()
 
     # 2 success + 2 failure (all reviewed) = 50% success rate
     summaries = [
@@ -398,11 +397,11 @@ async def test_check_success_rate_method():
 @pytest.mark.asyncio
 async def test_recency_gate():
     """All decisions older than 7 days -> excluded."""
-    learner, brain, heart, embeddings, http = _build_learner()
+    learner, brain, heart, embeddings, llm_client = _build_learner()
 
     old_date = _NOW - timedelta(days=14)
     summaries = [_make_decision_summary(created_at=old_date) for _ in range(3)]
-    brain.list_decisions.return_value = (summaries, 3)
+    brain.list_decisions.side_effect = [(summaries, 3), ([], 0)]
 
     details = [_make_decision_detail(s) for s in summaries]
     brain.get.side_effect = details
@@ -423,10 +422,10 @@ async def test_recency_gate():
 @pytest.mark.asyncio
 async def test_episode_lesson_clustering():
     """3+ similar lessons from episodes -> 1 procedure."""
-    learner, brain, heart, embeddings, http = _build_learner()
+    learner, brain, heart, embeddings, llm_client = _build_learner()
 
     # No decisions (pathway 1 empty)
-    brain.list_decisions.return_value = ([], 0)
+    brain.list_decisions.side_effect = [([], 0), ([], 0)]
 
     # 3 episodes with similar lessons
     ep_summaries = [_make_episode_summary() for _ in range(3)]
@@ -447,7 +446,7 @@ async def test_episode_lesson_clustering():
     ]
 
     # LLM returns procedure
-    http.post.return_value = _mock_llm_response(_llm_procedure_data("Episode Lesson"))
+    llm_client.call.return_value = _mock_llm_response(_llm_procedure_data("Episode Lesson"))
 
     # No duplicate
     heart.search_procedures.return_value = []
@@ -463,9 +462,9 @@ async def test_episode_lesson_clustering():
 @pytest.mark.asyncio
 async def test_too_few_episodes():
     """Only 1 episode with 1 lesson -> no cluster."""
-    learner, brain, heart, embeddings, http = _build_learner()
+    learner, brain, heart, embeddings, llm_client = _build_learner()
 
-    brain.list_decisions.return_value = ([], 0)
+    brain.list_decisions.side_effect = [([], 0), ([], 0)]
 
     ep_summaries = [_make_episode_summary()]
     heart.list_episodes.return_value = ep_summaries
@@ -482,10 +481,10 @@ async def test_too_few_episodes():
 @pytest.mark.asyncio
 async def test_dedup_skips_similar_existing():
     """If similar procedure exists (score > 0.85), skip creation."""
-    learner, brain, heart, embeddings, http = _build_learner()
+    learner, brain, heart, embeddings, llm_client = _build_learner()
 
     summaries = [_make_decision_summary() for _ in range(3)]
-    brain.list_decisions.return_value = (summaries, 3)
+    brain.list_decisions.side_effect = [(summaries, 3), ([], 0)]
     details = [_make_decision_detail(s) for s in summaries]
     brain.get.side_effect = details
 
@@ -496,7 +495,7 @@ async def test_dedup_skips_similar_existing():
         _similar_embedding(base, 0.01),
     ]
 
-    http.post.return_value = _mock_llm_response(_llm_procedure_data())
+    llm_client.call.return_value = _mock_llm_response(_llm_procedure_data())
 
     # Existing procedure with high similarity score
     heart.search_procedures.return_value = [_make_procedure_summary(score=0.90)]
@@ -510,13 +509,13 @@ async def test_dedup_skips_similar_existing():
 @pytest.mark.asyncio
 async def test_max_cap_enforcement():
     """Respects procedure_max_per_sleep cap."""
-    learner, brain, heart, embeddings, http = _build_learner(
+    learner, brain, heart, embeddings, llm_client = _build_learner(
         _make_settings(procedure_max_per_sleep=1)
     )
 
     # Set up enough decisions for 2 clusters
     summaries = [_make_decision_summary() for _ in range(6)]
-    brain.list_decisions.return_value = (summaries, 6)
+    brain.list_decisions.side_effect = [(summaries, 6), ([], 0)]
     details = [_make_decision_detail(s) for s in summaries]
     brain.get.side_effect = details
 
@@ -532,7 +531,7 @@ async def test_max_cap_enforcement():
         _similar_embedding(base2, 0.01),
     ]
 
-    http.post.return_value = _mock_llm_response(_llm_procedure_data())
+    llm_client.call.return_value = _mock_llm_response(_llm_procedure_data())
     heart.search_procedures.return_value = []
     heart.store_procedure.return_value = MagicMock()
 
@@ -546,7 +545,7 @@ async def test_max_cap_enforcement():
 @pytest.mark.asyncio
 async def test_disabled_learning_returns_empty():
     """When procedure_learning_enabled=False, returns empty stats."""
-    learner, brain, heart, embeddings, http = _build_learner(
+    learner, brain, heart, embeddings, llm_client = _build_learner(
         _make_settings(procedure_learning_enabled=False)
     )
 
@@ -565,11 +564,11 @@ async def test_no_embeddings_returns_zero():
     """If no EmbeddingProvider, pathways return 0."""
     brain = AsyncMock()
     heart = AsyncMock()
-    http = AsyncMock(spec=httpx.AsyncClient)
+    llm_client = AsyncMock()
     settings = _make_settings()
-    learner = ProcedureLearner(brain, heart, None, settings, http)
+    learner = ProcedureLearner(brain, heart, None, settings, llm_client)
 
-    brain.list_decisions.return_value = ([], 0)
+    brain.list_decisions.side_effect = [([], 0), ([], 0)]
     heart.list_episodes.return_value = []
 
     stats = await learner.run_sleep_learning()
@@ -581,9 +580,9 @@ async def test_no_embeddings_returns_zero():
 @pytest.mark.asyncio
 async def test_weak_review_retires():
     """Weak procedure with low effectiveness gets retired."""
-    learner, brain, heart, embeddings, http = _build_learner()
+    learner, brain, heart, embeddings, llm_client = _build_learner()
 
-    brain.list_decisions.return_value = ([], 0)
+    brain.list_decisions.side_effect = [([], 0), ([], 0)]
     heart.list_episodes.return_value = []
 
     weak_proc = _make_procedure_summary(name="Weak proc", score=0.5)
@@ -594,7 +593,7 @@ async def test_weak_review_retires():
         last_activated=_RECENT,
     )
 
-    http.post.return_value = _mock_llm_response({
+    llm_client.call.return_value = _mock_llm_response({
         "action": "retire",
         "reason": "Too unreliable",
     })
@@ -614,3 +613,65 @@ async def test_monitor_recovery_prompt_exists():
     assert "{recovery_actions}" in _MONITOR_RECOVERY_PROMPT
     assert "{context}" in _MONITOR_RECOVERY_PROMPT
     assert '"name"' in _MONITOR_RECOVERY_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: Issue #188
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_decision_pathway_passes_db_filters():
+    """Regression #188 Bug 1: list_decisions must use outcome+reviewed DB filters.
+
+    Previously called list_decisions(limit=100) with no filters, returning
+    100 most recent (all pending), missing reviewed successful decisions.
+    """
+    learner, brain, heart, embeddings, llm_client = _build_learner()
+
+    brain.list_decisions.side_effect = [([], 0), ([], 0)]
+    heart.list_episodes.return_value = []
+    heart.search_procedures.return_value = []
+
+    await learner.run_sleep_learning()
+
+    # Must be called twice: once for "success", once for "partial"
+    assert brain.list_decisions.call_count == 2
+    calls = brain.list_decisions.call_args_list
+
+    _, kwargs0 = calls[0]
+    assert kwargs0["outcome"] == "success"
+    assert kwargs0["reviewed"] is True
+
+    _, kwargs1 = calls[1]
+    assert kwargs1["outcome"] == "partial"
+    assert kwargs1["reviewed"] is True
+
+
+@pytest.mark.asyncio
+async def test_episode_pathway_logs_diagnostics(caplog):
+    """Regression #188 Bug 3: Episode pathway must log diagnostic info.
+
+    Previously failed silently with no logging.
+    """
+    import logging
+
+    learner, brain, heart, embeddings, llm_client = _build_learner()
+
+    brain.list_decisions.side_effect = [([], 0), ([], 0)]
+
+    ep_success = _make_episode_summary(outcome="success")
+    ep_failure = _make_episode_summary(outcome="failure")
+    ep_ongoing = _make_episode_summary(outcome="ongoing")
+    heart.list_episodes.return_value = [ep_success, ep_failure, ep_ongoing]
+
+    heart.get_episode.return_value = _make_episode_detail(
+        ep_success, lessons=["Single lesson"]
+    )
+    heart.search_procedures.return_value = []
+
+    with caplog.at_level(logging.INFO, logger="nous.handlers.procedure_learner"):
+        await learner.run_sleep_learning()
+
+    assert "Episode pathway" in caplog.text
+    assert "episodes fetched" in caplog.text or "lessons collected" in caplog.text

--- a/tests/test_sleep_handler.py
+++ b/tests/test_sleep_handler.py
@@ -291,7 +291,8 @@ class TestSleepStats:
         sleep_stats = {"facts_created": 0, "procedures_created": 0, "censors_retired": 0}
         await handler._phase_generalize(sleep_stats)
 
-        assert sleep_stats["procedures_created"] == 3
+        # After #188 fix: counts decisions_learned (3) + episodes_learned (1) = 4
+        assert sleep_stats["procedures_created"] == 4
 
     @pytest.mark.asyncio
     async def test_full_sleep_propagates_stats_to_event(self):
@@ -520,3 +521,32 @@ class TestSleepTriggerEndpoint:
 
         response = client.post("/sleep/trigger")
         assert response.status_code == 503
+
+
+# ===========================================================================
+# Regression: Issue #188
+# ===========================================================================
+
+
+class TestProcedureStatsCountBothPathways:
+    """Regression #188 Bug 2: procedures_created must count both pathways."""
+
+    @pytest.mark.asyncio
+    async def test_procedures_created_includes_episodes(self):
+        """procedures_created must sum decisions_learned + episodes_learned."""
+        handler, brain, heart, bus, _ = _make_sleep_handler()
+        handler._phase_review_decisions = AsyncMock(return_value=True)
+        handler._phase_prune = AsyncMock(return_value=True)
+        handler._phase_compress = AsyncMock(return_value=True)
+        handler._phase_reflect = AsyncMock(return_value=True)
+
+        handler._procedure_learner = AsyncMock()
+        handler._procedure_learner.run_sleep_learning = AsyncMock(
+            return_value={"decisions_learned": 2, "episodes_learned": 3, "weak_reviewed": 1}
+        )
+
+        await handler._run_sleep(_make_event("sleep_started"))
+
+        emitted = bus.emit.call_args[0][0]
+        # Must be 2 + 3 = 5, not just 2
+        assert emitted.data["procedures_created"] == 5


### PR DESCRIPTION
## Summary

Fixes #188 — Procedure learning during sleep cycles was completely non-functional (0 procedures ever created).

**Four bugs fixed:**

- **Bug 1 (critical):** `brain.py` `_list_decisions` inline mapper omitted `reviewed_at` field — all Python-side filters on `reviewed_at` saw `None`, even for reviewed decisions
- **Bug 2 (critical):** `procedure_learner.py` called `list_decisions(limit=100)` with no filters, returning 100 most recent decisions (all pending). The 124 reviewed successful ones were outside the window. Now passes `outcome` + `reviewed` DB filters
- **Bug 3:** `sleep_handler.py` `procedures_created` stats only counted `decisions_learned`, ignoring `episodes_learned` pathway
- **Bug 4:** Episode pathway had zero diagnostic logging — failures were invisible. Added logging at each stage (episodes fetched, lessons collected, clusters found)

**Also fixed:** Test LLM mock used `httpx.AsyncClient` spec which doesn't have `.call()` method — replaced with unconstrained `AsyncMock` matching `LLMClient` protocol. This was masked before because the buggy code never reached the LLM call.

## Files Changed

| File | Change |
|------|--------|
| `nous/brain/brain.py` | +1 line: add `reviewed_at=d.reviewed_at` to inline mapper |
| `nous/handlers/procedure_learner.py` | Pass DB filters + diagnostic logging |
| `nous/handlers/sleep_handler.py` | Count both pathways in stats |
| `tests/test_procedure_learner.py` | Update mocks for dual-query + add regression tests |
| `tests/test_sleep_handler.py` | Update assertion + add regression test |

## Test plan

- [x] 52 tests pass (0 failures) — `pytest tests/test_procedure_learner.py tests/test_sleep_handler.py`
- [x] All existing tests updated for new dual-query pattern (`side_effect` instead of `return_value`)
- [x] 3 new regression tests added (DB filter verification, episode pathway logging, stats counting)
- [ ] Monitor next 2-3 sleep cycles after deploy to confirm procedures are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)