### PR TITLE
feat: Add LoCoMo & LongMemEval benchmark adapters

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,135 @@
+# Nous Benchmark Adapters
+
+Minimal adapters to run Nous against memory benchmarks. 
+**One endpoint. One loop. Let Nous be Nous.**
+
+## Philosophy
+
+These adapters don't reach into Nous's internals. They:
+1. Feed conversations through `POST /chat` (Nous stores memory automatically)
+2. Ask questions through `POST /chat` (Nous recalls what it needs)
+3. Compare answers to gold labels
+
+This tests the **full cognitive pipeline** — not individual components.
+
+---
+
+## LoCoMo (ACL 2024)
+
+**What it tests:** Very long-term conversational memory (10 conversations spanning weeks/months)
+
+### Setup
+```bash
+# Get the data
+git clone https://github.com/snap-research/locomo.git
+# Data is at locomo/data/locomo10.json
+```
+
+### Run
+```bash
+# Full run (10 conversations, all QA)
+python nous_locomo_adapter.py \
+    --data ./locomo/data/locomo10.json \
+    --nous-url http://localhost:8000 \
+    --output ./results/locomo_results.jsonl
+
+# Quick test (1 conversation only)
+python nous_locomo_adapter.py \
+    --data ./locomo/data/locomo10.json \
+    --nous-url http://localhost:8000 \
+    --output ./results/locomo_test.jsonl \
+    --max-conversations 1
+```
+
+### Output
+- `locomo_results.jsonl` — per-question results with F1, BLEU-1, ROUGE-L
+- `locomo_results.aggregate.json` — overall and per-category scores
+
+### Baseline to beat
+- GPT-4 (full context): F1 = 32.1
+- RAG + GPT-3.5: F1 = ~28
+
+---
+
+## LongMemEval (ICLR 2025)
+
+**What it tests:** 5 core memory abilities across 500 questions
+
+### Setup
+```bash
+# Get the data
+mkdir -p data/
+cd data/
+wget https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/resolve/main/longmemeval_s_cleaned.json
+cd ..
+
+# Get the official evaluator
+git clone https://github.com/xiaowu0162/LongMemEval.git
+
+# Install eval dependencies
+cd LongMemEval
+pip install -r requirements-lite.txt
+cd ..
+```
+
+### Run
+```bash
+# Full run (500 questions, ~40 sessions each)
+python nous_longmemeval_adapter.py \
+    --data ./data/longmemeval_s_cleaned.json \
+    --nous-url http://localhost:8000 \
+    --output ./results/longmemeval_results.jsonl
+
+# Quick test (first 10 questions)
+python nous_longmemeval_adapter.py \
+    --data ./data/longmemeval_s_cleaned.json \
+    --nous-url http://localhost:8000 \
+    --output ./results/longmemeval_test.jsonl \
+    --max-questions 10
+
+# Resume from question 50 (if interrupted)
+python nous_longmemeval_adapter.py \
+    --data ./data/longmemeval_s_cleaned.json \
+    --nous-url http://localhost:8000 \
+    --output ./results/longmemeval_results.jsonl \
+    --start-from 50
+```
+
+### Official Scoring
+```bash
+# Local scores are approximate — use this for real numbers
+export OPENAI_API_KEY=your_key
+cd LongMemEval/src/evaluation
+python evaluate_qa.py gpt-4o ../../results/longmemeval_results.jsonl ../../data/longmemeval_oracle.json
+```
+
+### Output
+- `longmemeval_results.jsonl` — LongMemEval-compatible format (question_id + hypothesis)
+- `longmemeval_results.summary.json` — local F1/ROUGE-L scores by question type
+
+### Question Types Tested
+- **Information Extraction** — single-session fact recall
+- **Multi-Session Reasoning** — connecting facts across sessions  
+- **Knowledge Updates** — handling changed/corrected information
+- **Temporal Reasoning** — "before/after" time-based questions
+- **Abstention** — knowing when to say "I don't know"
+
+---
+
+## Cost Estimates
+
+| Benchmark | Questions | Sessions to Ingest | Est. API Cost | Est. Time |
+|-----------|----------|-------------------|---------------|-----------|
+| LoCoMo | ~100 QA | 10 conversations | $5-10 | 1-2 hours |
+| LongMemEval_S | 500 | ~40 per question | $30-60 | 4-8 hours |
+| LongMemEval_M | 500 | ~500 per question | $200+ | 24+ hours |
+
+---
+
+## Tips
+
+- **Start small:** Use `--max-conversations 1` or `--max-questions 5` first
+- **Monitor memory:** Watch Nous logs to see what facts/episodes get stored
+- **Rate limits:** Adjust `--delay` if hitting API limits
+- **Resume:** LongMemEval adapter supports `--start-from` for interrupted runs
+- **Fresh sessions:** Each conversation/question gets a unique session ID so there's no cross-contamination

--- a/benchmarks/nous_locomo_adapter.py
+++ b/benchmarks/nous_locomo_adapter.py
@@ -1,0 +1,387 @@
+"""
+Nous LoCoMo Benchmark Adapter
+==============================
+Feeds LoCoMo conversations through Nous's /chat endpoint,
+then asks benchmark questions and scores answers.
+
+Usage:
+    python nous_locomo_adapter.py \
+        --data ./data/locomo10.json \
+        --nous-url http://localhost:8000 \
+        --output ./results/locomo_results.jsonl
+
+Flow:
+    Phase 1 (Ingest):  Feed each conversation session turn-by-turn via POST /chat
+    Phase 2 (Test):    Send each QA question via POST /chat
+    Phase 3 (Score):   Compare answers to gold labels (BLEU, ROUGE-L, F1)
+"""
+
+import json
+import time
+import argparse
+import requests
+import uuid
+from pathlib import Path
+from datetime import datetime
+
+# ---------------------------------------------------------------------------
+# Scoring helpers (lightweight, no heavy deps needed)
+# ---------------------------------------------------------------------------
+
+def tokenize(text: str) -> list[str]:
+    """Simple whitespace + lowercase tokenizer."""
+    return text.lower().split()
+
+
+def compute_f1(prediction: str, reference: str) -> float:
+    """Token-level F1 between prediction and reference."""
+    pred_tokens = set(tokenize(prediction))
+    ref_tokens = set(tokenize(reference))
+    if not pred_tokens or not ref_tokens:
+        return 0.0
+    common = pred_tokens & ref_tokens
+    if not common:
+        return 0.0
+    precision = len(common) / len(pred_tokens)
+    recall = len(common) / len(ref_tokens)
+    return 2 * precision * recall / (precision + recall)
+
+
+def compute_bleu1(prediction: str, reference: str) -> float:
+    """Unigram BLEU (BLEU-1) — simple precision of pred tokens in ref."""
+    pred_tokens = tokenize(prediction)
+    ref_tokens = set(tokenize(reference))
+    if not pred_tokens:
+        return 0.0
+    hits = sum(1 for t in pred_tokens if t in ref_tokens)
+    return hits / len(pred_tokens)
+
+
+def _lcs_length(a: list, b: list) -> int:
+    """Longest common subsequence length."""
+    m, n = len(a), len(b)
+    dp = [[0] * (n + 1) for _ in range(m + 1)]
+    for i in range(1, m + 1):
+        for j in range(1, n + 1):
+            if a[i - 1] == b[j - 1]:
+                dp[i][j] = dp[i - 1][j - 1] + 1
+            else:
+                dp[i][j] = max(dp[i - 1][j], dp[i][j - 1])
+    return dp[m][n]
+
+
+def compute_rouge_l(prediction: str, reference: str) -> float:
+    """ROUGE-L F1 score."""
+    pred_tokens = tokenize(prediction)
+    ref_tokens = tokenize(reference)
+    if not pred_tokens or not ref_tokens:
+        return 0.0
+    lcs = _lcs_length(pred_tokens, ref_tokens)
+    precision = lcs / len(pred_tokens) if pred_tokens else 0.0
+    recall = lcs / len(ref_tokens) if ref_tokens else 0.0
+    if precision + recall == 0:
+        return 0.0
+    return 2 * precision * recall / (precision + recall)
+
+
+# ---------------------------------------------------------------------------
+# Nous API Client
+# ---------------------------------------------------------------------------
+
+class NousClient:
+    """Thin wrapper around Nous REST API — only uses /chat."""
+
+    def __init__(self, base_url: str, timeout: int = 120):
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    def chat(self, message: str, session_id: str) -> str:
+        """Send a message to Nous and return the response text."""
+        resp = requests.post(
+            f"{self.base_url}/chat",
+            json={"message": message, "session_id": session_id},
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        # Handle different response shapes
+        if isinstance(data, dict):
+            return data.get("response", data.get("reply", data.get("content", str(data))))
+        return str(data)
+
+    def health(self) -> bool:
+        """Check if Nous is reachable."""
+        try:
+            resp = requests.get(f"{self.base_url}/health", timeout=10)
+            return resp.status_code == 200
+        except Exception:
+            return False
+
+
+# ---------------------------------------------------------------------------
+# LoCoMo Adapter
+# ---------------------------------------------------------------------------
+
+def load_locomo(data_path: str) -> list[dict]:
+    """Load LoCoMo dataset (locomo10.json)."""
+    with open(data_path, "r") as f:
+        data = json.load(f)
+    # locomo10.json is a list of 10 conversation samples
+    if isinstance(data, dict):
+        data = [data]
+    return data
+
+
+def ingest_conversation(client: NousClient, sample: dict, session_id: str,
+                        delay: float = 0.5, verbose: bool = True) -> int:
+    """
+    Phase 1: Feed conversation history into Nous turn-by-turn.
+    
+    Each turn is sent as the speaker's message. We alternate speakers
+    to simulate a natural conversation Nous is observing/participating in.
+    
+    Returns the number of turns ingested.
+    """
+    conversation = sample.get("conversation", {})
+    speaker_a = conversation.get("speaker_a", "Speaker A")
+    speaker_b = conversation.get("speaker_b", "Speaker B")
+
+    # Collect all sessions in order
+    session_keys = sorted(
+        [k for k in conversation if k.startswith("session_")
+         and not k.endswith("_date_time")],
+        key=lambda x: int(x.split("_")[1])
+    )
+
+    turn_count = 0
+
+    # Initial context message so Nous knows what's happening
+    context_msg = (
+        f"I'm going to share a conversation between {speaker_a} and {speaker_b} "
+        f"that happened over multiple sessions. Please pay attention to all details, "
+        f"events, preferences, and facts mentioned. I'll ask you questions about it afterward."
+    )
+    client.chat(context_msg, session_id)
+    turn_count += 1
+
+    for session_key in session_keys:
+        session = conversation[session_key]
+        date_key = f"{session_key}_date_time"
+        session_date = conversation.get(date_key, "unknown date")
+
+        # Signal new session with timestamp
+        session_header = f"[Session on {session_date}]"
+        client.chat(session_header, session_id)
+        turn_count += 1
+
+        # Feed each turn
+        for turn in session:
+            speaker = turn.get("speaker", "Unknown")
+            text = turn.get("text", "")
+            if not text:
+                continue
+
+            message = f"{speaker}: {text}"
+            client.chat(message, session_id)
+            turn_count += 1
+
+            if verbose and turn_count % 20 == 0:
+                print(f"  ... ingested {turn_count} turns")
+
+            time.sleep(delay)  # Respect rate limits
+
+    if verbose:
+        print(f"  ✅ Ingested {turn_count} turns for session {session_id}")
+
+    return turn_count
+
+
+def run_qa(client: NousClient, sample: dict, session_id: str,
+           delay: float = 1.0, verbose: bool = True) -> list[dict]:
+    """
+    Phase 2 & 3: Ask questions and collect + score answers.
+    
+    Returns list of result dicts with question, gold answer, 
+    Nous response, and scores.
+    """
+    qa_items = sample.get("qa", [])
+    results = []
+
+    for i, qa in enumerate(qa_items):
+        question = qa.get("question", "")
+        gold_answer = qa.get("answer", "")
+        category = qa.get("category", "unknown")
+        evidence = qa.get("evidence", [])
+
+        if not question:
+            continue
+
+        # Ask Nous
+        prompt = f"Based on the conversation I shared with you, please answer this question: {question}"
+        nous_answer = client.chat(prompt, session_id)
+
+        # Score
+        f1 = compute_f1(nous_answer, gold_answer)
+        bleu = compute_bleu1(nous_answer, gold_answer)
+        rouge_l = compute_rouge_l(nous_answer, gold_answer)
+
+        result = {
+            "question_id": f"{sample.get('sample_id', 'unknown')}_{i}",
+            "category": category,
+            "question": question,
+            "gold_answer": gold_answer,
+            "nous_answer": nous_answer,
+            "evidence_ids": evidence,
+            "scores": {
+                "f1": round(f1, 4),
+                "bleu1": round(bleu, 4),
+                "rouge_l": round(rouge_l, 4),
+            }
+        }
+        results.append(result)
+
+        if verbose:
+            print(f"  Q{i+1}/{len(qa_items)} | F1={f1:.3f} BLEU={bleu:.3f} ROUGE-L={rouge_l:.3f}")
+            print(f"    Q: {question[:80]}...")
+            print(f"    Gold: {gold_answer[:80]}...")
+            print(f"    Nous: {nous_answer[:80]}...")
+
+        time.sleep(delay)
+
+    return results
+
+
+def compute_aggregate_scores(all_results: list[dict]) -> dict:
+    """Compute aggregate scores across all questions."""
+    if not all_results:
+        return {}
+
+    metrics = {"f1": [], "bleu1": [], "rouge_l": []}
+    by_category = {}
+
+    for r in all_results:
+        for metric in metrics:
+            metrics[metric].append(r["scores"][metric])
+
+        cat = r.get("category", "unknown")
+        if cat not in by_category:
+            by_category[cat] = {"f1": [], "bleu1": [], "rouge_l": []}
+        for metric in metrics:
+            by_category[cat][metric].append(r["scores"][metric])
+
+    def avg(lst):
+        return round(sum(lst) / len(lst), 4) if lst else 0.0
+
+    aggregate = {
+        "overall": {
+            "n_questions": len(all_results),
+            "f1": avg(metrics["f1"]),
+            "bleu1": avg(metrics["bleu1"]),
+            "rouge_l": avg(metrics["rouge_l"]),
+        },
+        "by_category": {
+            cat: {
+                "n_questions": len(scores["f1"]),
+                "f1": avg(scores["f1"]),
+                "bleu1": avg(scores["bleu1"]),
+                "rouge_l": avg(scores["rouge_l"]),
+            }
+            for cat, scores in by_category.items()
+        }
+    }
+    return aggregate
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="Nous LoCoMo Benchmark Adapter")
+    parser.add_argument("--data", required=True, help="Path to locomo10.json")
+    parser.add_argument("--nous-url", default="http://localhost:8000", help="Nous API base URL")
+    parser.add_argument("--output", default="./results/locomo_results.jsonl", help="Output results file")
+    parser.add_argument("--delay", type=float, default=0.5, help="Delay between API calls (seconds)")
+    parser.add_argument("--max-conversations", type=int, default=None, help="Limit conversations (for testing)")
+    parser.add_argument("--verbose", action="store_true", default=True)
+    args = parser.parse_args()
+
+    # Init
+    client = NousClient(args.nous_url)
+    print(f"🧠 Nous LoCoMo Benchmark Adapter")
+    print(f"   API: {args.nous_url}")
+    print(f"   Data: {args.data}")
+    print()
+
+    # Health check
+    if not client.health():
+        print("❌ Cannot reach Nous API. Is it running?")
+        return
+
+    print("✅ Nous API is healthy\n")
+
+    # Load data
+    samples = load_locomo(args.data)
+    if args.max_conversations:
+        samples = samples[:args.max_conversations]
+    print(f"📊 Loaded {len(samples)} conversations\n")
+
+    # Process each conversation
+    all_results = []
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    for idx, sample in enumerate(samples):
+        sample_id = sample.get("sample_id", f"conv_{idx}")
+        session_id = f"locomo-bench-{sample_id}-{uuid.uuid4().hex[:8]}"
+
+        print(f"{'='*60}")
+        print(f"📝 Conversation {idx+1}/{len(samples)}: {sample_id}")
+        print(f"   Session ID: {session_id}")
+        print(f"{'='*60}")
+
+        # Phase 1: Ingest
+        print("\n🔄 Phase 1: Ingesting conversation...")
+        n_turns = ingest_conversation(client, sample, session_id,
+                                       delay=args.delay, verbose=args.verbose)
+
+        # Phase 2 & 3: QA + Scoring
+        print(f"\n❓ Phase 2: Running QA ({len(sample.get('qa', []))} questions)...")
+        results = run_qa(client, sample, session_id,
+                        delay=args.delay, verbose=args.verbose)
+
+        all_results.extend(results)
+
+        # Write results incrementally
+        with open(output_path, "a") as f:
+            for r in results:
+                f.write(json.dumps(r) + "\n")
+
+        print(f"\n✅ Conversation {sample_id} complete: {len(results)} questions answered\n")
+
+    # Final aggregate scores
+    print(f"\n{'='*60}")
+    print(f"🏆 FINAL RESULTS")
+    print(f"{'='*60}")
+
+    aggregate = compute_aggregate_scores(all_results)
+
+    print(f"\n📊 Overall ({aggregate['overall']['n_questions']} questions):")
+    print(f"   F1:      {aggregate['overall']['f1']}")
+    print(f"   BLEU-1:  {aggregate['overall']['bleu1']}")
+    print(f"   ROUGE-L: {aggregate['overall']['rouge_l']}")
+
+    print(f"\n📊 By Category:")
+    for cat, scores in aggregate.get("by_category", {}).items():
+        print(f"   {cat} (n={scores['n_questions']}): F1={scores['f1']} BLEU={scores['bleu1']} ROUGE-L={scores['rouge_l']}")
+
+    # Save aggregate
+    agg_path = output_path.with_suffix(".aggregate.json")
+    with open(agg_path, "w") as f:
+        json.dump(aggregate, f, indent=2)
+    print(f"\n💾 Results saved to {output_path}")
+    print(f"💾 Aggregate saved to {agg_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/nous_longmemeval_adapter.py
+++ b/benchmarks/nous_longmemeval_adapter.py
@@ -1,0 +1,377 @@
+"""
+Nous LongMemEval Benchmark Adapter
+====================================
+Feeds LongMemEval conversation histories through Nous's /chat endpoint,
+then asks benchmark questions and collects answers for scoring.
+
+Usage:
+    python nous_longmemeval_adapter.py \
+        --data ./data/longmemeval_s_cleaned.json \
+        --nous-url http://localhost:8000 \
+        --output ./results/longmemeval_results.jsonl
+
+    # Then score with LongMemEval's official evaluator:
+    # cd LongMemEval/src/evaluation
+    # python evaluate_qa.py gpt-4o ../../results/longmemeval_results.jsonl ../../data/longmemeval_oracle.json
+
+Flow:
+    Phase 1 (Ingest):  Feed haystack sessions turn-by-turn via POST /chat
+    Phase 2 (Test):    Send the question via POST /chat
+    Phase 3 (Output):  Save in LongMemEval-compatible JSONL format
+
+Notes:
+    - LongMemEval's official evaluator uses GPT-4o for semantic matching
+    - This adapter also computes lightweight local scores (F1, ROUGE-L) for quick feedback
+    - For official results, always use the LongMemEval evaluator
+"""
+
+import json
+import time
+import argparse
+import requests
+import uuid
+from pathlib import Path
+from datetime import datetime
+
+# ---------------------------------------------------------------------------
+# Lightweight scoring (for quick local feedback — official eval uses GPT-4o)
+# ---------------------------------------------------------------------------
+
+def tokenize(text: str) -> list[str]:
+    return text.lower().split()
+
+
+def compute_f1(prediction: str, reference: str) -> float:
+    pred_tokens = set(tokenize(prediction))
+    ref_tokens = set(tokenize(reference))
+    if not pred_tokens or not ref_tokens:
+        return 0.0
+    common = pred_tokens & ref_tokens
+    if not common:
+        return 0.0
+    precision = len(common) / len(pred_tokens)
+    recall = len(common) / len(ref_tokens)
+    return 2 * precision * recall / (precision + recall)
+
+
+def _lcs_length(a: list, b: list) -> int:
+    m, n = len(a), len(b)
+    dp = [[0] * (n + 1) for _ in range(m + 1)]
+    for i in range(1, m + 1):
+        for j in range(1, n + 1):
+            if a[i - 1] == b[j - 1]:
+                dp[i][j] = dp[i - 1][j - 1] + 1
+            else:
+                dp[i][j] = max(dp[i - 1][j], dp[i][j - 1])
+    return dp[m][n]
+
+
+def compute_rouge_l(prediction: str, reference: str) -> float:
+    pred_tokens = tokenize(prediction)
+    ref_tokens = tokenize(reference)
+    if not pred_tokens or not ref_tokens:
+        return 0.0
+    lcs = _lcs_length(pred_tokens, ref_tokens)
+    precision = lcs / len(pred_tokens)
+    recall = lcs / len(ref_tokens)
+    if precision + recall == 0:
+        return 0.0
+    return 2 * precision * recall / (precision + recall)
+
+
+# ---------------------------------------------------------------------------
+# Nous API Client
+# ---------------------------------------------------------------------------
+
+class NousClient:
+    """Thin wrapper around Nous REST API — only uses /chat."""
+
+    def __init__(self, base_url: str, timeout: int = 120):
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    def chat(self, message: str, session_id: str) -> str:
+        resp = requests.post(
+            f"{self.base_url}/chat",
+            json={"message": message, "session_id": session_id},
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        if isinstance(data, dict):
+            return data.get("response", data.get("reply", data.get("content", str(data))))
+        return str(data)
+
+    def health(self) -> bool:
+        try:
+            resp = requests.get(f"{self.base_url}/health", timeout=10)
+            return resp.status_code == 200
+        except Exception:
+            return False
+
+
+# ---------------------------------------------------------------------------
+# LongMemEval Adapter
+# ---------------------------------------------------------------------------
+
+def load_longmemeval(data_path: str) -> list[dict]:
+    """Load LongMemEval dataset (json — list of 500 question instances)."""
+    with open(data_path, "r") as f:
+        data = json.load(f)
+    if isinstance(data, dict):
+        data = list(data.values())
+    return data
+
+
+def ingest_sessions(client: NousClient, instance: dict, session_id: str,
+                    delay: float = 0.3, verbose: bool = True) -> int:
+    """
+    Phase 1: Feed haystack sessions into Nous via /chat.
+    
+    Each instance has:
+      - haystack_sessions: list of sessions
+      - haystack_dates: list of timestamps for each session
+      
+    Each session is a list of turns: {"role": "user"/"assistant", "content": "..."}
+    
+    We send them as a conversation Nous is observing.
+    Returns total turns ingested.
+    """
+    sessions = instance.get("haystack_sessions", [])
+    dates = instance.get("haystack_dates", [])
+    
+    turn_count = 0
+
+    # Context message
+    context_msg = (
+        "I'm going to share a series of past conversation sessions with you. "
+        "Please pay close attention to all details, facts, preferences, events, "
+        "and any changes over time. I'll ask you a question about them afterward."
+    )
+    client.chat(context_msg, session_id)
+    turn_count += 1
+
+    for idx, session in enumerate(sessions):
+        # Session timestamp header
+        date_str = dates[idx] if idx < len(dates) else f"Session {idx + 1}"
+        header = f"[Conversation session from {date_str}]"
+        client.chat(header, session_id)
+        turn_count += 1
+
+        # Feed each turn
+        for turn in session:
+            role = turn.get("role", "user")
+            content = turn.get("content", "")
+            if not content:
+                continue
+
+            # Format as reported speech so Nous processes it as memory
+            if role == "user":
+                message = f"User said: {content}"
+            else:
+                message = f"Assistant said: {content}"
+
+            client.chat(message, session_id)
+            turn_count += 1
+
+            if verbose and turn_count % 50 == 0:
+                print(f"    ... {turn_count} turns ingested")
+
+            time.sleep(delay)
+
+    if verbose:
+        print(f"    ✅ {turn_count} turns ingested across {len(sessions)} sessions")
+
+    return turn_count
+
+
+def ask_question(client: NousClient, instance: dict, session_id: str) -> str:
+    """Phase 2: Ask the benchmark question via /chat."""
+    question = instance.get("question", "")
+    question_date = instance.get("question_date", "")
+
+    # Include temporal context if available
+    if question_date:
+        prompt = (
+            f"Today's date is {question_date}. "
+            f"Based on all the conversations I've shared with you, "
+            f"please answer this question: {question}"
+        )
+    else:
+        prompt = (
+            f"Based on all the conversations I've shared with you, "
+            f"please answer this question: {question}"
+        )
+
+    return client.chat(prompt, session_id)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="Nous LongMemEval Benchmark Adapter")
+    parser.add_argument("--data", required=True,
+                        help="Path to longmemeval_s_cleaned.json (or _m or _oracle)")
+    parser.add_argument("--nous-url", default="http://localhost:8000",
+                        help="Nous API base URL")
+    parser.add_argument("--output", default="./results/longmemeval_results.jsonl",
+                        help="Output results file (JSONL)")
+    parser.add_argument("--delay", type=float, default=0.3,
+                        help="Delay between API calls (seconds)")
+    parser.add_argument("--max-questions", type=int, default=None,
+                        help="Limit number of questions (for testing)")
+    parser.add_argument("--start-from", type=int, default=0,
+                        help="Skip first N questions (for resuming)")
+    parser.add_argument("--verbose", action="store_true", default=True)
+    args = parser.parse_args()
+
+    # Init
+    client = NousClient(args.nous_url)
+    print(f"🧠 Nous LongMemEval Benchmark Adapter")
+    print(f"   API: {args.nous_url}")
+    print(f"   Data: {args.data}")
+    print(f"   Output: {args.output}")
+    print()
+
+    # Health check
+    if not client.health():
+        print("❌ Cannot reach Nous API. Is it running?")
+        return
+    print("✅ Nous API is healthy\n")
+
+    # Load data
+    instances = load_longmemeval(args.data)
+    total = len(instances)
+    print(f"📊 Loaded {total} question instances\n")
+
+    # Apply slicing
+    instances = instances[args.start_from:]
+    if args.max_questions:
+        instances = instances[:args.max_questions]
+    print(f"   Processing {len(instances)} questions (start_from={args.start_from})\n")
+
+    # Process
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    all_results = []
+    scores_by_type = {}
+
+    for i, instance in enumerate(instances):
+        qid = instance.get("question_id", f"q_{i}")
+        qtype = instance.get("question_type", "unknown")
+        question = instance.get("question", "")
+        gold_answer = instance.get("answer", "")
+        n_sessions = len(instance.get("haystack_sessions", []))
+
+        # Each question gets its own session (fresh memory per question)
+        session_id = f"longmemeval-{qid}-{uuid.uuid4().hex[:6]}"
+
+        print(f"{'─'*50}")
+        print(f"  [{i+1}/{len(instances)}] {qid} ({qtype})")
+        print(f"  Sessions: {n_sessions} | Q: {question[:70]}...")
+
+        # Phase 1: Ingest conversation history
+        t0 = time.time()
+        n_turns = ingest_sessions(client, instance, session_id,
+                                   delay=args.delay, verbose=args.verbose)
+        ingest_time = time.time() - t0
+
+        # Phase 2: Ask the question
+        t1 = time.time()
+        nous_answer = ask_question(client, instance, session_id)
+        answer_time = time.time() - t1
+
+        # Local scoring (quick feedback — not official)
+        f1 = compute_f1(nous_answer, gold_answer)
+        rouge_l = compute_rouge_l(nous_answer, gold_answer)
+
+        # Track by type
+        if qtype not in scores_by_type:
+            scores_by_type[qtype] = {"f1": [], "rouge_l": [], "count": 0}
+        scores_by_type[qtype]["f1"].append(f1)
+        scores_by_type[qtype]["rouge_l"].append(rouge_l)
+        scores_by_type[qtype]["count"] += 1
+
+        print(f"  ⏱️  Ingest: {ingest_time:.1f}s | Answer: {answer_time:.1f}s")
+        print(f"  📊 F1={f1:.3f} ROUGE-L={rouge_l:.3f}")
+        print(f"  Gold: {gold_answer[:80]}")
+        print(f"  Nous: {nous_answer[:80]}")
+
+        # Save in LongMemEval-compatible format
+        # (question_id + hypothesis is what their evaluator expects)
+        result = {
+            "question_id": qid,
+            "hypothesis": nous_answer,
+            # Extra fields for our analysis (ignored by official evaluator)
+            "_question_type": qtype,
+            "_question": question,
+            "_gold_answer": gold_answer,
+            "_local_f1": round(f1, 4),
+            "_local_rouge_l": round(rouge_l, 4),
+            "_n_sessions": n_sessions,
+            "_n_turns_ingested": n_turns,
+            "_ingest_time_s": round(ingest_time, 1),
+            "_answer_time_s": round(answer_time, 1),
+        }
+        all_results.append(result)
+
+        # Write incrementally
+        with open(output_path, "a") as f:
+            f.write(json.dumps(result) + "\n")
+
+    # ---------------------------------------------------------------------------
+    # Summary
+    # ---------------------------------------------------------------------------
+    print(f"\n{'='*60}")
+    print(f"🏆 RESULTS SUMMARY (local scoring — use official evaluator for final)")
+    print(f"{'='*60}")
+
+    def avg(lst):
+        return sum(lst) / len(lst) if lst else 0.0
+
+    all_f1 = [r["_local_f1"] for r in all_results]
+    all_rouge = [r["_local_rouge_l"] for r in all_results]
+
+    print(f"\n📊 Overall ({len(all_results)} questions):")
+    print(f"   F1:      {avg(all_f1):.4f}")
+    print(f"   ROUGE-L: {avg(all_rouge):.4f}")
+
+    print(f"\n📊 By Question Type:")
+    for qtype, scores in sorted(scores_by_type.items()):
+        n = scores["count"]
+        f1_avg = avg(scores["f1"])
+        rl_avg = avg(scores["rouge_l"])
+        print(f"   {qtype:30s} (n={n:3d}): F1={f1_avg:.4f}  ROUGE-L={rl_avg:.4f}")
+
+    # Save summary
+    summary = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "data_file": args.data,
+        "n_questions": len(all_results),
+        "overall_f1": round(avg(all_f1), 4),
+        "overall_rouge_l": round(avg(all_rouge), 4),
+        "by_type": {
+            qtype: {
+                "count": scores["count"],
+                "f1": round(avg(scores["f1"]), 4),
+                "rouge_l": round(avg(scores["rouge_l"]), 4),
+            }
+            for qtype, scores in scores_by_type.items()
+        }
+    }
+    summary_path = output_path.with_suffix(".summary.json")
+    with open(summary_path, "w") as f:
+        json.dump(summary, f, indent=2)
+
+    print(f"\n💾 Results: {output_path}")
+    print(f"💾 Summary: {summary_path}")
+    print(f"\n📌 For official scores, run LongMemEval's evaluator:")
+    print(f"   cd LongMemEval/src/evaluation")
+    print(f"   python evaluate_qa.py gpt-4o {output_path} ./data/longmemeval_oracle.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/run_quick_test.sh
+++ b/benchmarks/run_quick_test.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Quick smoke test — runs 1 LoCoMo conversation + 5 LongMemEval questions
+# Usage: bash run_quick_test.sh [NOUS_URL]
+
+NOUS_URL=${1:-"http://localhost:8000"}
+RESULTS_DIR="./results"
+
+echo "🧠 Nous Benchmark Quick Test"
+echo "   API: $NOUS_URL"
+echo ""
+
+# Check Nous is up
+if ! curl -s "$NOUS_URL/health" > /dev/null 2>&1; then
+    echo "❌ Nous is not reachable at $NOUS_URL"
+    exit 1
+fi
+echo "✅ Nous is healthy"
+echo ""
+
+mkdir -p "$RESULTS_DIR"
+
+# --- LoCoMo ---
+if [ -f "./locomo/data/locomo10.json" ]; then
+    echo "📝 Running LoCoMo (1 conversation)..."
+    python nous_locomo_adapter.py \
+        --data ./locomo/data/locomo10.json \
+        --nous-url "$NOUS_URL" \
+        --output "$RESULTS_DIR/locomo_quick.jsonl" \
+        --max-conversations 1
+    echo ""
+else
+    echo "⚠️  LoCoMo data not found. Run: git clone https://github.com/snap-research/locomo.git"
+fi
+
+# --- LongMemEval ---
+if [ -f "./data/longmemeval_s_cleaned.json" ]; then
+    echo "📝 Running LongMemEval (5 questions)..."
+    python nous_longmemeval_adapter.py \
+        --data ./data/longmemeval_s_cleaned.json \
+        --nous-url "$NOUS_URL" \
+        --output "$RESULTS_DIR/longmemeval_quick.jsonl" \
+        --max-questions 5
+    echo ""
+else
+    echo "⚠️  LongMemEval data not found. Run:"
+    echo "   mkdir -p data && cd data"
+    echo "   wget https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/resolve/main/longmemeval_s_cleaned.json"
+fi
+
+echo "🏁 Quick test complete! Check $RESULTS_DIR/"


### PR DESCRIPTION
## What
Adds benchmark adapters to test Nous memory system against two academic benchmarks.

## Files
- `benchmarks/nous_locomo_adapter.py` — LoCoMo (ACL 2024)
- `benchmarks/nous_longmemeval_adapter.py` — LongMemEval (ICLR 2025)
- `benchmarks/run_quick_test.sh` — Smoke test
- `benchmarks/README.md` — Setup & run

## Design
Single endpoint only — all interactions via POST /chat. Tests full cognitive pipeline, not individual components.

## Baselines
- LoCoMo: GPT-4 F1 = 32.1
- LongMemEval: GPT-4o ~50-60%