### PR TITLE
fix(brain): increase decision description truncation from 200 to 500 chars

### DIFF
--- a/nous/cognitive/layer.py
+++ b/nous/cognitive/layer.py
@@ -454,7 +454,7 @@ class CognitiveLayer:
         try:
             if await self._deliberation.should_deliberate(frame):
                 decision_id = await self._deliberation.start(
-                    agent_id, user_input[:200], frame,
+                    agent_id, user_input[:500], frame,
                     session_id=session_id, session=session,
                 )
         except Exception:
@@ -649,7 +649,7 @@ class CognitiveLayer:
 
                     await self._deliberation.finalize(
                         decision_id,
-                        description=turn_result.response_text[:200],
+                        description=turn_result.response_text[:500],
                         confidence=confidence,
                         has_tool_errors=has_tool_errors,
                         session=session,


### PR DESCRIPTION
## Summary

- Increases decision description truncation from 200 to 500 characters in `layer.py` at the two decision-related code paths (deliberation start at line 457 and finalize at line 652)
- All other `[:200]` usages (episode summaries, tool arg previews, topic extraction, reflections) remain unchanged as they serve different purposes

Closes #198

## Test plan

- [x] Verified diff shows exactly 2 lines changed
- [x] All 39 topic persistence tests pass (unchanged `[:200]` behavior for topics)
- [x] 138 non-DB tests pass with zero regressions
- [x] Pre-existing failures confirmed on clean main (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)