### PR TITLE
fix: tune amnesia prevention parameters (#203)

### DIFF
--- a/nous/cognitive/context.py
+++ b/nous/cognitive/context.py
@@ -38,7 +38,15 @@ RELEVANCE_MIN_RESULTS: dict[str, int] = {
     "fact": 3, "decision": 2, "procedure": 2, "episode": 2,
 }
 RELEVANCE_MAX_RESULTS: dict[str, int] = {
-    "fact": 8, "decision": 5, "procedure": 3, "episode": 4,
+    "fact": 12, "decision": 7, "procedure": 5, "episode": 6,
+}
+
+# Default per-type fetch limits when RetrievalPlan doesn't specify.
+# Intentionally higher than RELEVANCE_MAX_RESULTS — upstream filters
+# (staleness, diversity, dedup) reduce the candidate pool before the
+# relevance filter caps results.
+DEFAULT_FETCH_LIMITS: dict[str, int] = {
+    "fact": 15, "decision": 8, "procedure": 5, "episode": 8,
 }
 
 # Markers that identify internal/system episodes (handler tasks, summarizers)
@@ -316,7 +324,7 @@ class ContextEngine:
         # 5. Decisions (F26: skip_types is primary skip mechanism)
         if budget.decisions > 0 and "decision" not in skip_types:
             try:
-                limit = _limits.get("decision", 5)
+                limit = _limits.get("decision", DEFAULT_FETCH_LIMITS.get("decision", 5))
                 q_text = _query_texts.get("decision", _default_query)
                 decisions = await self._brain.query(q_text, limit=limit, session=session)
                 logger.info("Tier3 decisions: %d results, has_embeddings=%s, scores=%s, descs=%s",
@@ -358,7 +366,7 @@ class ContextEngine:
         # 6. Facts (F10: retrieve -> apply_frame_boost -> dedup -> usage_boost -> truncate)
         if budget.facts > 0 and "fact" not in skip_types:
             try:
-                limit = _limits.get("fact", 5)
+                limit = _limits.get("fact", DEFAULT_FETCH_LIMITS.get("fact", 5))
                 q_text = _query_texts.get("fact", _default_query)
                 # Tier 3: exclude Tier 1 categories from semantic search
                 facts = await self._heart.search_facts(
@@ -413,7 +421,7 @@ class ContextEngine:
         # 7. Procedures
         if budget.procedures > 0 and "procedure" not in skip_types:
             try:
-                limit = _limits.get("procedure", 5)
+                limit = _limits.get("procedure", DEFAULT_FETCH_LIMITS.get("procedure", 5))
                 q_text = _query_texts.get("procedure", _default_query)
                 procedures = await self._heart.search_procedures(q_text, limit=limit, session=session)
                 if procedures:
@@ -484,7 +492,7 @@ class ContextEngine:
         # 8. Episodes
         if budget.episodes > 0 and "episode" not in skip_types:
             try:
-                limit = _limits.get("episode", 5)
+                limit = _limits.get("episode", DEFAULT_FETCH_LIMITS.get("episode", 5))
                 q_text = _query_texts.get("episode", _default_query)
                 episodes = await self._heart.search_episodes(q_text, limit=limit, session=session)
                 # Filter out system/internal episodes
@@ -660,7 +668,7 @@ class ContextEngine:
                 adjusted.append(r)
                 continue
             category = getattr(r, "category", "")
-            if category in {"rule", "preference"}:
+            if category in {"rule", "preference", "technical", "concept"}:
                 adjusted.append(r)
                 continue
             age_days = (now - created).days
@@ -675,7 +683,7 @@ class ContextEngine:
         """Prevent one topic from dominating recall results (007.2).
 
         Extracts a topic key from each item using topic_attr:
-        - String attrs (e.g. 'subject', 'category'): first word, lowercased
+        - String attrs (e.g. 'subject', 'category'): full string, stripped and lowercased
         - List attrs (e.g. 'tags'): first element, lowercased
         Items without the attr default to 'unknown'.
         """
@@ -689,7 +697,7 @@ class ContextEngine:
             if isinstance(raw, list):
                 topic_key = raw[0].lower() if raw else "unknown"
             elif isinstance(raw, str) and raw:
-                topic_key = raw.split()[0].lower()
+                topic_key = raw.strip().lower()
             else:
                 topic_key = "unknown"
 

--- a/nous/config.py
+++ b/nous/config.py
@@ -45,7 +45,7 @@ class Settings(BaseSettings):
     relevance_floor_enabled: bool = True
 
     # F017: Diminishing returns cutoff (used by adaptive relevance filter)
-    relevance_drop_ratio: float = 0.6
+    relevance_drop_ratio: float = 0.5
 
     # Adaptive relevance filter: per-type min/max result overrides (JSON dicts)
     # e.g. NOUS_RELEVANCE_MIN_RESULTS='{"fact": 2, "decision": 1}'
@@ -61,7 +61,7 @@ class Settings(BaseSettings):
 
     # F017: Staleness penalty
     staleness_penalty_enabled: bool = True
-    staleness_half_life_days: int = 14
+    staleness_half_life_days: int = 30
 
     # Runtime
     host: str = "0.0.0.0"

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -569,6 +569,25 @@ async def test_enforce_diversity_empty_list():
     assert result == []
 
 
+async def test_enforce_diversity_multiword_subjects_not_collapsed():
+    """F025: Multi-word subjects like 'Nous architecture' and 'Nous memory' are distinct topics."""
+    engine = _make_context_engine_light()
+    facts = [
+        _mock_fact(content="Nous arch uses event sourcing", subject="Nous architecture"),
+        _mock_fact(content="Nous arch uses CQRS", subject="Nous architecture"),
+        _mock_fact(content="Nous arch uses DDD", subject="Nous architecture"),
+        _mock_fact(content="Nous memory uses pgvector", subject="Nous memory"),
+        _mock_fact(content="Nous memory uses embeddings", subject="Nous memory"),
+    ]
+    result = engine._enforce_diversity(facts, "subject", max_per_subject=2)
+    # 2 from "Nous architecture" + 2 from "Nous memory" = 4
+    assert len(result) == 4
+    arch_count = sum(1 for f in result if f.subject == "Nous architecture")
+    mem_count = sum(1 for f in result if f.subject == "Nous memory")
+    assert arch_count == 2
+    assert mem_count == 2
+
+
 async def test_enforce_diversity_missing_attr_defaults_unknown():
     """23. Items without topic attr all map to 'unknown'."""
     engine = _make_context_engine_light()

--- a/tests/test_relevance_filter.py
+++ b/tests/test_relevance_filter.py
@@ -38,7 +38,7 @@ class TestRelevanceFilter:
     def test_max_k_cap(self):
         """Items > max_k are always trimmed."""
         engine = self._make_engine()
-        max_k = RELEVANCE_MAX_RESULTS["fact"]  # 8
+        max_k = RELEVANCE_MAX_RESULTS["fact"]  # 12
         items = [FakeItem(0.9 - i * 0.01) for i in range(max_k + 5)]
         result = engine._apply_relevance_filter(items, "fact")
         assert len(result) <= max_k

--- a/tests/test_staleness_penalty.py
+++ b/tests/test_staleness_penalty.py
@@ -29,7 +29,8 @@ class TestStalenessPenalty:
         assert result[0].score == 0.8
 
     def test_14_day_old_halved(self):
-        engine = self._make_engine()
+        # Uses explicit half_life=14; default changed to 30 in issue #203
+        engine = self._make_engine(half_life=14)
         item = FakeItem(score=0.8, created_at=datetime.now(timezone.utc) - timedelta(days=14))
         result = engine._apply_staleness_penalty([item])
         assert abs(result[0].score - 0.4) < 0.05
@@ -43,6 +44,18 @@ class TestStalenessPenalty:
     def test_preference_category_exempt(self):
         engine = self._make_engine()
         item = FakeItem(score=0.8, created_at=datetime.now(timezone.utc) - timedelta(days=60), category="preference")
+        result = engine._apply_staleness_penalty([item])
+        assert result[0].score == 0.8
+
+    def test_technical_category_exempt(self):
+        engine = self._make_engine()
+        item = FakeItem(score=0.8, created_at=datetime.now(timezone.utc) - timedelta(days=60), category="technical")
+        result = engine._apply_staleness_penalty([item])
+        assert result[0].score == 0.8
+
+    def test_concept_category_exempt(self):
+        engine = self._make_engine()
+        item = FakeItem(score=0.8, created_at=datetime.now(timezone.utc) - timedelta(days=60), category="concept")
         result = engine._apply_staleness_penalty([item])
         assert result[0].score == 0.8
 


### PR DESCRIPTION
## Summary

- **Fix subject diversity grouping** — `_enforce_diversity()` used `split()[0]` to extract topic keys, collapsing all facts with subjects like "Nous architecture", "Nous memory", "Nous version" into a single "nous" bucket (max 2 survivors). Now uses full subject string.
- **Raise default fetch limits** — Default retrieval fetched only 5 items per memory type from 800+ stored facts (0.6% sample). Increased to fact:15, decision:8, episode:8 with a `DEFAULT_FETCH_LIMITS` constant.
- **Raise relevance max-K caps** — Widened the relevance filter ceiling to accommodate more diverse candidates from the larger fetch pool.
- **Increase staleness half-life** — Changed from 14 to 30 days; added "technical" and "concept" categories to the decay exemption list alongside "rule" and "preference".
- **Soften drop ratio** — Threshold moved from 0.6 to 0.5 (only cut at 50%+ score drops).

All changes are parameter/config level — no schema migrations, no new dependencies.

## Test plan

- [x] New test: `test_enforce_diversity_multiword_subjects_not_collapsed` — verifies "Nous architecture" and "Nous memory" are treated as distinct topics
- [x] New tests: `test_technical_category_exempt` + `test_concept_category_exempt` — verifies staleness exemptions
- [x] Updated `test_14_day_old_halved` to use explicit `half_life=14` parameter
- [x] Updated `test_max_k_cap` comment to reflect new constant value (12)
- [x] All 35 unit tests pass (16 DB-dependent integration tests skipped without Postgres)

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)