### PR TITLE
fix: use immutable wrapper for array_to_string in generated column (#197)

### DIFF
--- a/sql/init.sql
+++ b/sql/init.sql
@@ -28,6 +28,15 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+-- ---------------------------------------------------------------------------
+-- 3b. Immutable wrapper for array_to_string (issue #197)
+--     PostgreSQL's array_to_string() is STABLE, not IMMUTABLE, so it cannot
+--     be used directly in GENERATED ALWAYS columns.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION immutable_array_to_string(arr text[], sep text)
+RETURNS text LANGUAGE sql IMMUTABLE PARALLEL SAFE
+AS $$ SELECT array_to_string(arr, sep) $$;
+
 -- ===========================================================================
 -- NOUS_SYSTEM SCHEMA (4 tables)
 -- ===========================================================================
@@ -343,11 +352,11 @@ CREATE TABLE heart.procedures (
         to_tsvector('english',
             name || ' '
             || COALESCE(description, '') || ' '
-            || COALESCE(array_to_string(core_patterns, ' '), '') || ' '
-            || COALESCE(array_to_string(implementation_notes, ' '), '') || ' '
-            || COALESCE(array_to_string(goals, ' '), '') || ' '
-            || COALESCE(array_to_string(core_tools, ' '), '') || ' '
-            || COALESCE(array_to_string(core_concepts, ' '), '')
+            || COALESCE(immutable_array_to_string(core_patterns, ' '), '') || ' '
+            || COALESCE(immutable_array_to_string(implementation_notes, ' '), '') || ' '
+            || COALESCE(immutable_array_to_string(goals, ' '), '') || ' '
+            || COALESCE(immutable_array_to_string(core_tools, ' '), '') || ' '
+            || COALESCE(immutable_array_to_string(core_concepts, ' '), '')
         )
     ) STORED,
     active BOOLEAN DEFAULT TRUE,

--- a/sql/migrations/023_procedure_fullbody_search.sql
+++ b/sql/migrations/023_procedure_fullbody_search.sql
@@ -1,10 +1,15 @@
 -- 023: Expand procedure search_tsv to include full body text (issue #197)
 --
 -- Before: to_tsvector('english', name || ' ' || COALESCE(description, ''))
--- After:  includes implementation_notes, goals, core_tools, core_concepts
+-- After:  includes core_patterns, implementation_notes, goals, core_tools, core_concepts
 --
--- PostgreSQL recomputes all rows automatically on generated column rebuild.
--- The GIN index idx_procedures_fts is also rebuilt automatically.
+-- PostgreSQL's array_to_string() is STABLE not IMMUTABLE, so it can't be used
+-- directly in GENERATED ALWAYS columns. We create an IMMUTABLE wrapper.
+
+-- Immutable wrapper for array_to_string (safe for text[] with constant delimiter)
+CREATE OR REPLACE FUNCTION immutable_array_to_string(arr text[], sep text)
+RETURNS text LANGUAGE sql IMMUTABLE PARALLEL SAFE
+AS $$ SELECT array_to_string(arr, sep) $$;
 
 ALTER TABLE heart.procedures DROP COLUMN search_tsv;
 
@@ -14,11 +19,11 @@ GENERATED ALWAYS AS (
   to_tsvector('english',
     name || ' '
     || COALESCE(description, '') || ' '
-    || COALESCE(array_to_string(core_patterns, ' '), '') || ' '
-    || COALESCE(array_to_string(implementation_notes, ' '), '') || ' '
-    || COALESCE(array_to_string(goals, ' '), '') || ' '
-    || COALESCE(array_to_string(core_tools, ' '), '') || ' '
-    || COALESCE(array_to_string(core_concepts, ' '), '')
+    || COALESCE(immutable_array_to_string(core_patterns, ' '), '') || ' '
+    || COALESCE(immutable_array_to_string(implementation_notes, ' '), '') || ' '
+    || COALESCE(immutable_array_to_string(goals, ' '), '') || ' '
+    || COALESCE(immutable_array_to_string(core_tools, ' '), '') || ' '
+    || COALESCE(immutable_array_to_string(core_concepts, ' '), '')
   )
 ) STORED;
 


### PR DESCRIPTION
## Summary

- Migration 023 failed with `generation expression is not immutable` because PostgreSQL's `array_to_string()` is STABLE, not IMMUTABLE
- Created `immutable_array_to_string()` SQL wrapper function marked IMMUTABLE
- Updated both migration 023 and `init.sql` to use the wrapper

## Root cause

PostgreSQL requires all functions in `GENERATED ALWAYS AS` expressions to be IMMUTABLE. `array_to_string()` is marked STABLE (it depends on locale settings for array formatting), so it cannot be used directly in generated columns.

## Test plan

- [ ] Verify migration 023 applies cleanly on existing database
- [ ] Verify `search_tsv` includes body text for new and existing procedures

Follow-up to #206. Closes #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)