### PR TITLE
feat: execution ledger dashboard tab (F032)

### DIFF
--- a/docs/features/F032-execution-ledger-dashboard.md
+++ b/docs/features/F032-execution-ledger-dashboard.md
@@ -1,0 +1,171 @@
+# F032: Execution Ledger Dashboard
+
+**Status:** Reviewed
+**Date:** 2026-03-30
+**Depends on:** F026 (Execution Integrity — deployed)
+**Blocks:** None (additive, UI-focused)
+**Review:** 3-agent review (architect + data specialist + devil's advocate), 6 P1s fixed
+
+---
+
+## Problem Statement
+
+The execution ledger (F026) tracks every tool call within a session — what was executed, whether it was allowed or blocked, side-effect classifications, and claim verification status. However, this data is currently only visible as a **summary section on the Overview tab**: a few stat cards and a table showing session-level totals.
+
+Operators cannot:
+- See **individual actions** within a session (tool name, arguments, status, timing)
+- Filter actions by status (allowed vs. blocked vs. error)
+- Understand the **timeline** of tool execution within a turn
+- Inspect **why** an action was blocked (result summary from the gate)
+- See side-effect classifications at a glance (read/write/external/irreversible)
+
+### Why a separate tab (not enhanced Overview)
+
+- Action timeline + filtering complexity would bloat `overview.js` past 500 lines
+- `/status` endpoint serves Telegram bot and MCP tools — per-action data would bloat their responses
+- Consistent with pattern: every major subsystem has a dedicated tab (decisions, graph, admission, rubric)
+
+### Why now
+
+- F026 is fully deployed and generating data in every session
+- The Overview tab integrity section is too compressed — operators need drill-down
+- Debugging blocked actions requires reading server logs, not the dashboard
+
+---
+
+## Solution: Dedicated Execution Ledger Tab
+
+Add a new "Execution" dashboard tab with two levels of detail:
+
+1. **Session list** — all active sessions with summary stats and status indicators
+2. **Session detail** — expandable per-session view showing every action with full metadata
+
+### Data source
+
+The execution ledger is **in-memory and session-scoped** (no database persistence). Data is served from `runner._ledgers` via a new REST endpoint. This means:
+- Data is available only for active sessions
+- When a session ends, its ledger is lost
+- This is acceptable for an operational monitoring dashboard
+
+### New REST endpoint
+
+**GET /dashboard/ledger?action_limit=50**
+
+Query parameters:
+- `action_limit` (int, default 50, max 200) — max actions returned per session
+
+Returns detailed action data for all active sessions:
+
+```json
+{
+  "enabled": {
+    "ledger": true,
+    "claim_verification": true,
+    "action_gating": true
+  },
+  "modes": {
+    "claim_verification": "enforce",
+    "action_gating": "enforce"
+  },
+  "sessions": [
+    {
+      "session_id": "abc-123",
+      "current_turn": 5,
+      "total_actions": 23,
+      "success_actions": 20,
+      "blocked_actions": 1,
+      "error_actions": 2,
+      "timeout_actions": 0,
+      "summary": "12 searches, 5 file writes, 3 bash",
+      "actions": [
+        {
+          "turn": 1,
+          "tool_name": "recall_deep",
+          "key_args": {"query": "authentication patterns"},
+          "status": "success",
+          "timestamp": "2026-03-30T14:22:01.000000+00:00",
+          "result_summary": "Found 5 matching facts...",
+          "side_effect_type": "none"
+        },
+        {
+          "turn": 3,
+          "tool_name": "write_file",
+          "key_args": {"path": "/tmp/auth.py"},
+          "status": "blocked",
+          "timestamp": "2026-03-30T14:23:15.000000+00:00",
+          "result_summary": "Action gating: duplicate write to same path",
+          "side_effect_type": "write"
+        }
+      ],
+      "actions_truncated": false
+    }
+  ]
+}
+```
+
+### Implementation notes (from review)
+
+1. **Snapshot before iteration**: `list(runner._ledgers.items())` and `list(ledger.actions)` at handler entry — prevents `RuntimeError` from concurrent mutation
+2. **Datetime serialization**: Call `a.timestamp.isoformat()` explicitly — `JSONResponse` cannot serialize `datetime` objects
+3. **Single-pass status counts**: Use `collections.Counter` over `a.status for a in actions` to compute all counts in one pass
+4. **Sensitive data redaction**: For `bash` tool `key_args`, redact patterns matching `[A-Z_]+=\S+` (env vars) and `Bearer \S+` (tokens) before serialization
+5. **Route ordering**: Register before `Mount("/dashboard", ...)` static mount to avoid shadowing
+6. **Shared config helper**: Extract `_build_integrity_config(settings)` callable from both `/status` and `/dashboard/ledger`
+7. **`escapeHtml` required**: All `key_args` values, `result_summary`, session IDs must be escaped in JS — `result_summary` contains raw tool output
+8. **No `pending_corrections`**: This field is consumed by `.pop()` at turn start and will nearly always read as 0 — removed from per-session response
+9. **`current_turn` property**: Add `@property current_turn` to `ExecutionLedger` to avoid accessing private `_current_turn`
+
+### UI Design
+
+#### Session List View (default)
+- **Stat cards row**: Active Sessions, Total Actions (all sessions), Blocked Actions, Error Actions, Claim Verification mode, Action Gating mode
+- **Session cards**: One card per active session showing:
+  - Session ID (truncated with copy-on-click)
+  - Current turn number
+  - Action counts by status (success/blocked/error/timeout)
+  - One-line summary
+  - "View Details" expand button
+- **Empty state**: "No active sessions" when no ledgers exist
+- **Auto-refresh**: 15s polling via `setInterval` when tab is active, cleared on tab switch
+
+#### Session Detail View (expanded)
+When a session card is expanded:
+- **Action timeline**: Grouped by turn number
+  - Each action shows: tool name, key args, status badge, side-effect badge, timestamp
+  - Status badges: green (success), red (blocked), yellow (error), grey (timeout)
+  - Side-effect badges: none (no badge), write (blue), external (orange), irreversible (red)
+- **Filter bar**: Filter by status (all/success/blocked/error/timeout) and by side-effect type
+- **Action count summary**: "Showing 15 of 23 actions" when filtered
+
+#### Overview tab update
+Keep existing `buildIntegritySection()` as summary. Add "View Details >" link that navigates to `#/execution`.
+
+### Known limitations
+- `result_summary` is truncated to 100 chars at record time in `ExecutionLedger` — may cut off gating rationale for blocked actions. Enhancement tracked separately.
+- No historical data — ledger is cleared when session ends
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `nous/cognitive/execution_ledger.py` | Add `@property current_turn`, add `redact_key_args()` helper |
+| `nous/api/rest.py` | Add `GET /dashboard/ledger` endpoint, extract `_build_integrity_config()` |
+| `static/dashboard/index.html` | Add nav link + view div for "Execution" tab |
+| `static/dashboard/js/ledger.js` | New JS module for the tab |
+| `static/dashboard/css/dashboard.css` | Add ledger-specific styles (badges, filters, turn groups) |
+| `static/dashboard/js/overview.js` | Add "View Details >" link to integrity section |
+| `tests/test_rest_ledger.py` | Tests for new endpoint |
+
+---
+
+## Testing
+
+1. **Endpoint test**: Mock runner with ledgers, verify JSON structure and all fields
+2. **Empty state test**: No ledgers returns empty sessions array
+3. **Serialization test**: Verify datetime is ISO string, all `ExecutedAction` fields included
+4. **Status counts**: Verify success/blocked/error/timeout counts are correct
+5. **Action limit**: Verify `action_limit` param truncates and sets `actions_truncated: true`
+6. **Sensitive data redaction**: Verify bash commands with env vars/Bearer tokens are redacted
+7. **Snapshot safety**: Verify response builds from snapshot, not live references

--- a/nous/api/rest.py
+++ b/nous/api/rest.py
@@ -252,15 +252,7 @@ def create_app(
                     },
                     "working_memory": working_memory_sessions,
                     "execution_integrity": {
-                        "enabled": {
-                            "ledger": settings.execution_ledger_enabled,
-                            "claim_verification": settings.claim_verification_enabled,
-                            "action_gating": settings.action_gating_enabled,
-                        },
-                        "modes": {
-                            "claim_verification": settings.claim_verification_mode,
-                            "action_gating": settings.action_gating_mode,
-                        },
+                        **_build_integrity_config(),
                         "active_ledgers": len(runner._ledgers),
                         "sessions": {
                             sid: {
@@ -1098,6 +1090,78 @@ def create_app(
             logger.error("Dashboard admission rejected error: %s", e)
             return JSONResponse({"error": str(e)}, status_code=500)
 
+    # --- F032: Execution Ledger Dashboard ---
+
+    def _build_integrity_config() -> dict[str, Any]:
+        """Shared helper for execution integrity config (used by /status and /dashboard/ledger)."""
+        return {
+            "enabled": {
+                "ledger": settings.execution_ledger_enabled,
+                "claim_verification": settings.claim_verification_enabled,
+                "action_gating": settings.action_gating_enabled,
+            },
+            "modes": {
+                "claim_verification": settings.claim_verification_mode,
+                "action_gating": settings.action_gating_mode,
+            },
+        }
+
+    async def dashboard_ledger(request: Request) -> JSONResponse:
+        """GET /dashboard/ledger - Execution ledger detail for dashboard."""
+        from collections import Counter
+
+        from nous.cognitive.execution_ledger import redact_key_args
+
+        try:
+            action_limit = max(1, min(int(request.query_params.get("action_limit", "50")), 200))
+        except ValueError:
+            action_limit = 50
+
+        try:
+            # Snapshot ledgers to avoid concurrent-mutation issues
+            ledger_snapshot = list(runner._ledgers.items())
+
+            sessions = []
+            for sid, ledger in ledger_snapshot:
+                actions_snapshot = list(ledger.actions)
+                status_counts: Counter[str] = Counter(a.status for a in actions_snapshot)
+
+                # Serialize actions (most recent first, capped by limit)
+                truncated = len(actions_snapshot) > action_limit
+                display_actions = actions_snapshot[-action_limit:] if truncated else actions_snapshot
+
+                serialized_actions = []
+                for a in display_actions:
+                    serialized_actions.append({
+                        "turn": a.turn,
+                        "tool_name": a.tool_name,
+                        "key_args": redact_key_args(a.tool_name, a.key_args),
+                        "status": a.status,
+                        "timestamp": a.timestamp.isoformat(),
+                        "result_summary": a.result_summary,
+                        "side_effect_type": a.side_effect_type,
+                    })
+
+                sessions.append({
+                    "session_id": sid,
+                    "current_turn": ledger.current_turn,
+                    "total_actions": len(actions_snapshot),
+                    "success_actions": status_counts.get("success", 0),
+                    "blocked_actions": status_counts.get("blocked", 0),
+                    "error_actions": status_counts.get("error", 0),
+                    "timeout_actions": status_counts.get("timeout", 0),
+                    "summary": ledger.one_line_summary(),
+                    "actions": serialized_actions,
+                    "actions_truncated": truncated,
+                })
+
+            result = _build_integrity_config()
+            result["sessions"] = sessions
+            return JSONResponse(result)
+        except Exception as e:
+            logger.error("Dashboard ledger error: %s", e)
+            return JSONResponse({"error": str(e)}, status_code=500)
+
     # --- F024 Phase 3b: Rubric endpoints ---
 
     async def get_rubric(request: Request) -> JSONResponse:
@@ -1325,6 +1389,8 @@ def create_app(
         # F021.1: Admission dashboard — rejected MUST be before admission (Starlette top-down matching)
         Route("/dashboard/admission/rejected", dashboard_admission_rejected),
         Route("/dashboard/admission", dashboard_admission),
+        # F032: Execution ledger dashboard
+        Route("/dashboard/ledger", dashboard_ledger),
     ]
 
     # Static dashboard mount — only add if directory exists (avoids crash during tests)

--- a/nous/cognitive/execution_ledger.py
+++ b/nous/cognitive/execution_ledger.py
@@ -8,6 +8,7 @@ session-scoped and in-memory only — no database dependency.
 from __future__ import annotations
 
 import logging
+import re
 from collections import Counter
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -153,6 +154,11 @@ class ExecutionLedger:
                 tool_name, status, self._current_turn, side_effect,
             )
         return action
+
+    @property
+    def current_turn(self) -> int:
+        """Public accessor for the current turn number."""
+        return self._current_turn
 
     @property
     def has_blocked_actions_this_turn(self) -> bool:
@@ -314,6 +320,26 @@ def classify_side_effect(tool_name: str, tool_input: dict[str, Any] | None = Non
     if tool_name == "bash":
         return _classify_bash_command(_extract_bash_command(tool_input or {}))
     return "write"
+
+
+_REDACT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"[A-Z_]{2,}=\S+"), "[REDACTED_ENV]"),
+    (re.compile(r"Bearer\s+\S+", re.IGNORECASE), "Bearer [REDACTED]"),
+    (re.compile(r"://\w+:[^@\s]+@"), "://[REDACTED]@"),
+]
+
+
+def redact_key_args(tool_name: str, key_args: dict[str, str]) -> dict[str, str]:
+    """Redact sensitive patterns from key_args before external exposure."""
+    if tool_name != "bash":
+        return key_args
+    result = {}
+    for k, v in key_args.items():
+        redacted = v
+        for pattern, replacement in _REDACT_PATTERNS:
+            redacted = pattern.sub(replacement, redacted)
+        result[k] = redacted
+    return result
 
 
 def _classify_bash_command(command: str) -> str:

--- a/static/dashboard/css/dashboard.css
+++ b/static/dashboard/css/dashboard.css
@@ -1114,3 +1114,191 @@ body {
 .correlation-table td.corr-cell:hover {
     opacity: 0.8;
 }
+
+/* ── F032: Execution Ledger ───────────────────────────────── */
+
+.ledger-sessions {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.ledger-session {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+}
+
+.ledger-session-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    cursor: pointer;
+    transition: background var(--transition);
+}
+.ledger-session-header:hover {
+    background: var(--surface-hover);
+}
+
+.ledger-session-id code {
+    font-size: 0.85rem;
+    color: var(--accent);
+    background: var(--accent-glow);
+    padding: 2px 8px;
+    border-radius: 4px;
+}
+
+.ledger-session-meta {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.ledger-session-summary {
+    flex: 1;
+    font-size: 0.85rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.ledger-expand-icon {
+    color: var(--muted);
+    transition: transform var(--transition);
+    flex-shrink: 0;
+}
+.ledger-session.expanded .ledger-expand-icon {
+    transform: rotate(180deg);
+}
+
+.ledger-badge {
+    font-size: 0.75rem;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-weight: 600;
+    white-space: nowrap;
+}
+.badge-turn { background: var(--border); color: var(--text); }
+.badge-actions { background: rgba(96, 165, 250, 0.15); color: #60a5fa; }
+.badge-blocked { background: rgba(248, 113, 113, 0.15); color: var(--red); }
+.badge-error { background: rgba(251, 191, 36, 0.15); color: var(--yellow); }
+.badge-truncated { background: rgba(107, 107, 138, 0.15); color: var(--muted); }
+
+/* Session detail */
+.ledger-session-detail {
+    border-top: 1px solid var(--border);
+    padding: 12px 16px 16px;
+}
+
+/* Filter bar */
+.ledger-filter-bar {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    margin-bottom: 12px;
+    flex-wrap: wrap;
+}
+
+.filter-btn {
+    background: var(--border);
+    border: none;
+    color: var(--muted);
+    padding: 4px 12px;
+    border-radius: 6px;
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: all var(--transition);
+    text-transform: capitalize;
+}
+.filter-btn:hover { background: var(--surface-hover); color: var(--text); }
+.filter-btn.active { background: var(--accent-dim); color: #fff; }
+.filter-separator { color: var(--border); margin: 0 4px; }
+
+/* Turn groups */
+.ledger-turn-group {
+    margin-bottom: 8px;
+}
+.ledger-turn-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 4px 0;
+    border-bottom: 1px solid var(--border);
+    margin-bottom: 4px;
+}
+
+/* Action rows */
+.ledger-action {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 8px;
+    border-radius: var(--radius-sm);
+    font-size: 0.85rem;
+    flex-wrap: wrap;
+}
+.ledger-action:hover { background: var(--surface-hover); }
+
+.ledger-tool-name {
+    font-weight: 600;
+    min-width: 100px;
+    color: var(--text);
+}
+
+.ledger-args {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 0.8rem;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* Status badges */
+.ledger-status-badge {
+    font-size: 0.7rem;
+    padding: 1px 8px;
+    border-radius: 8px;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+.ledger-status-badge.status-success { background: rgba(52, 211, 153, 0.15); color: var(--green); }
+.ledger-status-badge.status-blocked { background: rgba(248, 113, 113, 0.15); color: var(--red); }
+.ledger-status-badge.status-error   { background: rgba(251, 191, 36, 0.15); color: var(--yellow); }
+.ledger-status-badge.status-timeout { background: rgba(107, 107, 138, 0.15); color: var(--muted); }
+
+/* Side-effect badges */
+.ledger-effect-badge {
+    font-size: 0.7rem;
+    padding: 1px 6px;
+    border-radius: 8px;
+    font-weight: 500;
+}
+.ledger-effect-badge.effect-write       { background: rgba(96, 165, 250, 0.15); color: #60a5fa; }
+.ledger-effect-badge.effect-external    { background: rgba(251, 146, 60, 0.15); color: #fb923c; }
+.ledger-effect-badge.effect-irreversible { background: rgba(248, 113, 113, 0.15); color: var(--red); }
+
+.ledger-timestamp {
+    font-size: 0.75rem;
+    white-space: nowrap;
+    margin-left: auto;
+}
+
+.ledger-result-summary {
+    width: 100%;
+    font-size: 0.8rem;
+    color: var(--muted);
+    padding: 4px 8px 2px;
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    word-break: break-word;
+}
+
+.ledger-filter-count {
+    font-size: 0.8rem;
+    color: var(--muted);
+    margin-left: 8px;
+}

--- a/static/dashboard/index.html
+++ b/static/dashboard/index.html
@@ -47,6 +47,10 @@
                 <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6zm5 6a1 1 0 10-2 0v2H7a1 1 0 100 2h2v2a1 1 0 102 0v-2h2a1 1 0 100-2h-2V8z" clip-rule="evenodd"/></svg>
                 <span>Rubric</span>
             </a>
+            <a href="#/execution" class="nav-link" data-view="execution">
+                <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4 2a2 2 0 00-2 2v12a2 2 0 002 2h12a2 2 0 002-2V4a2 2 0 00-2-2H4zm3 3a1 1 0 011-1h4a1 1 0 110 2H8a1 1 0 01-1-1zm0 4a1 1 0 011-1h8a1 1 0 110 2H8a1 1 0 01-1-1zm0 4a1 1 0 011-1h5a1 1 0 110 2H8a1 1 0 01-1-1zM5 6a1 1 0 100-2 1 1 0 000 2zm0 4a1 1 0 100-2 1 1 0 000 2zm0 4a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/></svg>
+                <span>Execution</span>
+            </a>
         </div>
         <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Toggle sidebar">
             <svg viewBox="0 0 20 20" fill="currentColor" width="16" height="16"><path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
@@ -62,6 +66,7 @@
         <div id="view-health" class="view"></div>
         <div id="view-admission" class="view"></div>
         <div id="view-rubric" class="view"></div>
+        <div id="view-execution" class="view"></div>
     </main>
 
     <script src="lib/chart.min.js"></script>
@@ -75,5 +80,6 @@
     <script src="js/health.js"></script>
     <script src="js/admission.js"></script>
     <script src="js/rubric.js"></script>
+    <script src="js/ledger.js"></script>
 </body>
 </html>

--- a/static/dashboard/js/ledger.js
+++ b/static/dashboard/js/ledger.js
@@ -1,0 +1,316 @@
+/**
+ * Nous Dashboard — Execution Ledger View (F032)
+ *
+ * Displays per-session execution details: tool calls, statuses,
+ * side-effect classifications, and action gating results.
+ */
+
+/* global Dashboard, escapeHtml */
+
+var _ledgerRefreshInterval = null;
+
+Dashboard.registerView('execution', async function (container) {
+    Dashboard.showLoading(container);
+
+    try {
+        var data = await Dashboard.apiGet('/dashboard/ledger');
+        renderLedger(container, data);
+        startAutoRefresh(container);
+    } catch (err) {
+        Dashboard.showError(container, 'Failed to load execution ledger.', function () {
+            Dashboard.reloadView('execution');
+        });
+    }
+});
+
+function startAutoRefresh(container) {
+    stopAutoRefresh();
+    _ledgerRefreshInterval = setInterval(async function () {
+        if (Dashboard.currentView !== 'execution') {
+            stopAutoRefresh();
+            return;
+        }
+        try {
+            var data = await Dashboard.apiGet('/dashboard/ledger');
+            // Preserve expanded state
+            var expanded = {};
+            container.querySelectorAll('.ledger-session.expanded').forEach(function (el) {
+                var sid = el.dataset.sessionId;
+                if (sid) expanded[sid] = true;
+            });
+            var activeFilter = {};
+            var activeEffectFilter = {};
+            container.querySelectorAll('.ledger-filter-bar').forEach(function (bar) {
+                var sid = bar.closest('.ledger-session').dataset.sessionId;
+                if (!sid) return;
+                var statusBtn = bar.querySelector('.filter-btn:not(.effect-filter).active');
+                if (statusBtn) activeFilter[sid] = statusBtn.dataset.filter;
+                var effectBtn = bar.querySelector('.filter-btn.effect-filter.active');
+                if (effectBtn) activeEffectFilter[sid] = effectBtn.dataset.effectFilter;
+            });
+            renderLedger(container, data, expanded, activeFilter, activeEffectFilter);
+        } catch (err) {
+            // Silently skip refresh on error
+        }
+    }, 15000);
+}
+
+function stopAutoRefresh() {
+    if (_ledgerRefreshInterval) {
+        clearInterval(_ledgerRefreshInterval);
+        _ledgerRefreshInterval = null;
+    }
+}
+
+function renderLedger(container, data, expandedState, filterState, effectFilterState) {
+    expandedState = expandedState || {};
+    filterState = filterState || {};
+    effectFilterState = effectFilterState || {};
+
+    var enabled = data.enabled || {};
+    var modes = data.modes || {};
+    var sessions = data.sessions || [];
+
+    // Aggregate totals across sessions
+    var totalActions = 0, totalBlocked = 0, totalErrors = 0, totalSessions = sessions.length;
+    sessions.forEach(function (s) {
+        totalActions += s.total_actions || 0;
+        totalBlocked += s.blocked_actions || 0;
+        totalErrors += s.error_actions || 0;
+    });
+
+    var html = '<div class="view-header">' +
+        '<h1>Execution Ledger</h1>' +
+        '<p class="view-subtitle">F026 — Real-time tool execution tracking and action gating</p>' +
+        '</div>';
+
+    // Stat cards
+    html += '<div class="stat-grid">';
+    html += buildStatCard('Active Sessions', totalSessions, null, 'var(--muted)');
+    html += buildStatCard('Total Actions', totalActions, null, '#60a5fa');
+    html += buildIndicatorCard('Blocked', totalBlocked, totalBlocked > 0 ? 'bad' : 'good');
+    html += buildIndicatorCard('Errors', totalErrors, totalErrors > 0 ? 'warn' : 'good');
+    html += buildModeCard('Claim Verification', modes.claim_verification || 'off', !enabled.claim_verification);
+    html += buildModeCard('Action Gating', modes.action_gating || 'off', !enabled.action_gating);
+    html += '</div>';
+
+    // Sessions list
+    if (sessions.length === 0) {
+        html += '<div class="empty-state">' +
+            '<div class="empty-icon">&#x1D6B9;</div>' +
+            '<h3>No Active Sessions</h3>' +
+            '<p>Execution data will appear here when sessions are active. Data is auto-refreshed every 15 seconds.</p>' +
+            '</div>';
+    } else {
+        html += '<div class="section-header"><h2>Sessions</h2></div>';
+        html += '<div class="ledger-sessions">';
+        sessions.forEach(function (session) {
+            var isExpanded = expandedState[session.session_id] || false;
+            html += buildSessionCard(session, isExpanded, filterState[session.session_id] || 'all', effectFilterState[session.session_id] || 'all-effects');
+        });
+        html += '</div>';
+    }
+
+    container.innerHTML = html;
+
+    // Bind expand/collapse handlers
+    container.querySelectorAll('.ledger-session-header').forEach(function (header) {
+        header.addEventListener('click', function () {
+            var card = header.closest('.ledger-session');
+            card.classList.toggle('expanded');
+            var detail = card.querySelector('.ledger-session-detail');
+            if (detail) detail.style.display = card.classList.contains('expanded') ? 'block' : 'none';
+        });
+    });
+
+    // Bind status filter handlers
+    container.querySelectorAll('.filter-btn:not(.effect-filter)').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            var bar = btn.closest('.ledger-filter-bar');
+            bar.querySelectorAll('.filter-btn:not(.effect-filter)').forEach(function (b) { b.classList.remove('active'); });
+            btn.classList.add('active');
+            var sessionCard = btn.closest('.ledger-session');
+            applyFilters(sessionCard);
+        });
+    });
+
+    // Bind effect filter handlers
+    container.querySelectorAll('.filter-btn.effect-filter').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            var bar = btn.closest('.ledger-filter-bar');
+            bar.querySelectorAll('.filter-btn.effect-filter').forEach(function (b) { b.classList.remove('active'); });
+            btn.classList.add('active');
+            var sessionCard = btn.closest('.ledger-session');
+            applyFilters(sessionCard);
+        });
+    });
+}
+
+function buildSessionCard(session, isExpanded, activeFilter, activeEffectFilter) {
+    var sid = session.session_id;
+    var shortId = sid.length > 16 ? sid.slice(0, 16) + '\u2026' : sid;
+
+    var html = '<div class="ledger-session' + (isExpanded ? ' expanded' : '') + '" data-session-id="' + escapeHtml(sid) + '">';
+
+    // Header
+    html += '<div class="ledger-session-header">';
+    html += '<div class="ledger-session-id"><code>' + escapeHtml(shortId) + '</code></div>';
+    html += '<div class="ledger-session-meta">';
+    html += '<span class="ledger-badge badge-turn">Turn ' + (session.current_turn || 0) + '</span>';
+    html += '<span class="ledger-badge badge-actions">' + (session.total_actions || 0) + ' actions</span>';
+    if (session.blocked_actions > 0) {
+        html += '<span class="ledger-badge badge-blocked">' + session.blocked_actions + ' blocked</span>';
+    }
+    if (session.error_actions > 0) {
+        html += '<span class="ledger-badge badge-error">' + session.error_actions + ' errors</span>';
+    }
+    if (session.actions_truncated) {
+        html += '<span class="ledger-badge badge-truncated">truncated</span>';
+    }
+    html += '</div>';
+    html += '<div class="ledger-session-summary text-muted">' + escapeHtml(session.summary || '') + '</div>';
+    html += '<svg class="ledger-expand-icon" viewBox="0 0 20 20" fill="currentColor" width="16" height="16"><path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"/></svg>';
+    html += '</div>';
+
+    // Detail (hidden unless expanded)
+    html += '<div class="ledger-session-detail" style="display:' + (isExpanded ? 'block' : 'none') + '">';
+
+    // Filter bar
+    html += '<div class="ledger-filter-bar">';
+    var filters = ['all', 'success', 'blocked', 'error', 'timeout'];
+    filters.forEach(function (f) {
+        var cls = f === activeFilter ? ' active' : '';
+        html += '<button class="filter-btn' + cls + '" data-filter="' + f + '">' + f + '</button>';
+    });
+
+    // Side-effect filter
+    html += '<span class="filter-separator">|</span>';
+    var sideEffects = ['all-effects', 'none', 'write', 'external', 'irreversible'];
+    sideEffects.forEach(function (f) {
+        var label = f === 'all-effects' ? 'all effects' : f;
+        var cls = f === (activeEffectFilter || 'all-effects') ? ' active' : '';
+        html += '<button class="filter-btn effect-filter' + cls + '" data-effect-filter="' + f + '">' + label + '</button>';
+    });
+    html += '<span class="ledger-filter-count"></span>';
+    html += '</div>';
+
+    // Actions grouped by turn
+    var actions = session.actions || [];
+    var turnGroups = {};
+    actions.forEach(function (a) {
+        var t = a.turn;
+        if (!turnGroups[t]) turnGroups[t] = [];
+        turnGroups[t].push(a);
+    });
+
+    var turnNums = Object.keys(turnGroups).map(Number).sort(function (a, b) { return a - b; });
+
+    if (turnNums.length === 0) {
+        html += '<div class="text-muted" style="padding:12px">No actions recorded.</div>';
+    } else {
+        turnNums.forEach(function (turn) {
+            html += '<div class="ledger-turn-group">';
+            html += '<div class="ledger-turn-label">Turn ' + turn + '</div>';
+            turnGroups[turn].forEach(function (a) {
+                html += buildActionRow(a);
+            });
+            html += '</div>';
+        });
+    }
+
+    html += '</div>'; // session-detail
+    html += '</div>'; // session card
+
+    return html;
+}
+
+function buildActionRow(action) {
+    var statusClass = 'status-' + (action.status || 'success');
+    var effectClass = action.side_effect_type !== 'none' ? 'effect-' + action.side_effect_type : '';
+
+    var html = '<div class="ledger-action ' + statusClass + '" data-status="' + escapeHtml(action.status || '') + '" data-effect="' + escapeHtml(action.side_effect_type || 'none') + '">';
+
+    // Tool name
+    html += '<span class="ledger-tool-name">' + escapeHtml(action.tool_name) + '</span>';
+
+    // Key args
+    var args = action.key_args || {};
+    var argParts = Object.keys(args).map(function (k) {
+        return escapeHtml(k) + '=' + escapeHtml(Dashboard.truncate(args[k], 60));
+    });
+    if (argParts.length > 0) {
+        html += '<span class="ledger-args text-muted">' + argParts.join(' ') + '</span>';
+    }
+
+    // Badges
+    html += '<span class="ledger-status-badge ' + statusClass + '">' + escapeHtml(action.status) + '</span>';
+
+    if (action.side_effect_type && action.side_effect_type !== 'none') {
+        html += '<span class="ledger-effect-badge ' + effectClass + '">' + escapeHtml(action.side_effect_type) + '</span>';
+    }
+
+    // Timestamp
+    if (action.timestamp) {
+        var ts = new Date(action.timestamp);
+        html += '<span class="ledger-timestamp text-muted">' + ts.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', second: '2-digit' }) + '</span>';
+    }
+
+    // Result summary for non-success
+    if (action.status !== 'success' && action.result_summary) {
+        html += '<div class="ledger-result-summary">' + escapeHtml(action.result_summary) + '</div>';
+    }
+
+    html += '</div>';
+    return html;
+}
+
+function applyFilters(sessionCard) {
+    var bar = sessionCard.querySelector('.ledger-filter-bar');
+    var statusBtn = bar ? bar.querySelector('.filter-btn:not(.effect-filter).active') : null;
+    var effectBtn = bar ? bar.querySelector('.filter-btn.effect-filter.active') : null;
+    var statusFilter = statusBtn ? statusBtn.dataset.filter : 'all';
+    var effectFilter = effectBtn ? effectBtn.dataset.effectFilter : 'all-effects';
+
+    var actions = sessionCard.querySelectorAll('.ledger-action');
+    var shown = 0, total = actions.length;
+    actions.forEach(function (el) {
+        var matchStatus = statusFilter === 'all' || el.dataset.status === statusFilter;
+        var matchEffect = effectFilter === 'all-effects' || el.dataset.effect === effectFilter;
+        var visible = matchStatus && matchEffect;
+        el.style.display = visible ? '' : 'none';
+        if (visible) shown++;
+    });
+    var countEl = sessionCard.querySelector('.ledger-filter-count');
+    if (countEl) {
+        countEl.textContent = shown < total ? 'Showing ' + shown + ' of ' + total + ' actions' : '';
+    }
+}
+
+// Helper cards (matching overview.js patterns)
+function buildStatCard(label, value, delta, color) {
+    return '<div class="stat-card">' +
+        '<div class="stat-value" style="color:' + (color || 'inherit') + '">' + Dashboard.formatNumber(value) + '</div>' +
+        '<div class="stat-label">' + escapeHtml(label) + '</div>' +
+        '</div>';
+}
+
+function buildIndicatorCard(label, value, cls) {
+    return '<div class="stat-card">' +
+        '<div class="stat-value"><span class="stat-indicator ' + cls + '"></span>' + Dashboard.formatNumber(value) + '</div>' +
+        '<div class="stat-label">' + escapeHtml(label) + '</div>' +
+        '</div>';
+}
+
+function buildModeCard(label, mode, disabled) {
+    if (disabled) {
+        return '<div class="stat-card">' +
+            '<div class="stat-value" style="color:var(--muted)">off</div>' +
+            '<div class="stat-label">' + escapeHtml(label) + '</div>' +
+            '</div>';
+    }
+    var color = mode === 'enforce' ? 'var(--green)' : mode === 'warn' ? 'var(--yellow)' : 'var(--muted)';
+    return '<div class="stat-card">' +
+        '<div class="stat-value" style="color:' + color + '">' + escapeHtml(mode) + '</div>' +
+        '<div class="stat-label">' + escapeHtml(label) + '</div>' +
+        '</div>';
+}

--- a/static/dashboard/js/overview.js
+++ b/static/dashboard/js/overview.js
@@ -295,7 +295,8 @@ function buildIntegritySection(ei) {
     var claimMode = modes.claim_verification || 'off';
     var gateMode = modes.action_gating || 'off';
 
-    var html = '<div class="section-header"><h2>Execution Integrity</h2></div>';
+    var html = '<div class="section-header"><h2>Execution Integrity</h2>' +
+        '<a href="#/execution" style="font-size:0.85rem;color:var(--accent);text-decoration:none;margin-left:auto">View Details &rsaquo;</a></div>';
     html += '<div class="stat-grid">';
     html += buildStatCard('Active Sessions', ei.active_ledgers || 0, null, 'var(--muted)');
     html += buildStatCard('Actions Recorded', totalActions, null, '#60a5fa');

--- a/tests/test_rest_ledger.py
+++ b/tests/test_rest_ledger.py
@@ -1,0 +1,229 @@
+"""Tests for F032 execution ledger dashboard endpoint."""
+
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from nous.brain.brain import Brain
+from nous.cognitive.execution_ledger import (
+    ExecutedAction,
+    ExecutionLedger,
+    redact_key_args,
+)
+from nous.cognitive.layer import CognitiveLayer
+
+
+class MockAgentRunner:
+    def __init__(self):
+        self._conversations = {}
+        self._ledgers: dict[str, ExecutionLedger] = {}
+        self._pending_corrections: dict[str, list] = {}
+
+    async def start(self):
+        pass
+
+    async def close(self):
+        pass
+
+
+@pytest_asyncio.fixture
+async def brain(db, settings):
+    b = Brain(database=db, settings=settings)
+    yield b
+    await b.close()
+
+
+@pytest_asyncio.fixture
+async def cognitive(brain, heart, settings):
+    return CognitiveLayer(brain, heart, settings, identity_prompt="You are Nous.")
+
+
+@pytest.fixture
+def runner():
+    return MockAgentRunner()
+
+
+@pytest.fixture
+def app(runner, brain, heart, cognitive, db, settings):
+    from nous.api.rest import create_app
+    return create_app(runner, brain, heart, cognitive, db, settings)
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+def _make_ledger(session_id: str, actions: list[dict] | None = None) -> ExecutionLedger:
+    """Create a ledger with pre-populated actions."""
+    ledger = ExecutionLedger(session_id=session_id)
+    if actions:
+        for a in actions:
+            ledger.set_turn(a.get("turn", 0))
+            ledger.record(
+                tool_name=a["tool_name"],
+                tool_input=a.get("tool_input", {}),
+                result=a.get("result", "ok"),
+                status=a.get("status", "success"),
+            )
+    return ledger
+
+
+# ---------------------------------------------------------------------------
+# Endpoint tests
+# ---------------------------------------------------------------------------
+
+
+async def test_ledger_empty(client):
+    """No active ledgers returns empty sessions array."""
+    resp = await client.get("/dashboard/ledger")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["sessions"] == []
+    assert "enabled" in data
+    assert "modes" in data
+
+
+async def test_ledger_with_session(client, runner):
+    """Active session returns full action detail."""
+    ledger = _make_ledger("test-session-1", [
+        {"tool_name": "recall_deep", "tool_input": {"query": "test"}, "turn": 1},
+        {"tool_name": "write_file", "tool_input": {"path": "/tmp/f.py"}, "turn": 2},
+        {"tool_name": "bash", "tool_input": {"command": "ls -la"}, "turn": 2, "status": "success"},
+    ])
+    runner._ledgers["test-session-1"] = ledger
+
+    resp = await client.get("/dashboard/ledger")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert len(data["sessions"]) == 1
+    session = data["sessions"][0]
+    assert session["session_id"] == "test-session-1"
+    assert session["total_actions"] == 3
+    assert session["success_actions"] == 3
+    assert session["blocked_actions"] == 0
+    assert session["error_actions"] == 0
+    assert session["timeout_actions"] == 0
+    assert session["actions_truncated"] is False
+
+    actions = session["actions"]
+    assert len(actions) == 3
+
+    # Verify action fields
+    a0 = actions[0]
+    assert a0["tool_name"] == "recall_deep"
+    assert a0["status"] == "success"
+    assert a0["side_effect_type"] == "none"
+    assert "timestamp" in a0
+    # Verify timestamp is ISO format string (not a raw datetime)
+    assert isinstance(a0["timestamp"], str)
+    assert "T" in a0["timestamp"]
+
+
+async def test_ledger_status_counts(client, runner):
+    """Verify per-status counts are computed correctly."""
+    ledger = _make_ledger("count-session", [
+        {"tool_name": "recall_deep", "tool_input": {"query": "a"}, "turn": 1, "status": "success"},
+        {"tool_name": "write_file", "tool_input": {"path": "f"}, "turn": 1, "status": "blocked"},
+        {"tool_name": "bash", "tool_input": {"command": "x"}, "turn": 2, "status": "error"},
+        {"tool_name": "bash", "tool_input": {"command": "y"}, "turn": 2, "status": "timeout"},
+    ])
+    runner._ledgers["count-session"] = ledger
+
+    resp = await client.get("/dashboard/ledger")
+    session = resp.json()["sessions"][0]
+    assert session["success_actions"] == 1
+    assert session["blocked_actions"] == 1
+    assert session["error_actions"] == 1
+    assert session["timeout_actions"] == 1
+
+
+async def test_ledger_action_limit(client, runner):
+    """action_limit param truncates actions and sets truncated flag."""
+    actions = [
+        {"tool_name": "recall_deep", "tool_input": {"query": f"q{i}"}, "turn": i}
+        for i in range(10)
+    ]
+    ledger = _make_ledger("limit-session", actions)
+    runner._ledgers["limit-session"] = ledger
+
+    resp = await client.get("/dashboard/ledger?action_limit=3")
+    session = resp.json()["sessions"][0]
+    assert session["total_actions"] == 10
+    assert len(session["actions"]) == 3
+    assert session["actions_truncated"] is True
+
+
+async def test_ledger_action_limit_max_200(client, runner):
+    """action_limit is capped at 200."""
+    ledger = _make_ledger("cap-session", [
+        {"tool_name": "recall_deep", "tool_input": {"query": "q"}, "turn": 1},
+    ])
+    runner._ledgers["cap-session"] = ledger
+
+    # Even with limit=9999, should be capped at 200
+    resp = await client.get("/dashboard/ledger?action_limit=9999")
+    assert resp.status_code == 200
+
+
+async def test_ledger_multiple_sessions(client, runner):
+    """Multiple sessions are all returned."""
+    for i in range(3):
+        sid = f"multi-{i}"
+        runner._ledgers[sid] = _make_ledger(sid, [
+            {"tool_name": "recall_deep", "tool_input": {"query": "x"}, "turn": 1},
+        ])
+
+    resp = await client.get("/dashboard/ledger")
+    data = resp.json()
+    assert len(data["sessions"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Redaction tests
+# ---------------------------------------------------------------------------
+
+
+def test_redact_key_args_bash_env_var():
+    """Bash commands with env vars are redacted."""
+    result = redact_key_args("bash", {"command": "OPENAI_API_KEY=sk-abc123 python train.py"})
+    assert "sk-abc123" not in result["command"]
+    assert "[REDACTED_ENV]" in result["command"]
+
+
+def test_redact_key_args_bash_bearer():
+    """Bash commands with Bearer tokens are redacted."""
+    result = redact_key_args("bash", {"command": "curl -H 'Bearer sk-prod-secret' https://api.example.com"})
+    assert "sk-prod-secret" not in result["command"]
+    assert "Bearer [REDACTED]" in result["command"]
+
+
+def test_redact_key_args_bash_connection_string():
+    """Bash commands with connection strings are redacted."""
+    result = redact_key_args("bash", {"command": "psql postgres://user:hunter2@localhost/db"})
+    assert "hunter2" not in result["command"]
+    assert "[REDACTED]@" in result["command"]
+
+
+def test_redact_key_args_non_bash_unchanged():
+    """Non-bash tools are not redacted."""
+    args = {"query": "OPENAI_API_KEY=sk-abc123"}
+    result = redact_key_args("recall_deep", args)
+    assert result == args
+
+
+# ---------------------------------------------------------------------------
+# ExecutionLedger.current_turn property test
+# ---------------------------------------------------------------------------
+
+
+def test_current_turn_property():
+    """current_turn property exposes _current_turn."""
+    ledger = ExecutionLedger(session_id="test")
+    assert ledger.current_turn == 0
+    ledger.set_turn(5)
+    assert ledger.current_turn == 5


### PR DESCRIPTION
## Summary
- New **Execution** dashboard tab with per-session tool execution details
- `GET /dashboard/ledger` endpoint serving in-memory ledger data with snapshot safety
- Session list with stat cards (active sessions, total/blocked/error actions, gating modes)
- Expandable session detail with actions grouped by turn, status + side-effect filtering
- 15-second auto-refresh with state preservation (expanded cards, active filters)
- Sensitive data redaction for bash commands (env vars, Bearer tokens, connection strings)
- Shared `_build_integrity_config()` helper extracted from `/status` endpoint
- Overview tab "View Details" link navigating to the new tab

## Review notes
- **Spec review**: 3-agent team (architect + data specialist + devil's advocate) — 6 P1s, 8 P2s identified and fixed before implementation
- **Code review**: 3 P1s found (effect-filter wiring, filter-count element, action_limit=0 edge case) — all fixed
- Integration tests require running Postgres (`docker compose up -d postgres`)

## Files changed
| File | Change |
|------|--------|
| `docs/features/F032-execution-ledger-dashboard.md` | Feature spec (reviewed) |
| `nous/cognitive/execution_ledger.py` | `current_turn` property, `redact_key_args()` |
| `nous/api/rest.py` | `GET /dashboard/ledger`, `_build_integrity_config()` shared helper |
| `static/dashboard/index.html` | Nav link + view div |
| `static/dashboard/js/ledger.js` | New JS module (290 lines) |
| `static/dashboard/css/dashboard.css` | Ledger-specific styles |
| `static/dashboard/js/overview.js` | "View Details" link |
| `tests/test_rest_ledger.py` | 11 tests (5 unit + 6 integration) |

## Test plan
- [x] Unit tests pass: redaction, current_turn property (5/5)
- [ ] Integration tests: endpoint JSON structure, status counts, action_limit, multi-session (need DB)
- [ ] Manual: verify tab renders, expand/collapse, status filter, effect filter, auto-refresh


🤖 Generated with [Claude Code](https://claude.com/claude-code)