### PR TITLE
feat(identity): add environment section for runtime capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ PLAN-tests.md
 /.claude
 .worktrees
 tests/benchmark/results/
+nous.db

--- a/nous/identity/manager.py
+++ b/nous/identity/manager.py
@@ -25,7 +25,7 @@ from nous.storage.models import Agent, AgentIdentity
 
 logger = logging.getLogger(__name__)
 
-SECTIONS = ["character", "values", "protocols", "preferences", "boundaries"]
+SECTIONS = ["character", "values", "protocols", "preferences", "boundaries", "environment"]
 VALID_SECTIONS = set(SECTIONS) | {"status"}  # status is internal control field
 
 # Cache TTL in seconds

--- a/nous/identity/protocol.py
+++ b/nous/identity/protocol.py
@@ -45,6 +45,7 @@ appropriate section. Valid sections:
 - **boundaries** — topics to avoid, data restrictions, actions needing approval
 - **values** — what matters to the user, priorities
 - **protocols** — how to work together, workflows
+- **environment** — runtime capabilities: installed packages, OS tools, system constraints
 
 When ALL topics have been covered, call `complete_initiation` to finish setup.
 
@@ -88,7 +89,7 @@ STORE_IDENTITY_SCHEMA = {
         "properties": {
             "section": {
                 "type": "string",
-                "enum": ["character", "values", "protocols", "preferences", "boundaries"],
+                "enum": ["character", "values", "protocols", "preferences", "boundaries", "environment"],
                 "description": "Identity section to store.",
             },
             "content": {


### PR DESCRIPTION
## What
Adds `environment` as a new identity section that lists installed Python packages, OS tools, and explicitly what is NOT available.

## Why
- Eliminates token waste from `pip list` / `which` checks at runtime
- Prevents attempts to use unavailable tools (gh CLI, ImageMagick, LaTeX, etc.)
- Always in context — zero lookup cost
- Packages change rarely so it wont go stale

## Changes
- `manager.py`: Add `environment` to SECTIONS list
- `protocol.py`: Add to initiation prompt docs and `store_identity` schema enum
- **DB**: Populated environment section with current package inventory (already live)

## Content Categories
- **Python 3.12**: Data (pandas/numpy/matplotlib), Web (requests/httpx/aiohttp), Docs (python-docx/pptx/pillow), AI (anthropic/mcp), Auth, DB, Framework, Scheduling
- **OS Tools**: git, curl, wget, jq, sqlite3, ffmpeg, pandoc, node v20, graphviz, sed/awk/grep
- **Not Available**: gh CLI, zip/unzip, ImageMagick, LaTeX, Chrome/headless, file command