### PR TITLE
spec: F034.5 — Dynamic Heartbeat Checks

### DIFF
--- a/docs/features/F034.5-dynamic-heartbeat-checks.md
+++ b/docs/features/F034.5-dynamic-heartbeat-checks.md
@@ -1,0 +1,469 @@
+# F034.5 — Dynamic Heartbeat Checks
+
+**Status:** PROPOSED  
+**Priority:** P1 (high — unlocks conversational extensibility of heartbeat)  
+**Depends on:** F034 (heartbeat core), F034.1 (finding lifecycle)  
+**Author:** Nous + Tim  
+**Date:** 2026-04-04  
+
+## Problem
+
+Today, adding a new heartbeat check requires:
+1. Writing a Python class that extends `BaseCheck`
+2. Registering it in the application startup code with constructor dependencies
+3. Creating a PR, merging, and redeploying
+
+This means only a developer can add checks. Tim can't say "monitor HackerNews for AI agent papers every 6 hours" and have it just work. The heartbeat is powerful but **closed** — its sensor array is frozen at deploy time.
+
+Meanwhile, KAIROS-style agents (OpenClaw) offer a `CronCreateTool` that lets the agent dynamically create scheduled tasks at runtime from conversation. We want that same flexibility but integrated into our heartbeat ecosystem — so dynamic checks get findings, dedup, escalation, daily digest, and self-tuning for free.
+
+## Goals
+
+1. **Conversational check creation** — Tim says "add a check that..." → Nous creates it, heartbeat picks it up on next tick
+2. **Full lifecycle integration** — dynamic checks produce findings that flow through FindingStore (dedup, escalation, digest)
+3. **Management via conversation** — list, pause, resume, delete checks without touching code
+4. **Persistence** — dynamic checks survive restarts
+5. **Coexistence** — built-in checks (health, email, drive, self_initiated, behavior_drift) remain permanent and hardcoded; dynamic checks run alongside them
+
+## Non-Goals
+
+- Replacing built-in checks — they have typed constructor dependencies (Heart, Brain, embeddings) that dynamic checks can't replicate
+- Arbitrary Python execution — dynamic checks are prompt-driven, not code-driven
+- Replacing `schedule_task` — tasks are heavy work (write a report, do research); checks are lightweight polling (is there something to act on?)
+
+## Design
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  HeartbeatRunner                     │
+│                                                     │
+│  CheckRegistry                                      │
+│  ├── HealthCheck        (permanent, Python class)   │
+│  ├── SelfInitiatedCheck (permanent, Python class)   │
+│  ├── EmailCheck         (permanent, Python class)   │
+│  ├── DriveCheck         (permanent, Python class)   │
+│  ├── BehaviorDriftCheck (permanent, Python class)   │
+│  │                                                  │
+│  ├── DynamicCheck: "arxiv-agent-papers"  (from DB)  │
+│  ├── DynamicCheck: "hn-ai-news"          (from DB)  │
+│  └── DynamicCheck: "weather-alert"       (from DB)  │
+│                                                     │
+│  DynamicCheckLoader ←── heartbeat_dynamic_checks DB │
+└─────────────────────────────────────────────────────┘
+```
+
+Dynamic checks are a single Python class (`DynamicCheck`) that wraps a prompt + tools execution. Each instance is parameterized by a DB row.
+
+### Database Schema
+
+New table in `nous_system` schema:
+
+```sql
+CREATE TABLE nous_system.dynamic_checks (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_id    TEXT NOT NULL DEFAULT 'nous',
+    name        TEXT NOT NULL UNIQUE,
+    description TEXT NOT NULL,           -- human-readable purpose
+    prompt      TEXT NOT NULL,           -- instruction for the check
+    tools       TEXT[] DEFAULT '{}',     -- allowed tools: 'web_search', 'web_fetch', 'recall_deep', 'bash'
+    cron_expr   TEXT,                    -- cron expression (e.g., '0 */6 * * *') — NULL = use interval_seconds
+    interval_seconds INTEGER DEFAULT 3600,  -- fallback if no cron_expr
+    timeout_seconds  INTEGER DEFAULT 30,
+    enabled     BOOLEAN DEFAULT TRUE,
+    urgent      BOOLEAN DEFAULT FALSE,   -- runs during quiet hours
+    created_at  TIMESTAMPTZ DEFAULT now(),
+    updated_at  TIMESTAMPTZ DEFAULT now(),
+    created_by  TEXT DEFAULT 'conversation', -- 'conversation', 'api', 'heartbeat'
+    last_run_at TIMESTAMPTZ,
+    run_count   INTEGER DEFAULT 0,
+    error_count INTEGER DEFAULT 0,
+    last_error  TEXT,
+    metadata    JSONB DEFAULT '{}'       -- extensible (tags, notes, etc.)
+);
+
+CREATE INDEX idx_dynamic_checks_agent_enabled 
+    ON nous_system.dynamic_checks(agent_id, enabled);
+```
+
+### DynamicCheck Class
+
+A single generic class that wraps prompt execution:
+
+```python
+class DynamicCheck(BaseCheck):
+    """A prompt-driven heartbeat check loaded from DB."""
+
+    def __init__(
+        self,
+        check_id: str,
+        name: str,
+        prompt: str,
+        tools: list[str],
+        interval: int = 3600,
+        timeout: int = 30,
+        urgent: bool = False,
+        runner: AgentRunner | None = None,
+    ) -> None:
+        super().__init__()
+        self.check_id = check_id
+        self.name = name
+        self._prompt = prompt
+        self._tools = tools
+        self.interval = interval
+        self.timeout = timeout
+        self.urgent_override = urgent
+        self._runner = runner
+
+    async def run(self) -> CheckResult:
+        """Execute the check by running the prompt through the agent."""
+        if self._runner is None:
+            return CheckResult()
+
+        session_id = f"dynamic-check-{self.name}-{uuid4().hex[:8]}"
+
+        # Build the check instruction
+        instruction = (
+            f"[Dynamic Heartbeat Check: {self.name}]\n"
+            f"You are running a heartbeat check. Your job is to evaluate "
+            f"whether there is anything worth reporting.\n\n"
+            f"Instructions: {self._prompt}\n\n"
+            f"Respond with a JSON object:\n"
+            f'{{"has_findings": bool, "findings": [{{"summary": "...", '
+            f'"urgency": "high|normal|low", "needs_action": bool}}]}}\n\n'
+            f"If nothing noteworthy, return: {{\"has_findings\": false, \"findings\": []}}"
+        )
+
+        try:
+            response_text, _ctx, _usage = await self._runner.run_turn(
+                session_id, instruction,
+                platform="heartbeat",
+                skip_episode=True,
+                is_subtask=True,
+                tool_filter=self._tools if self._tools else None,
+            )
+
+            # Parse response
+            findings = self._parse_findings(response_text or "")
+            return CheckResult(
+                has_updates=bool(findings),
+                findings=findings,
+            )
+        except Exception as e:
+            logger.exception("DynamicCheck '%s' failed", self.name)
+            raise
+        finally:
+            try:
+                await self._runner.end_conversation(session_id)
+            except Exception:
+                pass
+
+    def _parse_findings(self, response: str) -> list[Finding]:
+        """Extract findings from LLM JSON response."""
+        import json
+        import re
+
+        # Try to extract JSON from response
+        json_match = re.search(r'\{.*\}', response, re.DOTALL)
+        if not json_match:
+            return []
+
+        try:
+            data = json.loads(json_match.group())
+        except json.JSONDecodeError:
+            return []
+
+        if not data.get("has_findings"):
+            return []
+
+        findings = []
+        for item in data.get("findings", []):
+            findings.append(Finding(
+                source=f"dynamic:{self.name}",
+                summary=item.get("summary", "")[:200],
+                urgency=item.get("urgency", "normal"),
+                needs_action=item.get("needs_action", False),
+                raw_data={"check_id": self.check_id, "dynamic": True},
+            ))
+
+        return findings
+```
+
+### DynamicCheckLoader
+
+Loads checks from DB and syncs with the CheckRegistry:
+
+```python
+class DynamicCheckLoader:
+    """Loads dynamic checks from DB and registers them in CheckRegistry."""
+
+    def __init__(
+        self,
+        db: Database,
+        registry: CheckRegistry,
+        runner: AgentRunner,
+        agent_id: str = "nous",
+    ) -> None:
+        self._db = db
+        self._registry = registry
+        self._runner = runner
+        self._agent_id = agent_id
+        self._loaded_ids: set[str] = set()
+
+    async def sync(self) -> int:
+        """Load/reload dynamic checks from DB. Returns count of active checks."""
+        rows = await self._fetch_enabled()
+        
+        current_ids = {str(r["id"]) for r in rows}
+        
+        # Unregister removed/disabled checks
+        for check_id in self._loaded_ids - current_ids:
+            name = self._id_to_name.get(check_id)
+            if name:
+                self._registry.unregister(name)
+        
+        # Register new/updated checks
+        for row in rows:
+            check = DynamicCheck(
+                check_id=str(row["id"]),
+                name=row["name"],
+                prompt=row["prompt"],
+                tools=row["tools"] or [],
+                interval=row["interval_seconds"],
+                timeout=row["timeout_seconds"],
+                urgent=row["urgent"],
+                runner=self._runner,
+            )
+            # Register as non-permanent (can be unregistered)
+            self._registry.register(check, permanent=False)
+        
+        self._loaded_ids = current_ids
+        return len(current_ids)
+
+    async def _fetch_enabled(self) -> list[dict]:
+        """Fetch all enabled dynamic checks for this agent."""
+        async with self._db.session() as session:
+            from sqlalchemy import text
+            result = await session.execute(text(
+                "SELECT * FROM nous_system.dynamic_checks "
+                "WHERE agent_id = :aid AND enabled = true"
+            ), {"aid": self._agent_id})
+            return [dict(r._mapping) for r in result.fetchall()]
+```
+
+### Sync Strategy
+
+The loader runs `sync()` at two points:
+1. **On startup** — `HeartbeatRunner.start()` calls `loader.sync()` before entering the tick loop
+2. **Periodic refresh** — every N ticks (configurable, default every 60 ticks ≈ 30 minutes at 30s tick), re-sync to pick up changes made via REST API or conversation
+
+This avoids watching the DB on every tick while still being responsive to changes.
+
+### Tool Exposure — Conversation Management
+
+Three new conversational tools for the agent:
+
+#### `heartbeat_check_create`
+
+```python
+{
+    "name": "heartbeat_check_create",
+    "description": "Create a new dynamic heartbeat check",
+    "parameters": {
+        "name": {"type": "string", "description": "Unique check name (slug)"},
+        "description": {"type": "string", "description": "What this check does"},
+        "prompt": {"type": "string", "description": "Instruction for the check"},
+        "tools": {"type": "array", "items": {"type": "string"}, "description": "Tools the check can use"},
+        "interval_seconds": {"type": "integer", "default": 3600},
+        "cron_expr": {"type": "string", "description": "Cron expression (optional, overrides interval)"},
+        "urgent": {"type": "boolean", "default": false}
+    }
+}
+```
+
+#### `heartbeat_check_manage`
+
+```python
+{
+    "name": "heartbeat_check_manage",
+    "description": "List, enable, disable, or delete dynamic heartbeat checks",
+    "parameters": {
+        "action": {"enum": ["list", "enable", "disable", "delete", "update"]},
+        "name": {"type": "string", "description": "Check name (required for enable/disable/delete/update)"},
+        "updates": {"type": "object", "description": "Fields to update (for action=update)"}
+    }
+}
+```
+
+### Conversation Flow Examples
+
+**Creating a check:**
+```
+Tim: "Add a heartbeat check that scans arxiv for new agent memory papers every 6 hours"
+
+Nous: → calls heartbeat_check_create(
+    name="arxiv-agent-memory",
+    description="Scan arxiv for new papers on agent memory systems",
+    prompt="Search arxiv.org for papers published in the last 24 hours about 
+            LLM agent memory, cognitive architectures, or retrieval-augmented 
+            generation. Report any new papers with title, authors, and a 
+            one-line summary.",
+    tools=["web_search", "web_fetch"],
+    interval_seconds=21600,  # 6 hours
+)
+
+Nous: "Done — I'll check arxiv for agent memory papers every 6 hours. 
+       Findings will show up in your daily digest and I'll ping you 
+       immediately if something looks important."
+```
+
+**Listing checks:**
+```
+Tim: "What checks are running?"
+
+Nous: → calls heartbeat_check_manage(action="list")
+
+Nous: "Here's what's active:
+       • health (permanent) — every 30min
+       • email (permanent) — every 5min  
+       • drive (permanent) — every 15min
+       • arxiv-agent-memory (dynamic) — every 6h, last ran 2h ago
+       • hn-ai-news (dynamic) — every 4h, last ran 45min ago"
+```
+
+**Pausing a check:**
+```
+Tim: "Pause the HN check"
+
+Nous: → calls heartbeat_check_manage(action="disable", name="hn-ai-news")
+
+Nous: "Paused. The HN check won't run until you re-enable it."
+```
+
+### REST API Endpoints
+
+For programmatic management (not just conversation):
+
+```
+GET    /admin/heartbeat/checks/dynamic          — list all dynamic checks
+POST   /admin/heartbeat/checks/dynamic          — create a new check
+PATCH  /admin/heartbeat/checks/dynamic/{name}   — update a check
+DELETE /admin/heartbeat/checks/dynamic/{name}    — delete a check
+POST   /admin/heartbeat/checks/dynamic/{name}/trigger  — force-run a check
+```
+
+### Budget & Safety
+
+Dynamic checks consume the same heartbeat token budget as cognitive triage. Additional safeguards:
+
+- **Max dynamic checks:** 10 (configurable via `HEARTBEAT_MAX_DYNAMIC_CHECKS`)
+- **Min interval:** 300 seconds (5 minutes) — prevent runaway polling
+- **Tool allowlist:** Only `web_search`, `web_fetch`, `recall_deep`, `recall_recent`, `bash` (read-only commands). No `write_file`, no `send_file`, no `learn_fact` from checks — checks are sensors, not actuators
+- **Timeout enforcement:** Each dynamic check inherits the standard `asyncio.wait_for` timeout from the tick loop
+- **Circuit breaker:** DynamicCheck inherits `BaseCheck` circuit breaker — 3 consecutive failures → disabled until manual reset
+- **Error tracking:** `error_count` and `last_error` updated in DB after failures
+
+### Cron Expression Support
+
+For checks that need specific schedules (not just intervals):
+
+```python
+from croniter import croniter
+
+class DynamicCheck(BaseCheck):
+    def __init__(self, ..., cron_expr: str | None = None):
+        self._cron = croniter(cron_expr) if cron_expr else None
+
+    def is_due(self, now: datetime | None = None) -> bool:
+        if not self.active:
+            return False
+        if self._cron:
+            # Cron-based scheduling
+            next_run = self._cron.get_next(datetime)
+            return now >= next_run
+        # Fall back to interval-based
+        return super().is_due(now)
+```
+
+`croniter` is already installed in our environment.
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `nous/heartbeat/dynamic.py` | **NEW** — DynamicCheck class + DynamicCheckLoader |
+| `nous/heartbeat/runner.py` | Add DynamicCheckLoader initialization + periodic sync |
+| `nous/heartbeat/registry.py` | Minor — ensure `unregister()` works for dynamic checks |
+| `nous/tools/heartbeat_tools.py` | **NEW** — `heartbeat_check_create` + `heartbeat_check_manage` tools |
+| `nous/api/routes/admin.py` | Add REST endpoints for dynamic check CRUD |
+| `nous/config.py` | Add `HEARTBEAT_MAX_DYNAMIC_CHECKS`, `HEARTBEAT_DYNAMIC_SYNC_INTERVAL` |
+| `alembic/versions/xxx_dynamic_checks.py` | **NEW** — migration for `nous_system.dynamic_checks` table |
+
+## Implementation Plan
+
+### Phase 1 — Core (MVP)
+
+1. Create `nous_system.dynamic_checks` table (migration)
+2. Implement `DynamicCheck` class with prompt execution + JSON parsing
+3. Implement `DynamicCheckLoader` with startup sync
+4. Wire loader into `HeartbeatRunner.start()`
+5. Add `heartbeat_check_create` and `heartbeat_check_manage` tools
+
+**Deliverable:** Tim can create/manage dynamic checks via conversation. Checks run on interval, produce findings, flow through FindingStore.
+
+**Effort:** 3–4 hours
+
+### Phase 2 — Polish
+
+6. Add cron expression support (croniter integration)
+7. Add REST API endpoints for programmatic management
+8. Add periodic sync (every N ticks)
+9. Track `run_count`, `error_count`, `last_error` in DB
+10. Add `tool_filter` support in `AgentRunner.run_turn()` (if not already present)
+
+**Deliverable:** Full cron scheduling, REST API, error tracking.
+
+**Effort:** 2–3 hours
+
+### Phase 3 — Self-Tuning Integration
+
+11. Dynamic checks emit outcome signals to HeartbeatTuner
+12. Tuner can adjust dynamic check intervals based on finding quality
+13. Auto-disable checks that produce only noise (>90% suppressed over 30 days)
+
+**Deliverable:** Dynamic checks self-tune like built-in checks.
+
+**Effort:** 1–2 hours
+
+## Testing Strategy
+
+**Unit tests:**
+- DynamicCheck parses valid JSON findings correctly
+- DynamicCheck handles malformed JSON gracefully (returns empty)
+- DynamicCheckLoader registers checks from DB rows
+- DynamicCheckLoader unregisters disabled/deleted checks on sync
+- Tool creates check with correct DB row
+- Tool validates name uniqueness
+- Min interval enforcement (rejects < 300s)
+- Max check count enforcement
+- Circuit breaker triggers after 3 failures
+
+**Integration tests:**
+- End-to-end: create check via tool → next tick runs it → finding appears in FindingStore
+- Disable check via tool → next sync → check no longer runs
+- Cron expression fires at correct times
+
+## Success Metrics
+
+- Tim can create a new heartbeat check in < 30 seconds via conversation
+- Dynamic checks produce findings that appear in daily digest
+- Zero code changes needed for new monitoring use cases
+- Dynamic checks survive server restart (DB-backed)
+
+## Risks
+
+- **LLM cost** — Each dynamic check run costs a full agent turn (~500-2000 tokens). Mitigated by minimum interval (5min), max checks (10), and daily token budget
+- **JSON parsing fragility** — LLM might not always return clean JSON. Mitigated by regex extraction + fallback to no-findings
+- **Tool leakage** — Dynamic checks could potentially use tools to modify state. Mitigated by tool allowlist (sensors only)
+- **Prompt injection** — A dynamic check's prompt could be crafted to manipulate the agent. Low risk since only Tim/admin can create checks, but worth noting


### PR DESCRIPTION
## F034.5 — Dynamic Heartbeat Checks

**Problem:** Adding new heartbeat checks requires writing Python + PR + deploy. Tim cannot add monitoring via conversation.

**Solution:** DB-backed dynamic checks that are prompt-driven, managed via conversation tools or REST API, and fully integrated with FindingStore.

**Key design:**
- `DynamicCheck` class wraps prompt execution via AgentRunner
- `DynamicCheckLoader` syncs DB → CheckRegistry on startup + periodic refresh
- New tools: `heartbeat_check_create`, `heartbeat_check_manage`
- Tool allowlist for safety (sensors only)
- Cron support via croniter
- Coexists with permanent built-in checks

**Phases:**
1. Core MVP — DB table, DynamicCheck, loader, conversation tools (~3-4h)
2. Polish — cron, REST API, error tracking (~2-3h)
3. Self-tuning integration (~1-2h)

**Not replacing** `schedule_task` — checks are sensors (lightweight polling), tasks are actuators (heavy work). A check can trigger a task when it finds something.