### PR TITLE
feat(f036.1): Cache Dashboard

### DIFF
--- a/docs/superpowers/plans/2026-04-05-f036.1-cache-dashboard.md
+++ b/docs/superpowers/plans/2026-04-05-f036.1-cache-dashboard.md
@@ -1,0 +1,216 @@
+# Implementation Plan: F036.1 Cache Dashboard
+
+**Feature:** F036.1 — Cache Dashboard  
+**Date:** 2026-04-05  
+**Depends on:** F036 (Prompt Cache Optimization), F035.4 (Context Visibility)  
+
+---
+
+## Overview
+
+Add a "Cache" tab to the Nous dashboard SPA showing prompt cache efficiency metrics. All data is in-memory from `ContextLogger` (200-entry deque). No database changes.
+
+## Architecture
+
+```
+GET /dashboard/cache
+    └─ context_logger.get_recent(limit=200)
+        └─ Iterate ContextLogEntry objects
+            └─ Aggregate: hit rates, token economics, breaks, sessions
+                └─ Return JSON
+
+static/dashboard/js/cache.js
+    └─ Dashboard.registerView('cache', ...)
+        └─ fetch('/dashboard/cache')
+            └─ Render stat cards + Chart.js charts + tables
+            └─ 30s auto-refresh
+```
+
+---
+
+## Task 1: REST Endpoint (nous/api/rest.py)
+
+Add `dashboard_cache` handler inline in rest.py (same pattern as `dashboard_ledger` — in-memory, no DB query function needed).
+
+**Location:** After `dashboard_observability` handler (~line 1376), before route registration.
+
+**Aggregation logic:**
+```python
+async def dashboard_cache(request: Request) -> JSONResponse:
+    if context_logger is None:
+        return JSONResponse({"error": "Context logging not enabled"}, status_code=503)
+    
+    entries = context_logger.get_recent(limit=200)
+    
+    # Filter to entries that have actual token data (API responded)
+    calls = [e for e in entries if e.input_tokens_actual is not None]
+    
+    total_calls = len(calls)
+    total_input = sum(e.input_tokens_actual or 0 for e in calls)
+    total_cache_read = sum(e.cache_read_tokens or 0 for e in calls)
+    total_cache_created = sum(e.cache_creation_tokens or 0 for e in calls)
+    total_breaks = sum(1 for e in calls if e.cache_break)
+    total_break_tokens = sum(e.cache_break_tokens_lost for e in calls if e.cache_break)
+    
+    # Per-session aggregation
+    sessions = {}
+    for e in calls:
+        sid = e.session_id
+        if sid not in sessions:
+            sessions[sid] = {"calls": 0, "input": 0, "cache_read": 0, "cache_created": 0, "breaks": 0}
+        s = sessions[sid]
+        s["calls"] += 1
+        s["input"] += e.input_tokens_actual or 0
+        s["cache_read"] += e.cache_read_tokens or 0
+        s["cache_created"] += e.cache_creation_tokens or 0
+        if e.cache_break:
+            s["breaks"] += 1
+    
+    # Break component distribution
+    component_counts = {}
+    for e in calls:
+        if e.cache_break:
+            for comp in e.cache_break_components:
+                component_counts[comp] = component_counts.get(comp, 0) + 1
+    
+    # Per-call timeline (newest first, last 50)
+    timeline = []
+    for e in calls[:50]:
+        cache_read = e.cache_read_tokens or 0
+        input_tok = e.input_tokens_actual or 0
+        hit_rate = round(cache_read / input_tok * 100, 1) if input_tok > 0 else 0
+        timeline.append({
+            "timestamp": e.timestamp,
+            "session_id": e.session_id,
+            "turn": e.turn_number,
+            "model": e.model,
+            "input_tokens": input_tok,
+            "cache_read": cache_read,
+            "cache_created": e.cache_creation_tokens or 0,
+            "hit_rate": hit_rate,
+            "cache_break": e.cache_break,
+            "break_components": e.cache_break_components if e.cache_break else [],
+        })
+    
+    # Session list (newest first)
+    session_list = []
+    for sid, s in sessions.items():
+        hit_rate = round(s["cache_read"] / s["input"] * 100, 1) if s["input"] > 0 else 0
+        session_list.append({
+            "session_id": sid,
+            "calls": s["calls"],
+            "input_tokens": s["input"],
+            "cache_read": s["cache_read"],
+            "cache_created": s["cache_created"],
+            "hit_rate": hit_rate,
+            "breaks": s["breaks"],
+        })
+    session_list.sort(key=lambda x: x["calls"], reverse=True)
+    
+    return JSONResponse({
+        "summary": {
+            "total_calls": total_calls,
+            "total_input_tokens": total_input,
+            "total_cache_read": total_cache_read,
+            "total_cache_created": total_cache_created,
+            "overall_hit_rate": round(total_cache_read / total_input * 100, 1) if total_input > 0 else 0,
+            "total_breaks": total_breaks,
+            "break_rate": round(total_breaks / total_calls * 100, 1) if total_calls > 0 else 0,
+            "tokens_lost_to_breaks": total_break_tokens,
+        },
+        "break_components": component_counts,
+        "sessions": session_list,
+        "timeline": timeline,
+    })
+```
+
+**Route registration** (add before static mount, ~line 2267):
+```python
+Route("/dashboard/cache", dashboard_cache),
+```
+
+---
+
+## Task 2: Frontend — index.html Changes
+
+Add nav link after Observability:
+```html
+<a href="#/cache" class="nav-link" data-view="cache">
+    <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor">
+        <path d="M3 12v3c0 1.657 3.134 3 7 3s7-1.343 7-3v-3c0 1.657-3.134 3-7 3s-7-1.343-7-3z"/>
+        <path d="M3 7v3c0 1.657 3.134 3 7 3s7-1.343 7-3V7c0 1.657-3.134 3-7 3S3 8.657 3 7z"/>
+        <path d="M17 5c0 1.657-3.134 3-7 3S3 6.657 3 5s3.134-3 7-3 7 1.343 7 3z"/>
+    </svg>
+    <span>Cache</span>
+</a>
+```
+
+Add view container:
+```html
+<div id="view-cache" class="view"></div>
+```
+
+Add script tag:
+```html
+<script src="js/cache.js"></script>
+```
+
+---
+
+## Task 3: Frontend — cache.js
+
+Vanilla JS following heartbeat.js pattern exactly:
+
+**Layout:**
+- **Row 1:** 4 stat cards — Total Calls, Cache Hit Rate (%), Tokens Saved, Cache Breaks
+- **Row 2:** 2 charts — Cache Hit Rate doughnut (read vs created vs uncached), Break Component distribution (pie/bar)
+- **Row 3:** Cache efficiency timeline — line chart showing hit_rate per call (last 50)
+- **Row 4:** Session table — per-session breakdown with hit rate, breaks, token counts
+- **Row 5:** Recent calls table — last 20 calls with cache details, break indicators
+
+**Auto-refresh:** 30 seconds (same as heartbeat).
+
+**Chart.js charts:**
+1. Token breakdown doughnut: cache_read (green), cache_created (blue), uncached (gray)
+2. Break components bar: horizontal bar chart of component_counts
+3. Efficiency timeline: line chart of hit_rate over recent calls
+
+---
+
+## Task 4: Tests (tests/test_f036_cache_dashboard.py)
+
+Test the REST endpoint aggregation logic:
+1. Empty context logger returns zeroes
+2. Entries with cache_read/cache_created aggregate correctly
+3. Hit rate calculation correct (cache_read / input_tokens * 100)
+4. Cache breaks counted and components distributed
+5. Per-session grouping works
+6. Timeline returns newest first, max 50
+7. Endpoint returns 503 when context_logger is None
+
+Use mock context_logger with fabricated ContextLogEntry objects.
+
+---
+
+## File Change Summary
+
+| File | Type | Lines (est.) |
+|------|------|-------------|
+| `nous/api/rest.py` | Edit | +80 (handler + route) |
+| `static/dashboard/index.html` | Edit | +10 (nav + view + script) |
+| `static/dashboard/js/cache.js` | New | ~350 |
+| `tests/test_f036_cache_dashboard.py` | New | ~150 |
+| **Total** | | **~590 lines** |
+
+No DB changes. No config changes. No schema changes.
+
+---
+
+## Execution Strategy
+
+3 parallel subagents:
+- **Agent A:** REST endpoint in rest.py + route registration
+- **Agent B:** index.html changes + cache.js frontend
+- **Agent C:** Tests
+
+All independent — no sequential dependencies.

--- a/nous/api/rest.py
+++ b/nous/api/rest.py
@@ -1375,6 +1375,94 @@ def create_app(
 
         return JSONResponse(result)
 
+    async def dashboard_cache(request: Request) -> JSONResponse:
+        """GET /dashboard/cache - Prompt cache efficiency metrics (F036.1)."""
+        if context_logger is None:
+            return JSONResponse({"error": "Context logging not enabled"}, status_code=503)
+
+        entries = context_logger.get_recent(limit=200)
+
+        # Filter to entries that have actual token data (API has responded)
+        calls = [e for e in entries if e.input_tokens_actual is not None]
+
+        total_calls = len(calls)
+        total_input = sum(e.input_tokens_actual or 0 for e in calls)
+        total_cache_read = sum(e.cache_read_tokens or 0 for e in calls)
+        total_cache_created = sum(e.cache_creation_tokens or 0 for e in calls)
+        total_breaks = sum(1 for e in calls if e.cache_break)
+        total_break_tokens = sum(e.cache_break_tokens_lost for e in calls if e.cache_break)
+
+        # Per-session aggregation
+        sessions: dict[str, dict] = {}
+        for e in calls:
+            sid = e.session_id
+            if sid not in sessions:
+                sessions[sid] = {"calls": 0, "input": 0, "cache_read": 0, "cache_created": 0, "breaks": 0}
+            s = sessions[sid]
+            s["calls"] += 1
+            s["input"] += e.input_tokens_actual or 0
+            s["cache_read"] += e.cache_read_tokens or 0
+            s["cache_created"] += e.cache_creation_tokens or 0
+            if e.cache_break:
+                s["breaks"] += 1
+
+        # Break component distribution
+        component_counts: dict[str, int] = {}
+        for e in calls:
+            if e.cache_break:
+                for comp in e.cache_break_components:
+                    component_counts[comp] = component_counts.get(comp, 0) + 1
+
+        # Per-call timeline (newest first, last 50)
+        timeline = []
+        for e in calls[:50]:
+            cache_read = e.cache_read_tokens or 0
+            input_tok = e.input_tokens_actual or 0
+            hit_rate = round(cache_read / input_tok * 100, 1) if input_tok > 0 else 0
+            timeline.append({
+                "timestamp": e.timestamp,
+                "session_id": e.session_id,
+                "turn": e.turn_number,
+                "model": e.model,
+                "input_tokens": input_tok,
+                "cache_read": cache_read,
+                "cache_created": e.cache_creation_tokens or 0,
+                "hit_rate": hit_rate,
+                "cache_break": e.cache_break,
+                "break_components": e.cache_break_components if e.cache_break else [],
+            })
+
+        # Session list sorted by calls descending
+        session_list = []
+        for sid, s in sessions.items():
+            hit_rate = round(s["cache_read"] / s["input"] * 100, 1) if s["input"] > 0 else 0
+            session_list.append({
+                "session_id": sid,
+                "calls": s["calls"],
+                "input_tokens": s["input"],
+                "cache_read": s["cache_read"],
+                "cache_created": s["cache_created"],
+                "hit_rate": hit_rate,
+                "breaks": s["breaks"],
+            })
+        session_list.sort(key=lambda x: x["calls"], reverse=True)
+
+        return JSONResponse({
+            "summary": {
+                "total_calls": total_calls,
+                "total_input_tokens": total_input,
+                "total_cache_read": total_cache_read,
+                "total_cache_created": total_cache_created,
+                "overall_hit_rate": round(total_cache_read / total_input * 100, 1) if total_input > 0 else 0,
+                "total_breaks": total_breaks,
+                "break_rate": round(total_breaks / total_calls * 100, 1) if total_calls > 0 else 0,
+                "tokens_lost_to_breaks": total_break_tokens,
+            },
+            "break_components": component_counts,
+            "sessions": session_list,
+            "timeline": timeline,
+        })
+
     # --- F024 Phase 3b: Rubric endpoints ---
 
     async def get_rubric(request: Request) -> JSONResponse:
@@ -2265,6 +2353,8 @@ def create_app(
         Route("/dashboard/heartbeat", dashboard_heartbeat),
         # F035: Observability dashboard
         Route("/dashboard/observability", dashboard_observability),
+        # F036.1: Cache dashboard
+        Route("/dashboard/cache", dashboard_cache),
         # F035.4: Context visibility
         Route("/context/log", context_log_list, methods=["GET"]),
         Route("/context/log/{id}", context_log_detail, methods=["GET"]),

--- a/static/dashboard/index.html
+++ b/static/dashboard/index.html
@@ -64,6 +64,14 @@
                 <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4 2a2 2 0 00-2 2v12a2 2 0 002 2h12a2 2 0 002-2V4a2 2 0 00-2-2H4zm3 3a1 1 0 011-1h4a1 1 0 110 2H8a1 1 0 01-1-1zm0 4a1 1 0 011-1h8a1 1 0 110 2H8a1 1 0 01-1-1zm0 4a1 1 0 011-1h5a1 1 0 110 2H8a1 1 0 01-1-1zM5 6a1 1 0 100-2 1 1 0 000 2zm0 4a1 1 0 100-2 1 1 0 000 2zm0 4a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/></svg>
                 <span>Execution</span>
             </a>
+            <a href="#/cache" class="nav-link" data-view="cache">
+                <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor">
+                    <path d="M3 12v3c0 1.657 3.134 3 7 3s7-1.343 7-3v-3c0 1.657-3.134 3-7 3s-7-1.343-7-3z"/>
+                    <path d="M3 7v3c0 1.657 3.134 3 7 3s7-1.343 7-3V7c0 1.657-3.134 3-7 3S3 8.657 3 7z"/>
+                    <path d="M17 5c0 1.657-3.134 3-7 3S3 6.657 3 5s3.134-3 7-3 7 1.343 7 3z"/>
+                </svg>
+                <span>Cache</span>
+            </a>
         </div>
         <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Toggle sidebar">
             <svg viewBox="0 0 20 20" fill="currentColor" width="16" height="16"><path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
@@ -82,6 +90,7 @@
         <div id="view-admission" class="view"></div>
         <div id="view-rubric" class="view"></div>
         <div id="view-execution" class="view"></div>
+        <div id="view-cache" class="view"></div>
     </main>
 
     <script src="lib/chart.min.js"></script>
@@ -98,5 +107,6 @@
     <script src="js/heartbeat.js"></script>
     <script src="js/ledger.js"></script>
     <script src="js/observability.js"></script>
+    <script src="js/cache.js"></script>
 </body>
 </html>

--- a/static/dashboard/js/cache.js
+++ b/static/dashboard/js/cache.js
@@ -1,0 +1,355 @@
+/**
+ * Nous Dashboard — Cache View (F036.1)
+ *
+ * API cache hit rates, token savings, break analysis,
+ * efficiency timeline, and per-session/call tables.
+ * Auto-refreshes every 30 seconds.
+ * Fetches from GET /dashboard/cache
+ */
+
+/* global Dashboard, Chart, escapeHtml */
+
+var _cacheRefreshInterval = null;
+var _cacheRefreshInFlight = false;
+var _cacheAbortController = null;
+
+Dashboard.registerView('cache', async function (container) {
+    Dashboard.showLoading(container);
+
+    try {
+        var data = await cacheFetch();
+        renderCache(container, data);
+        startCacheAutoRefresh(container);
+    } catch (err) {
+        Dashboard.showError(container, 'Failed to load cache data.', function () {
+            Dashboard.reloadView('cache');
+        });
+    }
+});
+
+function cacheFetch() {
+    if (_cacheAbortController) {
+        _cacheAbortController.abort();
+    }
+    _cacheAbortController = new AbortController();
+    return fetch('/dashboard/cache', { signal: _cacheAbortController.signal })
+        .then(function (res) {
+            if (!res.ok) throw new Error(res.status + ' ' + res.statusText);
+            return res.json();
+        })
+        .finally(function () {
+            _cacheAbortController = null;
+        });
+}
+
+function startCacheAutoRefresh(container) {
+    stopCacheAutoRefresh();
+    _cacheRefreshInterval = setInterval(async function () {
+        if (Dashboard.currentView !== 'cache') {
+            stopCacheAutoRefresh();
+            return;
+        }
+        if (_cacheRefreshInFlight) return;
+        _cacheRefreshInFlight = true;
+        try {
+            var data = await cacheFetch();
+            renderCache(container, data);
+        } catch (err) {
+            // Silently skip (including aborted requests)
+        } finally {
+            _cacheRefreshInFlight = false;
+        }
+    }, 30000);
+}
+
+function stopCacheAutoRefresh() {
+    if (_cacheRefreshInterval) {
+        clearInterval(_cacheRefreshInterval);
+        _cacheRefreshInterval = null;
+    }
+    if (_cacheAbortController) {
+        _cacheAbortController.abort();
+        _cacheAbortController = null;
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function formatTokens(n) {
+    if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
+    if (n >= 1000) return (n / 1000).toFixed(1) + 'K';
+    return String(n);
+}
+
+function hitRateColor(rate) {
+    if (rate >= 50) return '#22c55e';
+    if (rate >= 20) return '#eab308';
+    return '#ef4444';
+}
+
+function formatTime(ts) {
+    var d = new Date(ts);
+    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function formatTimeSeconds(ts) {
+    var d = new Date(ts);
+    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+// ── Main render ─────────────────────────────────────────────────────
+
+function renderCache(container, data) {
+    // Destroy existing charts before re-render
+    if (Dashboard.charts['cache']) {
+        Dashboard.charts['cache'].forEach(function (c) {
+            try { c.destroy(); } catch (e) { /* ignore */ }
+        });
+        Dashboard.charts['cache'] = [];
+    }
+
+    var summary = data.summary || {};
+    var sessions = data.sessions || [];
+    var timeline = data.timeline || [];
+    // F036.1: API returns break_components as {name: count} dict — convert to array
+    var rawBreakComponents = data.break_components || {};
+    var breakComponents = Object.keys(rawBreakComponents).map(function (k) {
+        return { name: k, count: rawBreakComponents[k] };
+    });
+
+    var html = '<div class="view-header">' +
+        '<h1>Cache</h1>' +
+        '<p class="view-subtitle">API cache performance, token savings, and break analysis</p>' +
+        '</div>';
+
+    // ── Row 1: Stat Cards ──
+    var hitRateVal = summary.overall_hit_rate != null ? summary.overall_hit_rate : 0;
+    var breakRateVal = summary.break_rate != null ? summary.break_rate : 0;
+
+    html += '<div class="stat-grid">';
+    html += buildCacheStatCard('Total API Calls', Dashboard.formatNumber(summary.total_calls || 0), '', 'var(--accent)');
+    html += buildCacheStatCard('Cache Hit Rate', hitRateVal + '%', '', hitRateColor(hitRateVal));
+    html += buildCacheStatCard('Tokens Saved', formatTokens(summary.total_cache_read || 0), 'cache_read tokens', '#22c55e');
+    html += buildCacheStatCard('Cache Breaks', Dashboard.formatNumber(summary.total_breaks || 0), breakRateVal + '% break rate', '#ef4444');
+    html += '</div>';
+
+    // ── Row 2: Two charts side by side ──
+    html += '<div class="chart-grid">';
+    html += '<div class="chart-card"><h3>Token Breakdown</h3><div class="chart-container"><canvas id="chart-cache-tokens"></canvas></div></div>';
+    html += '<div class="chart-card"><h3>Break Components</h3><div class="chart-container"><canvas id="chart-cache-breaks"></canvas></div></div>';
+    html += '</div>';
+
+    // ── Row 3: Efficiency Timeline ──
+    html += '<div class="chart-card mb-24"><h3>Efficiency Timeline</h3><div class="chart-container"><canvas id="chart-cache-timeline"></canvas></div></div>';
+
+    // ── Row 4: Session Table ──
+    html += '<div class="chart-card mb-24"><h3>Sessions</h3>';
+    if (sessions.length > 0) {
+        html += '<table style="width:100%;font-size:13px;border-collapse:collapse">';
+        html += '<thead><tr style="text-align:left;font-size:11px;text-transform:uppercase;letter-spacing:0.5px;color:var(--muted)">';
+        html += '<th style="padding:8px 12px">Session</th>';
+        html += '<th style="padding:8px 12px">Calls</th>';
+        html += '<th style="padding:8px 12px">Input Tokens</th>';
+        html += '<th style="padding:8px 12px">Cache Read</th>';
+        html += '<th style="padding:8px 12px">Hit Rate</th>';
+        html += '<th style="padding:8px 12px">Breaks</th>';
+        html += '</tr></thead><tbody>';
+        sessions.forEach(function (s) {
+            var sHitRate = s.hit_rate != null ? s.hit_rate : 0;
+            html += '<tr style="border-top:1px solid var(--border)">';
+            html += '<td style="padding:8px 12px"><code style="font-size:11px">' + escapeHtml(String(s.session_id || '').slice(0, 8)) + '</code></td>';
+            html += '<td style="padding:8px 12px">' + Dashboard.formatNumber(s.calls || 0) + '</td>';
+            html += '<td style="padding:8px 12px">' + formatTokens(s.input_tokens || 0) + '</td>';
+            html += '<td style="padding:8px 12px">' + formatTokens(s.cache_read || 0) + '</td>';
+            html += '<td style="padding:8px 12px;color:' + hitRateColor(sHitRate) + '">' + sHitRate + '%</td>';
+            html += '<td style="padding:8px 12px">' + Dashboard.formatNumber(s.breaks || 0) + '</td>';
+            html += '</tr>';
+        });
+        html += '</tbody></table>';
+    } else {
+        html += '<div class="empty-state" style="padding:24px"><p>No session data available</p></div>';
+    }
+    html += '</div>';
+
+    // ── Row 5: Recent Calls Table ──
+    var recentCalls = timeline.slice(0, 20);
+    html += '<div class="chart-card mb-24"><h3>Recent Calls</h3>';
+    if (recentCalls.length > 0) {
+        html += '<table style="width:100%;font-size:13px;border-collapse:collapse">';
+        html += '<thead><tr style="text-align:left;font-size:11px;text-transform:uppercase;letter-spacing:0.5px;color:var(--muted)">';
+        html += '<th style="padding:8px 12px">Time</th>';
+        html += '<th style="padding:8px 12px">Session</th>';
+        html += '<th style="padding:8px 12px">Turn</th>';
+        html += '<th style="padding:8px 12px">Model</th>';
+        html += '<th style="padding:8px 12px">Input</th>';
+        html += '<th style="padding:8px 12px">Cache Read</th>';
+        html += '<th style="padding:8px 12px">Hit Rate</th>';
+        html += '<th style="padding:8px 12px">Break</th>';
+        html += '</tr></thead><tbody>';
+        recentCalls.forEach(function (c) {
+            var cHitRate = c.hit_rate != null ? c.hit_rate : 0;
+            html += '<tr style="border-top:1px solid var(--border)">';
+            html += '<td style="padding:8px 12px;white-space:nowrap">' + formatTimeSeconds(c.timestamp) + '</td>';
+            html += '<td style="padding:8px 12px"><code style="font-size:11px">' + escapeHtml(String(c.session_id || '').slice(0, 8)) + '</code></td>';
+            html += '<td style="padding:8px 12px">' + (c.turn != null ? c.turn : '-') + '</td>';
+            html += '<td style="padding:8px 12px;font-size:11px">' + escapeHtml(c.model || '') + '</td>';
+            html += '<td style="padding:8px 12px">' + formatTokens(c.input_tokens || 0) + '</td>';
+            html += '<td style="padding:8px 12px">' + formatTokens(c.cache_read || 0) + '</td>';
+            html += '<td style="padding:8px 12px;color:' + hitRateColor(cHitRate) + '">' + cHitRate + '%</td>';
+            html += '<td style="padding:8px 12px">' + (c.cache_break ? '<span style="color:#ef4444">&#x25CF;</span>' : '') + '</td>';
+            html += '</tr>';
+        });
+        html += '</tbody></table>';
+    } else {
+        html += '<div class="empty-state" style="padding:24px"><p>No recent API calls</p></div>';
+    }
+    html += '</div>';
+
+    container.innerHTML = html;
+
+    // ── Create Charts ──
+    createCacheTokenChart(summary);
+    createCacheBreakChart(breakComponents);
+    createCacheTimelineChart(timeline);
+}
+
+// ── Stat card helper ────────────────────────────────────────────────
+
+function buildCacheStatCard(label, value, period, color) {
+    return '<div class="stat-card">' +
+        '<div class="stat-value" style="color:' + color + '">' + escapeHtml(String(value)) + '</div>' +
+        '<div class="stat-label">' + escapeHtml(label) + '</div>' +
+        (period ? '<div style="font-size:11px;color:var(--muted);margin-top:2px">' + escapeHtml(period) + '</div>' : '') +
+        '</div>';
+}
+
+// ── Token Breakdown Doughnut ────────────────────────────────────────
+
+function createCacheTokenChart(summary) {
+    var canvas = document.getElementById('chart-cache-tokens');
+    if (!canvas) return;
+
+    var cacheRead = summary.total_cache_read || 0;
+    var cacheCreated = summary.total_cache_created || 0;
+    var totalInput = summary.total_input_tokens || 0;
+    var uncached = Math.max(0, totalInput - cacheRead - cacheCreated);
+
+    var chart = new Chart(canvas, {
+        type: 'doughnut',
+        data: {
+            labels: ['Cache Read', 'Cache Created', 'Uncached'],
+            datasets: [{
+                data: [cacheRead, cacheCreated, uncached],
+                backgroundColor: ['#22c55e', '#3b82f6', '#4b5563'],
+                borderWidth: 0
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            cutout: '60%',
+            plugins: {
+                legend: { position: 'bottom' }
+            }
+        }
+    });
+    Dashboard.charts.cache = Dashboard.charts.cache || [];
+    Dashboard.charts.cache.push(chart);
+}
+
+// ── Break Components Horizontal Bar ─────────────────────────────────
+
+function createCacheBreakChart(breakComponents) {
+    var canvas = document.getElementById('chart-cache-breaks');
+    if (!canvas || !breakComponents || breakComponents.length === 0) return;
+
+    var palette = ['#f87171', '#fbbf24', '#60a5fa', '#34d399', '#a78bfa', '#fb923c', '#22d3ee', '#e879f9'];
+
+    var labels = breakComponents.map(function (c) { return c.component || c.name || 'unknown'; });
+    var values = breakComponents.map(function (c) { return c.count || 0; });
+    var colors = breakComponents.map(function (_, i) { return palette[i % palette.length]; });
+
+    var chart = new Chart(canvas, {
+        type: 'bar',
+        data: {
+            labels: labels,
+            datasets: [{
+                label: 'Breaks',
+                data: values,
+                backgroundColor: colors,
+                borderWidth: 0
+            }]
+        },
+        options: {
+            indexAxis: 'y',
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+                x: {
+                    beginAtZero: true,
+                    ticks: { precision: 0 },
+                    grid: { display: false }
+                },
+                y: {
+                    grid: { display: false }
+                }
+            },
+            plugins: {
+                legend: { display: false }
+            }
+        }
+    });
+    Dashboard.charts.cache = Dashboard.charts.cache || [];
+    Dashboard.charts.cache.push(chart);
+}
+
+// ── Efficiency Timeline Line Chart ──────────────────────────────────
+
+function createCacheTimelineChart(timeline) {
+    var canvas = document.getElementById('chart-cache-timeline');
+    if (!canvas || !timeline || timeline.length === 0) return;
+
+    // Reverse so oldest is on the left
+    var sorted = timeline.slice().reverse();
+
+    var labels = sorted.map(function (t) { return formatTime(t.timestamp); });
+    var hitRates = sorted.map(function (t) { return t.hit_rate != null ? t.hit_rate : 0; });
+
+    var chart = new Chart(canvas, {
+        type: 'line',
+        data: {
+            labels: labels,
+            datasets: [{
+                label: 'Hit Rate %',
+                data: hitRates,
+                borderColor: '#22c55e',
+                backgroundColor: 'rgba(34, 197, 94, 0.1)',
+                fill: true,
+                borderWidth: 2,
+                pointRadius: 2,
+                pointHoverRadius: 5
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+                x: {
+                    grid: { display: false }
+                },
+                y: {
+                    beginAtZero: true,
+                    max: 100,
+                    ticks: {
+                        callback: function (val) { return val + '%'; }
+                    }
+                }
+            },
+            plugins: {
+                legend: { display: false }
+            }
+        }
+    });
+    Dashboard.charts.cache = Dashboard.charts.cache || [];
+    Dashboard.charts.cache.push(chart);
+}

--- a/tests/test_f036_cache_dashboard.py
+++ b/tests/test_f036_cache_dashboard.py
@@ -1,0 +1,225 @@
+"""Tests for F036.1 Cache Dashboard endpoint (GET /dashboard/cache)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from starlette.testclient import TestClient
+
+from nous.api.rest import create_app
+from nous.config import Settings
+from nous.observability.context_logger import ContextLogEntry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_entry(
+    *,
+    session_id: str = "sess-1",
+    turn_number: int = 1,
+    input_tokens: int = 10000,
+    cache_read: int = 5000,
+    cache_created: int = 2000,
+    cache_break: bool = False,
+    break_components: list[str] | None = None,
+    break_tokens_lost: int = 0,
+    model: str = "claude-sonnet-4-5",
+    timestamp: str = "2026-04-05T12:00:00Z",
+) -> ContextLogEntry:
+    entry = ContextLogEntry(
+        id="test-" + str(turn_number),
+        session_id=session_id,
+        turn_number=turn_number,
+        timestamp=timestamp,
+        call_type="chat",
+        model=model,
+        frame_id="conversation",
+    )
+    entry.input_tokens_actual = input_tokens
+    entry.cache_read_tokens = cache_read
+    entry.cache_creation_tokens = cache_created
+    entry.cache_break = cache_break
+    entry.cache_break_components = break_components or []
+    entry.cache_break_tokens_lost = break_tokens_lost
+    return entry
+
+
+def _make_logger(entries: list[ContextLogEntry]) -> MagicMock:
+    mock = MagicMock()
+    mock.get_recent.return_value = entries
+    return mock
+
+
+def _make_client(entries: list[ContextLogEntry] | None = None, context_logger: MagicMock | None = ...) -> TestClient:
+    """Create a test client with a mocked context_logger.
+
+    If context_logger is ... (sentinel), build one from entries.
+    If context_logger is explicitly None, pass None.
+    """
+    if context_logger is ...:
+        mock_logger = _make_logger(entries or [])
+    else:
+        mock_logger = context_logger
+
+    settings = Settings()
+    app = create_app(
+        runner=MagicMock(),
+        brain=MagicMock(),
+        heart=MagicMock(),
+        cognitive=MagicMock(),
+        database=MagicMock(),
+        settings=settings,
+        context_logger=mock_logger,
+    )
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_empty_logger_returns_zeroes() -> None:
+    """No entries -> all summary fields are 0, empty sessions/timeline."""
+    client = _make_client(entries=[])
+    resp = client.get("/dashboard/cache")
+    assert resp.status_code == 200
+    data = resp.json()
+    summary = data["summary"]
+    assert summary["total_calls"] == 0
+    assert summary["total_input_tokens"] == 0
+    assert summary["total_cache_read"] == 0
+    assert summary["total_cache_created"] == 0
+    assert summary["overall_hit_rate"] == 0
+    assert summary["total_breaks"] == 0
+    assert summary["break_rate"] == 0
+    assert summary["tokens_lost_to_breaks"] == 0
+    assert data["sessions"] == []
+    assert data["timeline"] == []
+
+
+def test_entries_without_token_data_filtered() -> None:
+    """Entries where input_tokens_actual is None are excluded from aggregation."""
+    good = _make_entry(turn_number=1, input_tokens=8000, cache_read=4000)
+    no_tokens = ContextLogEntry(
+        id="test-none",
+        session_id="sess-1",
+        turn_number=2,
+        timestamp="2026-04-05T12:01:00Z",
+        call_type="chat",
+        model="claude-sonnet-4-5",
+        frame_id="conversation",
+    )
+    # input_tokens_actual defaults to None — should be filtered out
+    client = _make_client(entries=[good, no_tokens])
+    resp = client.get("/dashboard/cache")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["summary"]["total_calls"] == 1
+    assert data["summary"]["total_input_tokens"] == 8000
+
+
+def test_hit_rate_calculation() -> None:
+    """10000 input, 6000 cache_read -> 60.0% hit rate."""
+    entry = _make_entry(input_tokens=10000, cache_read=6000, cache_created=1000)
+    client = _make_client(entries=[entry])
+    resp = client.get("/dashboard/cache")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["summary"]["overall_hit_rate"] == 60.0
+    # Timeline entry should also reflect per-call hit rate
+    assert len(data["timeline"]) == 1
+    assert data["timeline"][0]["hit_rate"] == 60.0
+
+
+def test_cache_breaks_counted() -> None:
+    """3 entries, 1 with cache_break=True -> total_breaks=1."""
+    entries = [
+        _make_entry(turn_number=1, cache_break=False),
+        _make_entry(turn_number=2, cache_break=True, break_tokens_lost=500),
+        _make_entry(turn_number=3, cache_break=False),
+    ]
+    client = _make_client(entries=entries)
+    resp = client.get("/dashboard/cache")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["summary"]["total_breaks"] == 1
+    assert data["summary"]["tokens_lost_to_breaks"] == 500
+    # break_rate = 1/3 * 100 = 33.3%
+    assert data["summary"]["break_rate"] == 33.3
+
+
+def test_break_components_distributed() -> None:
+    """Entries with different break_components -> correct counts."""
+    entries = [
+        _make_entry(
+            turn_number=1,
+            cache_break=True,
+            break_components=["identity", "frame"],
+        ),
+        _make_entry(
+            turn_number=2,
+            cache_break=True,
+            break_components=["frame", "tools"],
+        ),
+        _make_entry(turn_number=3, cache_break=False),
+    ]
+    client = _make_client(entries=entries)
+    resp = client.get("/dashboard/cache")
+    assert resp.status_code == 200
+    data = resp.json()
+    components = data["break_components"]
+    assert components["identity"] == 1
+    assert components["frame"] == 2
+    assert components["tools"] == 1
+
+
+def test_per_session_grouping() -> None:
+    """Entries from 2 sessions -> 2 session entries with correct aggregates."""
+    entries = [
+        _make_entry(session_id="sess-a", turn_number=1, input_tokens=5000, cache_read=3000, cache_created=1000),
+        _make_entry(session_id="sess-a", turn_number=2, input_tokens=5000, cache_read=4000, cache_created=500),
+        _make_entry(session_id="sess-b", turn_number=1, input_tokens=8000, cache_read=2000, cache_created=3000),
+    ]
+    client = _make_client(entries=entries)
+    resp = client.get("/dashboard/cache")
+    assert resp.status_code == 200
+    data = resp.json()
+    sessions = {s["session_id"]: s for s in data["sessions"]}
+    assert len(sessions) == 2
+
+    a = sessions["sess-a"]
+    assert a["calls"] == 2
+    assert a["input_tokens"] == 10000
+    assert a["cache_read"] == 7000
+    assert a["cache_created"] == 1500
+    assert a["hit_rate"] == 70.0
+
+    b = sessions["sess-b"]
+    assert b["calls"] == 1
+    assert b["input_tokens"] == 8000
+    assert b["cache_read"] == 2000
+    assert b["hit_rate"] == 25.0
+
+
+def test_timeline_newest_first_max_50() -> None:
+    """60 entries -> timeline has 50 (capped)."""
+    entries = [
+        _make_entry(turn_number=i, timestamp=f"2026-04-05T{12 + i // 60:02d}:{i % 60:02d}:00Z")
+        for i in range(60)
+    ]
+    client = _make_client(entries=entries)
+    resp = client.get("/dashboard/cache")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["timeline"]) == 50
+
+
+def test_context_logger_none_returns_503() -> None:
+    """Pass context_logger=None -> 503 response."""
+    client = _make_client(context_logger=None)
+    resp = client.get("/dashboard/cache")
+    assert resp.status_code == 503
+    assert "not enabled" in resp.json()["error"].lower()


### PR DESCRIPTION
## Summary

- **REST endpoint** `GET /dashboard/cache` — aggregates cache metrics from in-memory ContextLogger (200-entry deque). Returns summary stats, per-session breakdown, break component distribution, and per-call timeline.
- **Dashboard tab** — new "Cache" panel in the SPA with stat cards, 3 Chart.js visualizations (token doughnut, break components bar, efficiency timeline), and 2 data tables (sessions + recent calls).
- **Auto-refresh** every 30 seconds, following heartbeat.js pattern.

No database changes. Pure in-memory aggregation from F036's CacheBreakDetector + Anthropic API cache token usage data.

**Files:** 5 changed (1 new JS module, 1 new test file, 1 plan doc, 2 modified)
**Tests:** 8 new, 0 regressions

## Test plan

- [x] 8 endpoint tests pass (empty logger, token filtering, hit rate math, breaks, sessions, timeline cap, 503 on None)
- [x] All 92 F036 tests pass (cache_optimizer + schema_tier + tool_cache + runner + dashboard)
- [ ] Manual: navigate to dashboard → Cache tab → verify stat cards, charts, and tables render
- [ ] Manual: verify 30s auto-refresh updates data

🤖 Generated with [Claude Code](https://claude.com/claude-code)