### PR TITLE
fix: increase subtask_max_timeout to 900s and add env var overrides

### DIFF
--- a/nous/config.py
+++ b/nous/config.py
@@ -228,8 +228,14 @@ class Settings(BaseSettings):
     subtask_enabled: bool = True
     subtask_workers: int = 2
     subtask_poll_interval: float = 2.0
-    subtask_default_timeout: int = 120
-    subtask_max_timeout: int = 600
+    subtask_default_timeout: int = Field(
+        default=120,
+        validation_alias="NOUS_SUBTASK_DEFAULT_TIMEOUT",
+    )
+    subtask_max_timeout: int = Field(
+        default=900,
+        validation_alias="NOUS_SUBTASK_MAX_TIMEOUT",
+    )
     subtask_max_concurrent: int = 3
     schedule_enabled: bool = True
     schedule_check_interval: int = 60


### PR DESCRIPTION
## Problem
Daily AI briefing subtask consistently timing out at 600s (the hard max). Research tasks require ~20 tool calls, each needing an LLM API roundtrip (10-30s on sonnet) = 300-600s of API time alone, leaving no margin.

## Changes
- **subtask_max_timeout**: 600 → 900 (now configurable via `NOUS_SUBTASK_MAX_TIMEOUT`)
- **subtask_default_timeout**: now configurable via `NOUS_SUBTASK_DEFAULT_TIMEOUT`

## Why 900s?
- 20 tool calls × 30s avg API time = 600s baseline
- Need ~50% headroom for web_fetch latency and email delivery
- 900s = 15 minutes, reasonable for complex research+delivery tasks
- Configurable via env var for further tuning without code changes