### PR TITLE
fix: make ActionGate duplicate detection smarter (#285)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,6 +319,7 @@ DB connection vars are **unprefixed** (shared with docker-compose). All others u
 | `NOUS_ACTION_GATING_MODE` | `enforce` | Action gating mode (shadow/warn/enforce) |
 | `NOUS_ACTION_GATING_MODEL` | `claude-haiku-4-5-20251001` | Model for Tier 3 LLM gate |
 | `NOUS_ACTION_GATING_EXTERNAL_ONLY` | `false` | Skip Tier 2, only gate external/irreversible |
+| `NOUS_ACTION_GATING_TURN_WINDOW` | `5` | Only block duplicates within this many turns |
 | `NOUS_PROCEDURE_SCORE_FLOOR` | `0.40` | Minimum score for procedures when embeddings enabled (F038) |
 | `NOUS_MMR_ENABLED` | `false` | Enable MMR diversity re-ranking in recall_deep |
 | `NOUS_MMR_DIVERSITY_WEIGHT` | `0.7` | MMR relevance vs diversity weight (1.0=pure relevance, 0.0=pure diversity) |

--- a/docs/superpowers/plans/2026-04-10-issue-285-smarter-action-gate.md
+++ b/docs/superpowers/plans/2026-04-10-issue-285-smarter-action-gate.md
@@ -1,0 +1,151 @@
+# Issue #285: Make ActionGate Duplicate Detection Smarter
+
+## Problem
+
+ActionGate Tier 2 (consistency check) uses overly simplistic duplicate detection that produces false positives, blocking legitimate tool calls. Two root causes:
+
+1. **`_args_similar()` returns True if ANY shared key matches** — `action=disable` on two different checks triggers a false positive
+2. **`_summarize_args()` only captures the FIRST matching key** — loses distinguishing information (e.g., `name` field)
+
+## Evidence
+
+```
+T9 heartbeat_check_manage action=disable name=ci-schema-sync-monitor (success)
+T9 heartbeat_check_manage action=disable name=pr-fixes-monitor [BLOCKED: Duplicate]
+```
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `nous/cognitive/execution_ledger.py` | Fix `_summarize_args` to capture ALL key args; add `heartbeat_check_manage` and `heartbeat_check_create` to registries; add `send_file` to registries |
+| `nous/cognitive/action_gate.py` | Fix `_args_similar` to require ALL shared keys to match; add turn-distance window to `_consistency_check` |
+| `nous/config.py` | Add `action_gating_turn_window` config (default 5) |
+| `tests/test_action_gate.py` | Update tests for ALL-key-match semantics; add multi-target and turn-window tests |
+| `tests/test_execution_integrity.py` | Update any tests affected by `_summarize_args` changes |
+
+## Implementation
+
+### Phase 1: Fix `_summarize_args` in `execution_ledger.py`
+
+**Current behavior** (line ~288-301):
+```python
+if key_names:
+    for name in key_names:
+        if name in args:
+            result[name] = str(args[name])[:80]
+            break  # Only first matching key  <-- BUG
+else:
+    for k, v in args.items():
+        result[k] = str(v)[:80]
+        break  # Only first arg  <-- BUG
+```
+
+**New behavior**: Capture ALL matching key args, not just the first. For fallback, capture all args (up to 5 to prevent bloat).
+
+```python
+if key_names:
+    for name in key_names:
+        if name in args:
+            result[name] = str(args[name])[:80]
+    # No break — capture all matching key args
+else:
+    for k, v in list(args.items())[:5]:
+        result[k] = str(v)[:80]
+    # Capture up to 5 args for unknown tools
+```
+
+**Add to `_KEY_ARGS`**:
+```python
+"heartbeat_check_manage": ["action", "name"],
+"heartbeat_check_create": ["name", "prompt"],
+"send_file": ["path", "file_path"],
+```
+
+**Add to `WRITE_TOOLS`**:
+```python
+"heartbeat_check_manage",
+"heartbeat_check_create",
+"send_file",
+```
+
+### Phase 2: Fix `_args_similar` in `action_gate.py`
+
+**Current behavior** (line ~199-228): Returns True if ANY shared key has matching value.
+
+**New behavior**: Returns True only if ALL shared keys match. If no shared keys, returns False (unchanged).
+
+```python
+def _args_similar(self, prior_args, new_args) -> bool:
+    shared_keys = set(prior_args) & set(new_args)
+    if not shared_keys:
+        return False
+
+    for key in shared_keys:
+        prior_val = prior_args[key].strip().lower()
+        new_val = new_args[key].strip().lower()
+
+        if key in PATH_KEYS:
+            prior_val = prior_val.rstrip("/").removeprefix("./")
+            new_val = new_val.rstrip("/").removeprefix("./")
+
+        if prior_val != new_val:
+            return False  # ANY difference means not similar
+
+    return True  # ALL shared keys match
+```
+
+### Phase 3: Add turn-distance window to `_consistency_check`
+
+**Current behavior**: Checks last 20 actions of same tool name.
+
+**New behavior**: Also filter by turn distance — only consider actions within `action_gating_turn_window` turns.
+
+```python
+def _consistency_check(self, tool_name, tool_input, ledger) -> GateResult:
+    new_key_args = ledger._summarize_args(tool_name, tool_input)
+    turn_window = self._settings.action_gating_turn_window
+    min_turn = ledger.current_turn - turn_window
+
+    recent = [
+        a for a in ledger.actions[-20:]
+        if a.tool_name == tool_name
+        and a.status == "success"
+        and a.turn >= min_turn
+    ]
+    # ... rest unchanged
+```
+
+### Phase 4: Add config in `config.py`
+
+```python
+action_gating_turn_window: int = 5  # Only block duplicates within this many turns
+```
+
+### Phase 5: Update tests
+
+**Tests to update in `test_action_gate.py`**:
+- `test_any_key_match_triggers_similar` → rename and invert: now ALL keys must match, so mixed match returns False
+- `test_one_side_missing_key` → still True (only shared key `path` matches)
+- Add: `test_all_shared_keys_must_match` — same tool, same action, different name → not similar
+- Add: `test_multi_target_disable_not_blocked` — heartbeat_check_manage with different names passes
+- Add: `test_same_bash_different_target_not_blocked` — bash with different commands passes
+- Add: `test_exact_duplicate_still_blocked` — exact same args still caught
+- Add: `test_turn_window_allows_old_duplicates` — action beyond turn window passes
+- Add: `test_turn_window_blocks_recent_duplicates` — action within turn window blocked
+
+**Tests to check in `test_execution_integrity.py`**:
+- Any test relying on single-key `_summarize_args` output
+
+## Acceptance Criteria (from issue)
+
+- [x] Disabling two different heartbeat checks in the same turn should not be blocked
+- [x] Running similar bash commands with different targets should not be blocked
+- [x] Genuine duplicates (exact same tool + exact same args) should still be caught
+- [x] Add tests for multi-target scenarios
+
+## Risk Assessment
+
+- **LOW risk**: The change is strictly more permissive (fewer false positives). The only risk is missing genuine duplicates, but requiring ALL shared keys to match is still a strong signal.
+- Turn-distance window prevents stale matches from blocking current work.
+- All existing tests will be reviewed and updated to match new semantics.

--- a/nous/cognitive/action_gate.py
+++ b/nous/cognitive/action_gate.py
@@ -134,10 +134,15 @@ class ActionGate:
         # Summarize new args the same way the ledger summarizes recorded args
         new_key_args = ledger._summarize_args(tool_name, tool_input)  # noqa: SLF001
 
+        turn_window = self._settings.action_gating_turn_window
+        min_turn = ledger.current_turn - turn_window
+
         recent = [
             a
             for a in ledger.actions[-20:]
-            if a.tool_name == tool_name and a.status == "success"
+            if a.tool_name == tool_name
+            and a.status == "success"
+            and a.turn > min_turn
         ]
 
         for prior in recent:
@@ -201,20 +206,22 @@ class ActionGate:
         prior_args: dict[str, str],
         new_args: dict[str, str],
     ) -> bool:
-        """Return True if ANY shared key has matching values.
+        """Return True if ALL shared keys have matching values.
 
         Comparison is case-insensitive with whitespace stripped.  Keys that
-        represent file paths (``path``, ``file``, ``command``) receive
-        additional normalisation: trailing slashes are removed and leading
-        ``./`` is stripped so ``./foo.py`` and ``foo.py`` are treated as
-        identical.
+        represent file paths (``path``, ``file``) receive additional
+        normalisation: trailing slashes are removed and leading ``./`` is
+        stripped so ``./foo.py`` and ``foo.py`` are treated as identical.
+
+        Returns False when there are no shared keys.
         """
-        PATH_KEYS = {"path", "file"}
+        PATH_KEYS = {"path", "file", "file_path"}
 
-        for key in prior_args:
-            if key not in new_args:
-                continue
+        shared_keys = set(prior_args) & set(new_args)
+        if not shared_keys:
+            return False
 
+        for key in shared_keys:
             prior_val = prior_args[key].strip().lower()
             new_val = new_args[key].strip().lower()
 
@@ -222,10 +229,10 @@ class ActionGate:
                 prior_val = prior_val.rstrip("/").removeprefix("./")
                 new_val = new_val.rstrip("/").removeprefix("./")
 
-            if prior_val == new_val:
-                return True
+            if prior_val != new_val:
+                return False
 
-        return False
+        return True
 
     def _build_gate_prompt(
         self,

--- a/nous/cognitive/execution_ledger.py
+++ b/nous/cognitive/execution_ledger.py
@@ -45,10 +45,14 @@ WRITE_TOOLS: set[str] = {
     "schedule_task",
     "cancel_task",
     "run_python",  # Can call learn_fact() and modify state
+    "heartbeat_check_manage",
+    "heartbeat_check_create",
 }
 
 # External side effects — extend when email/notification tools are registered
-EXTERNAL_TOOLS: set[str] = set()
+EXTERNAL_TOOLS: set[str] = {
+    "send_file",  # Sends files to Telegram
+}
 
 # Irreversible — extend when irreversible tools are registered
 IRREVERSIBLE_TOOLS: set[str] = set()
@@ -82,6 +86,9 @@ _KEY_ARGS: dict[str, list[str]] = {
     "web_fetch": ["url"],
     "run_python": [],  # Too large to summarize — spec says skip
     "get_procedure": ["name", "procedure_name"],
+    "heartbeat_check_manage": ["action", "name"],
+    "heartbeat_check_create": ["name", "prompt"],
+    "send_file": ["file_path"],
 }
 
 
@@ -292,12 +299,10 @@ class ExecutionLedger:
             for name in key_names:
                 if name in args:
                     result[name] = str(args[name])[:80]
-                    break  # Only first matching key
         else:
-            # Fallback: first arg, truncated
-            for k, v in args.items():
+            # Fallback: capture up to 5 args for unknown tools
+            for k, v in list(args.items())[:5]:
                 result[k] = str(v)[:80]
-                break
 
         return result
 

--- a/nous/config.py
+++ b/nous/config.py
@@ -314,6 +314,7 @@ class Settings(BaseSettings):
     action_gating_mode: Literal["shadow", "warn", "enforce"] = "enforce"
     action_gating_model: str = "claude-haiku-4-5-20251001"
     action_gating_external_only: bool = False  # True = skip Tier 2, only gate external/irreversible
+    action_gating_turn_window: int = 5  # Only block duplicates within this many turns
 
     # F030: MMR Diversity Re-Ranking
     mmr_enabled: bool = False

--- a/tests/test_action_gate.py
+++ b/tests/test_action_gate.py
@@ -35,6 +35,7 @@ def _make_settings(**kwargs) -> types.SimpleNamespace:
         "action_gating_model": "claude-haiku-4-5-20251001",
         "action_gating_enabled": True,
         "action_gating_external_only": False,
+        "action_gating_turn_window": 5,
     }
     defaults.update(kwargs)
     return types.SimpleNamespace(**defaults)
@@ -212,12 +213,20 @@ class TestArgsSimilar:
         gate = self._gate()
         assert gate._args_similar({"command": "./foo"}, {"command": "foo"}) is False
 
-    def test_any_key_match_triggers_similar(self):
-        # If path matches, result is True even if query differs
+    def test_all_shared_keys_must_match(self):
+        # ALL shared keys must match — path matches but query differs → False
         gate = self._gate()
         assert gate._args_similar(
             {"path": "out.txt", "query": "a"},
             {"path": "out.txt", "query": "b"},
+        ) is False
+
+    def test_all_shared_keys_matching_returns_true(self):
+        # ALL shared keys match → True
+        gate = self._gate()
+        assert gate._args_similar(
+            {"path": "out.txt", "query": "a"},
+            {"path": "out.txt", "query": "a"},
         ) is True
 
     def test_empty_dicts(self):
@@ -675,3 +684,140 @@ class TestConsistencyCheckDuplicateReport:
             "write_file", {"path": "output/report.txt"}, ledger
         )
         assert result.approved is False
+
+
+# ===========================================================================
+# Issue #285: Multi-target scenarios (acceptance criteria)
+# ===========================================================================
+
+
+class TestMultiTargetNotBlocked:
+    """Disabling two different heartbeat checks in the same turn should not be blocked."""
+
+    @pytest.mark.asyncio
+    async def test_different_heartbeat_checks_not_blocked(self):
+        gate = ActionGate(_make_settings())
+        ledger = _ledger()
+        ledger.set_turn(1)
+        ledger.record(
+            "heartbeat_check_manage",
+            {"action": "disable", "name": "ci-schema-sync-monitor"},
+            "ok",
+            "success",
+        )
+        result = await gate.check(
+            "heartbeat_check_manage",
+            {"action": "disable", "name": "pr-fixes-monitor"},
+            ledger,
+        )
+        assert result.approved is True
+
+    @pytest.mark.asyncio
+    async def test_same_heartbeat_check_still_blocked(self):
+        gate = ActionGate(_make_settings())
+        ledger = _ledger()
+        ledger.set_turn(1)
+        ledger.record(
+            "heartbeat_check_manage",
+            {"action": "disable", "name": "ci-schema-sync-monitor"},
+            "ok",
+            "success",
+        )
+        result = await gate.check(
+            "heartbeat_check_manage",
+            {"action": "disable", "name": "ci-schema-sync-monitor"},
+            ledger,
+        )
+        assert result.approved is False
+        assert "Duplicate" in result.reason
+
+    @pytest.mark.asyncio
+    async def test_different_bash_targets_not_blocked(self):
+        gate = ActionGate(_make_settings())
+        ledger = _ledger()
+        ledger.set_turn(1)
+        ledger.record(
+            "bash",
+            {"command": "psql -c 'UPDATE dynamic_checks SET enabled=false WHERE name=$$ci-schema$$'"},
+            "ok",
+            "success",
+        )
+        result = await gate.check(
+            "bash",
+            {"command": "psql -c 'UPDATE dynamic_checks SET enabled=false WHERE name=$$pr-fixes$$'"},
+            ledger,
+        )
+        assert result.approved is True
+
+    @pytest.mark.asyncio
+    async def test_exact_duplicate_bash_still_blocked(self):
+        gate = ActionGate(_make_settings())
+        ledger = _ledger()
+        ledger.set_turn(1)
+        cmd = "psql -c 'UPDATE dynamic_checks SET enabled=false WHERE name=$$check-a$$'"
+        ledger.record("bash", {"command": cmd}, "ok", "success")
+        result = await gate.check("bash", {"command": cmd}, ledger)
+        assert result.approved is False
+
+
+# ===========================================================================
+# Issue #285: Turn-distance window
+# ===========================================================================
+
+
+class TestTurnWindow:
+    @pytest.mark.asyncio
+    async def test_old_action_beyond_window_not_blocked(self):
+        """Action beyond turn window should not be blocked."""
+        gate = ActionGate(_make_settings(action_gating_turn_window=5))
+        ledger = _ledger()
+        ledger.set_turn(1)
+        ledger.record("write_file", {"path": "f.txt"}, "ok", "success")
+        ledger.set_turn(7)  # 6 turns later, beyond window of 5
+        result = await gate.check("write_file", {"path": "f.txt"}, ledger)
+        assert result.approved is True
+
+    @pytest.mark.asyncio
+    async def test_recent_action_within_window_blocked(self):
+        """Action within turn window should still be blocked."""
+        gate = ActionGate(_make_settings(action_gating_turn_window=5))
+        ledger = _ledger()
+        ledger.set_turn(3)
+        ledger.record("write_file", {"path": "f.txt"}, "ok", "success")
+        ledger.set_turn(7)  # 4 turns later, within window of 5
+        result = await gate.check("write_file", {"path": "f.txt"}, ledger)
+        assert result.approved is False
+
+    @pytest.mark.asyncio
+    async def test_turn_window_boundary_exact(self):
+        """Action exactly at window boundary (turn > min_turn) should be blocked."""
+        gate = ActionGate(_make_settings(action_gating_turn_window=5))
+        ledger = _ledger()
+        ledger.set_turn(3)
+        ledger.record("write_file", {"path": "f.txt"}, "ok", "success")
+        ledger.set_turn(8)  # 5 turns later, min_turn=3, turn 3 is NOT > 3
+        result = await gate.check("write_file", {"path": "f.txt"}, ledger)
+        assert result.approved is True  # Boundary: exactly at window edge passes
+
+    @pytest.mark.asyncio
+    async def test_turn_window_same_turn_blocked(self):
+        """Action on the same turn is always within window."""
+        gate = ActionGate(_make_settings(action_gating_turn_window=5))
+        ledger = _ledger()
+        ledger.set_turn(1)
+        ledger.record("learn_fact", {"subject": "sky", "content": "blue"}, "ok", "success")
+        result = await gate.check(
+            "learn_fact", {"subject": "sky", "content": "blue"}, ledger
+        )
+        assert result.approved is False
+
+    @pytest.mark.asyncio
+    async def test_turn_window_configurable(self):
+        """A window of 1 only blocks actions from the current or previous turn."""
+        gate = ActionGate(_make_settings(action_gating_turn_window=1))
+        ledger = _ledger()
+        ledger.set_turn(1)
+        ledger.record("write_file", {"path": "f.txt"}, "ok", "success")
+        ledger.set_turn(3)  # 2 turns later, beyond window of 1
+        result = await gate.check("write_file", {"path": "f.txt"}, ledger)
+        assert result.approved is True

--- a/tests/test_execution_integrity.py
+++ b/tests/test_execution_integrity.py
@@ -59,6 +59,7 @@ def _make_settings(**kwargs) -> types.SimpleNamespace:
         "action_gating_model": "claude-haiku-4-5-20251001",
         "action_gating_enabled": True,
         "action_gating_external_only": False,
+        "action_gating_turn_window": 5,
     }
     defaults.update(kwargs)
     return types.SimpleNamespace(**defaults)
@@ -254,12 +255,12 @@ class TestSummarizeArgs:
         assert "foo" in result
         assert result["foo"] == "bar"
 
-    def test_summarize_args_prefer_first_matching_key(self):
-        """For write_file, 'path' is preferred over 'file_path'."""
+    def test_summarize_args_captures_all_matching_keys(self):
+        """For write_file, both 'path' and 'file_path' are captured."""
         ledger = _make_ledger()
         result = ledger._summarize_args("write_file", {"path": "p.txt", "file_path": "fp.txt"})
         assert result.get("path") == "p.txt"
-        assert "file_path" not in result
+        assert result.get("file_path") == "fp.txt"
 
 
 class TestHasBlockedActionsThisTurn:


### PR DESCRIPTION
## Summary

- **Fix `_args_similar` to require ALL shared keys to match** (was ANY) — prevents false positives when same action targets different resources (e.g., disabling two different heartbeat checks)
- **Fix `_summarize_args` to capture ALL key args** (was only first) — ensures distinguishing fields like `name` are preserved for comparison
- **Add turn-distance window** to `_consistency_check` — stale actions from many turns ago no longer block current calls (configurable via `NOUS_ACTION_GATING_TURN_WINDOW`, default 5)
- **Register `heartbeat_check_manage`/`heartbeat_check_create`** in `WRITE_TOOLS` and `_KEY_ARGS`
- **Move `send_file` to `EXTERNAL_TOOLS`** for proper Tier 3 LLM gating (Telegram API calls)

## Evidence from Issue

```
T9 heartbeat_check_manage action=disable name=ci-schema-sync-monitor (success)
T9 heartbeat_check_manage action=disable name=pr-fixes-monitor [BLOCKED: Duplicate]
```

After this fix, the second call correctly passes — `name` differs so ALL-match returns False.

## Files Changed

| File | Change |
|------|--------|
| `nous/cognitive/action_gate.py` | ALL-match semantics in `_args_similar`, turn-window in `_consistency_check` |
| `nous/cognitive/execution_ledger.py` | Capture all key args, register new tools |
| `nous/config.py` | Add `action_gating_turn_window` setting |
| `tests/test_action_gate.py` | 11 new tests (multi-target + turn-window), updated existing |
| `tests/test_execution_integrity.py` | Updated test helper + assertion |
| `CLAUDE.md` | Document new env var |

## Test plan

- [x] 154/154 tests pass (`test_action_gate.py` + `test_execution_integrity.py`)
- [x] Multi-target heartbeat disable: not blocked
- [x] Different bash targets: not blocked
- [x] Exact duplicates: still blocked
- [x] Turn window: old actions pass, recent duplicates blocked
- [x] Boundary behavior verified (uses `>` not `>=`)

## Review

3-agent architecture review (arch + spec + devil's advocate) before implementation. Implementation review: APPROVE with 0 P1/P2.

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)