### PR TITLE
fix: skip thinking params for haiku model override

### DIFF
--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -565,8 +565,12 @@ class AgentRunner:
         if stream:
             payload["stream"] = True
 
+        # Resolve effective model once for capability guards below
+        effective_model = payload["model"]
+
         # Extended thinking (skip for utility calls like reflection)
-        if not skip_thinking:
+        # Haiku 4.5 does NOT support thinking — only Sonnet 4.6+ and Opus 4.6+.
+        if not skip_thinking and "haiku" not in effective_model:
             if self._settings.thinking_mode == "adaptive":
                 payload["thinking"] = {"type": "adaptive"}
             elif self._settings.thinking_mode == "manual":
@@ -577,7 +581,6 @@ class AgentRunner:
 
         # Effort parameter ("high" is API default, so only send if different)
         # Supported by Sonnet 4.6 and Opus 4.6. Haiku 4.5 does NOT support it.
-        effective_model = payload["model"]
         if (
             self._settings.effort != "high"
             and "haiku" not in effective_model

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -724,6 +724,25 @@ def test_payload_adaptive_with_effort():
     assert payload["output_config"] == {"effort": "medium"}
 
 
+def test_payload_thinking_skipped_for_haiku():
+    """thinking params omitted when model is haiku (unsupported)."""
+    s = Settings(ANTHROPIC_API_KEY="test-key", thinking_mode="adaptive", model="claude-haiku-4-5-20251001")
+    r = AgentRunner(MockCognitiveLayer(), MockBrain(), MockHeart(), s)
+    payload = r._build_api_payload("system", [{"role": "user", "content": "hi"}])
+    assert "thinking" not in payload
+
+
+def test_payload_thinking_skipped_for_haiku_model_override():
+    """thinking params omitted when model_override is haiku (subtask worker path)."""
+    s = Settings(ANTHROPIC_API_KEY="test-key", thinking_mode="adaptive", model="claude-opus-4-6")
+    r = AgentRunner(MockCognitiveLayer(), MockBrain(), MockHeart(), s)
+    payload = r._build_api_payload(
+        "system", [{"role": "user", "content": "hi"}],
+        model_override="claude-haiku-4-5-20251001",
+    )
+    assert "thinking" not in payload
+
+
 def test_payload_effort_skipped_for_haiku():
     """effort parameter omitted when model is haiku (unsupported)."""
     s = Settings(ANTHROPIC_API_KEY="test-key", effort="medium", model="claude-haiku-4-5-20251001")


### PR DESCRIPTION
## Summary
- **Bug**: Subtask worker calls API with `model_override=haiku` but `_build_api_payload` sends `thinking: {type: "adaptive"}` unconditionally when `thinking_mode` is set → Anthropic returns 400 "adaptive thinking is not supported on this model"
- **Fix**: Add `"haiku" not in effective_model` guard to thinking param block, mirroring the existing effort parameter guard. Moved `effective_model` computation above both guards to share it.
- **Tests**: Added `test_payload_thinking_skipped_for_haiku` and `test_payload_thinking_skipped_for_haiku_model_override`

## Test plan
- [x] New tests pass (4/4 payload tests)
- [x] Existing thinking tests still pass
- [ ] CI green
- [ ] Deploy and verify subtask worker no longer 400s

🤖 Generated with [Claude Code](https://claude.com/claude-code)