### PR TITLE
feat: F038.1 — DAG Node Completion Check

### DIFF
--- a/docs/features/F038.1-dag-completion-check.md
+++ b/docs/features/F038.1-dag-completion-check.md
@@ -1,0 +1,266 @@
+# F038.1 — DAG Node Completion Check
+
+> **Status:** Draft v1
+> **Priority:** P1
+> **Author:** Nous + Tim
+> **Date:** 2026-04-10
+> **Parent:** F038 (Unified DAG Orchestration)
+> **Depends on:** F038
+
+---
+
+## Problem Statement
+
+DAG nodes currently track completion by monitoring their underlying primitive (subtask or check). When a subtask **launches an async external process** — such as a Claude Code job, a CI pipeline, or any long-running shell task — the subtask itself completes immediately ("I launched the job"), but the actual work is still running.
+
+The orchestrator sees subtask=completed → advances to the next wave → downstream nodes start before their dependencies are actually done.
+
+### Real Example (April 10, 2026)
+
+A DAG was created to implement feature F054:
+1. **Wave 0:** Clone repo (subtask) ✅
+2. **Wave 1:** Analyze spec via Claude Code (subtask launches CC job, returns immediately) — orchestrator sees "completed"
+3. **Wave 2:** Implement feature — starts immediately, but Wave 1's CC job is still running. No analysis context available. Node fails.
+
+**Root cause:** The DAG has no concept of "the subtask finished, but the real work hasn't."
+
+### Scope of the Problem
+
+This isn't just a Claude Code issue. Any async handoff breaks the DAG:
+- Claude Code jobs (runner.sh)
+- CI/CD pipelines (GitHub Actions, Jenkins)
+- File generation processes
+- External API operations with async callbacks
+- Database migrations
+- Build processes
+
+---
+
+## Solution: `completion_check` Field
+
+Add an **optional `completion_check` field** to any DAG node. This is a **shell command** that the orchestrator runs each tick to determine if the node's real work is actually done.
+
+### Contract
+
+```
+completion_check: "<any shell command>"
+
+Exit code 0  → node is complete, advance to next wave
+Exit code !0 → still running, check again next tick
+```
+
+The orchestrator doesn't interpret the command's output — it only checks the exit code. This makes it universally composable with any tool, process, or system.
+
+### Examples
+
+```yaml
+# Claude Code job
+completion_check: "python3 /path/to/runner.sh status job-abc123 | grep -q completed"
+
+# File existence
+completion_check: "test -f /tmp/results/output.json"
+
+# CI pipeline
+completion_check: "curl -sf https://api.github.com/repos/org/repo/actions/runs/123 | jq -e '.status == \"completed\"'"
+
+# Process finished
+completion_check: "! pgrep -f 'my-long-process'"
+
+# Custom script
+completion_check: "python3 /path/to/check_status.py --job-id xyz"
+
+# Multiple conditions (all must pass)
+completion_check: "test -f /tmp/done.flag && curl -sf http://localhost:8080/health"
+```
+
+---
+
+## Architecture
+
+### Schema Change
+
+```python
+class DAGNodeSpec(BaseModel):
+    name: str
+    type: DAGNodeType
+    instructions: str = ""
+    # ... existing fields ...
+    completion_check: str | None = Field(
+        None,
+        description="Shell command polled each tick. Exit 0 = done, non-zero = still running."
+    )
+```
+
+### Orchestrator Behavior Change
+
+The change is localized to `_sync_node_statuses()` in the orchestrator:
+
+```
+Current flow:
+  node.status == "running" && subtask.status == "completed"
+    → node.status = "completed"  ← WRONG for async handoffs
+
+New flow:
+  node.status == "running" && subtask.status == "completed"
+    → if node.completion_check exists:
+        node.status = "awaiting_check"  ← NEW intermediate state
+    → else:
+        node.status = "completed"  ← unchanged for simple subtasks
+
+  node.status == "awaiting_check":
+    → run completion_check shell command
+    → exit 0?  → node.status = "completed"
+    → exit !0? → stay in "awaiting_check", try again next tick
+    → timed out (node.timeout_seconds exceeded)? → node.status = "failed"
+```
+
+### New Node Status: `awaiting_check`
+
+Add to `DAGNodeStatus` enum:
+
+```python
+class DAGNodeStatus(str, Enum):
+    pending = "pending"
+    ready = "ready"
+    running = "running"
+    awaiting_check = "awaiting_check"  # NEW: subtask done, polling completion_check
+    completed = "completed"
+    failed = "failed"
+    blocked = "blocked"
+    cancelled = "cancelled"
+```
+
+`awaiting_check` is a non-terminal status. The orchestrator treats it as "still in progress" for dependency resolution — downstream nodes will NOT be launched.
+
+### Status File Convention
+
+For Claude Code jobs and other processes that need to communicate state, we establish a convention:
+
+```
+/tmp/nous-workspace/dag-status/<dag_id>/<node_name>/status    → "running" | "completed" | "failed"
+/tmp/nous-workspace/dag-status/<dag_id>/<node_name>/result    → stdout/output of the process
+/tmp/nous-workspace/dag-status/<dag_id>/<node_name>/error     → error message if failed
+```
+
+The subtask that launches a CC job writes the job ID to this path. The `completion_check` reads from it. This is a **convention, not a requirement** — the completion_check can check anything.
+
+Example flow for a CC node:
+
+1. Subtask prompt: "Launch CC job, write job ID to `/tmp/nous-workspace/dag-status/{dag_id}/{node_name}/job_id`"
+2. `completion_check`: `"JOB=$(cat /tmp/nous-workspace/dag-status/{dag_id}/{node_name}/job_id) && python3 runner.sh status $JOB | grep -q completed"`
+
+### Result Capture
+
+When `completion_check` passes (exit 0), the orchestrator should also capture the node's result for `context_flow` edges. Options:
+
+1. **stdout of the check command** — simple, but limited
+2. **Read from status file** — `result` file at the conventional path
+3. **Subtask result + check result combined** — the subtask's result (e.g., "launched job X") plus whatever the check produces
+
+**Recommendation:** Read from the status file at `dag-status/<dag_id>/<node_name>/result` if it exists. Fall back to the subtask's original result. This gives the launched process a way to pass rich context downstream.
+
+```python
+async def _read_node_result(self, node: DAGNode, dag: ExecutionDAG) -> str | None:
+    """Read result from status file convention, fall back to subtask result."""
+    status_dir = f"/tmp/nous-workspace/dag-status/{dag.id.hex[:8]}/{node.name}"
+    result_file = f"{status_dir}/result"
+    try:
+        with open(result_file) as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        return node.result  # Fall back to subtask result
+```
+
+---
+
+## DB Migration
+
+Migration `033_dag_completion_check.sql`:
+
+```sql
+-- Add completion_check column to dag_nodes
+ALTER TABLE dag_nodes ADD COLUMN completion_check TEXT;
+
+-- Add 'awaiting_check' to valid statuses
+-- (If using CHECK constraint, update it; if enum-free, no change needed)
+```
+
+---
+
+## Implementation Plan
+
+### Phase 1: Core (MVP)
+1. Add `completion_check: str | None` to `DAGNodeSpec` schema
+2. Add `awaiting_check` to `DAGNodeStatus` enum
+3. Add `completion_check` column to `dag_nodes` table (migration 033)
+4. Modify `_sync_subtask_node()` — transition to `awaiting_check` if completion_check exists
+5. Add `_poll_completion_check()` method — runs shell command, handles exit code
+6. Modify `_advance_dag()` — poll `awaiting_check` nodes each tick
+7. Ensure `awaiting_check` is treated as non-terminal (nodes downstream stay pending)
+
+### Phase 2: Result Capture
+8. Implement status file convention directory creation
+9. Add `_read_node_result()` for enriched context_flow from async processes
+10. Update `_build_predecessor_context()` to prefer status file results
+
+### Phase 3: Observability
+11. Show `awaiting_check` state in dashboard (yellow/amber indicator)
+12. Display last check time and attempt count in node detail panel
+13. Log each poll attempt with exit code for debugging
+
+### Phase 4: Timeout & Retry
+14. Track `check_attempts` counter on the node
+15. Respect `timeout_seconds` for total awaiting_check duration
+16. Optional `completion_check_interval` to control poll frequency (default: every tick)
+17. Optional `max_check_attempts` for bounded retries
+
+---
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `nous/dag/schemas.py` | Add `completion_check` field to `DAGNodeSpec`, add `awaiting_check` status |
+| `nous/dag/orchestrator.py` | Add `_poll_completion_check()`, modify `_sync_subtask_node()`, update `_advance_dag()` |
+| `nous/dag/store.py` | Persist `completion_check` column |
+| `nous/storage/models.py` | Add `completion_check` column to `DAGNode` model |
+| `sql/migrations/033_dag_completion_check.sql` | New migration |
+| `static/dashboard/js/dag.js` | Handle `awaiting_check` status display |
+| `nous/api/tools.py` | Pass `completion_check` through `dag_create` tool |
+| `tests/test_dag_orchestrator.py` | New tests for completion_check flow |
+
+---
+
+## Test Plan
+
+1. **No completion_check** — existing behavior unchanged, subtask complete → node complete
+2. **With completion_check, immediate pass** — check exits 0 on first poll → node completes
+3. **With completion_check, delayed pass** — check fails 3 ticks, then exits 0 → node completes on 4th tick
+4. **With completion_check, timeout** — check never passes, timeout_seconds exceeded → node fails
+5. **Downstream blocking** — node in `awaiting_check` → dependent nodes stay `pending`
+6. **Context flow from status file** — result file written by async process flows to downstream node
+7. **Cancel while awaiting_check** — DAG cancelled → node transitions from `awaiting_check` to `cancelled`
+8. **Check command failure** — command itself errors (not found, permission denied) → handle gracefully, don't crash orchestrator
+9. **Concurrent ticks** — two ticks overlap while check is running → lock prevents double-poll
+
+---
+
+## Constraints & Guardrails
+
+- **Shell command timeout:** Each completion_check invocation has a hard 10-second timeout. Long-running checks must be async themselves.
+- **No secrets in check commands:** completion_check is stored in DB. Never embed API keys — use environment variables or file references.
+- **Idempotent checks only:** The check command must be safe to run repeatedly. It should be a read/query operation, never a mutation.
+- **Max poll duration:** Bounded by `timeout_seconds` on the node. Default 120s for simple checks, recommend 600s for CC jobs.
+
+---
+
+## Why Not Other Approaches
+
+| Approach | Rejected Because |
+|----------|-----------------|
+| New `claude_code` node type | Not universal — need a new type for every async tool |
+| Subtask polls internally | Burns tokens on polling loops, hits timeout limits |
+| Two-phase node status (started → verified) | Requires subtask to know about DAG state — tight coupling |
+| Webhook/callback from external process | Requires HTTP endpoint, complex infra, not all tools support it |
+
+`completion_check` is the simplest universal primitive. One optional field, zero new node types, works with any process that can be queried via shell.


### PR DESCRIPTION
## F038.1 — DAG Node Completion Check

**Solves:** Issue #292 (DAG orchestrator doesn't track Claude Code job completion)

### The Problem
DAG nodes complete when their subtask finishes — but if the subtask *launches* an async process (CC job, CI pipeline, etc.), the subtask returns immediately while the real work is still running. Downstream nodes start too early.

### The Solution
**One optional field:** `completion_check` — a shell command polled each orchestrator tick.

- Exit code 0 → node is actually done, advance
- Exit code non-zero → still running, check next tick

### Why This Design
- **Universal** — works with CC jobs, CI, file watchers, APIs, anything queryable via shell
- **Zero new node types** — just one optional field on existing nodes
- **Minimal orchestrator change** — new `awaiting_check` intermediate status, one new poll method
- **Convention over configuration** — status file path pattern for result capture

### Examples
```
# CC job
completion_check: "python3 runner.sh status job-xyz | grep -q completed"

# File exists  
completion_check: "test -f /tmp/output.json"

# CI pipeline
completion_check: "curl -sf https://api.github.com/.../runs/123 | jq -e '.status == \"completed\"'"
```

### Implementation: 4 phases
1. Core MVP (schema + orchestrator + migration)
2. Result capture via status files
3. Dashboard observability
4. Timeout & retry guards

Closes #292