### PR TITLE
fix: preserve full 100-decision window for skewed outcomes in procedure learner

### DIFF
--- a/nous/handlers/procedure_learner.py
+++ b/nous/handlers/procedure_learner.py
@@ -228,16 +228,24 @@ class ProcedureLearner:
             # Fetch reviewed successful decisions — pass filters to DB
             # to avoid the window problem where 100 most recent are all pending.
             # Issue #188 Bug 1: was list_decisions(limit=100) with no filters.
+            # Budget-based fetch: fill the full window with successes first,
+            # then use remaining budget for partials so skewed distributions
+            # don't shrink the total candidate pool below _TOTAL_WINDOW.
+            _TOTAL_WINDOW = 100
             decisions_success, _ = await self._brain.list_decisions(
-                limit=50, outcome="success", reviewed=True
+                limit=_TOTAL_WINDOW, outcome="success", reviewed=True
             )
-            decisions_partial, _ = await self._brain.list_decisions(
-                limit=50, outcome="partial", reviewed=True
-            )
+            _remaining = max(0, _TOTAL_WINDOW - len(decisions_success))
+            if _remaining > 0:
+                decisions_partial, _ = await self._brain.list_decisions(
+                    limit=_remaining, outcome="partial", reviewed=True
+                )
+            else:
+                decisions_partial = []
             successful = list(decisions_success) + list(decisions_partial)
             logger.info(
-                "Decision pathway: %d success + %d partial = %d reviewed decisions",
-                len(decisions_success), len(decisions_partial), len(successful),
+                "Decision pathway: %d success + %d partial = %d reviewed decisions (window=%d)",
+                len(decisions_success), len(decisions_partial), len(successful), _TOTAL_WINDOW,
             )
             if len(successful) < self._settings.procedure_cluster_min_size:
                 logger.info(


### PR DESCRIPTION
## Summary

- Replaces two fixed `limit=50` queries in `_learn_from_decisions()` with a budget-based approach that preserves the full 100-decision candidate window
- Successes are fetched first up to `_TOTAL_WINDOW=100`, then remaining budget is used for partials — preventing skewed outcome distributions from silently shrinking the pool
- Updates the `logger.info` line to report the budget window size

## Problem

In `nous/handlers/procedure_learner.py` (lines 232–235), both `success` and `partial` queries used `limit=50`. With skewed outcome distributions (e.g. 80 successes and 5 partials), the original code would fetch 50 successes + 50 partials for a max of 100, but real-world skewed data only yields 55 candidates instead of the intended ~100 window.

## Fix

```python
_TOTAL_WINDOW = 100
decisions_success, _ = await self._brain.list_decisions(
    limit=_TOTAL_WINDOW, outcome="success", reviewed=True
)
_remaining = max(0, _TOTAL_WINDOW - len(decisions_success))
if _remaining > 0:
    decisions_partial, _ = await self._brain.list_decisions(
        limit=_remaining, outcome="partial", reviewed=True
    )
else:
    decisions_partial = []
```

## References

Addresses the P2 review comment left on PR #189 ("fix: procedure learning broken — sleep cycle creates 0 procedures").

## Test plan

- [x] Ran `pytest tests/ -x -q -k "procedure_learner"` — 21 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)