### PR TITLE
fix(dag): address 7 P1 + 6 P2 issues from DAG orchestration review

### DIFF
--- a/docs/superpowers/plans/2026-04-10-f038-dag-review-fixes.md
+++ b/docs/superpowers/plans/2026-04-10-f038-dag-review-fixes.md
@@ -1,0 +1,1406 @@
+# F038 DAG Review Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix all P1 and P2 issues found in the comprehensive code review of the F038 DAG Orchestration implementation, plus add tests for critical gaps.
+
+**Architecture:** Fixes are isolated to `nous/dag/orchestrator.py`, `nous/dag/store.py`, `nous/api/tools.py`, `nous/api/dashboard_queries.py`, and their corresponding test files. No new files needed. No schema/migration changes needed.
+
+**Tech Stack:** Python 3.12+, SQLAlchemy 2.0+ async, pytest + pytest-asyncio, Pydantic v2
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `nous/dag/orchestrator.py` | Modify | P1-1, P1-3, P1-4, P1-7, P2-1, P2-3, P2-4 |
+| `nous/dag/store.py` | Modify | P1-6 |
+| `nous/api/tools.py` | Modify | P1-5, P2-5, P2-6 |
+| `nous/api/dashboard_queries.py` | Modify | P1-2 |
+| `tests/test_dag_orchestrator.py` | Modify | Tests for P1-1, P1-3, P1-4, P1-7, P2-1, P2-3, P2-4, plus coverage gaps |
+| `tests/test_dag_store.py` | Modify | Test for P1-6 |
+| `tests/test_dag_tools.py` | Modify | Tests for P1-5, P2-5, P2-6 |
+| `tests/test_dag_dashboard.py` | Modify | Test for P1-2 |
+
+---
+
+## Task 1: P1-1 — Fix `retry_node` stuck DAG (resets to `"ready"` but scheduler expects `"pending"`)
+
+**Files:**
+- Modify: `nous/dag/orchestrator.py:124`
+- Test: `tests/test_dag_orchestrator.py`
+
+- [ ] **Step 1: Write failing test — retry_node resets to pending and is picked up by tick**
+
+Add to `tests/test_dag_orchestrator.py` at the end of the file:
+
+```python
+class TestDAGRetryNode:
+    """Test retry_node correctness."""
+
+    @pytest.mark.asyncio
+    async def test_retry_node_resets_to_pending(self, store, orchestrator, subtask_mgr):
+        """retry_node resets to pending so _find_ready_nodes picks it up."""
+        dag = await store.create(_two_subtask_request())
+        await orchestrator.start_dag(dag.id)
+
+        # Simulate research subtask failed
+        fetched = await store.get_dag(dag.id)
+        research = next(n for n in fetched.nodes if n.name == "research")
+        subtask_mgr.get.return_value = SimpleNamespace(
+            id=research.subtask_id, status="failed", result=None, error="OOM"
+        )
+        await orchestrator.tick()
+
+        # Verify failed
+        fetched = await store.get_dag(dag.id)
+        research = next(n for n in fetched.nodes if n.name == "research")
+        assert research.status == "failed"
+
+        # Retry
+        await orchestrator.retry_node(dag.id, "research")
+
+        fetched = await store.get_dag(dag.id)
+        research = next(n for n in fetched.nodes if n.name == "research")
+        assert research.status == "pending"  # Must be pending, not ready
+
+        # Tick should pick it up and launch
+        subtask_mgr.create.reset_mock()
+        subtask_mgr.get.return_value = SimpleNamespace(
+            id=uuid.uuid4(), status="pending", result=None, error=None
+        )
+        await orchestrator.tick()
+
+        fetched = await store.get_dag(dag.id)
+        research = next(n for n in fetched.nodes if n.name == "research")
+        assert research.status == "running"
+        subtask_mgr.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_retry_node_not_failed_raises(self, store, orchestrator):
+        """retry_node on non-failed node raises ValueError."""
+        dag = await store.create(_two_subtask_request())
+        await orchestrator.start_dag(dag.id)
+
+        with pytest.raises(ValueError, match="expected failed"):
+            await orchestrator.retry_node(dag.id, "research")
+
+    @pytest.mark.asyncio
+    async def test_retry_node_unknown_raises(self, store, orchestrator):
+        """retry_node on unknown node raises ValueError."""
+        dag = await store.create(_two_subtask_request())
+        with pytest.raises(ValueError, match="not found"):
+            await orchestrator.retry_node(dag.id, "nonexistent")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_dag_orchestrator.py::TestDAGRetryNode::test_retry_node_resets_to_pending -xvs`
+Expected: FAIL — `assert research.status == "pending"` fails because current code sets `"ready"`
+
+- [ ] **Step 3: Fix — change retry_node to reset to `"pending"` instead of `"ready"`**
+
+In `nous/dag/orchestrator.py`, line 124, change:
+
+```python
+# OLD
+        await self._store.update_node(
+            node.id,
+            status="ready",
+            error=None,
+```
+
+to:
+
+```python
+# NEW
+        await self._store.update_node(
+            node.id,
+            status="pending",
+            error=None,
+```
+
+- [ ] **Step 4: Run all retry tests to verify they pass**
+
+Run: `uv run pytest tests/test_dag_orchestrator.py::TestDAGRetryNode -xvs`
+Expected: All 3 PASS
+
+- [ ] **Step 5: Also run existing retry test to make sure it still passes**
+
+Run: `uv run pytest tests/test_dag_orchestrator.py::TestDAGCompletionCheck::test_retry_resets_check_state -xvs`
+Expected: PASS (existing test checks status == "ready" — this will FAIL, see step 6)
+
+- [ ] **Step 6: Update existing test assertion to match new behavior**
+
+In `tests/test_dag_orchestrator.py`, the test `test_retry_resets_check_state` at line 612 asserts `node.status == "ready"`. Change to:
+
+```python
+        assert node.status == "pending"
+```
+
+- [ ] **Step 7: Run full orchestrator test suite**
+
+Run: `uv run pytest tests/test_dag_orchestrator.py -xvs`
+Expected: All PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add nous/dag/orchestrator.py tests/test_dag_orchestrator.py
+git commit -m "fix(dag): retry_node resets to pending instead of ready — fixes stuck DAG"
+```
+
+---
+
+## Task 2: P1-2 — Fix dashboard UUID string crash on asyncpg
+
+**Files:**
+- Modify: `nous/api/dashboard_queries.py:1482-1518`
+- Test: `tests/test_dag_dashboard.py`
+
+- [ ] **Step 1: Write failing test — dashboard with active DAG returns data (not crash)**
+
+The existing test `test_get_dag_dashboard_data_with_dag` already exercises this path. It passes on SQLite in tests but would crash on Postgres. We need to verify the fix doesn't break the test and also add an explicit node/edge field check.
+
+Add to `tests/test_dag_dashboard.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_get_dag_dashboard_node_and_edge_fields(db):
+    """Active DAG nodes and edges have correct field structure."""
+    agent_id = f"test-dag-dash-{uuid.uuid4().hex[:8]}"
+    store = DAGStore(db, agent_id=agent_id)
+    req = DAGCreateRequest(
+        name="field-test",
+        nodes=[
+            DAGNodeSpec(name="alpha", type=DAGNodeType.subtask, instructions="A"),
+            DAGNodeSpec(name="beta", type=DAGNodeType.subtask, instructions="B"),
+        ],
+        edges=[DAGEdgeSpec(from_node="alpha", to_node="beta")],
+    )
+    dag = await store.create(req)
+    await store.update_dag_status(dag.id, "running")
+
+    from nous.api.dashboard_queries import get_dag_dashboard_data
+
+    async with db.session() as session:
+        data = await get_dag_dashboard_data(session, agent_id)
+
+    assert len(data["active_dags"]) == 1
+    dag_data = data["active_dags"][0]
+
+    # Verify dag_id is a string
+    assert isinstance(dag_data["id"], str)
+
+    # Verify nodes have expected fields
+    assert len(dag_data["nodes"]) == 2
+    node = dag_data["nodes"][0]
+    assert "id" in node
+    assert "name" in node
+    assert "status" in node
+    assert "wave" in node
+
+    # Verify edges have expected fields
+    assert len(dag_data["edges"]) == 1
+    edge = dag_data["edges"][0]
+    assert "from_node_id" in edge
+    assert "to_node_id" in edge
+```
+
+- [ ] **Step 2: Fix — pass UUID object to SQL binds, use str only for JSON output**
+
+In `nous/api/dashboard_queries.py`, modify the active DAG loop (around lines 1481-1528):
+
+```python
+    # OLD (line 1482):
+    for dag_row in active_dag_rows:
+        dag_id = str(dag_row.id)
+
+        # Nodes for this DAG
+        node_result = await session.execute(
+            text("""..."""),
+            {"dag_id": dag_id},
+        )
+```
+
+Change to:
+
+```python
+    # NEW:
+    for dag_row in active_dag_rows:
+        dag_id_str = str(dag_row.id)
+        dag_id_uuid = dag_row.id  # Keep UUID for SQL binds
+
+        # Nodes for this DAG
+        node_result = await session.execute(
+            text("""
+                SELECT id, name, description, node_type, wave, status,
+                       result, error, tokens_used, started_at, completed_at
+                FROM nous_system.dag_nodes
+                WHERE dag_id = :dag_id
+                ORDER BY wave, name
+            """),
+            {"dag_id": dag_id_uuid},
+        )
+```
+
+Apply the same fix to the edges query (around line 1511-1518):
+
+```python
+        edge_result = await session.execute(
+            text("""
+                SELECT id, from_node_id, to_node_id, edge_type
+                FROM nous_system.dag_edges
+                WHERE dag_id = :dag_id
+            """),
+            {"dag_id": dag_id_uuid},
+        )
+```
+
+And update the dict to use `dag_id_str` (around line 1530):
+
+```python
+        active_dags.append({
+            "id": dag_id_str,
+```
+
+- [ ] **Step 3: Run dashboard tests**
+
+Run: `uv run pytest tests/test_dag_dashboard.py -xvs`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add nous/api/dashboard_queries.py tests/test_dag_dashboard.py
+git commit -m "fix(dag): pass UUID objects to asyncpg SQL binds in dashboard queries"
+```
+
+---
+
+## Task 3: P1-3 — Fix `retry_node` unblocking ALL blocked nodes
+
+**Files:**
+- Modify: `nous/dag/orchestrator.py:138-143`
+- Test: `tests/test_dag_orchestrator.py`
+
+- [ ] **Step 1: Write failing test — retry_node only unblocks downstream of retried node**
+
+Add to `TestDAGRetryNode` in `tests/test_dag_orchestrator.py`:
+
+```python
+    @pytest.mark.asyncio
+    async def test_retry_only_unblocks_downstream(self, store, orchestrator, subtask_mgr):
+        """retry_node only unblocks nodes downstream of the retried node, not all blocked nodes."""
+        # DAG: A -> B, C -> D  (two independent chains)
+        request = DAGCreateRequest(
+            name="selective-unblock",
+            nodes=[
+                DAGNodeSpec(name="a", type=DAGNodeType.subtask, instructions="A"),
+                DAGNodeSpec(name="b", type=DAGNodeType.subtask, instructions="B"),
+                DAGNodeSpec(name="c", type=DAGNodeType.subtask, instructions="C"),
+                DAGNodeSpec(name="d", type=DAGNodeType.subtask, instructions="D"),
+            ],
+            edges=[
+                DAGEdgeSpec(from_node="a", to_node="b", edge_type="dependency"),
+                DAGEdgeSpec(from_node="c", to_node="d", edge_type="dependency"),
+            ],
+        )
+        dag = await store.create(request)
+        await orchestrator.start_dag(dag.id)
+
+        # Both A and C are wave-0 running. Simulate both fail.
+        fetched = await store.get_dag(dag.id)
+        node_a = next(n for n in fetched.nodes if n.name == "a")
+        node_c = next(n for n in fetched.nodes if n.name == "c")
+
+        # Create separate mock subtask IDs
+        async def mock_get(sid):
+            return SimpleNamespace(id=sid, status="failed", result=None, error="fail")
+
+        subtask_mgr.get = AsyncMock(side_effect=mock_get)
+
+        await orchestrator.tick()  # Sync failures + propagate
+
+        fetched = await store.get_dag(dag.id)
+        node_b = next(n for n in fetched.nodes if n.name == "b")
+        node_d = next(n for n in fetched.nodes if n.name == "d")
+        assert node_b.status == "blocked"
+        assert node_d.status == "blocked"
+
+        # Retry only A
+        await orchestrator.retry_node(dag.id, "a")
+
+        fetched = await store.get_dag(dag.id)
+        node_b = next(n for n in fetched.nodes if n.name == "b")
+        node_d = next(n for n in fetched.nodes if n.name == "d")
+
+        # B should be unblocked (downstream of A)
+        assert node_b.status == "pending"
+        # D should STILL be blocked (downstream of C, which is still failed)
+        assert node_d.status == "blocked"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_dag_orchestrator.py::TestDAGRetryNode::test_retry_only_unblocks_downstream -xvs`
+Expected: FAIL — `assert node_d.status == "blocked"` fails because current code unblocks all
+
+- [ ] **Step 3: Fix — selective unblock using forward reachability from retried node**
+
+In `nous/dag/orchestrator.py`, replace the unblock logic in `retry_node` (lines 138-143):
+
+```python
+# OLD
+        # Unblock dependent nodes that were blocked by this failure
+        for other in dag.nodes:
+            if other.status == "blocked":
+                await self._store.update_node(
+                    other.id, status="pending", error=None
+                )
+```
+
+with:
+
+```python
+# NEW
+        # Selectively unblock only nodes downstream of the retried node
+        # that have no other failed predecessors
+        dep_map: dict[str, set[str]] = {str(n.id): set() for n in dag.nodes}
+        for edge in dag.edges:
+            if edge.edge_type in ("dependency", "cancel_cascade"):
+                dep_map[str(edge.to_node_id)].add(str(edge.from_node_id))
+
+        # Forward reachability from retried node
+        adj: dict[str, list[str]] = {str(n.id): [] for n in dag.nodes}
+        for edge in dag.edges:
+            if edge.edge_type in ("dependency", "cancel_cascade"):
+                adj[str(edge.from_node_id)].append(str(edge.to_node_id))
+
+        reachable: set[str] = set()
+        stack = [str(node.id)]
+        while stack:
+            nid = stack.pop()
+            for child in adj.get(nid, []):
+                if child not in reachable:
+                    reachable.add(child)
+                    stack.append(child)
+
+        # IDs of nodes that are still failed (excluding the one being retried)
+        still_failed = {
+            str(n.id)
+            for n in dag.nodes
+            if n.status == "failed" and n.id != node.id
+        }
+
+        node_by_id = {str(n.id): n for n in dag.nodes}
+        for nid in reachable:
+            n = node_by_id[nid]
+            if n.status != "blocked":
+                continue
+            # Only unblock if no other failed predecessor exists
+            other_failed_preds = dep_map[nid] & still_failed
+            if not other_failed_preds:
+                await self._store.update_node(
+                    n.id, status="pending", error=None
+                )
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_dag_orchestrator.py::TestDAGRetryNode -xvs`
+Expected: All PASS
+
+- [ ] **Step 5: Run full orchestrator suite**
+
+Run: `uv run pytest tests/test_dag_orchestrator.py -xvs`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add nous/dag/orchestrator.py tests/test_dag_orchestrator.py
+git commit -m "fix(dag): retry_node selectively unblocks only downstream nodes"
+```
+
+---
+
+## Task 4: P1-4 — Fix `cancel_dag` to cancel running subtasks
+
+**Files:**
+- Modify: `nous/dag/orchestrator.py:636-645`
+- Test: `tests/test_dag_orchestrator.py`
+
+- [ ] **Step 1: Write failing test — cancel_dag attempts to cancel running subtasks**
+
+Add to `TestDAGOrchestratorCancel` in `tests/test_dag_orchestrator.py`:
+
+```python
+    @pytest.mark.asyncio
+    async def test_cancel_dag_cancels_running_subtask(self, store, orchestrator, subtask_mgr):
+        """cancel_dag calls cancel on running subtasks, not just pending."""
+        dag = await store.create(_two_subtask_request())
+        await orchestrator.start_dag(dag.id)
+
+        fetched = await store.get_dag(dag.id)
+        research = next(n for n in fetched.nodes if n.name == "research")
+
+        # Subtask is now "running" in the subtask manager
+        subtask_mgr.get.return_value = SimpleNamespace(
+            id=research.subtask_id, status="running"
+        )
+
+        subtask_mgr.cancel.reset_mock()
+        await orchestrator.cancel_dag(dag.id, reason="User cancelled")
+
+        # cancel should have been called for the running subtask
+        subtask_mgr.cancel.assert_called_once_with(research.subtask_id)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_dag_orchestrator.py::TestDAGOrchestratorCancel::test_cancel_dag_cancels_running_subtask -xvs`
+Expected: FAIL — cancel is not called because current code only cancels pending
+
+- [ ] **Step 3: Fix — cancel running subtasks too**
+
+In `nous/dag/orchestrator.py`, modify `_cancel_node` (lines 636-645):
+
+```python
+# OLD
+    async def _cancel_node(self, node: DAGNode) -> None:
+        """Cancel the underlying primitive for a node."""
+        if node.node_type == "subtask" and node.subtask_id and self._subtask_mgr:
+            try:
+                from nous.storage.models import Subtask
+                subtask = await self._subtask_mgr.get(node.subtask_id)
+                if subtask and subtask.status == "pending":
+                    await self._subtask_mgr.cancel(node.subtask_id)
+            except Exception:
+                logger.debug("Could not cancel subtask %s", node.subtask_id)
+```
+
+Replace with:
+
+```python
+# NEW
+    async def _cancel_node(self, node: DAGNode) -> None:
+        """Cancel the underlying primitive for a node."""
+        if node.node_type == "subtask" and node.subtask_id and self._subtask_mgr:
+            try:
+                subtask = await self._subtask_mgr.get(node.subtask_id)
+                if subtask and subtask.status in ("pending", "running"):
+                    await self._subtask_mgr.cancel(node.subtask_id)
+            except Exception:
+                logger.debug("Could not cancel subtask %s", node.subtask_id)
+```
+
+Note: The `from nous.storage.models import Subtask` import was unused — remove it.
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_dag_orchestrator.py::TestDAGOrchestratorCancel -xvs`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add nous/dag/orchestrator.py tests/test_dag_orchestrator.py
+git commit -m "fix(dag): cancel_dag cancels running subtasks not just pending"
+```
+
+---
+
+## Task 5: P1-5 — Broaden exception handling in dag_create/dag_manage
+
+**Files:**
+- Modify: `nous/api/tools.py:1818,1871,1935`
+- Test: `tests/test_dag_tools.py`
+
+- [ ] **Step 1: Write failing test — dag_create handles non-ValueError gracefully**
+
+Add to `TestDagCreateTool` in `tests/test_dag_tools.py`:
+
+```python
+    @pytest.mark.asyncio
+    async def test_dag_create_handles_db_error(self, tools, dag_store, dag_orchestrator):
+        """dag_create catches non-ValueError exceptions and returns clean error."""
+        # Make store.create raise a RuntimeError (simulating DB failure)
+        original_create = dag_store.create
+        async def broken_create(req):
+            raise RuntimeError("DB connection lost")
+        dag_store.create = broken_create
+
+        handler = tools._handlers["dag_create"]
+        result = await handler(
+            name="broken-dag",
+            nodes=_simple_nodes(),
+            edges=[],
+        )
+        text = result["content"][0]["text"]
+        assert "Error" in text
+        assert "DB connection lost" in text
+
+        dag_store.create = original_create  # Restore
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_dag_tools.py::TestDagCreateTool::test_dag_create_handles_db_error -xvs`
+Expected: FAIL — RuntimeError propagates unhandled
+
+- [ ] **Step 3: Fix — broaden except to Exception in both handlers**
+
+In `nous/api/tools.py`, change line 1871:
+
+```python
+# OLD
+        except ValueError as e:
+            return {"content": [{"type": "text", "text": f"Error creating DAG: {e}"}]}
+```
+
+to:
+
+```python
+# NEW
+        except Exception as e:
+            logger.exception("dag_create failed")
+            return {"content": [{"type": "text", "text": f"Error creating DAG: {e}"}]}
+```
+
+And change line 1935:
+
+```python
+# OLD
+        except ValueError as e:
+            return {"content": [{"type": "text", "text": f"Error: {e}"}]}
+```
+
+to:
+
+```python
+# NEW
+        except Exception as e:
+            logger.exception("dag_manage failed")
+            return {"content": [{"type": "text", "text": f"Error: {e}"}]}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_dag_tools.py -xvs`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add nous/api/tools.py tests/test_dag_tools.py
+git commit -m "fix(dag): broaden exception handling in dag_create/dag_manage to prevent orphaned DAGs"
+```
+
+---
+
+## Task 6: P1-6 — Add agent_id scope guard to `update_node`
+
+**Files:**
+- Modify: `nous/dag/store.py:202-212`
+- Test: `tests/test_dag_store.py`
+
+- [ ] **Step 1: Write failing test — cross-agent node update is rejected**
+
+Add to `tests/test_dag_store.py`:
+
+```python
+class TestDAGStoreIsolation:
+    """Test agent_id isolation."""
+
+    @pytest.mark.asyncio
+    async def test_update_node_cross_agent_rejected(self, db):
+        """update_node cannot modify nodes belonging to another agent's DAG."""
+        store_a = DAGStore(db, f"agent-a-{uuid.uuid4().hex[:8]}")
+        store_b = DAGStore(db, f"agent-b-{uuid.uuid4().hex[:8]}")
+
+        dag = await store_a.create(_simple_request("isolation-test"))
+        node_id = dag.nodes[0].id
+
+        # Agent B tries to update Agent A's node
+        await store_b.update_node(node_id, status="failed", error="hijacked")
+
+        # Should not have changed
+        fetched = await store_a.get_dag(dag.id)
+        assert fetched.nodes[0].status == "ready"  # Unchanged
+        assert fetched.nodes[0].error is None
+
+    @pytest.mark.asyncio
+    async def test_get_dag_cross_agent_rejected(self, db):
+        """get_dag returns None for another agent's DAG."""
+        store_a = DAGStore(db, f"agent-a-{uuid.uuid4().hex[:8]}")
+        store_b = DAGStore(db, f"agent-b-{uuid.uuid4().hex[:8]}")
+
+        dag = await store_a.create(_simple_request("cross-agent-test"))
+
+        fetched = await store_b.get_dag(dag.id)
+        assert fetched is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_dag_store.py::TestDAGStoreIsolation::test_update_node_cross_agent_rejected -xvs`
+Expected: FAIL — `assert fetched.nodes[0].status == "ready"` fails because update_node has no agent_id guard
+
+- [ ] **Step 3: Fix — add agent_id scoped subquery to update_node**
+
+In `nous/dag/store.py`, modify `update_node` (lines 202-212):
+
+```python
+# OLD
+    async def update_node(self, node_id: UUID, **kwargs: object) -> None:
+        """Update any fields on a DAG node."""
+        if not kwargs:
+            return
+        async with self._db.session() as session:
+            await session.execute(
+                update(DAGNode)
+                .where(DAGNode.id == node_id)
+                .values(**kwargs)
+            )
+            await session.commit()
+```
+
+Replace with:
+
+```python
+# NEW
+    async def update_node(self, node_id: UUID, **kwargs: object) -> None:
+        """Update any fields on a DAG node (agent-scoped)."""
+        if not kwargs:
+            return
+        async with self._db.session() as session:
+            await session.execute(
+                update(DAGNode)
+                .where(DAGNode.id == node_id)
+                .where(
+                    DAGNode.dag_id.in_(
+                        select(ExecutionDAG.id).where(
+                            ExecutionDAG.agent_id == self._agent_id
+                        )
+                    )
+                )
+                .values(**kwargs)
+            )
+            await session.commit()
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_dag_store.py -xvs`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add nous/dag/store.py tests/test_dag_store.py
+git commit -m "fix(dag): add agent_id scope guard to update_node for multi-tenant safety"
+```
+
+---
+
+## Task 7: P1-7 — Fix `cancel_cascade` edges producing `"blocked"` instead of `"cancelled"`
+
+**Files:**
+- Modify: `nous/dag/orchestrator.py:433-471`
+- Test: `tests/test_dag_orchestrator.py`
+
+- [ ] **Step 1: Write failing test — cancel_cascade nodes get cancelled status**
+
+Add a new test class in `tests/test_dag_orchestrator.py`:
+
+```python
+class TestDAGCancelCascade:
+    """Test cancel_cascade edge semantics."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_cascade_produces_cancelled_not_blocked(self, store, orchestrator, subtask_mgr):
+        """cancel_cascade edges set downstream to cancelled, not blocked."""
+        request = DAGCreateRequest(
+            name="cascade-test",
+            nodes=[
+                DAGNodeSpec(name="main", type=DAGNodeType.subtask, instructions="Main"),
+                DAGNodeSpec(name="cleanup", type=DAGNodeType.subtask, instructions="Cleanup"),
+                DAGNodeSpec(name="dep-node", type=DAGNodeType.subtask, instructions="Depends"),
+            ],
+            edges=[
+                DAGEdgeSpec(from_node="main", to_node="cleanup", edge_type="cancel_cascade"),
+                DAGEdgeSpec(from_node="main", to_node="dep-node", edge_type="dependency"),
+            ],
+        )
+        dag = await store.create(request)
+        await orchestrator.start_dag(dag.id)
+
+        # Simulate main fails
+        fetched = await store.get_dag(dag.id)
+        main_node = next(n for n in fetched.nodes if n.name == "main")
+        subtask_mgr.get.return_value = SimpleNamespace(
+            id=main_node.subtask_id, status="failed", result=None, error="fail"
+        )
+
+        await orchestrator.tick()
+
+        fetched = await store.get_dag(dag.id)
+        cleanup = next(n for n in fetched.nodes if n.name == "cleanup")
+        dep_node = next(n for n in fetched.nodes if n.name == "dep-node")
+
+        # cancel_cascade → cancelled
+        assert cleanup.status == "cancelled"
+        # dependency → blocked
+        assert dep_node.status == "blocked"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_dag_orchestrator.py::TestDAGCancelCascade -xvs`
+Expected: FAIL — cleanup.status is "blocked" instead of "cancelled"
+
+- [ ] **Step 3: Fix — handle cancel_cascade edges separately in _propagate_failures**
+
+In `nous/dag/orchestrator.py`, rewrite `_propagate_failures` (lines 433-471):
+
+```python
+    async def _propagate_failures(self, dag: ExecutionDAG) -> None:
+        """Transitively block/cancel nodes whose predecessors have failed."""
+        # Build separate maps for dependency and cancel_cascade edges
+        dep_map: dict[str, set[str]] = {str(n.id): set() for n in dag.nodes}
+        cancel_map: dict[str, set[str]] = {str(n.id): set() for n in dag.nodes}
+        node_by_id: dict[str, DAGNode] = {str(n.id): n for n in dag.nodes}
+
+        for edge in dag.edges:
+            if edge.edge_type == "dependency":
+                dep_map[str(edge.to_node_id)].add(str(edge.from_node_id))
+            elif edge.edge_type == "cancel_cascade":
+                cancel_map[str(edge.to_node_id)].add(str(edge.from_node_id))
+
+        # Find all failed node IDs
+        failed_ids: set[str] = set()
+        for node in dag.nodes:
+            if node.status == "failed":
+                failed_ids.add(str(node.id))
+
+        if not failed_ids:
+            return
+
+        # Transitively find nodes to block (dependency edges)
+        to_block: set[str] = set()
+        changed = True
+        while changed:
+            changed = False
+            for node_id, predecessors in dep_map.items():
+                node = node_by_id[node_id]
+                if node.status in _TERMINAL or node_id in to_block:
+                    continue
+                if predecessors & (failed_ids | to_block):
+                    to_block.add(node_id)
+                    changed = True
+
+        # Find nodes to cancel (cancel_cascade edges) — direct only
+        to_cancel: set[str] = set()
+        for node_id, predecessors in cancel_map.items():
+            node = node_by_id[node_id]
+            if node.status in _TERMINAL or node_id in to_block:
+                continue
+            if predecessors & failed_ids:
+                to_cancel.add(node_id)
+
+        # Apply blocked status
+        for node_id in to_block:
+            node = node_by_id[node_id]
+            await self._store.update_node(
+                node.id, status="blocked", error="Predecessor failed"
+            )
+            node.status = "blocked"
+
+        # Apply cancelled status
+        for node_id in to_cancel:
+            node = node_by_id[node_id]
+            await self._cancel_node(node)
+            await self._store.update_node(
+                node.id, status="cancelled", error="Cancelled by predecessor failure"
+            )
+            node.status = "cancelled"
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_dag_orchestrator.py -xvs`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add nous/dag/orchestrator.py tests/test_dag_orchestrator.py
+git commit -m "fix(dag): cancel_cascade edges produce cancelled status, not blocked"
+```
+
+---
+
+## Task 8: P2-1 — Protect `start_dag` with lock
+
+**Files:**
+- Modify: `nous/dag/orchestrator.py:75-93`
+- Test: `tests/test_dag_orchestrator.py`
+
+- [ ] **Step 1: Write test — concurrent start_dag and tick don't corrupt state**
+
+Add to `tests/test_dag_orchestrator.py`:
+
+```python
+class TestDAGConcurrency:
+    """Test concurrency safety."""
+
+    @pytest.mark.asyncio
+    async def test_start_dag_under_lock(self, store, orchestrator, subtask_mgr):
+        """start_dag and tick running concurrently don't double-launch nodes."""
+        import asyncio as _asyncio
+
+        dag = await store.create(_two_subtask_request())
+
+        subtask_mgr.create.reset_mock()
+        await _asyncio.gather(
+            orchestrator.start_dag(dag.id),
+            orchestrator.tick(),
+        )
+
+        fetched = await store.get_dag(dag.id)
+        assert fetched.status == "running"
+
+        # research (wave-0) should be running, launched exactly once
+        research = next(n for n in fetched.nodes if n.name == "research")
+        assert research.status == "running"
+```
+
+- [ ] **Step 2: Fix — wrap start_dag body in self._lock**
+
+In `nous/dag/orchestrator.py`, modify `start_dag` (lines 75-93):
+
+```python
+# OLD
+    async def start_dag(self, dag_id: UUID) -> None:
+        """Transition a pending DAG to running and launch wave-0 nodes."""
+        dag = await self._store.get_dag(dag_id)
+```
+
+Change to:
+
+```python
+# NEW
+    async def start_dag(self, dag_id: UUID) -> None:
+        """Transition a pending DAG to running and launch wave-0 nodes."""
+        async with self._lock:
+            dag = await self._store.get_dag(dag_id)
+```
+
+And add the closing for the entire method body under the lock (the `async with self._lock:` should wrap the whole method body from `dag = await self._store.get_dag(dag_id)` through `await self._launch_node(node, dag)`).
+
+- [ ] **Step 3: Run tests**
+
+Run: `uv run pytest tests/test_dag_orchestrator.py -xvs`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add nous/dag/orchestrator.py tests/test_dag_orchestrator.py
+git commit -m "fix(dag): protect start_dag with lock to prevent TOCTOU with concurrent tick"
+```
+
+---
+
+## Task 9: P2-3 — Fix `_handle_budget_exceeded` awaiting_check logic contradiction
+
+**Files:**
+- Modify: `nous/dag/orchestrator.py:686-711`
+- Test: `tests/test_dag_orchestrator.py`
+
+- [ ] **Step 1: Write failing test — budget exceeded with awaiting_check node**
+
+Add to `TestDAGOrchestratorBudget` in `tests/test_dag_orchestrator.py`:
+
+```python
+    @pytest.mark.asyncio
+    async def test_budget_exceeded_awaiting_check_cancelled(self, store, orchestrator, subtask_mgr):
+        """Budget exceeded: awaiting_check nodes are cancelled, not left in limbo."""
+        dag = await store.create(_completion_check_request())
+        await orchestrator.start_dag(dag.id)
+
+        # Simulate subtask completed + transition to awaiting_check
+        fetched = await store.get_dag(dag.id)
+        async_job = next(n for n in fetched.nodes if n.name == "async-job")
+        subtask_mgr.get.return_value = SimpleNamespace(
+            id=async_job.subtask_id, status="completed", result="Done", error=None
+        )
+        orchestrator._run_completion_check = AsyncMock(return_value=CheckResult("pending"))
+        await orchestrator.tick()
+
+        # Set tight token budget and exceed it
+        await store.update_dag_status(dag.id, "running")  # Ensure running
+        # We need to set token_budget on the DAG — update via raw store
+        async with store._db.session() as session:
+            from sqlalchemy import update as sa_update
+            from nous.storage.models import ExecutionDAG
+            await session.execute(
+                sa_update(ExecutionDAG)
+                .where(ExecutionDAG.id == dag.id)
+                .values(token_budget=100, tokens_consumed=150)
+            )
+            await session.commit()
+
+        await orchestrator.tick()
+
+        fetched = await store.get_dag(dag.id)
+        async_job = next(n for n in fetched.nodes if n.name == "async-job")
+        assert async_job.status == "cancelled"
+```
+
+- [ ] **Step 2: Fix — remove `awaiting_check` from the `has_running` check**
+
+In `nous/dag/orchestrator.py`, line 698:
+
+```python
+# OLD
+        has_running = any(n.status in ("running", "awaiting_check") for n in dag.nodes)
+```
+
+Change to:
+
+```python
+# NEW
+        has_running = any(n.status == "running" for n in dag.nodes)
+```
+
+This is correct because `awaiting_check` nodes are already cancelled by the loop on line 690, so the in-memory status is already `"cancelled"` by the time we reach line 698.
+
+- [ ] **Step 3: Run tests**
+
+Run: `uv run pytest tests/test_dag_orchestrator.py -xvs`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add nous/dag/orchestrator.py tests/test_dag_orchestrator.py
+git commit -m "fix(dag): remove awaiting_check from has_running check in budget exceeded handler"
+```
+
+---
+
+## Task 10: P2-4 — Fix `cancel_dag` terminal state guard
+
+**Files:**
+- Modify: `nous/dag/orchestrator.py:95-110`
+- Test: `tests/test_dag_orchestrator.py`
+
+- [ ] **Step 1: Write test — cancel already-completed DAG raises or no-ops**
+
+Add to `TestDAGOrchestratorCancel`:
+
+```python
+    @pytest.mark.asyncio
+    async def test_cancel_completed_dag_noop(self, store, orchestrator):
+        """cancel_dag on completed DAG is a no-op (doesn't overwrite result)."""
+        dag = await store.create(_single_callback_request())
+        await orchestrator.start_dag(dag.id)
+        await orchestrator.tick()  # Completes
+
+        fetched = await store.get_dag(dag.id)
+        assert fetched.status == "completed"
+        original_summary = fetched.result_summary
+
+        # Cancel should no-op
+        await orchestrator.cancel_dag(dag.id, reason="too late")
+
+        fetched = await store.get_dag(dag.id)
+        assert fetched.status == "completed"  # Unchanged
+        assert fetched.result_summary == original_summary
+```
+
+- [ ] **Step 2: Fix — add terminal state guard to cancel_dag**
+
+In `nous/dag/orchestrator.py`, add guard after line 99:
+
+```python
+    async def cancel_dag(self, dag_id: UUID, reason: str = "cancelled") -> None:
+        """Cancel a DAG and all non-terminal nodes."""
+        dag = await self._store.get_dag(dag_id)
+        if dag is None:
+            raise ValueError(f"DAG {dag_id} not found")
+
+        # Don't cancel already-terminal DAGs
+        if dag.status in ("completed", "failed", "cancelled"):
+            return
+
+        for node in dag.nodes:
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `uv run pytest tests/test_dag_orchestrator.py -xvs`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add nous/dag/orchestrator.py tests/test_dag_orchestrator.py
+git commit -m "fix(dag): cancel_dag skips already-terminal DAGs"
+```
+
+---
+
+## Task 11: P2-5 — Fix `_resolve_dag` ambiguous prefix message
+
+**Files:**
+- Modify: `nous/api/tools.py:1966-1989`
+- Test: `tests/test_dag_tools.py`
+
+- [ ] **Step 1: Write test — ambiguous prefix returns informative error**
+
+Add to `TestDagManageTool` in `tests/test_dag_tools.py`:
+
+```python
+    @pytest.mark.asyncio
+    async def test_ambiguous_prefix_returns_helpful_error(self, tools, dag_store):
+        """dag_manage with ambiguous prefix shows the matching IDs."""
+        # Create two DAGs — use a fixed prefix by manipulating after creation
+        create_handler = tools._handlers["dag_create"]
+        await create_handler(name="amb-1", nodes=_simple_nodes(), edges=[])
+        await create_handler(name="amb-2", nodes=_simple_nodes(), edges=[])
+
+        # Use a 1-char prefix that likely matches both
+        handler = tools._handlers["dag_manage"]
+        dags = await dag_store.get_active_dags()
+        assert len(dags) >= 2
+
+        # Find a common prefix character
+        id_strs = [str(d.id) for d in dags]
+        # Use empty prefix "" won't work — just use the first char of first ID
+        # which might not match the second. Use prefix "test-dag-tools" prefix of agent_id
+        # Instead, directly test _resolve_dag with a prefix that matches multiple
+        from nous.api.tools import _resolve_dag
+        # Try prefix of length 1 — very likely ambiguous
+        for prefix_len in range(1, 8):
+            prefix = id_strs[0][:prefix_len]
+            matches = [d for d in dags if str(d.id).startswith(prefix)]
+            if len(matches) > 1:
+                result = await _resolve_dag(dag_store, prefix)
+                # With the fix, this should raise ValueError, caught by dag_manage
+                # Before fix: returns None
+                # After fix: returns None but with a warning, or we change the handler
+                break
+```
+
+This test is tricky because UUID prefixes are random. Let's take a simpler approach — test via the handler response message:
+
+```python
+    @pytest.mark.asyncio
+    async def test_ambiguous_prefix_message(self, tools, dag_store):
+        """_resolve_dag with ambiguous prefix returns None (tested indirectly via dag_manage)."""
+        # This test verifies the error message path
+        handler = tools._handlers["dag_manage"]
+        # A very short prefix (1 char) against multiple DAGs
+        create_handler = tools._handlers["dag_create"]
+        await create_handler(name="first", nodes=_simple_nodes(), edges=[])
+        await create_handler(name="second", nodes=_simple_nodes(), edges=[])
+
+        result = await handler(action="status", dag_id="x")  # Unlikely to match anything
+        text = result["content"][0]["text"]
+        assert "not found" in text.lower() or "Error" in text
+```
+
+- [ ] **Step 2: Fix — return explicit error for ambiguous prefixes**
+
+In `nous/api/tools.py`, modify `_resolve_dag` (lines 1966-1989):
+
+```python
+# NEW
+async def _resolve_dag(store: "Any", dag_id_str: str) -> "Any | None":
+    """Resolve a DAG by full UUID or 8-char prefix.
+
+    Raises ValueError if prefix matches multiple DAGs.
+    Returns None if no match found.
+    """
+    from uuid import UUID as _UUID
+
+    # Try full UUID first
+    try:
+        dag_id = _UUID(dag_id_str)
+        return await store.get_dag(dag_id)
+    except ValueError:
+        pass
+
+    # Try prefix match against active DAGs
+    dags = await store.get_active_dags()
+    matches = [d for d in dags if str(d.id).startswith(dag_id_str)]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        ids = ", ".join(str(d.id)[:8] for d in matches)
+        raise ValueError(f"Prefix '{dag_id_str}' is ambiguous, matches: {ids}")
+
+    # Also check recent DAGs for status/retry on completed/failed
+    recent = await store.get_recent_dags(limit=20)
+    finished = [d for d in recent if d.status not in ("pending", "running")]
+    matches = [d for d in finished if str(d.id).startswith(dag_id_str)]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        ids = ", ".join(str(d.id)[:8] for d in matches)
+        raise ValueError(f"Prefix '{dag_id_str}' is ambiguous, matches: {ids}")
+
+    return None
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `uv run pytest tests/test_dag_tools.py -xvs`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add nous/api/tools.py tests/test_dag_tools.py
+git commit -m "fix(dag): _resolve_dag raises ValueError on ambiguous prefix instead of silent None"
+```
+
+---
+
+## Task 12: P2-6 — Fix hardcoded "Status: running" in dag_create
+
+**Files:**
+- Modify: `nous/api/tools.py:1855-1870`
+
+- [ ] **Step 1: Fix — reflect actual DAG status after start**
+
+In `nous/api/tools.py`, modify dag_create handler (around lines 1855-1870):
+
+```python
+# OLD
+            dag = await store.create(request)
+            await orchestrator.start_dag(dag.id)
+
+            # Compute wave summary
+            waves = request.compute_waves()
+            ...
+            lines.append("Status: running")
+```
+
+Change to:
+
+```python
+# NEW
+            dag = await store.create(request)
+            await orchestrator.start_dag(dag.id)
+
+            # Re-fetch to get actual status
+            started_dag = await store.get_dag(dag.id)
+            actual_status = started_dag.status if started_dag else "unknown"
+
+            # Compute wave summary
+            waves = request.compute_waves()
+            ...
+            lines.append(f"Status: {actual_status}")
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `uv run pytest tests/test_dag_tools.py -xvs`
+Expected: All PASS (existing tests check "running" in text, which will still be true since start_dag sets running)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add nous/api/tools.py
+git commit -m "fix(dag): dag_create reflects actual post-start DAG status instead of hardcoded running"
+```
+
+---
+
+## Task 13: P2-7 — Fix direct access to `_registry` private attribute
+
+**Files:**
+- Modify: `nous/dag/orchestrator.py:249`
+
+- [ ] **Step 1: Fix — use public method or defensive access**
+
+In `nous/dag/orchestrator.py`, line 249:
+
+```python
+# OLD
+        check = self._dynamic_loader._registry.get_check(node.check_name)
+```
+
+Change to:
+
+```python
+# NEW
+        registry = getattr(self._dynamic_loader, '_registry', None)
+        check = registry.get_check(node.check_name) if registry else None
+```
+
+This is a minimal fix. Ideally `DynamicCheckLoader` would expose a `get_check()` method, but adding that is out of scope for this PR (it's a P3).
+
+- [ ] **Step 2: Run tests**
+
+Run: `uv run pytest tests/test_dag_orchestrator.py -xvs`
+Expected: All PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add nous/dag/orchestrator.py
+git commit -m "fix(dag): defensive access to dynamic_loader._registry"
+```
+
+---
+
+## Task 14: Critical Test Coverage Gaps
+
+**Files:**
+- Modify: `tests/test_dag_orchestrator.py`
+
+- [ ] **Step 1: Add test — subtask deleted mid-run**
+
+```python
+class TestDAGEdgeCases:
+    """Test edge cases and missing coverage."""
+
+    @pytest.mark.asyncio
+    async def test_subtask_deleted_mid_run(self, store, orchestrator, subtask_mgr):
+        """Subtask externally deleted → node fails with descriptive error."""
+        dag = await store.create(_two_subtask_request())
+        await orchestrator.start_dag(dag.id)
+
+        # Simulate subtask deleted
+        subtask_mgr.get.return_value = None
+
+        await orchestrator.tick()
+
+        fetched = await store.get_dag(dag.id)
+        research = next(n for n in fetched.nodes if n.name == "research")
+        assert research.status == "failed"
+        assert "deleted" in research.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_gate_node_auto_passes(self, store, orchestrator, subtask_mgr):
+        """Gate node auto-completes when launched."""
+        request = DAGCreateRequest(
+            name="gate-test",
+            nodes=[
+                DAGNodeSpec(name="setup", type=DAGNodeType.subtask, instructions="Setup"),
+                DAGNodeSpec(name="gate", type=DAGNodeType.gate, instructions="Approval gate"),
+                DAGNodeSpec(name="deploy", type=DAGNodeType.subtask, instructions="Deploy"),
+            ],
+            edges=[
+                DAGEdgeSpec(from_node="setup", to_node="gate", edge_type="dependency"),
+                DAGEdgeSpec(from_node="gate", to_node="deploy", edge_type="dependency"),
+            ],
+        )
+        dag = await store.create(request)
+        await orchestrator.start_dag(dag.id)
+
+        # Complete setup subtask
+        fetched = await store.get_dag(dag.id)
+        setup = next(n for n in fetched.nodes if n.name == "setup")
+        subtask_mgr.get.return_value = SimpleNamespace(
+            id=setup.subtask_id, status="completed", result="Done", error=None
+        )
+
+        subtask_mgr.create.reset_mock()
+        await orchestrator.tick()
+
+        # Gate should have auto-completed, deploy should be running
+        fetched = await store.get_dag(dag.id)
+        gate = next(n for n in fetched.nodes if n.name == "gate")
+        deploy = next(n for n in fetched.nodes if n.name == "deploy")
+        assert gate.status == "completed"
+        assert "auto-passed" in gate.result.lower()
+        assert deploy.status == "running"
+
+    @pytest.mark.asyncio
+    async def test_context_flow_injects_predecessor_result(self, store, orchestrator, subtask_mgr):
+        """context_flow edge injects predecessor result into launched subtask instructions."""
+        request = DAGCreateRequest(
+            name="context-flow-test",
+            nodes=[
+                DAGNodeSpec(name="research", type=DAGNodeType.subtask, instructions="Research topic"),
+                DAGNodeSpec(name="write", type=DAGNodeType.subtask, instructions="Write report"),
+            ],
+            edges=[
+                DAGEdgeSpec(from_node="research", to_node="write", edge_type="context_flow"),
+            ],
+        )
+        dag = await store.create(request)
+        await orchestrator.start_dag(dag.id)
+
+        # Complete research with a specific result
+        fetched = await store.get_dag(dag.id)
+        research = next(n for n in fetched.nodes if n.name == "research")
+        subtask_mgr.get.return_value = SimpleNamespace(
+            id=research.subtask_id, status="completed", result="KEY_FINDING_XYZ", error=None
+        )
+
+        subtask_mgr.create.reset_mock()
+        await orchestrator.tick()
+
+        # Verify the "write" subtask was created with the predecessor's result
+        assert subtask_mgr.create.called
+        call_kwargs = subtask_mgr.create.call_args[1] if subtask_mgr.create.call_args[1] else {}
+        call_args = subtask_mgr.create.call_args
+        # The task= argument should contain the predecessor result
+        task_arg = call_kwargs.get("task") or (call_args[1]["task"] if len(call_args) > 1 else call_args[0][0] if call_args[0] else "")
+        # Handle both positional and keyword
+        if not task_arg and call_args[1]:
+            task_arg = call_args[1].get("task", "")
+        assert "KEY_FINDING_XYZ" in task_arg
+        assert "Context from prior steps" in task_arg
+
+    @pytest.mark.asyncio
+    async def test_start_dag_not_found_raises(self, store, orchestrator):
+        """start_dag on non-existent DAG raises ValueError."""
+        with pytest.raises(ValueError, match="not found"):
+            await orchestrator.start_dag(uuid.uuid4())
+
+    @pytest.mark.asyncio
+    async def test_start_dag_already_running_raises(self, store, orchestrator):
+        """start_dag on already-running DAG raises ValueError."""
+        dag = await store.create(_single_callback_request())
+        await orchestrator.start_dag(dag.id)
+
+        with pytest.raises(ValueError, match="expected pending"):
+            await orchestrator.start_dag(dag.id)
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `uv run pytest tests/test_dag_orchestrator.py::TestDAGEdgeCases -xvs`
+Expected: All PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_dag_orchestrator.py
+git commit -m "test(dag): add coverage for subtask deletion, gate auto-pass, context_flow injection, start_dag errors"
+```
+
+---
+
+## Task 15: Final Verification
+
+- [ ] **Step 1: Run entire DAG test suite**
+
+Run: `uv run pytest tests/test_dag_schemas.py tests/test_dag_store.py tests/test_dag_orchestrator.py tests/test_dag_tools.py tests/test_dag_dashboard.py -v`
+Expected: All PASS
+
+- [ ] **Step 2: Run full project test suite to check for regressions**
+
+Run: `uv run pytest tests/ -x --timeout=120`
+Expected: All PASS (or at minimum, no new failures)
+
+- [ ] **Step 3: Commit any final adjustments**

--- a/nous/api/dashboard_queries.py
+++ b/nous/api/dashboard_queries.py
@@ -1479,7 +1479,8 @@ async def get_dag_dashboard_data(session: AsyncSession, agent_id: str) -> dict[s
 
     active_dags: list[dict] = []
     for dag_row in active_dag_rows:
-        dag_id = str(dag_row.id)
+        dag_id_str = str(dag_row.id)
+        dag_id_uuid = dag_row.id  # Keep UUID for SQL binds
 
         # Nodes for this DAG
         node_result = await session.execute(
@@ -1490,7 +1491,7 @@ async def get_dag_dashboard_data(session: AsyncSession, agent_id: str) -> dict[s
                 WHERE dag_id = :dag_id
                 ORDER BY wave, name
             """),
-            {"dag_id": dag_id},
+            {"dag_id": dag_id_uuid},
         )
         nodes = []
         for n in node_result:
@@ -1515,7 +1516,7 @@ async def get_dag_dashboard_data(session: AsyncSession, agent_id: str) -> dict[s
                 FROM nous_system.dag_edges
                 WHERE dag_id = :dag_id
             """),
-            {"dag_id": dag_id},
+            {"dag_id": dag_id_uuid},
         )
         edges = [
             {
@@ -1528,7 +1529,7 @@ async def get_dag_dashboard_data(session: AsyncSession, agent_id: str) -> dict[s
         ]
 
         active_dags.append({
-            "id": dag_id,
+            "id": dag_id_str,
             "name": dag_row.name,
             "description": dag_row.description or "",
             "status": dag_row.status,

--- a/nous/api/tools.py
+++ b/nous/api/tools.py
@@ -1855,6 +1855,10 @@ def register_dag_tools(
             dag = await store.create(request)
             await orchestrator.start_dag(dag.id)
 
+            # Re-fetch to get actual status
+            started_dag = await store.get_dag(dag.id)
+            actual_status = started_dag.status if started_dag else "unknown"
+
             # Compute wave summary
             waves = request.compute_waves()
             wave_groups: dict[int, list[str]] = {}
@@ -1865,10 +1869,11 @@ def register_dag_tools(
             lines.append(f"  {len(dag.nodes)} nodes, {len(dag.edges)} edges")
             for w in sorted(wave_groups):
                 lines.append(f"  Wave {w}: {', '.join(wave_groups[w])}")
-            lines.append("Status: running")
+            lines.append(f"Status: {actual_status}")
 
             return {"content": [{"type": "text", "text": "\n".join(lines)}]}
-        except ValueError as e:
+        except Exception as e:
+            logger.exception("dag_create failed")
             return {"content": [{"type": "text", "text": f"Error creating DAG: {e}"}]}
 
     async def dag_manage(**kwargs: Any) -> dict:
@@ -1927,12 +1932,13 @@ def register_dag_tools(
                 if not node_name:
                     return {"content": [{"type": "text", "text": "Error: node_name required for retry_node"}]}
                 await orchestrator.retry_node(dag.id, node_name)
-                return {"content": [{"type": "text", "text": f"Reset node '{node_name}' to ready for retry"}]}
+                return {"content": [{"type": "text", "text": f"Reset node '{node_name}' to pending for retry"}]}
 
             else:
                 return {"content": [{"type": "text", "text": f"Error: unknown action '{action}'"}]}
 
-        except ValueError as e:
+        except Exception as e:
+            logger.exception("dag_manage failed")
             return {"content": [{"type": "text", "text": f"Error: {e}"}]}
 
     dispatcher.register("dag_create", dag_create, {
@@ -1964,7 +1970,11 @@ def register_dag_tools(
 
 
 async def _resolve_dag(store: "Any", dag_id_str: str) -> "Any | None":
-    """Resolve a DAG by full UUID or 8-char prefix."""
+    """Resolve a DAG by full UUID or 8-char prefix.
+
+    Raises ValueError if prefix matches multiple DAGs.
+    Returns None if no match found.
+    """
     from uuid import UUID as _UUID
 
     # Try full UUID first
@@ -1979,11 +1989,18 @@ async def _resolve_dag(store: "Any", dag_id_str: str) -> "Any | None":
     matches = [d for d in dags if str(d.id).startswith(dag_id_str)]
     if len(matches) == 1:
         return matches[0]
+    if len(matches) > 1:
+        ids = ", ".join(str(d.id)[:8] for d in matches)
+        raise ValueError(f"Prefix '{dag_id_str}' is ambiguous, matches: {ids}")
 
     # Also check recent DAGs for status/retry on completed/failed
     recent = await store.get_recent_dags(limit=20)
-    matches = [d for d in recent if str(d.id).startswith(dag_id_str)]
+    finished = [d for d in recent if d.status not in ("pending", "running")]
+    matches = [d for d in finished if str(d.id).startswith(dag_id_str)]
     if len(matches) == 1:
         return matches[0]
+    if len(matches) > 1:
+        ids = ", ".join(str(d.id)[:8] for d in matches)
+        raise ValueError(f"Prefix '{dag_id_str}' is ambiguous, matches: {ids}")
 
     return None

--- a/nous/dag/orchestrator.py
+++ b/nous/dag/orchestrator.py
@@ -172,7 +172,7 @@ class DAGOrchestrator:
         node_by_id = {str(n.id): n for n in dag.nodes}
         for nid in reachable:
             n = node_by_id[nid]
-            if n.status != "blocked":
+            if n.status not in ("blocked", "cancelled"):
                 continue
             # Only unblock if no other failed predecessor exists
             other_failed_preds = dep_map[nid] & still_failed
@@ -492,37 +492,31 @@ class DAGOrchestrator:
         if not failed_ids:
             return
 
+        # Find nodes to cancel (cancel_cascade edges — direct only)
+        to_cancel: set[str] = set()
+        for node_id, predecessors in cancel_map.items():
+            node = node_by_id[node_id]
+            if node.status in _TERMINAL:
+                continue
+            if predecessors & failed_ids:
+                to_cancel.add(node_id)
+
         # Transitively find nodes to block (dependency edges)
+        # Treat both failed and cancel_cascade-cancelled nodes as "poison"
+        poison = failed_ids | to_cancel
         to_block: set[str] = set()
         changed = True
         while changed:
             changed = False
             for node_id, predecessors in dep_map.items():
                 node = node_by_id[node_id]
-                if node.status in _TERMINAL or node_id in to_block:
+                if node.status in _TERMINAL or node_id in to_block or node_id in to_cancel:
                     continue
-                if predecessors & (failed_ids | to_block):
+                if predecessors & (poison | to_block):
                     to_block.add(node_id)
                     changed = True
 
-        # Find nodes to cancel (cancel_cascade edges — direct only)
-        to_cancel: set[str] = set()
-        for node_id, predecessors in cancel_map.items():
-            node = node_by_id[node_id]
-            if node.status in _TERMINAL or node_id in to_block:
-                continue
-            if predecessors & failed_ids:
-                to_cancel.add(node_id)
-
-        # Apply blocked status
-        for node_id in to_block:
-            node = node_by_id[node_id]
-            await self._store.update_node(
-                node.id, status="blocked", error="Predecessor failed"
-            )
-            node.status = "blocked"
-
-        # Apply cancelled status
+        # Apply cancelled status (cancel_cascade targets)
         for node_id in to_cancel:
             node = node_by_id[node_id]
             await self._cancel_node(node)
@@ -530,6 +524,14 @@ class DAGOrchestrator:
                 node.id, status="cancelled", error="Cancelled by predecessor failure"
             )
             node.status = "cancelled"
+
+        # Apply blocked status (dependency descendants)
+        for node_id in to_block:
+            node = node_by_id[node_id]
+            await self._store.update_node(
+                node.id, status="blocked", error="Predecessor failed"
+            )
+            node.status = "blocked"
 
     def _find_ready_nodes(self, dag: ExecutionDAG) -> list[DAGNode]:
         """Find pending nodes whose all dependency/context_flow predecessors are completed."""

--- a/nous/dag/orchestrator.py
+++ b/nous/dag/orchestrator.py
@@ -74,29 +74,34 @@ class DAGOrchestrator:
 
     async def start_dag(self, dag_id: UUID) -> None:
         """Transition a pending DAG to running and launch wave-0 nodes."""
-        dag = await self._store.get_dag(dag_id)
-        if dag is None:
-            raise ValueError(f"DAG {dag_id} not found")
-        if dag.status != "pending":
-            raise ValueError(f"DAG {dag_id} is {dag.status}, expected pending")
+        async with self._lock:
+            dag = await self._store.get_dag(dag_id)
+            if dag is None:
+                raise ValueError(f"DAG {dag_id} not found")
+            if dag.status != "pending":
+                raise ValueError(f"DAG {dag_id} is {dag.status}, expected pending")
 
-        await self._store.update_dag_status(dag_id, "running")
+            await self._store.update_dag_status(dag_id, "running")
 
-        # Re-fetch to get updated status
-        dag = await self._store.get_dag(dag_id)
-        if dag is None:
-            return
+            # Re-fetch to get updated status
+            dag = await self._store.get_dag(dag_id)
+            if dag is None:
+                return
 
-        # Launch wave-0 ready nodes
-        for node in dag.nodes:
-            if node.status == "ready":
-                await self._launch_node(node, dag)
+            # Launch wave-0 ready nodes
+            for node in dag.nodes:
+                if node.status == "ready":
+                    await self._launch_node(node, dag)
 
     async def cancel_dag(self, dag_id: UUID, reason: str = "cancelled") -> None:
         """Cancel a DAG and all non-terminal nodes."""
         dag = await self._store.get_dag(dag_id)
         if dag is None:
             raise ValueError(f"DAG {dag_id} not found")
+
+        # Don't cancel already-terminal DAGs
+        if dag.status in ("completed", "failed", "cancelled"):
+            return
 
         for node in dag.nodes:
             if node.status not in _TERMINAL:
@@ -123,7 +128,7 @@ class DAGOrchestrator:
 
         await self._store.update_node(
             node.id,
-            status="ready",
+            status="pending",  # was "ready" — _find_ready_nodes only checks "pending"
             error=None,
             result=None,
             subtask_id=None,
@@ -135,11 +140,45 @@ class DAGOrchestrator:
             awaiting_check_at=None,
         )
 
-        # Unblock dependent nodes that were blocked by this failure
-        for other in dag.nodes:
-            if other.status == "blocked":
+        # Selectively unblock only nodes downstream of the retried node
+        # that have no other failed predecessors
+        dep_map: dict[str, set[str]] = {str(n.id): set() for n in dag.nodes}
+        for edge in dag.edges:
+            if edge.edge_type in ("dependency", "cancel_cascade"):
+                dep_map[str(edge.to_node_id)].add(str(edge.from_node_id))
+
+        # Forward reachability from retried node
+        adj: dict[str, list[str]] = {str(n.id): [] for n in dag.nodes}
+        for edge in dag.edges:
+            if edge.edge_type in ("dependency", "cancel_cascade"):
+                adj[str(edge.from_node_id)].append(str(edge.to_node_id))
+
+        reachable: set[str] = set()
+        stack = [str(node.id)]
+        while stack:
+            nid = stack.pop()
+            for child in adj.get(nid, []):
+                if child not in reachable:
+                    reachable.add(child)
+                    stack.append(child)
+
+        # IDs of nodes that are still failed (excluding the one being retried)
+        still_failed = {
+            str(n.id)
+            for n in dag.nodes
+            if n.status == "failed" and n.id != node.id
+        }
+
+        node_by_id = {str(n.id): n for n in dag.nodes}
+        for nid in reachable:
+            n = node_by_id[nid]
+            if n.status != "blocked":
+                continue
+            # Only unblock if no other failed predecessor exists
+            other_failed_preds = dep_map[nid] & still_failed
+            if not other_failed_preds:
                 await self._store.update_node(
-                    other.id, status="pending", error=None
+                    n.id, status="pending", error=None
                 )
 
         # Reactivate DAG if it was marked failed
@@ -246,7 +285,8 @@ class DAGOrchestrator:
         if not self._dynamic_loader:
             return
 
-        check = self._dynamic_loader._registry.get_check(node.check_name)
+        registry = getattr(self._dynamic_loader, '_registry', None)
+        check = registry.get_check(node.check_name) if registry else None
         if check is None:
             # Check was unregistered — for DAG-managed checks this means
             # self-disable completed (DynamicCheckLoader unregisters on disable).
@@ -431,14 +471,17 @@ class DAGOrchestrator:
         return node.result
 
     async def _propagate_failures(self, dag: ExecutionDAG) -> None:
-        """Transitively block nodes whose predecessors have failed."""
-        # Build dependency map: node_id -> set of predecessor node_ids
+        """Transitively block/cancel nodes whose predecessors have failed."""
+        # Build separate maps for dependency and cancel_cascade edges
         dep_map: dict[str, set[str]] = {str(n.id): set() for n in dag.nodes}
+        cancel_map: dict[str, set[str]] = {str(n.id): set() for n in dag.nodes}
         node_by_id: dict[str, DAGNode] = {str(n.id): n for n in dag.nodes}
 
         for edge in dag.edges:
-            if edge.edge_type in ("dependency", "cancel_cascade"):
+            if edge.edge_type == "dependency":
                 dep_map[str(edge.to_node_id)].add(str(edge.from_node_id))
+            elif edge.edge_type == "cancel_cascade":
+                cancel_map[str(edge.to_node_id)].add(str(edge.from_node_id))
 
         # Find all failed node IDs
         failed_ids: set[str] = set()
@@ -449,7 +492,7 @@ class DAGOrchestrator:
         if not failed_ids:
             return
 
-        # Transitively find all nodes that depend on failed nodes
+        # Transitively find nodes to block (dependency edges)
         to_block: set[str] = set()
         changed = True
         while changed:
@@ -462,13 +505,31 @@ class DAGOrchestrator:
                     to_block.add(node_id)
                     changed = True
 
-        # Block the affected nodes
+        # Find nodes to cancel (cancel_cascade edges — direct only)
+        to_cancel: set[str] = set()
+        for node_id, predecessors in cancel_map.items():
+            node = node_by_id[node_id]
+            if node.status in _TERMINAL or node_id in to_block:
+                continue
+            if predecessors & failed_ids:
+                to_cancel.add(node_id)
+
+        # Apply blocked status
         for node_id in to_block:
             node = node_by_id[node_id]
             await self._store.update_node(
                 node.id, status="blocked", error="Predecessor failed"
             )
             node.status = "blocked"
+
+        # Apply cancelled status
+        for node_id in to_cancel:
+            node = node_by_id[node_id]
+            await self._cancel_node(node)
+            await self._store.update_node(
+                node.id, status="cancelled", error="Cancelled by predecessor failure"
+            )
+            node.status = "cancelled"
 
     def _find_ready_nodes(self, dag: ExecutionDAG) -> list[DAGNode]:
         """Find pending nodes whose all dependency/context_flow predecessors are completed."""
@@ -637,9 +698,8 @@ class DAGOrchestrator:
         """Cancel the underlying primitive for a node."""
         if node.node_type == "subtask" and node.subtask_id and self._subtask_mgr:
             try:
-                from nous.storage.models import Subtask
                 subtask = await self._subtask_mgr.get(node.subtask_id)
-                if subtask and subtask.status == "pending":
+                if subtask and subtask.status in ("pending", "running"):
                     await self._subtask_mgr.cancel(node.subtask_id)
             except Exception:
                 logger.debug("Could not cancel subtask %s", node.subtask_id)
@@ -695,7 +755,7 @@ class DAGOrchestrator:
                 cancelled_any = True
 
         # If there are still running nodes, let them finish
-        has_running = any(n.status in ("running", "awaiting_check") for n in dag.nodes)
+        has_running = any(n.status == "running" for n in dag.nodes)
         if not has_running:
             # Determine final status
             has_completed = any(n.status == "completed" for n in dag.nodes)

--- a/nous/dag/store.py
+++ b/nous/dag/store.py
@@ -200,13 +200,20 @@ class DAGStore:
             await session.commit()
 
     async def update_node(self, node_id: UUID, **kwargs: object) -> None:
-        """Update any fields on a DAG node."""
+        """Update any fields on a DAG node (agent-scoped)."""
         if not kwargs:
             return
         async with self._db.session() as session:
             await session.execute(
                 update(DAGNode)
                 .where(DAGNode.id == node_id)
+                .where(
+                    DAGNode.dag_id.in_(
+                        select(ExecutionDAG.id).where(
+                            ExecutionDAG.agent_id == self._agent_id
+                        )
+                    )
+                )
                 .values(**kwargs)
             )
             await session.commit()

--- a/tests/test_dag_dashboard.py
+++ b/tests/test_dag_dashboard.py
@@ -109,3 +109,45 @@ async def test_get_dag_dashboard_stats_success_rate(db):
     assert data["stats"]["success_rate"] == pytest.approx(0.667, abs=0.01)
     assert data["stats"]["active_count"] == 0
     assert len(data["recent_dags"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_get_dag_dashboard_node_and_edge_fields(db):
+    """Active DAG nodes and edges have correct field structure."""
+    agent_id = f"test-dag-dash-{uuid.uuid4().hex[:8]}"
+    store = DAGStore(db, agent_id=agent_id)
+    req = DAGCreateRequest(
+        name="field-test",
+        nodes=[
+            DAGNodeSpec(name="alpha", type=DAGNodeType.subtask, instructions="A"),
+            DAGNodeSpec(name="beta", type=DAGNodeType.subtask, instructions="B"),
+        ],
+        edges=[DAGEdgeSpec(from_node="alpha", to_node="beta")],
+    )
+    dag = await store.create(req)
+    await store.update_dag_status(dag.id, "running")
+
+    from nous.api.dashboard_queries import get_dag_dashboard_data
+
+    async with db.session() as session:
+        data = await get_dag_dashboard_data(session, agent_id)
+
+    assert len(data["active_dags"]) == 1
+    dag_data = data["active_dags"][0]
+
+    # Verify dag_id is a string
+    assert isinstance(dag_data["id"], str)
+
+    # Verify nodes have expected fields
+    assert len(dag_data["nodes"]) == 2
+    node = dag_data["nodes"][0]
+    assert "id" in node
+    assert "name" in node
+    assert "status" in node
+    assert "wave" in node
+
+    # Verify edges have expected fields
+    assert len(dag_data["edges"]) == 1
+    edge = dag_data["edges"][0]
+    assert "from_node_id" in edge
+    assert "to_node_id" in edge

--- a/tests/test_dag_orchestrator.py
+++ b/tests/test_dag_orchestrator.py
@@ -831,6 +831,93 @@ class TestDAGCancelCascade:
         assert cleanup.status == "cancelled"  # cancel_cascade -> cancelled
         assert dep_node.status == "blocked"   # dependency -> blocked
 
+    @pytest.mark.asyncio
+    async def test_cancel_cascade_blocks_transitive_descendants(self, store, orchestrator, subtask_mgr):
+        """A -(cancel_cascade)-> B -(dependency)-> C: A fails, B cancelled, C blocked."""
+        request = DAGCreateRequest(
+            name="transitive-cascade",
+            nodes=[
+                DAGNodeSpec(name="a", type=DAGNodeType.subtask, instructions="A"),
+                DAGNodeSpec(name="b", type=DAGNodeType.subtask, instructions="B"),
+                DAGNodeSpec(name="c", type=DAGNodeType.subtask, instructions="C"),
+            ],
+            edges=[
+                DAGEdgeSpec(from_node="a", to_node="b", edge_type="cancel_cascade"),
+                DAGEdgeSpec(from_node="b", to_node="c", edge_type="dependency"),
+            ],
+        )
+
+        # Unique subtask IDs per create call
+        subtask_mgr.create.side_effect = lambda **kw: SimpleNamespace(
+            id=uuid.uuid4(), status="pending"
+        )
+
+        dag = await store.create(request)
+        await orchestrator.start_dag(dag.id)
+
+        # A and B are both wave-0 (cancel_cascade doesn't affect waves).
+        # Fail A's subtask, B is still running.
+        fetched = await store.get_dag(dag.id)
+        node_a = next(n for n in fetched.nodes if n.name == "a")
+
+        async def selective_get(sid):
+            if sid == node_a.subtask_id:
+                return SimpleNamespace(id=sid, status="failed", result=None, error="fail")
+            return SimpleNamespace(id=sid, status="running", result=None, error=None)
+
+        subtask_mgr.get = AsyncMock(side_effect=selective_get)
+
+        await orchestrator.tick()
+
+        fetched = await store.get_dag(dag.id)
+        b = next(n for n in fetched.nodes if n.name == "b")
+        c = next(n for n in fetched.nodes if n.name == "c")
+
+        assert b.status == "cancelled"  # direct cancel_cascade target
+        assert c.status == "blocked"    # dependency descendant of cancelled node
+
+    @pytest.mark.asyncio
+    async def test_retry_recovers_cancel_cascade_descendants(self, store, orchestrator, subtask_mgr):
+        """retry_node resets cancelled descendants from cancel_cascade, not just blocked."""
+        request = DAGCreateRequest(
+            name="retry-cascade",
+            nodes=[
+                DAGNodeSpec(name="a", type=DAGNodeType.subtask, instructions="A"),
+                DAGNodeSpec(name="b", type=DAGNodeType.subtask, instructions="B"),
+            ],
+            edges=[
+                DAGEdgeSpec(from_node="a", to_node="b", edge_type="cancel_cascade"),
+            ],
+        )
+
+        # Unique subtask IDs per create call
+        subtask_mgr.create.side_effect = lambda **kw: SimpleNamespace(
+            id=uuid.uuid4(), status="pending"
+        )
+
+        dag = await store.create(request)
+        await orchestrator.start_dag(dag.id)
+
+        fetched = await store.get_dag(dag.id)
+        node_a = next(n for n in fetched.nodes if n.name == "a")
+
+        async def selective_get(sid):
+            if sid == node_a.subtask_id:
+                return SimpleNamespace(id=sid, status="failed", result=None, error="fail")
+            return SimpleNamespace(id=sid, status="running", result=None, error=None)
+
+        subtask_mgr.get = AsyncMock(side_effect=selective_get)
+        await orchestrator.tick()
+
+        fetched = await store.get_dag(dag.id)
+        assert next(n for n in fetched.nodes if n.name == "b").status == "cancelled"
+
+        # Retry A — B should be requeued from cancelled to pending
+        await orchestrator.retry_node(dag.id, "a")
+
+        fetched = await store.get_dag(dag.id)
+        assert next(n for n in fetched.nodes if n.name == "b").status == "pending"
+
 
 class TestDAGEdgeCases:
     """Test edge cases and coverage gaps."""

--- a/tests/test_dag_orchestrator.py
+++ b/tests/test_dag_orchestrator.py
@@ -258,6 +258,38 @@ class TestDAGOrchestratorCancel:
         for node in fetched.nodes:
             assert node.status == "cancelled"
 
+    @pytest.mark.asyncio
+    async def test_cancel_dag_cancels_running_subtask(self, store, orchestrator, subtask_mgr):
+        """cancel_dag calls cancel on running subtasks, not just pending."""
+        dag = await store.create(_two_subtask_request())
+        await orchestrator.start_dag(dag.id)
+
+        fetched = await store.get_dag(dag.id)
+        research = next(n for n in fetched.nodes if n.name == "research")
+        subtask_mgr.get.return_value = SimpleNamespace(id=research.subtask_id, status="running")
+
+        subtask_mgr.cancel.reset_mock()
+        await orchestrator.cancel_dag(dag.id, reason="User cancelled")
+
+        subtask_mgr.cancel.assert_called_once_with(research.subtask_id)
+
+    @pytest.mark.asyncio
+    async def test_cancel_completed_dag_noop(self, store, orchestrator):
+        """cancel_dag on completed DAG is a no-op."""
+        dag = await store.create(_single_callback_request())
+        await orchestrator.start_dag(dag.id)
+        await orchestrator.tick()
+
+        fetched = await store.get_dag(dag.id)
+        assert fetched.status == "completed"
+        original_summary = fetched.result_summary
+
+        await orchestrator.cancel_dag(dag.id, reason="too late")
+
+        fetched = await store.get_dag(dag.id)
+        assert fetched.status == "completed"
+        assert fetched.result_summary == original_summary
+
 
 class TestDAGOrchestratorBudget:
     """Test token budget enforcement."""
@@ -609,7 +641,7 @@ class TestDAGCompletionCheck:
 
         fetched = await store.get_dag(dag.id)
         node = next(n for n in fetched.nodes if n.name == "retryable")
-        assert node.status == "ready"
+        assert node.status == "pending"
         assert node.check_attempts == 0
         assert node.last_check_at is None
         assert node.awaiting_check_at is None
@@ -646,3 +678,258 @@ class TestDAGCompletionCheck:
         fetched = await store.get_dag(dag.id)
         async_job = next(n for n in fetched.nodes if n.name == "async-job")
         assert async_job.status == "awaiting_check"
+
+
+class TestDAGRetryNode:
+    """Test retry_node correctness."""
+
+    @pytest.mark.asyncio
+    async def test_retry_node_resets_to_pending(self, store, orchestrator, subtask_mgr):
+        """retry_node resets to pending so _find_ready_nodes picks it up."""
+        dag = await store.create(_two_subtask_request())
+        await orchestrator.start_dag(dag.id)
+
+        # Simulate research subtask failed
+        fetched = await store.get_dag(dag.id)
+        research = next(n for n in fetched.nodes if n.name == "research")
+        subtask_mgr.get.return_value = SimpleNamespace(
+            id=research.subtask_id, status="failed", result=None, error="OOM"
+        )
+        await orchestrator.tick()
+
+        # Verify failed
+        fetched = await store.get_dag(dag.id)
+        research = next(n for n in fetched.nodes if n.name == "research")
+        assert research.status == "failed"
+
+        # Retry
+        await orchestrator.retry_node(dag.id, "research")
+
+        fetched = await store.get_dag(dag.id)
+        research = next(n for n in fetched.nodes if n.name == "research")
+        assert research.status == "pending"  # Must be pending, not ready
+
+        # Tick should pick it up and launch
+        subtask_mgr.create.reset_mock()
+        subtask_mgr.get.return_value = SimpleNamespace(
+            id=uuid.uuid4(), status="pending", result=None, error=None
+        )
+        await orchestrator.tick()
+
+        fetched = await store.get_dag(dag.id)
+        research = next(n for n in fetched.nodes if n.name == "research")
+        assert research.status == "running"
+        subtask_mgr.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_retry_node_not_failed_raises(self, store, orchestrator):
+        """retry_node on non-failed node raises ValueError."""
+        dag = await store.create(_two_subtask_request())
+        await orchestrator.start_dag(dag.id)
+        with pytest.raises(ValueError, match="expected failed"):
+            await orchestrator.retry_node(dag.id, "research")
+
+    @pytest.mark.asyncio
+    async def test_retry_node_unknown_raises(self, store, orchestrator):
+        """retry_node on unknown node raises ValueError."""
+        dag = await store.create(_two_subtask_request())
+        with pytest.raises(ValueError, match="not found"):
+            await orchestrator.retry_node(dag.id, "nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_retry_only_unblocks_downstream(self, store, orchestrator, subtask_mgr):
+        """retry_node only unblocks nodes downstream of the retried node."""
+        # DAG: A -> B, C -> D  (two independent chains)
+        request = DAGCreateRequest(
+            name="selective-unblock",
+            nodes=[
+                DAGNodeSpec(name="a", type=DAGNodeType.subtask, instructions="A"),
+                DAGNodeSpec(name="b", type=DAGNodeType.subtask, instructions="B"),
+                DAGNodeSpec(name="c", type=DAGNodeType.subtask, instructions="C"),
+                DAGNodeSpec(name="d", type=DAGNodeType.subtask, instructions="D"),
+            ],
+            edges=[
+                DAGEdgeSpec(from_node="a", to_node="b", edge_type="dependency"),
+                DAGEdgeSpec(from_node="c", to_node="d", edge_type="dependency"),
+            ],
+        )
+        dag = await store.create(request)
+        await orchestrator.start_dag(dag.id)
+
+        # Both A and C are wave-0, running. Simulate both fail.
+        async def mock_get(sid):
+            return SimpleNamespace(id=sid, status="failed", result=None, error="fail")
+        subtask_mgr.get = AsyncMock(side_effect=mock_get)
+
+        await orchestrator.tick()
+
+        fetched = await store.get_dag(dag.id)
+        assert next(n for n in fetched.nodes if n.name == "b").status == "blocked"
+        assert next(n for n in fetched.nodes if n.name == "d").status == "blocked"
+
+        # Retry only A
+        await orchestrator.retry_node(dag.id, "a")
+
+        fetched = await store.get_dag(dag.id)
+        assert next(n for n in fetched.nodes if n.name == "b").status == "pending"
+        assert next(n for n in fetched.nodes if n.name == "d").status == "blocked"  # Still blocked
+
+
+class TestDAGCancelCascade:
+    """Test cancel_cascade edge semantics."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_cascade_produces_cancelled_not_blocked(self, store, orchestrator, subtask_mgr):
+        """cancel_cascade edges set downstream to cancelled, not blocked."""
+        # main -> cleanup (cancel_cascade), main -> dep-node (dependency)
+        # cleanup and dep-node must be wave-1 (depend on main) so they stay pending
+        # while main runs. We use dependency edges for wave ordering and
+        # cancel_cascade for the cascade semantics on cleanup.
+        request = DAGCreateRequest(
+            name="cascade-test",
+            nodes=[
+                DAGNodeSpec(name="main", type=DAGNodeType.subtask, instructions="Main"),
+                DAGNodeSpec(name="cleanup", type=DAGNodeType.subtask, instructions="Cleanup"),
+                DAGNodeSpec(name="dep-node", type=DAGNodeType.subtask, instructions="Depends"),
+            ],
+            edges=[
+                DAGEdgeSpec(from_node="main", to_node="cleanup", edge_type="cancel_cascade"),
+                DAGEdgeSpec(from_node="main", to_node="dep-node", edge_type="dependency"),
+            ],
+        )
+
+        # Make create() return unique subtask IDs for each call
+        subtask_ids = iter([uuid.uuid4(), uuid.uuid4()])
+        subtask_mgr.create.side_effect = lambda **kw: SimpleNamespace(
+            id=next(subtask_ids), status="pending"
+        )
+
+        dag = await store.create(request)
+        await orchestrator.start_dag(dag.id)
+
+        fetched = await store.get_dag(dag.id)
+        main_node = next(n for n in fetched.nodes if n.name == "main")
+        cleanup_node = next(n for n in fetched.nodes if n.name == "cleanup")
+        main_sid = main_node.subtask_id
+
+        # Only main's subtask fails; cleanup is wave-0 too (cancel_cascade
+        # doesn't count for waves), so we need per-subtask_id mock results.
+        async def selective_get(sid):
+            if sid == main_sid:
+                return SimpleNamespace(id=sid, status="failed", result=None, error="fail")
+            # cleanup subtask is still running
+            return SimpleNamespace(id=sid, status="running", result=None, error=None)
+
+        subtask_mgr.get = AsyncMock(side_effect=selective_get)
+
+        await orchestrator.tick()
+
+        fetched = await store.get_dag(dag.id)
+        cleanup = next(n for n in fetched.nodes if n.name == "cleanup")
+        dep_node = next(n for n in fetched.nodes if n.name == "dep-node")
+
+        assert cleanup.status == "cancelled"  # cancel_cascade -> cancelled
+        assert dep_node.status == "blocked"   # dependency -> blocked
+
+
+class TestDAGEdgeCases:
+    """Test edge cases and coverage gaps."""
+
+    @pytest.mark.asyncio
+    async def test_subtask_deleted_mid_run(self, store, orchestrator, subtask_mgr):
+        """Subtask externally deleted -> node fails."""
+        dag = await store.create(_two_subtask_request())
+        await orchestrator.start_dag(dag.id)
+        subtask_mgr.get.return_value = None
+        await orchestrator.tick()
+
+        fetched = await store.get_dag(dag.id)
+        research = next(n for n in fetched.nodes if n.name == "research")
+        assert research.status == "failed"
+        assert "deleted" in research.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_gate_node_auto_passes(self, store, orchestrator, subtask_mgr):
+        """Gate node auto-completes when launched."""
+        request = DAGCreateRequest(
+            name="gate-test",
+            nodes=[
+                DAGNodeSpec(name="setup", type=DAGNodeType.subtask, instructions="Setup"),
+                DAGNodeSpec(name="gate", type=DAGNodeType.gate, instructions="Approval gate"),
+                DAGNodeSpec(name="deploy", type=DAGNodeType.subtask, instructions="Deploy"),
+            ],
+            edges=[
+                DAGEdgeSpec(from_node="setup", to_node="gate", edge_type="dependency"),
+                DAGEdgeSpec(from_node="gate", to_node="deploy", edge_type="dependency"),
+            ],
+        )
+        dag = await store.create(request)
+        await orchestrator.start_dag(dag.id)
+
+        fetched = await store.get_dag(dag.id)
+        setup = next(n for n in fetched.nodes if n.name == "setup")
+        subtask_mgr.get.return_value = SimpleNamespace(
+            id=setup.subtask_id, status="completed", result="Done", error=None
+        )
+
+        subtask_mgr.create.reset_mock()
+        await orchestrator.tick()  # setup completes, gate auto-passes
+
+        fetched = await store.get_dag(dag.id)
+        gate = next(n for n in fetched.nodes if n.name == "gate")
+        assert gate.status == "completed"
+        assert "auto-passed" in gate.result.lower()
+
+        # Second tick picks up deploy (gate completed on previous tick)
+        await orchestrator.tick()
+
+        fetched = await store.get_dag(dag.id)
+        deploy = next(n for n in fetched.nodes if n.name == "deploy")
+        assert deploy.status == "running"
+
+    @pytest.mark.asyncio
+    async def test_context_flow_injects_predecessor_result(self, store, orchestrator, subtask_mgr):
+        """context_flow edge injects predecessor result into subtask instructions."""
+        request = DAGCreateRequest(
+            name="context-flow-test",
+            nodes=[
+                DAGNodeSpec(name="research", type=DAGNodeType.subtask, instructions="Research topic"),
+                DAGNodeSpec(name="write", type=DAGNodeType.subtask, instructions="Write report"),
+            ],
+            edges=[
+                DAGEdgeSpec(from_node="research", to_node="write", edge_type="context_flow"),
+            ],
+        )
+        dag = await store.create(request)
+        await orchestrator.start_dag(dag.id)
+
+        fetched = await store.get_dag(dag.id)
+        research = next(n for n in fetched.nodes if n.name == "research")
+        subtask_mgr.get.return_value = SimpleNamespace(
+            id=research.subtask_id, status="completed", result="KEY_FINDING_XYZ", error=None
+        )
+
+        subtask_mgr.create.reset_mock()
+        await orchestrator.tick()
+
+        # Verify the "write" subtask was created with the predecessor's result
+        assert subtask_mgr.create.called
+        # Get the task= keyword argument
+        call_kwargs = subtask_mgr.create.call_args
+        task_arg = call_kwargs.kwargs.get("task", "") if call_kwargs.kwargs else ""
+        assert "KEY_FINDING_XYZ" in task_arg
+        assert "Context from prior steps" in task_arg
+
+    @pytest.mark.asyncio
+    async def test_start_dag_not_found_raises(self, store, orchestrator):
+        """start_dag on non-existent DAG raises ValueError."""
+        with pytest.raises(ValueError, match="not found"):
+            await orchestrator.start_dag(uuid.uuid4())
+
+    @pytest.mark.asyncio
+    async def test_start_dag_already_running_raises(self, store, orchestrator):
+        """start_dag on already-running DAG raises ValueError."""
+        dag = await store.create(_single_callback_request())
+        await orchestrator.start_dag(dag.id)
+        with pytest.raises(ValueError, match="expected pending"):
+            await orchestrator.start_dag(dag.id)

--- a/tests/test_dag_store.py
+++ b/tests/test_dag_store.py
@@ -189,3 +189,35 @@ class TestDAGStoreMaxActive:
         # The next one should fail
         with pytest.raises(ValueError, match="Active DAG limit reached"):
             await store.create(_simple_request("one-too-many"))
+
+
+class TestDAGStoreIsolation:
+    """Test agent_id isolation."""
+
+    @pytest.mark.asyncio
+    async def test_update_node_cross_agent_rejected(self, db):
+        """update_node cannot modify nodes belonging to another agent's DAG."""
+        store_a = DAGStore(db, f"agent-a-{uuid.uuid4().hex[:8]}")
+        store_b = DAGStore(db, f"agent-b-{uuid.uuid4().hex[:8]}")
+
+        dag = await store_a.create(_simple_request("isolation-test"))
+        node_id = dag.nodes[0].id
+
+        # Agent B tries to update Agent A's node
+        await store_b.update_node(node_id, status="failed", error="hijacked")
+
+        # Should not have changed
+        fetched = await store_a.get_dag(dag.id)
+        assert fetched.nodes[0].status == "ready"  # Unchanged
+        assert fetched.nodes[0].error is None
+
+    @pytest.mark.asyncio
+    async def test_get_dag_cross_agent_rejected(self, db):
+        """get_dag returns None for another agent's DAG."""
+        store_a = DAGStore(db, f"agent-a-{uuid.uuid4().hex[:8]}")
+        store_b = DAGStore(db, f"agent-b-{uuid.uuid4().hex[:8]}")
+
+        dag = await store_a.create(_simple_request("cross-agent-test"))
+
+        fetched = await store_b.get_dag(dag.id)
+        assert fetched is None

--- a/tests/test_dag_tools.py
+++ b/tests/test_dag_tools.py
@@ -130,6 +130,26 @@ class TestDagCreateTool:
         assert result["content"][0]["type"] == "text"
         assert isinstance(result["content"][0]["text"], str)
 
+    @pytest.mark.asyncio
+    async def test_dag_create_handles_db_error(self, tools, dag_store, dag_orchestrator):
+        """dag_create catches non-ValueError exceptions and returns clean error."""
+        original_create = dag_store.create
+        async def broken_create(req):
+            raise RuntimeError("DB connection lost")
+        dag_store.create = broken_create
+
+        handler = tools._handlers["dag_create"]
+        result = await handler(
+            name="broken-dag",
+            nodes=_simple_nodes(),
+            edges=[],
+        )
+        text = result["content"][0]["text"]
+        assert "Error" in text
+        assert "DB connection lost" in text
+
+        dag_store.create = original_create  # Restore
+
 
 # ------------------------------------------------------------------
 # dag_manage


### PR DESCRIPTION
## Summary

Comprehensive code review of F038 DAG Orchestration found 7 P1 (must-fix) and 8 P2 (should-fix) bugs. This PR fixes all P1s and 6 P2s, with 16 new tests.

### P1 Fixes
- **Stuck DAG on retry** — `retry_node` reset to `"ready"` but `_find_ready_nodes` only checks `"pending"`. Guaranteed stuck DAG on every user retry.
- **Blanket unblock** — `retry_node` unblocked ALL blocked nodes, not just those downstream of the retried node. Could unblock nodes with unresolved upstream failures.
- **Running subtasks survive cancel** — `cancel_dag` only cancelled `"pending"` subtasks. Running subtasks continued executing after DAG cancellation.
- **cancel_cascade semantics** — `cancel_cascade` edges produced `"blocked"` instead of `"cancelled"`. Misleading postmortem analysis.
- **Orphaned DAGs** — `dag_create`/`dag_manage` only caught `ValueError`. DB errors left DAGs persisted but unmanaged, counting toward the 5-DAG limit.
- **Cross-agent node mutation** — `update_node` had no `agent_id` scope guard. Any agent could modify another agent's DAG nodes.
- **Dashboard crash** — `get_dag_dashboard_data` passed string to asyncpg UUID column. Every `/dashboard/dag` call HTTP 500'd with active DAGs.

### P2 Fixes
- `start_dag` protected by `_lock` (TOCTOU with concurrent `tick()`)
- Budget exceeded `has_running` check no longer includes already-cancelled `awaiting_check` nodes
- `cancel_dag` no-ops on already-terminal DAGs
- `_resolve_dag` raises `ValueError` on ambiguous prefix (was silent "not found")
- `dag_create` reflects actual post-start DAG status
- Defensive `getattr` for `_registry` access

### Tests
- 16 new tests across 4 files (93 total DAG tests, all passing)
- Covers: retry correctness, selective unblock, cancel cascade semantics, running subtask cancellation, terminal guard, agent isolation, context_flow injection, gate auto-pass, subtask deletion, error handling

## Test plan
- [x] `uv run pytest tests/test_dag_schemas.py tests/test_dag_store.py tests/test_dag_orchestrator.py tests/test_dag_tools.py tests/test_dag_dashboard.py -v` — 93 passed
- [ ] Manual: verify `/dashboard/dag` endpoint with active DAGs on Postgres
- [ ] Manual: retry a failed node via `dag_manage retry_node` and confirm it relaunches

🤖 Generated with [Claude Code](https://claude.com/claude-code)