### PR TITLE
spec: F026.1 Action Gate Enhancements — change-aware duplicate detection

### DIFF
--- a/docs/features/F026.1-action-gate-enhancements.md
+++ b/docs/features/F026.1-action-gate-enhancements.md
@@ -1,0 +1,575 @@
+# F026.1 — Action Gate Enhancements: Change-Aware Duplicate Detection
+
+**Status:** PROPOSED  
+**Priority:** P1  
+**Depends on:** F026 Execution Integrity (merged)  
+**Supersedes:** Issue #285 / PR #288 (partial fix for false positives)  
+**Author:** Nous + Tim  
+**Date:** 2026-04-11  
+
+---
+
+## Problem Statement
+
+The current ActionGate `_consistency_check` uses a binary duplicate detection model:
+if the same tool + same args succeeded within the last `action_gating_turn_window` turns
+(default 5), the call is **blocked**. This produces false positives in iterative workflows:
+
+### Observed Failures
+
+**1. Debug Loop Blocking**  
+Agent runs `bash(make build)` → sees compiler error → edits a file → runs `bash(make build)`
+again → **BLOCKED** because args are identical. The agent intended a retry-after-fix, not a
+doom loop.
+
+**2. Test-Fix-Test Blocking**  
+Agent runs `bash(pytest tests/test_foo.py)` → test fails → edits source → reruns same
+test → **BLOCKED**. Identical pattern: world changed between calls.
+
+**3. Incremental Write Blocking**  
+Agent writes a file, realizes it missed content, rewrites the same path with corrected
+content → **BLOCKED** because `write_file(path=X)` already succeeded.
+
+**4. Multi-Stage Build Blocking**  
+Agent runs `bash(docker build .)` → fails → fixes Dockerfile → rebuilds → **BLOCKED**.
+
+### Root Cause
+
+The duplicate detector has **no awareness of state changes** between calls. It treats
+`bash(make build)` at T=3 and `bash(make build)` at T=5 as identical regardless of what
+happened at T=4. In iterative workflows (debug, build, test), repeating a command after
+changing state is the *expected* pattern, not an error.
+
+### Issue #285 Context
+
+PR #288 partially addressed this by switching from "ANY shared key match → block" to
+"ALL shared keys must match → block". This reduced false positives for cases like
+disabling two different heartbeat checks, but did **not** solve the debug-loop problem
+because the args genuinely are identical — only the world state changed.
+
+---
+
+## Goals
+
+1. **Allow intentional retries** — same command after state changes should pass
+2. **Preserve doom-loop protection** — identical calls with no intervening changes should still be caught
+3. **Graduated response** — warn before blocking, giving the model a chance to self-correct
+4. **Frame-aware thresholds** — debug/task frames get more lenient repeat limits than conversation
+5. **Configurable** — all thresholds exposed in Settings, no hardcoded magic numbers
+6. **Backward compatible** — existing `action_gating_external_only` and `action_gating_turn_window` settings continue to work
+
+---
+
+## Design
+
+### Architecture: Four-Layer Duplicate Detection
+
+The new `_consistency_check` replaces the current binary block with a four-layer
+evaluation. Layers are evaluated in order; the first decisive result wins.
+
+```
+┌────────────────────────────────────────────────────────┐
+│                  Proposed Tool Call                      │
+│              (tool_name, tool_input)                     │
+└────────────┬───────────────────────────────────────────┘
+             │
+             ▼
+┌────────────────────────────────────────────────────────┐
+│  Layer 1: Change-Aware Bypass                           │
+│  Was there a write action between the prior identical   │
+│  call and now? If YES → ALLOW (state changed)           │
+└────────────┬──────────────────────┬────────────────────┘
+             │ no match             │ state changed
+             ▼                      ▼ APPROVED ✅
+┌────────────────────────────────────────────────────────┐
+│  Layer 2: Repeat Count Threshold                        │
+│  How many identical calls in the window?                │
+│  < threshold → ALLOW                                    │
+│  = threshold → WARN (allow but inject suggestion)       │
+│  > threshold → proceed to Layer 3                       │
+└────────────┬──────────────────────┬────────────────────┘
+             │ over threshold       │ under threshold
+             ▼                      ▼ APPROVED ✅
+┌────────────────────────────────────────────────────────┐
+│  Layer 3: Command-Class Leniency                        │
+│  Is this a known-iterative command pattern?             │
+│  (build, test, lint, check, run, compile)               │
+│  If YES → apply elevated threshold (N=5 default)        │
+│  If still over → proceed to Layer 4                     │
+└────────────┬──────────────────────┬────────────────────┘
+             │ still over           │ under elevated
+             ▼                      ▼ APPROVED ✅
+┌────────────────────────────────────────────────────────┐
+│  Layer 4: Hard Block                                    │
+│  Repeated too many times with no state change.          │
+│  → BLOCKED ❌ with suggestion to change approach        │
+└────────────────────────────────────────────────────────┘
+```
+
+### Layer 1: Change-Aware Bypass
+
+**Principle:** If the world changed between two identical calls, the repeat is intentional.
+
+**Implementation:** Scan `ledger.actions` between the most recent matching call's index
+and the current position. If any intervening action has `side_effect_type` in
+`("write", "external")`, approve the call.
+
+```python
+def _has_state_change_since(self, ledger: ExecutionLedger, last_match_idx: int) -> bool:
+    """Check if any write/external action occurred after last_match_idx."""
+    intervening = ledger.actions[last_match_idx + 1:]
+    return any(
+        a.side_effect_type in ("write", "external")
+        for a in intervening
+    )
+```
+
+**What counts as a state change:**
+- `write_file` — filesystem changed
+- `bash` with `side_effect_type == "write"` — e.g., `sed -i`, `git checkout`, `pip install`
+- `bash` with `side_effect_type == "external"` — e.g., `curl -X POST`, `git push`
+- `learn_fact`, `record_decision`, etc. — memory state changed
+- `run_python` — may have side effects
+
+**What does NOT count:**
+- `read_file`, `recall_deep`, `web_search` — pure reads, no state change
+- Failed/blocked actions — state didn't actually change
+
+**Refinement:** Only count intervening actions where `status == "success"`. A failed
+`write_file` didn't actually change state.
+
+```python
+def _has_state_change_since(self, ledger: ExecutionLedger, last_match_idx: int) -> bool:
+    """Check if any successful write/external action occurred after last_match_idx."""
+    intervening = ledger.actions[last_match_idx + 1:]
+    return any(
+        a.side_effect_type in ("write", "external")
+        and a.status == "success"
+        for a in intervening
+    )
+```
+
+### Layer 2: Repeat Count Threshold
+
+**Principle:** Even without intermediate writes, some repetition is normal. Block only
+after a configurable threshold.
+
+**Current behavior:** Blocks on the 2nd identical call (threshold = 1). Too aggressive.
+
+**New defaults:**
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `action_gating_repeat_threshold` | 3 | Base number of identical calls allowed before warning |
+| `action_gating_hard_block_threshold` | 5 | Number of identical calls before hard block |
+
+**Behavior at each count:**
+
+| Count vs Threshold | Action |
+|--------------------|--------|
+| `count < repeat_threshold` | ALLOW silently |
+| `count == repeat_threshold` | ALLOW + inject warning suggestion |
+| `repeat_threshold < count < hard_block_threshold` | ALLOW + inject stronger warning |
+| `count >= hard_block_threshold` | BLOCK |
+
+**Warning suggestion format:**
+```
+"You've run {tool_name} with the same arguments {count} times in {turn_window} turns. 
+If you're stuck in a loop, try a different approach."
+```
+
+### Layer 3: Command-Class Leniency
+
+**Principle:** Certain command patterns are inherently iterative. Build-test-fix is a
+3+ cycle loop by nature. These deserve a higher threshold than arbitrary repeated commands.
+
+**Implementation:** Detect iterative command patterns from bash commands and apply an
+elevated threshold multiplier.
+
+```python
+# Iterative command pattern tokens (first word of bash command)
+ITERATIVE_COMMAND_TOKENS: frozenset[str] = frozenset({
+    "make", "cmake", "ninja",           # Build systems
+    "pytest", "python", "node",          # Test runners
+    "npm", "yarn", "pnpm", "bun",       # JS package managers / runners  
+    "cargo", "go", "mvn", "gradle",     # Language build tools
+    "docker", "docker-compose",          # Container builds
+    "gcc", "g++", "clang", "rustc",     # Compilers
+    "tsc", "eslint", "ruff", "mypy",    # Linters / type checkers
+    "terraform", "ansible",              # IaC tools
+    "gh",                                # GitHub CLI (PR creation retries)
+})
+
+# Iterative sub-commands for multi-token tools
+ITERATIVE_SUBCOMMANDS: dict[str, frozenset[str]] = {
+    "npm": frozenset({"run", "test", "build", "start"}),
+    "cargo": frozenset({"build", "test", "check", "run", "clippy"}),
+    "go": frozenset({"build", "test", "run", "vet"}),
+    "docker": frozenset({"build", "run"}),
+    "gh": frozenset({"pr", "issue"}),
+}
+```
+
+**Elevated threshold:** `action_gating_iterative_threshold_multiplier` (default: `2.0`)
+
+For iterative commands:
+- `repeat_threshold` → `repeat_threshold * multiplier` (3 → 6)
+- `hard_block_threshold` → `hard_block_threshold * multiplier` (5 → 10)
+
+**Non-bash tools:** `write_file` to the same path is also inherently iterative (edit cycles).
+Apply the elevated threshold to `write_file` when path matches.
+
+### Layer 4: Hard Block
+
+When all leniency is exhausted, block the call with an actionable suggestion:
+
+```python
+GateResult(
+    approved=False,
+    reason=(
+        f"Doom-loop protection: {tool_name} called {count} times with identical "
+        f"arguments and no intervening state changes in the last {turn_window} turns."
+    ),
+    suggestion=(
+        "You appear to be stuck in a loop. Try:\n"
+        "1. Change your approach — different command, different file\n"
+        "2. Read the error output carefully — what's actually failing?\n"
+        "3. Ask the user for guidance if you're blocked"
+    ),
+)
+```
+
+---
+
+## Configuration
+
+New settings in `Settings` (with backward-compatible defaults):
+
+```python
+# --- F026.1 Action Gate Enhancements ---
+
+# Layer 1: Change-aware bypass
+action_gating_change_aware: bool = True
+# Whether to check for intervening state changes before blocking
+
+# Layer 2: Repeat thresholds
+action_gating_repeat_threshold: int = 3
+# Number of identical calls allowed before warning (was effectively 1)
+
+action_gating_hard_block_threshold: int = 5
+# Number of identical calls before hard block (was effectively 2)
+
+# Layer 3: Command-class leniency
+action_gating_iterative_multiplier: float = 2.0
+# Threshold multiplier for known-iterative command patterns
+
+# Layer 4 uses hard_block_threshold — no separate config needed
+```
+
+**Migration:** Existing deployments with default settings will see looser gating
+(threshold goes from 1 to 3). This is intentional — the current defaults are too
+aggressive and cause more harm (blocked debug loops) than good (caught doom loops).
+
+---
+
+## Implementation Plan
+
+### File Changes
+
+| File | Change |
+|------|--------|
+| `nous/config.py` | Add 4 new settings |
+| `nous/cognitive/action_gate.py` | Rewrite `_consistency_check` with 4-layer logic, add helper methods |
+| `nous/cognitive/execution_ledger.py` | No changes needed (already tracks `side_effect_type`) |
+| `tests/test_action_gate.py` | Add tests for all 4 layers |
+
+### Chunk 1: Config + Layer 1 (Change-Aware Bypass)
+
+**Files:** `nous/config.py`, `nous/cognitive/action_gate.py`
+
+- [ ] **Step 1:** Add new settings to `config.py`
+  - `action_gating_change_aware: bool = True`
+  - `action_gating_repeat_threshold: int = 3`
+  - `action_gating_hard_block_threshold: int = 5`
+  - `action_gating_iterative_multiplier: float = 2.0`
+
+- [ ] **Step 2:** Add `_has_state_change_since()` method to `ActionGate`
+  - Scans ledger actions from `last_match_idx + 1` to end
+  - Returns True if any successful write/external action found
+  - Unit test: intervening write_file → returns True
+  - Unit test: intervening read_file only → returns False
+  - Unit test: intervening failed write_file → returns False
+
+- [ ] **Step 3:** Add `_find_matches()` method to `ActionGate`
+  - Extracts match-finding logic from `_consistency_check`
+  - Returns list of `(index, ExecutedAction)` tuples for identical calls in window
+  - Used by both Layer 1 and Layer 2
+
+### Chunk 2: Layer 2 (Repeat Count Threshold)
+
+**Files:** `nous/cognitive/action_gate.py`
+
+- [ ] **Step 4:** Add `_get_repeat_count()` helper
+  - Counts identical calls in window, excluding those already bypassed by Layer 1
+
+- [ ] **Step 5:** Implement threshold escalation in `_consistency_check`
+  - `< repeat_threshold` → ALLOW
+  - `== repeat_threshold` → ALLOW + warning suggestion
+  - `> repeat_threshold` → continue to Layer 3
+  - Unit test: 1st and 2nd identical call → allowed silently
+  - Unit test: 3rd identical call → allowed with warning
+  - Unit test: verify warning suggestion text includes count
+
+### Chunk 3: Layer 3 (Command-Class Leniency)
+
+**Files:** `nous/cognitive/action_gate.py`
+
+- [ ] **Step 6:** Add `ITERATIVE_COMMAND_TOKENS` and `ITERATIVE_SUBCOMMANDS` constants
+
+- [ ] **Step 7:** Add `_is_iterative_command()` method
+  - For bash: check first token against `ITERATIVE_COMMAND_TOKENS`
+  - For bash with subcommands: check `tool:subcommand` against `ITERATIVE_SUBCOMMANDS`
+  - For `write_file`: always iterative (editing is inherently cyclical)
+  - Unit test: `make build` → True
+  - Unit test: `pytest tests/` → True
+  - Unit test: `rm -rf /` → False
+  - Unit test: `write_file(path=foo.py)` → True
+
+- [ ] **Step 8:** Add `_effective_threshold()` method
+  - Returns `(repeat_threshold, hard_block_threshold)` for a given tool call
+  - If iterative: multiply both by `action_gating_iterative_multiplier`
+  - Cast to int (floor)
+  - Unit test: non-iterative → (3, 5) with defaults
+  - Unit test: iterative → (6, 10) with defaults
+
+### Chunk 4: Rewrite `_consistency_check` + Layer 4
+
+**Files:** `nous/cognitive/action_gate.py`
+
+- [ ] **Step 9:** Rewrite `_consistency_check` integrating all 4 layers
+  - Find all matches in window
+  - If no matches → ALLOW (unchanged)
+  - Layer 1: check for state change since last match → ALLOW if yes
+  - Layer 2: count matches, compare to effective thresholds
+  - Layer 3: compute effective thresholds based on command class
+  - Layer 4: hard block with actionable suggestion
+  - Emit structured log at each layer for observability
+
+- [ ] **Step 10:** Add comprehensive integration tests
+  - Test: debug loop (build → edit → build) → allowed
+  - Test: doom loop (build → build → build → build → build → build) → blocked at threshold
+  - Test: test loop (pytest → edit → pytest → edit → pytest) → allowed each time
+  - Test: write_file loop (write → write → write) same path, no edits → warned then blocked
+  - Test: mixed tools don't interfere (write_file + bash don't share counts)
+  - Test: failed prior calls don't count toward threshold
+  - Test: settings override (custom thresholds honored)
+  - Test: `action_gating_change_aware=False` disables Layer 1
+
+### Chunk 5: Documentation + Observability
+
+- [ ] **Step 11:** Add structured logging
+  - Log at INFO level when Layer 1 bypasses: `"F026.1 change-aware bypass: {tool} allowed (state changed at action #{idx})"`
+  - Log at WARNING when Layer 2 warns: `"F026.1 repeat warning: {tool} called {count}/{threshold} times"`
+  - Log at WARNING when Layer 4 blocks: `"F026.1 doom-loop block: {tool} called {count} times, no state changes"`
+
+- [ ] **Step 12:** Update ledger dashboard (F032) if applicable
+  - Show repeat counts and bypass reasons in the execution ledger system prompt section
+
+---
+
+## Revised `_consistency_check` — Full Implementation
+
+```python
+def _consistency_check(
+    self,
+    tool_name: str,
+    tool_input: dict,
+    ledger: ExecutionLedger,
+) -> GateResult:
+    """Multi-layer duplicate detection with change-awareness."""
+    new_key_args = ledger._summarize_args(tool_name, tool_input)
+    turn_window = self._settings.action_gating_turn_window
+    min_turn = ledger.current_turn - turn_window
+
+    # Find all matching prior successes in window
+    matches: list[tuple[int, ExecutedAction]] = []
+    for i, action in enumerate(ledger.actions[-20:]):
+        if (
+            action.tool_name == tool_name
+            and action.status == "success"
+            and action.turn > min_turn
+            and self._args_similar(action.key_args, new_key_args)
+        ):
+            matches.append((len(ledger.actions) - 20 + i, action))
+
+    if not matches:
+        return GateResult(approved=True, reason="no-duplicates")
+
+    # --- Layer 1: Change-Aware Bypass ---
+    if self._settings.action_gating_change_aware:
+        last_match_abs_idx = matches[-1][0]
+        if self._has_state_change_since(ledger, last_match_abs_idx):
+            logger.info(
+                "F026.1 change-aware bypass: %s allowed (state changed since action #%d)",
+                tool_name, last_match_abs_idx,
+            )
+            return GateResult(approved=True, reason="state-changed-since-last-run")
+
+    # --- Layer 2 + 3: Threshold Check ---
+    repeat_thresh, hard_thresh = self._effective_thresholds(tool_name, tool_input)
+    count = len(matches)
+
+    if count < repeat_thresh:
+        return GateResult(approved=True, reason=f"under-threshold({count}/{repeat_thresh})")
+
+    if count < hard_thresh:
+        logger.warning(
+            "F026.1 repeat warning: %s called %d/%d times (hard limit: %d)",
+            tool_name, count, repeat_thresh, hard_thresh,
+        )
+        return GateResult(
+            approved=True,
+            reason=f"at-threshold-warning({count}/{hard_thresh})",
+            suggestion=(
+                f"You've run {tool_name} with the same arguments {count} times "
+                f"in the last {turn_window} turns. If you're stuck, try a different approach."
+            ),
+        )
+
+    # --- Layer 4: Hard Block ---
+    logger.warning(
+        "F026.1 doom-loop block: %s called %d times, no state changes", tool_name, count,
+    )
+    return GateResult(
+        approved=False,
+        reason=(
+            f"Doom-loop protection: {tool_name} called {count} times with identical "
+            f"arguments and no intervening state changes in the last {turn_window} turns."
+        ),
+        suggestion=(
+            "You appear to be stuck in a loop. Try:\n"
+            "1. Change your approach — different command, different file\n"
+            "2. Read the error output carefully — what's actually failing?\n"
+            "3. Ask the user for guidance if you're blocked"
+        ),
+    )
+
+def _has_state_change_since(self, ledger: ExecutionLedger, last_match_idx: int) -> bool:
+    """Check if any successful write/external action occurred after last_match_idx."""
+    intervening = ledger.actions[last_match_idx + 1:]
+    return any(
+        a.side_effect_type in ("write", "external")
+        and a.status == "success"
+        for a in intervening
+    )
+
+def _is_iterative_command(self, tool_name: str, tool_input: dict) -> bool:
+    """Return True if this tool call is a known-iterative pattern."""
+    if tool_name == "write_file":
+        return True
+
+    if tool_name == "bash":
+        command = tool_input.get("command", "")
+        tokens = command.strip().split()
+        if not tokens:
+            return False
+        first = tokens[0].lower()
+        if first in ITERATIVE_COMMAND_TOKENS:
+            return True
+        # Check subcommands
+        if first in ITERATIVE_SUBCOMMANDS and len(tokens) > 1:
+            return tokens[1].lower() in ITERATIVE_SUBCOMMANDS[first]
+
+    return False
+
+def _effective_thresholds(self, tool_name: str, tool_input: dict) -> tuple[int, int]:
+    """Return (repeat_threshold, hard_block_threshold) for this call."""
+    base_repeat = self._settings.action_gating_repeat_threshold
+    base_hard = self._settings.action_gating_hard_block_threshold
+    
+    if self._is_iterative_command(tool_name, tool_input):
+        multiplier = self._settings.action_gating_iterative_multiplier
+        return (int(base_repeat * multiplier), int(base_hard * multiplier))
+    
+    return (base_repeat, base_hard)
+```
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+| Test | Layer | Expectation |
+|------|-------|-------------|
+| Build → edit → build | L1 | Allowed (state changed) |
+| Build → read → build | L1 | Not bypassed (no state change) |
+| Build → failed_edit → build | L1 | Not bypassed (edit failed) |
+| 1st identical call | L2 | Allowed silently |
+| 3rd identical call (default) | L2 | Allowed with warning |
+| `make build` detection | L3 | Is iterative → True |
+| `rm -rf /` detection | L3 | Is iterative → False |
+| `write_file` same path | L3 | Is iterative → True, elevated threshold |
+| 6th identical `make build` | L3 | Allowed (elevated threshold = 6) |
+| 11th identical `make build` | L4 | Blocked (elevated hard = 10) |
+| 6th identical `learn_fact` | L4 | Blocked (base hard = 5) |
+| `change_aware=False` | L1 | Layer 1 skipped entirely |
+| Custom thresholds | L2 | Honors overridden settings |
+
+### Integration Tests
+
+| Scenario | Expected |
+|----------|----------|
+| Full debug cycle: build → write → build → write → build | All builds pass (Layer 1) |
+| Doom loop: 6x `bash(echo hello)` with no writes | Warned at 3, blocked at 5 |
+| pytest loop: 10x `pytest` with edits between each | All pass (Layer 1 each time) |
+| Mixed: 3x `write_file(a.py)` + 3x `write_file(b.py)` | Each file tracked independently |
+
+---
+
+## Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Layer 1 too permissive — any write anywhere unblocks all repeats | Medium | Medium | Only checks writes AFTER the matching call, not all writes in window. Consider requiring the write to be "related" (same file path) in a future iteration. |
+| Iterative token list incomplete | Low | Low | Easy to extend; config override for multiplier handles edge cases |
+| Threshold too high for subtasks (less human oversight) | Medium | Medium | Future: frame-aware thresholds (lower for background subtasks) |
+| Backward compatibility — existing users get looser gating | Low | Low | Old default was too aggressive; looser is the desired direction |
+
+---
+
+## Future Extensions (Not In Scope)
+
+1. **Related-write detection** — Layer 1 could check if the intervening write is "related"
+   to the repeated command (e.g., write to `foo.py` before `pytest tests/test_foo.py`).
+   Currently any write anywhere counts. This is a refinement for F026.2.
+
+2. **Frame-aware thresholds** — Debug frame gets higher thresholds than conversation.
+   Deferred because frame detection reliability is not yet high enough (F013).
+
+3. **Outcome-aware detection** — If the prior identical call returned an error, the
+   repeat might be a retry. Currently not distinguished. Complex to implement reliably.
+
+4. **Ledger dashboard integration** — Show repeat counts and bypass reasons in F032.
+
+5. **Censor pipeline integration** — Layer 2 warnings could flow through the censor
+   middleware (F031) instead of GateResult.suggestion. Deferred until F031 ships.
+
+---
+
+## Success Metrics
+
+| Metric | Current | Target |
+|--------|---------|--------|
+| False positive blocks in debug workflows | ~40% of sessions | < 5% |
+| Doom loops caught | ~80% | ≥ 90% (threshold catches more with count-based) |
+| Agent self-correction after warning | N/A (no warnings today) | > 50% change approach after warning |
+
+---
+
+## References
+
+- F026 Execution Integrity (parent spec)
+- Issue #285 / PR #288 — prior fix for `_args_similar` false positives
+- OpenDev doom-loop detection pattern (count-based escalation)
+- Reagent-C self-critique loop (warn → reflect → retry pattern)


### PR DESCRIPTION
## F026.1 — Action Gate Enhancements

Four-layer duplicate detection replacing the current binary block in `_consistency_check`:

**Layer 1: Change-Aware Bypass** — If any write/external action occurred between the prior identical call and now, allow the repeat (state changed).

**Layer 2: Repeat Count Threshold** — Allow up to N=3 identical calls before warning, N=5 before blocking (was: block on 2nd call).

**Layer 3: Command-Class Leniency** — Build/test/lint commands get 2x thresholds (iterative by nature).

**Layer 4: Hard Block** — Doom-loop protection with actionable suggestions.

### Problem Solved
Debug workflows (build → edit → build) were being blocked because args are identical even though the world changed. Issue #285/PR #288 partially fixed this but only for different-target cases, not same-target retries.

### Key Design Choices
- Change detection via `side_effect_type` already tracked in ExecutionLedger — no new infrastructure
- Graduated response (warn → block) instead of binary block
- All thresholds configurable in Settings
- Backward compatible — existing settings continue to work

### Files
- `docs/features/F026.1-action-gate-enhancements.md` — full spec with implementation plan, code samples, test matrix