### PR TITLE
fix(streaming): keep /chat/stream alive during long pre_turn, compaction, and tool runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,6 +303,7 @@ DB connection vars are **unprefixed** (shared with docker-compose). All others u
 | `NOUS_RRF_K` | `60` | RRF smoothing constant for hybrid search rank fusion |
 | `NOUS_TOOL_TIMEOUT` | `120` | Max seconds for any single tool execution |
 | `NOUS_KEEPALIVE_INTERVAL` | `10` | Seconds between keepalive events during tool execution |
+| `NOUS_SSE_PING_INTERVAL` | `15` | Seconds between SSE comment-line pings on `/chat/stream`. Keeps the socket warm during stalls in pre_turn, compaction, or any non-streaming phase. Comment lines are ignored by SSE clients but reset their read timer. |
 | `NOUS_GRAPH_RECALL_ENABLED` | `true` | Enable graph expansion in recall_deep |
 | `NOUS_GRAPH_RECALL_MAX_EXPAND` | `5` | Max seed results to expand |
 | `NOUS_GRAPH_RECALL_DECAY` | `0.7` | Score decay per graph hop |

--- a/nous/api/rest.py
+++ b/nous/api/rest.py
@@ -35,6 +35,8 @@ Endpoints:
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -144,8 +146,38 @@ def create_app(
                 session_id, message, platform=platform,
                 user_id=user_id, user_display_name=user_display_name,
             )
+            aiter = stream.__aiter__()
+            ping_interval = settings.sse_ping_interval
+            pending: asyncio.Task | None = None
             try:
-                async for event in stream:
+                while True:
+                    if pending is None:
+                        pending = asyncio.create_task(aiter.__anext__())
+
+                    # Race the next event against the ping interval. We use
+                    # asyncio.wait (not wait_for) so that on timeout the task
+                    # is NOT cancelled — it stays pending and we resume waiting
+                    # on the next iteration. This keeps bytes flowing to the
+                    # client during stalls in pre_turn, compaction, or any
+                    # other non-streaming phase of stream_chat.
+                    done, _ = await asyncio.wait(
+                        {pending}, timeout=ping_interval
+                    )
+                    if not done:
+                        # No event in window — emit SSE comment-line ping.
+                        # Comment lines (starting with `:`) are ignored by
+                        # spec-compliant SSE clients but reset their socket
+                        # read timer. See WHATWG EventSource spec.
+                        yield ": keepalive\n\n"
+                        continue
+
+                    try:
+                        event = pending.result()
+                    except StopAsyncIteration:
+                        pending = None
+                        break
+                    pending = None
+
                     event_data: dict[str, Any] = {
                         "type": event.type,
                         "text": event.text,
@@ -161,6 +193,13 @@ def create_app(
                 error_data = json.dumps({"type": "error", "text": str(e)})
                 yield f"data: {error_data}\n\n"
             finally:
+                # Cancel any in-flight __anext__ task before closing the
+                # generator to avoid "Task was destroyed but it is pending"
+                # warnings on client disconnect.
+                if pending is not None and not pending.done():
+                    pending.cancel()
+                    with contextlib.suppress(BaseException):
+                        await pending
                 # Ensure stream_chat generator is closed on client disconnect
                 # so its finally block (post_turn cleanup) runs deterministically.
                 await stream.aclose()

--- a/nous/config.py
+++ b/nous/config.py
@@ -161,6 +161,12 @@ class Settings(BaseSettings):
     keepalive_interval: int = Field(
         default=10, validation_alias="NOUS_KEEPALIVE_INTERVAL"
     )  # Seconds between keepalive events during tool execution
+    sse_ping_interval: int = Field(
+        default=15, validation_alias="NOUS_SSE_PING_INTERVAL"
+    )  # Seconds between SSE comment-line pings on /chat/stream — keeps
+    # the socket alive during stalls in pre_turn, compaction, or any
+    # other non-streaming phase of stream_chat. Comment lines (`:`) are
+    # ignored by spec-compliant SSE clients but reset their read timer.
 
     # SmartCompress (F020 Phase 1)
     smart_compress_enabled: bool = Field(

--- a/nous/telegram_bot.py
+++ b/nous/telegram_bot.py
@@ -714,10 +714,21 @@ class NousTelegramBot:
         typing_task = asyncio.create_task(_typing_loop())
 
         try:
+            # Override read timeout to None for the streaming call only.
+            # The server emits SSE comment-line keepalives every
+            # NOUS_SSE_PING_INTERVAL seconds (default 15s) so the socket
+            # stays warm even during long pre_turn / compaction / tool
+            # phases. The shared client's 300s read timeout would otherwise
+            # cap turn duration arbitrarily. connect/write/pool timeouts
+            # are still enforced to catch real network failures fast.
+            stream_timeout = httpx.Timeout(
+                connect=10, read=None, write=10, pool=10
+            )
             async with self._http.stream(
                 "POST",
                 f"{self.nous_url}/chat/stream",
                 json=payload,
+                timeout=stream_timeout,
             ) as response:
                 if response.status_code != 200:
                     error_body = await response.aread()

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -5,6 +5,7 @@ MockAgentRunner for /chat endpoints.
 Real Postgres (existing conftest.py fixtures) for DB-backed endpoints.
 """
 
+import asyncio
 import uuid
 
 import pytest
@@ -399,3 +400,93 @@ async def test_health_db_down(mock_runner, brain, heart, cognitive, settings):
         assert data["status"] == "unhealthy"
     else:
         assert resp.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# /chat/stream SSE keepalive (defense against client read timeout during
+# stalls in pre_turn / compaction / any non-streaming phase of stream_chat)
+# ---------------------------------------------------------------------------
+
+
+class _StallingStreamRunner(MockAgentRunner):
+    """Runner whose stream_chat stalls before yielding any events.
+
+    Simulates a slow pre_turn / compaction / cold-cache recall.
+    """
+
+    def __init__(self, stall_seconds: float) -> None:
+        super().__init__()
+        self.stall_seconds = stall_seconds
+
+    async def stream_chat(
+        self,
+        session_id,
+        user_message,
+        platform=None,
+        user_id=None,
+        user_display_name=None,
+    ):
+        from nous.api.runner import StreamEvent
+
+        # Simulate stall — no events emitted for this duration
+        await asyncio.sleep(self.stall_seconds)
+        yield StreamEvent(type="text_delta", text="hello")
+        yield StreamEvent(type="done", stop_reason="end_turn")
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_emits_keepalive_during_stall(
+    brain, heart, cognitive, db, settings
+):
+    """Server emits SSE comment-line pings while stream_chat is stalled."""
+    from nous.api.rest import create_app
+
+    # Tighten ping interval and stall longer than it so a ping is forced.
+    object.__setattr__(settings, "sse_ping_interval", 1)
+    runner = _StallingStreamRunner(stall_seconds=2.5)
+
+    app = create_app(runner, brain, heart, cognitive, db, settings)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test", timeout=30
+    ) as c:
+        async with c.stream(
+            "POST", "/chat/stream", json={"message": "hi"}
+        ) as resp:
+            assert resp.status_code == 200
+            chunks: list[str] = []
+            async for chunk in resp.aiter_text():
+                chunks.append(chunk)
+            body = "".join(chunks)
+
+    # SSE comment-line keepalive must appear before the data event,
+    # since the runner stalls 2.5s with ping_interval=1.
+    assert ": keepalive" in body, f"no keepalive in response: {body!r}"
+    # Real event still flows through after the stall completes.
+    assert '"type": "text_delta"' in body
+    assert '"text": "hello"' in body
+    # At least 2 keepalives expected (2.5s stall, 1s interval)
+    assert body.count(": keepalive") >= 2
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_no_keepalive_when_events_flow(
+    brain, heart, cognitive, db, settings
+):
+    """When events flow faster than ping_interval, no keepalive comments."""
+    from nous.api.rest import create_app
+
+    object.__setattr__(settings, "sse_ping_interval", 5)
+    runner = _StallingStreamRunner(stall_seconds=0.0)  # no stall
+
+    app = create_app(runner, brain, heart, cognitive, db, settings)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test", timeout=10
+    ) as c:
+        async with c.stream(
+            "POST", "/chat/stream", json={"message": "hi"}
+        ) as resp:
+            assert resp.status_code == 200
+            body = "".join([c async for c in resp.aiter_text()])
+
+    assert '"type": "text_delta"' in body
+    assert ": keepalive" not in body


### PR DESCRIPTION
## Summary
- Server-side SSE comment-line keepalive in `rest.py event_generator` catches stalls in `pre_turn`, compaction, and any non-streaming phase of `stream_chat` — not just tool dispatch
- Telegram bot lifts the 300s `read` timeout for `/chat/stream` calls only; non-streaming endpoints keep their safety net
- New `NOUS_SSE_PING_INTERVAL` setting (default 15s)

## Why
The existing `_stream_with_keepalive` and `_dispatch_with_keepalive` only cover (a) waiting for Anthropic's first byte and (b) tool execution. `pre_turn` (intent classification + recall_deep + embeddings) and mid-turn compaction (LLM call) ran with zero keepalive coverage. On cold caches or large compaction passes a single turn could exceed the bot's 300s read timeout, producing the `Stream cancelled (client disconnect) for session ...` log even though the user was still waiting.

## Design
- Replaced `async for event in stream` with `asyncio.wait({pending}, timeout=ping_interval)` race pattern. Critical: `wait_for` would cancel the underlying generator on timeout — `wait` returns the pending set without cancelling.
- On window expiry: yield `: keepalive\n\n` (SSE comment line, ignored by spec-compliant clients but resets the socket read timer).
- Pending task is cancelled and awaited in `finally` before `stream.aclose()` to avoid \"Task was destroyed\" warnings on disconnect.
- Bot uses per-request `httpx.Timeout(connect=10, read=None, write=10, pool=10)` for the streaming call only — `connect`/`write`/`pool` still catch real network failures fast.

## Test plan
- [x] `test_chat_stream_emits_keepalive_during_stall` — runner stalls 2.5s with `ping_interval=1`, asserts ≥2 `: keepalive` comments appear before the data event
- [x] `test_chat_stream_no_keepalive_when_events_flow` — events flow immediately with `ping_interval=5`, asserts zero keepalive comments
- [x] Full `test_rest.py` + `test_streaming_keepalive.py` + `test_unpopulated_columns.py`: 31 passed (2 unrelated pre-existing failures: `test_search_facts` SQLite/pgvector syntax mismatch, `test_default_tool_timeout` `.env` leak)
- [ ] Manual smoke: long turn via Telegram with a tool call >60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)