### PR TITLE
feat(F043): cross-encoder reranking for sleep-cycle graph backfill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,7 @@ nous/
 | F038 | Unified DAG Orchestration (DAGStore, DAGOrchestrator, DAG tools, dashboard tab) | #289 |
 | F040 | Graph Densification (orphan backfill, reverse linking, per-relation thresholds, density dashboard, cluster discovery) | — |
 | F042 | Cross-Encoder Reranking (sigmoid-normalized, async, head-truncation, feature-flagged, optional sentence-transformers dep) | #312 |
+| F043 | Cross-Encoder Reranking in Sleep-Cycle Graph Backfill (precision pre-filter before cosine gate, reuses F042 reranker, feature-flagged, _ce_stats telemetry) | — |
 
 ## How to Work
 
@@ -331,6 +332,9 @@ DB connection vars are **unprefixed** (shared with docker-compose). All others u
 | `NOUS_CROSS_ENCODER_MODEL` | `cross-encoder/ms-marco-MiniLM-L-6-v2` | Cross-encoder model name for F042 reranking |
 | `NOUS_CROSS_ENCODER_MAX_CANDIDATES` | `30` | Max candidates to rerank (head-truncation, tail untouched) |
 | `NOUS_CROSS_ENCODER_TEXT_LIMIT` | `512` | Max chars per doc fed to cross-encoder |
+| `NOUS_CE_BACKFILL_ENABLED` | `false` | Enable F043 cross-encoder reranking in F040 sleep-cycle graph backfill (requires sentence-transformers, reuses F042 model) |
+| `NOUS_CE_BACKFILL_TOP_K` | `10` | Max candidates per orphan reranked by cross-encoder before cosine verification |
+| `NOUS_CE_BACKFILL_MIN_SCORE` | `0.30` | Sigmoid-normalized CE score floor — candidates below this are dropped before the cosine gate |
 | `NOUS_CRITIC_SKILL_INJECTION` | `disabled` | Critic skill injection mode: enabled, disabled, log_only |
 | `NOUS_CRITIC_SKILL_SLOTS` | `2` | Reserved procedure slots for Critic-recommended skills |
 | `NOUS_EMBEDDING_SKILL_SLOTS` | `3` | Procedure slots for embedding similarity search |

--- a/docs/features/F043-ce-rerank-sleep-backfill.md
+++ b/docs/features/F043-ce-rerank-sleep-backfill.md
@@ -1,0 +1,369 @@
+# F043: Cross-Encoder Reranking for Sleep-Cycle Graph Backfill
+
+**Status:** Shipped
+**Proposed by:** Tim + Nous
+**Date:** 2026-04-14
+**Depends on:** F040 (Graph Densification — deployed), F042 (Cross-Encoder Reranking — deployed PR #312/#313)
+**Blocks:** None (additive, feature-flagged)
+**Supplements:** F040 (precision improvement on auto-linked edges)
+
+---
+
+## Problem Statement
+
+F040 Graph Densification runs during sleep and backfills graph edges for orphan memories (facts, decisions, episodes, procedures) using a two-stage candidate pipeline:
+
+1. **Candidate gathering** — hybrid search (RRF vector + keyword) for same-type linking, or vector + keyword merged for cross-type linking
+2. **Threshold gate** — per-relation cosine similarity threshold verification before `create_edge()`
+
+Stage 1 uses a bi-encoder (the stored embedding) — it returns many candidates that are topically near the orphan but may not be the *best* matches. Stage 2 is a pointwise cosine check that's cheap but coarse-grained: if the stored embedding happens to be cosine-close, the edge is created regardless of whether the two texts actually share semantic content the way a cross-encoder would see.
+
+The result: graph edges get polluted with "close but not quite" links that erode spreading activation precision and make the graph noisier than it should be.
+
+### Current Flow (F040)
+
+```
+orphan fact "Tim moved to Silver Spring in March"
+  │
+  ▼
+hybrid_search(vector+keyword)  →  10 candidates by RRF rank
+  │
+  ▼
+for each candidate:
+    cosine(orphan_emb, cand_emb) ≥ threshold (0.82) ?
+      yes → create_edge()
+      no  → skip
+```
+
+Problem: a candidate fact "Maryland is a state near DC" has high cosine with "Tim moved to Silver Spring" because they share DC/Maryland context, so the edge gets created — but the two facts aren't really about the same thing.
+
+### Proposed Flow (F043)
+
+```
+orphan fact "Tim moved to Silver Spring in March"
+  │
+  ▼
+hybrid_search(vector+keyword)  →  10 candidates by RRF rank
+  │
+  ▼
+cross_encoder_rerank(orphan, candidates, text_fn)  [NEW]
+  │
+  ▼
+keep top-K with CE score ≥ min_score floor  [NEW]
+  │
+  ▼
+for each surviving candidate:
+    cosine(orphan_emb, cand_emb) ≥ threshold (0.82) ?
+      yes → create_edge()
+      no  → skip
+```
+
+The cosine gate stays — it's a correctness floor. CE is inserted *before* the cosine gate so it acts as a **precision pre-filter**, pruning candidates that look topically close but are semantically unrelated. Candidates the cross-encoder would score `<0.3` are dropped without spending a cosine query.
+
+### Why Sleep Is a Better Fit Than Recall
+
+F042 placed CE reranking in `recall_deep` where latency is visible to the user (~30-50ms per query). That's acceptable but not ideal. Sleep is genuinely async — it runs on idle timers, has no user waiting, and processes candidates in batches. The CE cost is **free** relative to the value it adds.
+
+A secondary win: sleep is where we could eventually **fine-tune** the cross-encoder on actual link outcomes (which edges got traversed, which got contradicted later), feeding back into F042's Phase 2 roadmap. F043 is the prerequisite for that because it's where we accumulate the training signal.
+
+---
+
+## Solution
+
+### Scope: MVP — Backfill Only
+
+F043 MVP inserts CE reranking into both backfill code paths in `nous/brain/graph_densifier.py`:
+
+- `_backfill_same_type()` — between `hybrid_search()` and the cosine-verification loop
+- `_backfill_cross_type()` — after the content fetch and before the re-embed/cosine loop
+
+**Out of MVP scope:**
+- Contradiction-detection candidate filtering (see Phase 2 below — different semantics, different risks)
+- Fact-at-ingest dedup (no current rerank point; separate effort)
+- Fine-tuning / knowledge distillation (F042 Phase 2-3 territory)
+
+### Part 1: Candidate Adapter
+
+The existing F042 reranker `nous/heart/reranker.cross_encoder_rerank()` expects candidates with a mutable `.score` attribute and an optional `text_fn` to extract the reranking text. F040's `hybrid_search()` returns `list[tuple[UUID, float]]` — no `.score` attribute, no text.
+
+**New module:** `nous/brain/backfill_rerank.py`
+
+```python
+from __future__ import annotations
+import logging
+from dataclasses import dataclass
+from typing import Sequence
+from uuid import UUID
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from nous.heart.reranker import CROSS_ENCODER_AVAILABLE, cross_encoder_rerank
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RerankCandidate:
+    id: UUID
+    content: str
+    score: float  # mutable; reranker writes sigmoid CE score here
+
+
+async def fetch_candidate_content(
+    session: AsyncSession,
+    table: str,
+    content_col: str,
+    candidate_ids: Sequence[UUID],
+) -> dict[UUID, str]:
+    """Batch-fetch text for reranking.
+
+    Returns dict[id → content]. Missing / empty rows are omitted.
+    """
+    if not candidate_ids:
+        return {}
+    placeholders = ", ".join(f":id_{i}" for i in range(len(candidate_ids)))
+    params = {f"id_{i}": cid for i, cid in enumerate(candidate_ids)}
+    sql = text(
+        f"SELECT t.id, {content_col} AS content "
+        f"FROM {table} t WHERE t.id IN ({placeholders})"
+    )
+    rows = await session.execute(sql, params)
+    return {row.id: row.content for row in rows if row.content}
+
+
+async def ce_rerank_backfill_candidates(
+    query_text: str,
+    candidate_rows: Sequence[tuple[UUID, float]],
+    content_map: dict[UUID, str],
+    *,
+    settings,
+    log_context: str = "",
+) -> list[tuple[UUID, float]]:
+    """Rerank F040 backfill candidates via cross-encoder.
+
+    Returns the surviving candidates in CE-ranked order. Each survivor's
+    RRF score is REPLACED with the sigmoid CE score. If CE is unavailable
+    or disabled, returns ``candidate_rows`` unchanged.
+
+    A candidate is dropped if:
+      - its content is missing/empty
+      - its sigmoid CE score < ``settings.ce_backfill_min_score``
+      - it falls outside the top ``settings.ce_backfill_top_k``
+    """
+    if (
+        not settings.ce_backfill_enabled
+        or not CROSS_ENCODER_AVAILABLE
+        or not candidate_rows
+        or not query_text
+    ):
+        return list(candidate_rows)
+
+    # Build RerankCandidate wrappers; drop rows with no content up front.
+    wrapped: list[RerankCandidate] = []
+    for cand_id, rrf in candidate_rows:
+        content = content_map.get(cand_id, "")
+        if not content:
+            continue
+        wrapped.append(RerankCandidate(id=cand_id, content=content, score=float(rrf)))
+
+    if not wrapped:
+        return []
+
+    reranked = await cross_encoder_rerank(
+        query=query_text,
+        candidates=wrapped,
+        text_fn=lambda c: c.content,
+        model_name=settings.cross_encoder_model,
+        max_candidates=settings.ce_backfill_top_k * 2,  # give CE headroom
+        text_limit=settings.cross_encoder_text_limit,
+    )
+
+    kept: list[tuple[UUID, float]] = []
+    for c in reranked[: settings.ce_backfill_top_k]:
+        if c.score < settings.ce_backfill_min_score:
+            break  # list is already sigmoid-DESC; nothing below will pass
+        kept.append((c.id, c.score))
+
+    pruned = len(wrapped) - len(kept)
+    if pruned > 0:
+        logger.debug(
+            "CE backfill rerank: kept=%d pruned=%d ctx=%s",
+            len(kept), pruned, log_context,
+        )
+    return kept
+```
+
+### Part 2: Integration in `_backfill_same_type`
+
+After `hybrid_search()` returns candidates (graph_densifier.py:185):
+
+```python
+candidates = await hybrid_search(...)  # existing
+if not candidates:
+    return 0
+
+# F043: CE rerank between hybrid search and cosine verification
+if self._settings.ce_backfill_enabled:
+    content_map = await fetch_candidate_content(
+        session, table, content_col,
+        [c[0] for c in candidates],
+    )
+    candidates = await ce_rerank_backfill_candidates(
+        query_text=orphan_content,
+        candidate_rows=candidates,
+        content_map=content_map,
+        settings=self._settings,
+        log_context=f"{entity_type}-same:{orphan_id}",
+    )
+    if not candidates:
+        return 0
+```
+
+The downstream cosine-verification loop is unchanged. The cosine gate still has the final word — CE is purely a pruning step.
+
+### Part 3: Integration in `_backfill_cross_type`
+
+The cross-type path already fetches candidate content in `candidate_content: dict[UUID, str]` at line 309-311. CE rerank is inserted there:
+
+```python
+candidate_content = {
+    row.id: row.content for row in result if row.content
+}
+
+# F043: CE rerank cross-type candidates before re-embed loop
+if self._settings.ce_backfill_enabled and candidate_content:
+    ranked = await ce_rerank_backfill_candidates(
+        query_text=orphan_content,
+        candidate_rows=[(cid, 0.0) for cid in candidate_content.keys()],
+        content_map=candidate_content,
+        settings=self._settings,
+        log_context=f"{source_type}->{target_type}:{orphan_id}",
+    )
+    surviving = {cid for cid, _ in ranked}
+    candidate_content = {
+        cid: txt for cid, txt in candidate_content.items() if cid in surviving
+    }
+```
+
+### Part 4: Configuration
+
+New fields in `nous/config.py`:
+
+```python
+# F043: CE reranking for sleep-cycle backfill
+ce_backfill_enabled: bool = False
+ce_backfill_top_k: int = 10
+ce_backfill_min_score: float = 0.30  # sigmoid-normalized CE score floor
+```
+
+Env vars: `NOUS_CE_BACKFILL_ENABLED`, `NOUS_CE_BACKFILL_TOP_K`, `NOUS_CE_BACKFILL_MIN_SCORE`.
+
+Reuses F042's `cross_encoder_model` and `cross_encoder_text_limit` — no new model config.
+
+### Part 5: Telemetry
+
+Track CE pruning effectiveness in `sleep_stats` and the sleep handler log line:
+
+- `run_backfill_cycle()` accumulates `ce_kept` / `ce_pruned` counters via a `GraphDensifier._ce_stats` dict, returned alongside the existing per-type counts.
+- `_phase_graph_densification()` in `sleep_handler.py` adds these to `sleep_stats` and logs:
+
+  ```
+  F040 graph densification: 12 backfill edges (CE kept=45 pruned=18), 3 bridge edges
+  ```
+
+No new dashboard tab in MVP — the existing `/dashboard/density` already shows edge counts; CE stats flow through sleep_stats for log-based analysis first.
+
+### Part 6: Graceful Degradation
+
+- `CROSS_ENCODER_AVAILABLE=False` (sentence-transformers absent) → adapter returns input unchanged
+- `ce_backfill_enabled=False` (default) → adapter short-circuits before any DB work
+- `content_map` empty (e.g. all candidates had NULL content) → return empty list, log at DEBUG
+- CE load/predict exception → handled by the F042 reranker (returns candidates unchanged)
+- Downstream cosine gate unchanged → even if CE misbehaves, no false-positive edges leak through
+
+---
+
+## Pipeline Position Rationale
+
+CE goes **before** cosine verification because:
+1. CE on 10 candidates is faster than 10 serial cosine SQL queries — pruning first saves DB round-trips
+2. The cosine gate is a *correctness floor*, not a ranker. It should operate on a high-precision candidate set, not a high-recall one.
+3. CE can catch cases where stored embeddings happen to be close for the wrong reason (shared context words, topical drift) — cosine can't see through that because it's pointwise on the bi-encoder.
+
+CE does **not** replace cosine because:
+1. Cross-encoders are trained for query-passage relevance, not exact-text identity. The cosine threshold is the hard guarantee that two nodes are "about the same thing" at the embedding level.
+2. If CE is ever wrong in a systemic way, the cosine floor is the backstop.
+
+---
+
+## Future Phases (Not in MVP)
+
+### Phase 2: Contradiction-Detection Candidate Filtering
+
+`FactManager._find_contradiction_candidates()` currently does a SQL self-join with same `LOWER(subject)` + cosine-distance in [0.75, 0.95). Every candidate pair then goes through the expensive LLM resolver.
+
+CE could pre-filter the candidate pairs by scoring `(fact1.content, fact2.content)` and keeping only the top-N — saving LLM tokens on obvious non-matches.
+
+**Why not MVP:** the semantics are different (CE scores query-doc relevance, not contradiction entailment). If CE ranks a true-contradiction pair low, we lose a true positive and never fire the LLM. Requires careful validation against a labeled pair set we don't have yet.
+
+### Phase 3: Contradiction Subject Expansion
+
+Beyond re-ranking, CE could let us *drop* the same-subject constraint in `_find_contradiction_candidates` and use hybrid search + CE to find contradictory pairs that use different subject wording ("Tim lives in Maryland" vs "user is in Silver Spring"). Bigger recall win, bigger risk.
+
+### Phase 4: Link-Outcome Fine-Tuning
+
+Use which edges got traversed (spreading activation) and which got contradicted as positive/negative training pairs. Fine-tune the cross-encoder on Nous-specific link relevance. This is the F042 Phase 2 roadmap, now with a data source.
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| CE prunes too aggressively → fewer edges than F040 alone | MEDIUM | Feature flag default OFF; `ce_backfill_min_score` tunable; log kept/pruned counters for monitoring |
+| CE disagrees with cosine on obvious matches | LOW | Cosine gate is the floor — CE only reorders/prunes, can't bypass threshold |
+| First-query model load during sleep phase (~2-3s) | LOW | Sleep already tolerates multi-second phases; `huggingface_cache` volume persists model across restarts (F042-docker) |
+| Model-score scale coupling between F042 recall and F043 backfill | LOW | Both use the same sigmoid-normalized [0,1] range; `ce_backfill_min_score` is independent of F042's consumers |
+| DB round-trip cost for content fetch (`fetch_candidate_content`) | LOW | Single query per orphan, batched via `IN (...)` placeholders; N=10 candidates |
+| Sleep phase test count regression | MEDIUM | No new phase added — F043 is inside existing `graph_densification` phase; phase count is unchanged |
+
+---
+
+## Metrics & Evaluation
+
+Log during the backfill phase:
+
+- **`ce_kept`** — candidates that survived CE pruning, per sleep cycle
+- **`ce_pruned`** — candidates dropped by CE, per sleep cycle
+- **`edges_created`** — unchanged existing metric, now expected to drop slightly when CE is enabled (that's the precision improvement)
+- **`ce_prune_rate`** — `ce_pruned / (ce_kept + ce_pruned)` — target 20-50% based on F042 observation that cross-encoders typically prune ~30% of bi-encoder candidates
+
+Watch for regressions:
+- If `edges_created` drops to zero, CE min_score is too high
+- If `ce_prune_rate` is zero, CE isn't disagreeing with hybrid search (consider lowering top_k or raising min_score)
+
+---
+
+## Implementation Estimate
+
+- `nous/brain/backfill_rerank.py` (new): ~120 LOC
+- `nous/brain/graph_densifier.py` (modified): ~40 LOC
+- `nous/config.py`: 3 fields
+- `nous/handlers/sleep_handler.py`: ~5 LOC (stats propagation)
+- `tests/test_backfill_rerank.py` (new): ~180 LOC unit
+- `tests/test_graph_densifier.py` (extended): ~60 LOC integration (monkeypatched reranker)
+- Docs: CLAUDE.md env vars + shipped row, INDEX.md, spec status
+
+**Total: ~405 LOC + dependency reuse from F042.**
+
+---
+
+## Dependencies
+
+**No new deps.** Reuses:
+- `nous/heart/reranker.py` (F042, shipped)
+- `sentence-transformers>=3.0.0` (F042 optional dep, already in `[rerank]` extra and Dockerfile as of PR #313)
+- `huggingface_cache` Docker volume (F042 docker PR #313)
+
+The `[rerank]` extra is already installed in the Nous container. F043 requires zero deploy changes beyond flipping `NOUS_CE_BACKFILL_ENABLED=true`.

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -157,6 +157,7 @@ All shipped implementation specs with PR references:
 | F038 | Memory Quality & Context Loading Fixes | ✅ Shipped | Quality gate 0.55, fact 30-char min, procedure floor 0.40, episode recency weighting, user_direct admission bonus, task synthesis, context dedup, bash batching hints |
 | F040 | [Graph Densification](F040-graph-densification.md) | ✅ Shipped | Orphan backfill engine, reverse linking (decision/procedure/episode), per-relation thresholds, edge confidence scoring, cluster discovery, density dashboard |
 | F042 | [Cross-Encoder Reranking](F042-cross-encoder-reranking.md) | ✅ Shipped | Cross-encoder reranking stage in recall_deep — sigmoid-normalized scores, async executor, head-truncation, feature-flagged, optional sentence-transformers dep |
+| F043 | [CE Rerank Sleep Backfill](F043-ce-rerank-sleep-backfill.md) | ✅ Shipped | Cross-encoder reranking applied to F040 graph backfill during sleep — precision pre-filter before cosine gate, reuses F042 reranker, feature-flagged, `_ce_stats` telemetry |
 
 ### Phase 2 — Quality (next to build)
 

--- a/docs/superpowers/plans/2026-04-14-f043-ce-rerank-sleep-backfill.md
+++ b/docs/superpowers/plans/2026-04-14-f043-ce-rerank-sleep-backfill.md
@@ -1,0 +1,317 @@
+# F043 CE Rerank for Sleep-Cycle Backfill — Implementation Plan
+
+**Date:** 2026-04-14
+**Author:** lead (Nous forge)
+**Spec:** `docs/features/F043-ce-rerank-sleep-backfill.md`
+**Status:** v2 — revised after 3-agent review (arch `2ae17477`, impl `1c8eed8a`, devil `65b4a55c`). APPROVED WITH REVISIONS, ready to implement.
+
+## Review findings incorporated
+
+**P1 — all three reviewers converged on the same issue:**
+
+- `nous/handlers/sleep_handler.py:893` does `total_edges = sum(result.values())` and `graph_densifier.py:453` does `total = sum(results.values())`. Adding `ce_kept`/`ce_pruned` as top-level keys would silently inflate edge totals, break `sleep_stats["orphan_edges_created"]`, and flunk the existing `tests/test_sleep_densification.py::test_graph_densification_phase_runs` assertion (`orphan_edges_created == 5`).
+- **Fix:** nest CE stats under a distinct, non-numeric-summing key `_ce_stats`. The sleep handler pops it before summing; `run_backfill_cycle` also pops before its own sum. Existing tests that use `in`/key-containment keep passing; existing exact-sum assertions stay correct.
+
+**P2 addressed:**
+- **`max_candidates=top_k`** (not `top_k * 2`). Reviewer impl-043 confirmed the doubling pays for CE inference that gets sliced off anyway, because `hybrid_search` already caps at 10.
+- **Rename `ce_kept` → `ce_survived`.** Devil-043's point: "kept" implies edges finalized, but cosine gate can still reject post-CE. Use `ce_survived` (passed CE rerank) and track `ce_pruned` separately. Do NOT add a third counter for post-cosine edges — the existing per-type counts already capture that.
+- **`fetch_candidate_content` adds `AND t.agent_id = :agent_id`** — defense-in-depth. All three reviewers flagged.
+- **Adapter takes `entity_type` instead of raw `table`/`content_col`**, does the `_ENTITY_CONFIG` lookup internally (arch-043 P2-2). Cleaner signature, less injection surface.
+- **Whitespace-only content is dropped**: `if row.content and row.content.strip()` in `fetch_candidate_content` (impl-043 P2-2).
+- **Risk table row corrected:** the "`weight = min(rrf_score, 1.0)` else branch never hit under F043" claim is wrong — `find_orphans` does NOT guarantee `embedding IS NOT NULL` in every entity_type (devil-043 P2-2, verified: the `WHERE t.embedding IS NOT NULL` clause is conditional). CE sigmoid outputs (0,1) make it numerically safe regardless, so the overwrite is still OK — but document the real reason, not the wrong one.
+- **Unit tests restricted to `heart.facts` content_col** (plain `t.content`). Episode uses a JSON path (`structured_summary->>'summary'`) that sqlite doesn't parse the same way as Postgres. For non-fact entity types, integration tests either use the real Postgres fixture or mock `fetch_candidate_content` directly (impl-043 P2-4).
+- **Cross-type single-candidate bypass** documented in the graceful-degradation matrix. F042 reranker short-circuits on `len(candidates) <= 1`, so a lone cross-type survivor skips `ce_backfill_min_score` — cosine gate remains the correctness floor (devil-043 P2-3).
+- **Test suite gains:** duplicate candidate IDs, `len < top_k` under-fill, None/whitespace content, single-candidate bypass note, agent_id filter verification.
+
+**P3 addressed:**
+- **Cross-type candidate iteration order deterministic**: use `sorted(candidate_ids)` so tied CE scores break ties on UUID, not set-iteration order.
+- **`sleep_stats.get("ce_backfill_*", 0)` defensive reads** in the log-line formatting so future refactors that drop the counters don't crash.
+- **Empty-content drop** in `ce_rerank_backfill_candidates` is a no-op for cross-type (content_map already filtered) — comment the intent so it's not "removed as dead code" later.
+- **Module docstring** on `backfill_rerank.py` notes that F042 config (`cross_encoder_model`, `cross_encoder_text_limit`) is intentionally shared.
+- **`_ce_stats` as method-local, returned in result dict** rather than instance state — eliminates reset and future re-entrancy concerns (impl-043 P3-2, devil-043 P2-4). Now a `run_backfill_cycle`-local dict passed down via a new internal `_ctx` parameter (or via the session-scoped stat-accumulator pattern).
+
+## Resolved open questions
+
+1. **Per-cycle `_ce_stats`?** Yes — method-local, not instance state. All three reviewers agreed.
+2. **Share `ce_backfill_top_k` with F042 `cross_encoder_max_candidates`?** No — different budgets. F042's 30 is user-visible recall; backfill's 10 right-sizes `hybrid_search`'s 10-candidate output.
+3. **`agent_id` filter on `fetch_candidate_content`?** Yes — defense-in-depth, zero cost.
+4. **Adapter for `discover_clusters`?** MVP cut correct — that path uses hub-to-hub hand-rolled cosine, not `hybrid_search`. Defer.
+
+---
+
+## Scope
+
+Insert F042's cross-encoder reranker into F040's graph-densification backfill paths (same-type and cross-type) during the sleep cycle. Reuses `nous/heart/reranker.cross_encoder_rerank()` — no new reranker code. Adds a thin adapter (`nous/brain/backfill_rerank.py`) to bridge the shape mismatch between `hybrid_search()`'s `list[tuple[UUID, float]]` and the reranker's mutable-`.score` contract. Feature-flagged off by default. Ship MVP only — contradiction-path filtering is explicitly deferred to Phase 2 in the spec.
+
+## Key decisions
+
+1. **Adapter module rather than polymorphic reranker.** F042's reranker accepts arbitrary objects via `text_fn`. We wrap `(UUID, rrf_score)` tuples in a `RerankCandidate` dataclass with a mutable `.score`, batch-fetch content in a single `IN (...)` query, and drop empty-content rows up front. Keeps graph_densifier.py clean.
+
+2. **CE before cosine verification, not after.** Cosine is the correctness floor; CE is a precision pre-filter. Saves DB round-trips too — we only cosine-verify CE survivors. If CE ever misbehaves, cosine catches it.
+
+3. **Replace RRF score with sigmoid CE score post-rerank.** The downstream cosine loop doesn't actually read the RRF score (it computes its own `weight = float(sim_row.similarity)`), so score overwrite is safe — verified by reading `_backfill_same_type` end-to-end.
+
+4. **Same F042 `cross_encoder_model` + `text_limit` settings.** Three new F043 settings only: enable flag, top_k, min_score. No per-stage model choice in MVP.
+
+5. **Telemetry via `GraphDensifier._ce_stats` dict.** Per-cycle `ce_kept` / `ce_pruned` counters accumulate, then `run_backfill_cycle()` returns them in the stats dict alongside per-type counts. Sleep handler logs them.
+
+## Files
+
+### New
+
+1. **`nous/brain/backfill_rerank.py`** (~130 LOC)
+   - `@dataclass RerankCandidate` (id/content/score) — mutable (no `slots=True`, tradeoff documented in module docstring).
+   - `async fetch_candidate_content(session, agent_id, entity_type, candidate_ids) -> dict[UUID, str]` — takes `entity_type` and looks up `_ENTITY_CONFIG` internally for `(table, content_col)`. Filters `AND t.agent_id = :agent_id` for defense-in-depth. One SQL `IN` query. Drops rows whose content is None/empty/whitespace-only.
+   - `async ce_rerank_backfill_candidates(query_text, candidate_rows, content_map, *, settings, log_context) -> list[tuple[UUID, float]]` — the main entry point. Short-circuits cleanly on: `settings.ce_backfill_enabled=False`, `CROSS_ENCODER_AVAILABLE=False`, empty `candidate_rows`, empty `query_text`. Logs kept/pruned counts at DEBUG.
+   - Passes `max_candidates=settings.ce_backfill_top_k` (NOT `top_k * 2`) to the F042 reranker.
+   - **Important:** does NOT import `sentence_transformers` directly. Only imports `CROSS_ENCODER_AVAILABLE` and `cross_encoder_rerank` from `nous.heart.reranker`, which already has the ImportError guard.
+   - Module docstring notes: F042 config (`cross_encoder_model`, `cross_encoder_text_limit`) is intentionally shared.
+   - Import `_ENTITY_CONFIG` from `nous.brain.graph_densifier` — this creates a `backfill_rerank → graph_densifier` import edge. To avoid circularity (graph_densifier imports from backfill_rerank), move `_ENTITY_CONFIG` to a small leaf module `nous/brain/_entity_config.py` that both import from. Alternatively, the adapter can accept an injected dict parameter. **Decision: introduce `nous/brain/_entity_config.py`** — one-time refactor, fully backward-compat for graph_densifier which re-exports via `from nous.brain._entity_config import _ENTITY_CONFIG`.
+
+2. **`tests/test_backfill_rerank.py`** (~250 LOC, 14 unit tests)
+   - `test_ce_rerank_disabled_passthrough` — `ce_backfill_enabled=False` → input returned unchanged
+   - `test_ce_rerank_unavailable_passthrough` — monkeypatch `CROSS_ENCODER_AVAILABLE=False`
+   - `test_ce_rerank_empty_candidates` — `[]` in, `[]` out
+   - `test_ce_rerank_empty_query` — `query_text=""` → input returned unchanged
+   - `test_ce_rerank_drops_empty_content` — candidates with no matching `content_map` entry are dropped
+   - `test_ce_rerank_respects_top_k` — 20 candidates, `top_k=5` → at most 5 returned
+   - `test_ce_rerank_applies_min_score_floor` — fake model scores straddle floor; only those above survive
+   - `test_ce_rerank_preserves_rrf_when_short_circuited` — CE unavailable → original tuple list verbatim
+   - `test_ce_rerank_replaces_score_with_sigmoid` — CE runs → returned tuples carry sigmoid scores
+   - `test_ce_rerank_single_candidate_bypass` — one candidate, CE short-circuits; verify min_score floor is NOT applied (documents the F042 behavior so it's not a surprise). Cosine gate downstream is the correctness floor for this case.
+   - `test_ce_rerank_under_filled_top_k` — 3 candidates, `top_k=10` → returns 3 (not zero, not error)
+   - `test_ce_rerank_duplicate_candidate_ids_in_input` — same UUID appears twice in `candidate_rows`; verify both wrapper instances are processed (dedup is NOT the adapter's job; caller guarantees uniqueness today via `set`/dict)
+   - `test_fetch_candidate_content_agent_id_filter` — insert a row for agent A and agent B with identical id (different row UUIDs); verify fetch returns only the caller's agent_id
+   - `test_fetch_candidate_content_drops_whitespace` — row with `content="   "` or `content=None` omitted from result
+   - **Sqlite limitation:** unit tests for `fetch_candidate_content` only exercise `entity_type="fact"` (plain `t.content`). Other entity types are integration-tested against Postgres OR mocked at the adapter boundary.
+
+### Modified
+
+3. **`nous/brain/graph_densifier.py`** (~55 LOC added, no deletions)
+   - Import `ce_rerank_backfill_candidates`, `fetch_candidate_content` at top.
+   - **No `self._ce_stats` instance state.** Instead, `run_backfill_cycle` creates a local dict `ce_stats = {"survived": 0, "pruned": 0}` and threads it through to the two backfill helpers via a new `ce_stats: dict | None = None` kwarg.
+   - `_backfill_same_type(..., ce_stats=None)` — after `hybrid_search` returns candidates, insert the CE rerank block. If `ce_stats is not None`, accumulate counts there.
+   - `_backfill_cross_type(..., ce_stats=None)` — after `candidate_content = {...}`, iterate over `sorted(candidate_content.keys())` (deterministic), CE-rerank, filter map, optionally accumulate `ce_stats`.
+   - **`run_backfill_cycle` return shape:** `{"facts": int, "decisions": int, "episodes": int, "procedures": int, "_ce_stats": {"survived": int, "pruned": int}}`. The `_` prefix signals "not a per-type edge count — do not sum me." Inside the function, the existing `total = sum(results.values())` becomes:
+     ```python
+     edges = {k: v for k, v in results.items() if not k.startswith("_")}
+     total = sum(edges.values())
+     ```
+   - `_ENTITY_CONFIG` extraction to `nous/brain/_entity_config.py`: move the dict, re-import from here for back-compat.
+
+4. **`nous/config.py`** (~4 LOC)
+   Add in the F040 graph-backfill section:
+   ```python
+   # F043: CE reranking for sleep-cycle backfill
+   ce_backfill_enabled: bool = False
+   ce_backfill_top_k: int = 10
+   ce_backfill_min_score: float = 0.30
+   ```
+
+5. **`nous/handlers/sleep_handler.py`** (~10 LOC)
+   - `_phase_graph_densification`: pop `_ce_stats` from the result dict BEFORE `sum(result.values())`:
+     ```python
+     ce_stats = result.pop("_ce_stats", {"survived": 0, "pruned": 0})
+     total_edges = sum(result.values())  # unchanged semantics
+     sleep_stats["ce_backfill_survived"] = ce_stats["survived"]
+     sleep_stats["ce_backfill_pruned"] = ce_stats["pruned"]
+     ```
+   - Update the existing log line to (defensive `.get` for future-proofing):
+     ```
+     F040 graph densification: %d backfill edges (CE survived=%d pruned=%d), %d bridge edges
+     ```
+     via `sleep_stats.get("ce_backfill_survived", 0)` / `sleep_stats.get("ce_backfill_pruned", 0)`.
+
+6. **`tests/test_graph_densifier.py`** (~70 LOC added)
+   - `test_backfill_same_type_with_ce_rerank` — seed 5 facts, enable `ce_backfill_enabled`, monkeypatch `nous.heart.reranker._load_cross_encoder` with a fake model whose `predict` scores by substring; verify only CE-top candidates become edges, and `_ce_stats["survived"]/["pruned"]` accumulate.
+   - `test_backfill_ce_disabled_matches_baseline` — `ce_backfill_enabled=False` → behavior identical to pre-F043 baseline (regression guard). Assert `_ce_stats == {"survived": 0, "pruned": 0}`.
+   - `test_run_backfill_cycle_returns_ce_stats` — returned dict includes `_ce_stats` nested key and does NOT leak CE counters into `sum(result.values())` or per-type counts.
+   - `test_run_backfill_cycle_sum_values_unchanged` — **regression guard for the P1 bug**: compute `sum(v for k, v in result.items() if not k.startswith("_"))` and verify it equals the sum of per-type edge counts, independent of CE stats.
+
+7. **`tests/test_sleep_densification.py`** (~25 LOC added)
+   - Extend the existing `test_graph_densification_phase_runs` to have the mocked `run_backfill_cycle` return `{"facts": 3, "decisions": 2, "episodes": 0, "procedures": 0, "_ce_stats": {"survived": 5, "pruned": 3}}`.
+   - Assert `sleep_stats["orphan_edges_created"] == 5` (UNCHANGED — this is the regression guard for the P1 bug).
+   - Assert `sleep_stats["ce_backfill_survived"] == 5` and `sleep_stats["ce_backfill_pruned"] == 3`.
+   - Use `caplog` (pytest fixture) to verify the log line contains `CE survived=5 pruned=3`.
+
+8. **`CLAUDE.md`** — 3 env var rows (`NOUS_CE_BACKFILL_ENABLED`, `_TOP_K`, `_MIN_SCORE`), plus a new row in the What's Shipped table: `| F043 | CE reranking applied to F040 graph backfill during sleep (precision pre-filter before cosine gate, feature-flagged, shared reranker with F042) | — |`
+
+9. **`docs/features/F043-ce-rerank-sleep-backfill.md`** — `Status: Draft` → `Status: Shipped`, PR link filled post-merge
+
+10. **`docs/features/INDEX.md`** — add F043 row following the F040/F042 format
+
+### Not modified
+
+- `nous/heart/reranker.py` — reused as-is
+- `pyproject.toml`, `Dockerfile`, `docker-compose.yml` — no new deps, F042 already installed `[rerank]`
+- `nous/runtime_config.py` — F043 does not need a runtime toggle path in MVP (sleep phase re-reads settings each cycle; flipping env var + restart is fine)
+
+## Pipeline positions (concrete)
+
+### `_backfill_same_type` (nous/brain/graph_densifier.py:143)
+
+```python
+candidates = await hybrid_search(...)          # existing line 174-185
+if not candidates:
+    return 0
+
+# F043 insertion: rerank before cosine verify
+if self._settings.ce_backfill_enabled:
+    content_map = await fetch_candidate_content(
+        session, table, content_col,
+        [c[0] for c in candidates],
+    )
+    before = len(candidates)
+    candidates = await ce_rerank_backfill_candidates(
+        query_text=orphan_content,
+        candidate_rows=candidates,
+        content_map=content_map,
+        settings=self._settings,
+        log_context=f"{entity_type}-same:{orphan_id}",
+    )
+    after = len(candidates)
+    self._ce_stats["ce_kept"] += after
+    self._ce_stats["ce_pruned"] += max(before - after, 0)
+    if not candidates:
+        return 0
+
+# existing cosine verification loop below — unchanged
+for cand_id, rrf_score in candidates:
+    ...
+```
+
+### `_backfill_cross_type` (nous/brain/graph_densifier.py:232)
+
+```python
+candidate_content: dict[UUID, str] = {       # existing line 309-311
+    row.id: row.content for row in result if row.content
+}
+
+# F043 insertion: rerank cross-type survivors before re-embed loop
+if self._settings.ce_backfill_enabled and candidate_content:
+    synthetic_rows = [(cid, 0.0) for cid in candidate_content.keys()]
+    before = len(synthetic_rows)
+    ranked = await ce_rerank_backfill_candidates(
+        query_text=orphan_content,
+        candidate_rows=synthetic_rows,
+        content_map=candidate_content,
+        settings=self._settings,
+        log_context=f"{source_type}->{target_type}:{orphan_id}",
+    )
+    surviving = {cid for cid, _ in ranked}
+    candidate_content = {
+        cid: txt for cid, txt in candidate_content.items() if cid in surviving
+    }
+    after = len(candidate_content)
+    self._ce_stats["ce_kept"] += after
+    self._ce_stats["ce_pruned"] += max(before - after, 0)
+
+# existing re-embed + cosine loop below — unchanged
+```
+
+## Implementation phases
+
+**Phase A — python-eng-043 (sequential, foundation):**
+1. Create `nous/brain/backfill_rerank.py` with dataclass + two functions
+2. Add 3 settings fields to `nous/config.py`
+3. Wire CE rerank into `_backfill_same_type` and `_backfill_cross_type`
+4. Add `_ce_stats` init + reset + return in `run_backfill_cycle`
+5. Propagate stats through `_phase_graph_densification`
+6. Import smoke: `python -c "from nous.brain.graph_densifier import GraphDensifier; from nous.brain.backfill_rerank import ce_rerank_backfill_candidates"` → no ImportError
+
+**Phase B — test-eng-043 (after Phase A):**
+7. `tests/test_backfill_rerank.py` with 10 unit tests, deterministic fake model via monkeypatch
+8. Extend `tests/test_graph_densifier.py` with 3 integration tests
+9. Extend `tests/test_sleep_densification.py` with the stat-propagation assertion
+10. Run: `pytest tests/test_backfill_rerank.py tests/test_graph_densifier.py tests/test_sleep_densification.py -v`
+
+**Phase C — docs-eng-043 (after Phase A, parallelizable with B):**
+11. Update `CLAUDE.md` env var table + shipped row
+12. Update `docs/features/F043-*.md` Status (will flip to Shipped post-merge, plan leaves as Draft)
+13. Update `docs/features/INDEX.md`
+
+**Phase D — lead:**
+14. Run code-reviewer subagent on the full diff
+15. Address any P1/P2 findings inline; P3s optional
+16. Commit, push branch, open PR
+17. Merge after CI green
+18. `review_outcome` on every subagent + lead decision
+
+Each subagent follows forge protocol with unique `agent_id`, creates a decision FIRST via `pre_action`, streams ≥10 thoughts, finalizes via `update_decision`, and reports back.
+
+## Test strategy
+
+**Unit (test_backfill_rerank.py):** 10 tests, no DB, fake model via monkeypatch on `nous.heart.reranker._load_cross_encoder` + `CROSS_ENCODER_AVAILABLE=True`. Verifies adapter semantics in isolation — contract, score overwrite, top-K, min-score floor, graceful degradation.
+
+**Integration (test_graph_densifier.py):** 3 tests, real in-memory sqlite + real `GraphDensifier`, fake reranker. Verifies the insertion point actually runs, only survivors hit the cosine loop, and `_ce_stats` accumulates.
+
+**Sleep handler (test_sleep_densification.py):** 1 extended test, mocked densifier, verifies stat propagation into `sleep_stats` and the log line.
+
+Monkeypatch strategy (same as F042 tests): set `CROSS_ENCODER_AVAILABLE=True` on the imported module, then replace `_load_cross_encoder` with a fake that returns a stub whose `predict(pairs)` returns a deterministic list. This avoids any real torch import.
+
+## Graceful degradation matrix
+
+| Condition | Behavior |
+|---|---|
+| `sentence-transformers` not installed | adapter returns candidates unchanged, no-op |
+| `ce_backfill_enabled=False` (default) | adapter short-circuits before any DB work |
+| `CROSS_ENCODER_AVAILABLE=False` | same as above — reranker returns input |
+| `candidate_rows` empty | returns `[]` |
+| `content_map` empty / all candidates have NULL content | returns `[]`, logs DEBUG |
+| `query_text` empty | returns candidates unchanged |
+| Reranker raises | caught inside F042 reranker, returns candidates unchanged |
+| `top_k < 1` | safeguard in adapter: `top_k = max(top_k, 1)` |
+| `min_score` outside [0,1] | no clamp needed; sigmoid output is already in (0,1) |
+| Single cross-type candidate | F042 reranker short-circuits on `len <= 1` → bypasses `min_score` floor. Cosine gate is the backstop. |
+
+## Risk / Mitigation
+
+| Risk | Mitigation |
+|---|---|
+| CE prunes true positives | Cosine gate unchanged — precision floor preserved. Flag defaults off. |
+| DB round-trip cost for content fetch | Single `IN` query per orphan, N≤10; batched, no N+1 |
+| Test fixture shape mismatch with existing `test_graph_densifier` conftest | Mirror existing `_insert_fact` helper; test-eng must read conftest first |
+| `_ENTITY_CONFIG[entity_type]` content_col is an f-string-injected identifier | Existing codebase relies on this; we're not making it worse — but note in code review |
+| Sleep phase test count regression | No new phase; inside existing `graph_densification`. Existing phase-count tests untouched. |
+| Score overwrite surprises downstream reader | `_backfill_same_type` reads `rrf_score` in the `else` branch when `orphan_embedding` is None. That branch IS reachable (find_orphans does not hard-require non-null embedding for every type). However: CE sigmoid output is in (0, 1), which is within the valid `weight` range for `create_edge()` — so the overwrite is numerically safe even when the branch fires. Verified by devil-043. |
+| Cross-type has no RRF score to overwrite | We pass synthetic `0.0` RRF scores; CE overwrites with sigmoid; downstream only uses the CE-survival set, not the scores. Safe. |
+| **P1 regression: sum-of-values double counts CE stats** | Fixed by nesting CE stats under `_ce_stats` key and filtering `not k.startswith("_")` in both sum sites. New regression-guard test `test_run_backfill_cycle_sum_values_unchanged`. |
+| Single cross-type candidate bypasses `ce_backfill_min_score` | F042 reranker short-circuits on `len <= 1`. Cosine gate downstream remains the correctness floor. Documented in graceful-degradation matrix; `test_ce_rerank_single_candidate_bypass` pins the behavior. |
+
+## Open questions (for review team)
+
+1. **Does `_ce_stats` need to be per-run_backfill_cycle or cumulative?** Plan says per-cycle (reset at start). Review confirm.
+2. **Should `ce_backfill_top_k` and `cross_encoder_max_candidates` (F042) share a setting?** Plan says separate — sleep budget differs from recall budget. Review confirm.
+3. **Does `fetch_candidate_content` need an agent_id filter?** The candidate IDs came from `hybrid_search()` which already filtered by agent_id, so IDs are agent-scoped. But defense-in-depth would add `AND t.agent_id = :agent_id`. Review decide.
+4. **Should we also add an adapter for `discover_clusters()`?** That's F040's bridge-edge discovery. Out of MVP scope but worth flagging. Review confirm MVP cut.
+
+## Resolved (from exploration)
+
+- `hybrid_search` returns `list[tuple[UUID, float]]` — confirmed, adapter needed.
+- Cosine gate at line 201-212 is the correctness floor — CE is additive.
+- `_ENTITY_CONFIG[entity_type]` exposes `content_col` — we have a reliable text source.
+- No new sleep phase; F043 is inside existing `graph_densification` phase 8.
+- F042 reranker signature confirmed: `async cross_encoder_rerank(query, candidates, text_fn, *, model_name, max_candidates, text_limit) -> list` — matches our adapter expectation.
+
+## Out of scope (explicit)
+
+- Contradiction-detection candidate filtering — spec Phase 2
+- Fact-at-ingest dedup via CE — separate effort
+- Fine-tuning on link outcomes — F042 Phase 2 territory
+- Dashboard UI for CE stats — log-based observability first
+- Cluster-discovery (`discover_clusters`) reranking — defer
+- Runtime config override (`RuntimeConfig.get_ce_backfill_enabled`) — sleep phase restart is acceptable for MVP
+
+## LOC estimate
+
+| Area | LOC |
+|---|---|
+| `backfill_rerank.py` | ~120 |
+| `graph_densifier.py` | ~40 |
+| `config.py` | ~4 |
+| `sleep_handler.py` | ~8 |
+| `test_backfill_rerank.py` | ~180 |
+| `test_graph_densifier.py` | ~60 |
+| `test_sleep_densification.py` | ~20 |
+| docs | ~15 |
+| **Total** | **~447** |

--- a/nous/brain/_entity_config.py
+++ b/nous/brain/_entity_config.py
@@ -1,0 +1,29 @@
+"""Shared entity configuration for F040 graph densification.
+
+Extracted from ``nous.brain.graph_densifier`` as a leaf module so that
+``nous.brain.backfill_rerank`` (F043) can import the same table/column
+mapping without creating a circular dependency between
+``backfill_rerank`` and ``graph_densifier``.
+
+Shape: ``dict[entity_type -> (table, type_name, content_column, extra_where)]``.
+
+``graph_densifier`` re-imports ``_ENTITY_CONFIG`` from this module at the
+same location its local definition used to live, so all existing
+references inside ``graph_densifier`` continue to resolve unchanged.
+"""
+
+from __future__ import annotations
+
+# Entity configuration: (table, type_name, content_column, extra_where)
+# content_column uses `t.` alias for the main table.
+_ENTITY_CONFIG: dict[str, tuple[str, str, str, str]] = {
+    "fact": ("heart.facts", "fact", "t.content", "t.active = true"),
+    "decision": ("brain.decisions", "decision", "t.description", "1=1"),
+    "episode": (
+        "heart.episodes",
+        "episode",
+        "t.structured_summary->>'summary'",
+        "t.active = true AND t.structured_summary IS NOT NULL",
+    ),
+    "procedure": ("heart.procedures", "procedure", "t.description", "t.active = true"),
+}

--- a/nous/brain/backfill_rerank.py
+++ b/nous/brain/backfill_rerank.py
@@ -1,0 +1,179 @@
+"""F043 — Cross-encoder rerank adapter for F040 sleep-cycle graph backfill.
+
+This module is a thin adapter that bridges the shape mismatch between
+``hybrid_search()``'s ``list[tuple[UUID, float]]`` return type and the
+F042 cross-encoder reranker's mutable-``.score`` contract. It wraps each
+``(UUID, rrf_score)`` row in a small dataclass, fetches the reranking
+text for the candidate set in one ``IN (...)`` query, then delegates to
+``nous.heart.reranker.cross_encoder_rerank`` for the actual scoring.
+
+Design notes:
+
+* **Settings sharing with F042.** ``cross_encoder_model`` and
+  ``cross_encoder_text_limit`` are intentionally shared with F042; the
+  MVP runs one reranker model across both recall and sleep backfill.
+  Only the enable flag, top-K, and min-score floor are F043-specific.
+* **``len(candidates) <= 1`` short-circuit in F042.** The F042 reranker
+  returns the candidate list unchanged when there is 0 or 1 element.
+  That path bypasses the ``ce_backfill_min_score`` floor for a lone
+  survivor — the downstream cosine gate in
+  ``graph_densifier._backfill_same_type`` / ``_backfill_cross_type``
+  remains the correctness floor for that case. Documented behavior.
+* **No ``sentence_transformers`` import here.** We only depend on
+  ``CROSS_ENCODER_AVAILABLE`` and ``cross_encoder_rerank`` from
+  ``nous.heart.reranker``, which already holds the ImportError guard.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Sequence
+from uuid import UUID
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from nous.brain._entity_config import _ENTITY_CONFIG
+from nous.heart.reranker import CROSS_ENCODER_AVAILABLE, cross_encoder_rerank
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RerankCandidate:
+    """Mutable wrapper to satisfy the F042 reranker's ``.score`` mutation contract."""
+
+    id: UUID
+    content: str
+    score: float
+
+
+async def fetch_candidate_content(
+    session: AsyncSession,
+    agent_id: str,
+    entity_type: str,
+    candidate_ids: Sequence[UUID],
+) -> dict[UUID, str]:
+    """Batch-fetch reranking text for F040 backfill candidates.
+
+    Uses ``_ENTITY_CONFIG[entity_type]`` to look up the table and content
+    column. Adds ``AND t.agent_id = :agent_id`` for defense-in-depth even
+    though upstream ``hybrid_search`` already scopes IDs by agent. Rows
+    whose content is ``None`` / empty / whitespace-only are omitted.
+    """
+    if not candidate_ids:
+        return {}
+    config = _ENTITY_CONFIG[entity_type]
+    # _ENTITY_CONFIG tuple shape: (table, type_name, content_col, extra_where)
+    table = config[0]
+    content_col = config[2]
+    placeholders = ", ".join(f":id_{i}" for i in range(len(candidate_ids)))
+    params: dict[str, object] = {
+        f"id_{i}": cid for i, cid in enumerate(candidate_ids)
+    }
+    params["agent_id"] = agent_id
+    sql = text(
+        f"SELECT t.id, {content_col} AS content "
+        f"FROM {table} t "
+        f"WHERE t.id IN ({placeholders}) AND t.agent_id = :agent_id"
+    )
+    rows = await session.execute(sql, params)
+    result: dict[UUID, str] = {}
+    for row in rows:
+        content = row.content
+        if content and str(content).strip():
+            result[row.id] = str(content)
+    return result
+
+
+async def ce_rerank_backfill_candidates(
+    query_text: str,
+    candidate_rows: Sequence[tuple[UUID, float]],
+    content_map: dict[UUID, str],
+    *,
+    settings,
+    log_context: str = "",
+) -> list[tuple[UUID, float]]:
+    """Rerank F040 backfill candidates via the F042 cross-encoder.
+
+    Returns survivors in CE-ranked order with sigmoid-normalized scores
+    replacing the input RRF scores. Short-circuits (returning
+    ``list(candidate_rows)`` unchanged) when:
+
+    * ``settings.ce_backfill_enabled`` is False,
+    * ``CROSS_ENCODER_AVAILABLE`` is False (``sentence-transformers``
+      not installed),
+    * ``candidate_rows`` is empty,
+    * ``query_text`` is empty.
+
+    Candidates whose content is missing from ``content_map`` (for
+    cross-type the map is already filtered; for same-type any row whose
+    content was NULL/whitespace in ``fetch_candidate_content`` is gone)
+    are dropped up front. Remaining wrapped candidates are fed to the
+    F042 reranker with ``max_candidates = ce_backfill_top_k`` (no
+    doubling — F042 plan P2-1 fix: ``hybrid_search`` already caps at 10
+    and the head is sliced to top-K anyway).
+
+    Survivors are walked in sigmoid-DESC order and kept until the first
+    ``score < ce_backfill_min_score`` — the stable sort inside F042
+    guarantees that break is correct.
+
+    NOTE: The F042 reranker short-circuits on ``len(candidates) <= 1``,
+    so a lone survivor bypasses ``min_score``. The downstream cosine
+    gate in ``graph_densifier._backfill_same_type`` /
+    ``_backfill_cross_type`` is the correctness floor for that case.
+    """
+    if (
+        not settings.ce_backfill_enabled
+        or not CROSS_ENCODER_AVAILABLE
+        or not candidate_rows
+        or not query_text
+    ):
+        return list(candidate_rows)
+
+    # Wrap only rows with non-empty content. Rows missing from content_map
+    # (e.g. NULL/whitespace-only content filtered by fetch_candidate_content)
+    # are dropped entirely. This is a no-op for cross-type callers whose
+    # content_map is already filtered — documented so it isn't removed as
+    # dead code later.
+    wrapped: list[RerankCandidate] = []
+    for cand_id, rrf in candidate_rows:
+        content = content_map.get(cand_id, "")
+        if not content:
+            continue
+        wrapped.append(
+            RerankCandidate(id=cand_id, content=content, score=float(rrf))
+        )
+
+    if not wrapped:
+        return []
+
+    top_k = max(int(getattr(settings, "ce_backfill_top_k", 10)), 1)
+    min_score = float(getattr(settings, "ce_backfill_min_score", 0.30))
+
+    reranked = await cross_encoder_rerank(
+        query=query_text,
+        candidates=wrapped,
+        text_fn=lambda c: c.content,
+        model_name=settings.cross_encoder_model,
+        max_candidates=top_k,  # NO doubling — see plan P2-1 fix
+        text_limit=settings.cross_encoder_text_limit,
+    )
+
+    kept: list[tuple[UUID, float]] = []
+    for c in reranked[:top_k]:
+        # Head is sigmoid-DESC, so break on first below-floor entry.
+        if c.score < min_score:
+            break
+        kept.append((c.id, c.score))
+
+    pruned = len(wrapped) - len(kept)
+    if pruned > 0:
+        logger.debug(
+            "CE backfill rerank: kept=%d pruned=%d ctx=%s",
+            len(kept),
+            pruned,
+            log_context,
+        )
+    return kept

--- a/nous/brain/graph_densifier.py
+++ b/nous/brain/graph_densifier.py
@@ -15,6 +15,11 @@ from uuid import UUID
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from nous.brain._entity_config import _ENTITY_CONFIG
+from nous.brain.backfill_rerank import (
+    ce_rerank_backfill_candidates,
+    fetch_candidate_content,
+)
 from nous.brain.embeddings import EmbeddingProvider
 from nous.brain.graph_linker import GraphLinker, common_template_text, edge_confidence
 from nous.config import Settings
@@ -22,20 +27,6 @@ from nous.heart.search import hybrid_search
 from nous.storage.database import Database
 
 logger = logging.getLogger(__name__)
-
-# Entity configuration: (table, type_name, content_column, extra_where)
-# content_column uses `t.` alias for the main table.
-_ENTITY_CONFIG: dict[str, tuple[str, str, str, str]] = {
-    "fact": ("heart.facts", "fact", "t.content", "t.active = true"),
-    "decision": ("brain.decisions", "decision", "t.description", "1=1"),
-    "episode": (
-        "heart.episodes",
-        "episode",
-        "t.structured_summary->>'summary'",
-        "t.active = true AND t.structured_summary IS NOT NULL",
-    ),
-    "procedure": ("heart.procedures", "procedure", "t.description", "t.active = true"),
-}
 
 # Relation types for different type pairs
 _RELATION_MAP: dict[tuple[str, str], str] = {
@@ -146,6 +137,7 @@ class GraphDensifier:
         orphan_id: UUID,
         orphan_content: str,
         session: AsyncSession,
+        ce_stats: dict[str, int] | None = None,
     ) -> int:
         """Link an orphan to similar nodes of the same type using hybrid search.
 
@@ -186,6 +178,29 @@ class GraphDensifier:
 
         if not candidates:
             return 0
+
+        # F043: CE rerank before cosine verification (precision pre-filter).
+        if self._settings.ce_backfill_enabled:
+            content_map = await fetch_candidate_content(
+                session,
+                self._agent_id,
+                entity_type,
+                [c[0] for c in candidates],
+            )
+            before = len(candidates)
+            candidates = await ce_rerank_backfill_candidates(
+                query_text=orphan_content,
+                candidate_rows=candidates,
+                content_map=content_map,
+                settings=self._settings,
+                log_context=f"{entity_type}-same:{orphan_id}",
+            )
+            after = len(candidates)
+            if ce_stats is not None:
+                ce_stats["survived"] += after
+                ce_stats["pruned"] += max(before - after, 0)
+            if not candidates:
+                return 0
 
         # For each candidate, verify actual cosine similarity meets threshold
         # (RRF scores are rank-based, not directly comparable to similarity thresholds)
@@ -236,6 +251,7 @@ class GraphDensifier:
         orphan_content: str,
         target_type: str,
         session: AsyncSession,
+        ce_stats: dict[str, int] | None = None,
     ) -> int:
         """Link an orphan to nodes of a different type.
 
@@ -310,6 +326,29 @@ class GraphDensifier:
             row.id: row.content for row in result if row.content
         }
 
+        # F043: CE rerank cross-type survivors before the re-embed loop.
+        if self._settings.ce_backfill_enabled and candidate_content:
+            sorted_ids = sorted(candidate_content.keys())  # deterministic tie-break
+            synthetic_rows = [(cid, 0.0) for cid in sorted_ids]
+            before = len(synthetic_rows)
+            ranked = await ce_rerank_backfill_candidates(
+                query_text=orphan_content,
+                candidate_rows=synthetic_rows,
+                content_map=candidate_content,
+                settings=self._settings,
+                log_context=f"{source_type}->{target_type}:{orphan_id}",
+            )
+            surviving = {cid for cid, _ in ranked}
+            candidate_content = {
+                cid: txt
+                for cid, txt in candidate_content.items()
+                if cid in surviving
+            }
+            after = len(candidate_content)
+            if ce_stats is not None:
+                ce_stats["survived"] += after
+                ce_stats["pruned"] += max(before - after, 0)
+
         edges_created = 0
         relation = _get_relation(source_type, target_type)
 
@@ -351,7 +390,11 @@ class GraphDensifier:
 
         return edges_created
 
-    async def backfill_orphan_facts(self, max_count: int | None = None) -> int:
+    async def backfill_orphan_facts(
+        self,
+        max_count: int | None = None,
+        ce_stats: dict[str, int] | None = None,
+    ) -> int:
         """Find orphan facts and connect them to similar facts and decisions."""
         if not self._settings.graph_backfill_enabled:
             return 0
@@ -363,14 +406,22 @@ class GraphDensifier:
             for orphan_id, content in orphans:
                 if self._interrupted:
                     break
-                total += await self._backfill_same_type("fact", orphan_id, content, session)
-                total += await self._backfill_cross_type("fact", orphan_id, content, "decision", session)
+                total += await self._backfill_same_type(
+                    "fact", orphan_id, content, session, ce_stats=ce_stats
+                )
+                total += await self._backfill_cross_type(
+                    "fact", orphan_id, content, "decision", session, ce_stats=ce_stats
+                )
             await session.commit()
 
         logger.info("F040: backfill_orphan_facts created %d edges from %d orphans", total, len(orphans))
         return total
 
-    async def backfill_orphan_decisions(self, max_count: int | None = None) -> int:
+    async def backfill_orphan_decisions(
+        self,
+        max_count: int | None = None,
+        ce_stats: dict[str, int] | None = None,
+    ) -> int:
         """Find orphan decisions and connect them to similar decisions and facts."""
         if not self._settings.graph_backfill_enabled:
             return 0
@@ -382,14 +433,22 @@ class GraphDensifier:
             for orphan_id, content in orphans:
                 if self._interrupted:
                     break
-                total += await self._backfill_same_type("decision", orphan_id, content, session)
-                total += await self._backfill_cross_type("decision", orphan_id, content, "fact", session)
+                total += await self._backfill_same_type(
+                    "decision", orphan_id, content, session, ce_stats=ce_stats
+                )
+                total += await self._backfill_cross_type(
+                    "decision", orphan_id, content, "fact", session, ce_stats=ce_stats
+                )
             await session.commit()
 
         logger.info("F040: backfill_orphan_decisions created %d edges from %d orphans", total, len(orphans))
         return total
 
-    async def backfill_orphan_episodes(self, max_count: int | None = None) -> int:
+    async def backfill_orphan_episodes(
+        self,
+        max_count: int | None = None,
+        ce_stats: dict[str, int] | None = None,
+    ) -> int:
         """Find orphan episodes and connect them to similar episodes and facts."""
         if not self._settings.graph_backfill_enabled:
             return 0
@@ -401,14 +460,22 @@ class GraphDensifier:
             for orphan_id, content in orphans:
                 if self._interrupted:
                     break
-                total += await self._backfill_same_type("episode", orphan_id, content, session)
-                total += await self._backfill_cross_type("episode", orphan_id, content, "fact", session)
+                total += await self._backfill_same_type(
+                    "episode", orphan_id, content, session, ce_stats=ce_stats
+                )
+                total += await self._backfill_cross_type(
+                    "episode", orphan_id, content, "fact", session, ce_stats=ce_stats
+                )
             await session.commit()
 
         logger.info("F040: backfill_orphan_episodes created %d edges from %d orphans", total, len(orphans))
         return total
 
-    async def backfill_orphan_procedures(self, max_count: int | None = None) -> int:
+    async def backfill_orphan_procedures(
+        self,
+        max_count: int | None = None,
+        ce_stats: dict[str, int] | None = None,
+    ) -> int:
         """Find orphan procedures and connect them to similar nodes."""
         if not self._settings.graph_backfill_enabled:
             return 0
@@ -420,39 +487,67 @@ class GraphDensifier:
             for orphan_id, content in orphans:
                 if self._interrupted:
                     break
-                total += await self._backfill_same_type("procedure", orphan_id, content, session)
-                total += await self._backfill_cross_type("procedure", orphan_id, content, "fact", session)
-                total += await self._backfill_cross_type("procedure", orphan_id, content, "decision", session)
+                total += await self._backfill_same_type(
+                    "procedure", orphan_id, content, session, ce_stats=ce_stats
+                )
+                total += await self._backfill_cross_type(
+                    "procedure", orphan_id, content, "fact", session, ce_stats=ce_stats
+                )
+                total += await self._backfill_cross_type(
+                    "procedure", orphan_id, content, "decision", session, ce_stats=ce_stats
+                )
             await session.commit()
 
         logger.info("F040: backfill_orphan_procedures created %d edges from %d orphans", total, len(orphans))
         return total
 
-    async def run_backfill_cycle(self) -> dict[str, int]:
+    async def run_backfill_cycle(self) -> dict:
         """Orchestrate a full backfill cycle across all entity types.
 
-        Returns a dict mapping entity type to number of edges created.
+        Returns a dict mapping entity type to number of edges created plus
+        a ``_ce_stats`` key carrying F043 reranker survival counters. The
+        leading underscore on ``_ce_stats`` signals "not a per-type edge
+        count — do not sum me" to downstream consumers that aggregate
+        ``result.values()``.
         """
         self._interrupted = False
-        results: dict[str, int] = {}
+        ce_stats: dict[str, int] = {"survived": 0, "pruned": 0}
+        results: dict = {}
 
-        results["facts"] = await self.backfill_orphan_facts()
-        if self._interrupted:
+        def _log_and_return(aborted: bool) -> dict:
+            # Filter `_`-prefixed keys from the edge-total sum so CE counters
+            # never inflate the per-type totals (F043 P1 regression guard).
+            edge_total = sum(v for k, v in results.items() if not k.startswith("_"))
+            results["_ce_stats"] = ce_stats
+            per_type = {k: v for k, v in results.items() if not k.startswith("_")}
+            if aborted:
+                logger.info(
+                    "F040: backfill cycle aborted (interrupt) — %d edges so far "
+                    "(per_type=%s ce=%s)",
+                    edge_total, per_type, ce_stats,
+                )
+            else:
+                logger.info(
+                    "F040: backfill cycle complete — %d total edges "
+                    "(per_type=%s ce=%s)",
+                    edge_total, per_type, ce_stats,
+                )
             return results
 
-        results["decisions"] = await self.backfill_orphan_decisions()
+        results["facts"] = await self.backfill_orphan_facts(ce_stats=ce_stats)
         if self._interrupted:
-            return results
+            return _log_and_return(aborted=True)
 
-        results["episodes"] = await self.backfill_orphan_episodes()
+        results["decisions"] = await self.backfill_orphan_decisions(ce_stats=ce_stats)
         if self._interrupted:
-            return results
+            return _log_and_return(aborted=True)
 
-        results["procedures"] = await self.backfill_orphan_procedures()
+        results["episodes"] = await self.backfill_orphan_episodes(ce_stats=ce_stats)
+        if self._interrupted:
+            return _log_and_return(aborted=True)
 
-        total = sum(results.values())
-        logger.info("F040: backfill cycle complete — %d total edges created (%s)", total, results)
-        return results
+        results["procedures"] = await self.backfill_orphan_procedures(ce_stats=ce_stats)
+        return _log_and_return(aborted=False)
 
     async def discover_clusters(self, max_bridges: int = 20) -> int:
         """Discover disconnected graph components and create bridge edges.

--- a/nous/config.py
+++ b/nous/config.py
@@ -297,6 +297,11 @@ class Settings(BaseSettings):
     graph_health_orphan_warn_threshold: float = 0.40
     graph_health_check_enabled: bool = True
 
+    # F043: CE reranking for sleep-cycle graph backfill (reuses F042 reranker)
+    ce_backfill_enabled: bool = False
+    ce_backfill_top_k: int = 10
+    ce_backfill_min_score: float = 0.30
+
     # F012: Procedure Learning (K-Line auto-creation)
     procedure_learning_enabled: bool = True
     procedure_cluster_min_size: int = 3

--- a/nous/handlers/sleep_handler.py
+++ b/nous/handlers/sleep_handler.py
@@ -890,8 +890,12 @@ class SleepHandler:
         try:
             self._graph_densifier._interrupted = self._interrupted
             result = await self._graph_densifier.run_backfill_cycle()
+            # F043: pop CE stats BEFORE sum so they don't inflate edge totals.
+            ce_stats = result.pop("_ce_stats", {"survived": 0, "pruned": 0})
             total_edges = sum(result.values())
             sleep_stats["orphan_edges_created"] = total_edges
+            sleep_stats["ce_backfill_survived"] = ce_stats.get("survived", 0)
+            sleep_stats["ce_backfill_pruned"] = ce_stats.get("pruned", 0)
 
             if not self._interrupted:
                 self._graph_densifier._interrupted = self._interrupted
@@ -899,8 +903,10 @@ class SleepHandler:
                 sleep_stats["bridge_edges_created"] = bridges
 
             logger.info(
-                "F040 graph densification: %d backfill edges, %d bridge edges",
+                "F040 graph densification: %d backfill edges (CE survived=%d pruned=%d), %d bridge edges",
                 total_edges,
+                sleep_stats.get("ce_backfill_survived", 0),
+                sleep_stats.get("ce_backfill_pruned", 0),
                 sleep_stats.get("bridge_edges_created", 0),
             )
             return True

--- a/tests/test_backfill_rerank.py
+++ b/tests/test_backfill_rerank.py
@@ -1,0 +1,456 @@
+"""F043 — Cross-encoder rerank adapter unit tests.
+
+Deterministic tests using a FakeModel + monkeypatched `_load_cross_encoder`
+so the real `sentence-transformers` dependency is never imported. Follows
+the pattern established by ``tests/test_f042_reranker.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+
+import nous.heart.reranker as reranker_mod
+from nous.brain import backfill_rerank as br
+
+
+# ---------------------------------------------------------------------------
+# FakeModel + helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeModel:
+    """Fake CrossEncoder returning deterministic floats."""
+
+    def __init__(self, score_fn=None, raises: Exception | None = None):
+        self.score_fn = score_fn or (lambda pairs: [0.5] * len(pairs))
+        self.raises = raises
+        self.pairs_seen: list[tuple[str, str]] = []
+        self.call_count = 0
+
+    def predict(self, pairs):
+        self.call_count += 1
+        pairs_list = list(pairs)
+        self.pairs_seen.extend(pairs_list)
+        if self.raises is not None:
+            raise self.raises
+        return self.score_fn(pairs_list)
+
+
+def make_settings(**overrides):
+    """Build a minimal settings SimpleNamespace carrying only the fields the adapter reads."""
+    defaults = dict(
+        ce_backfill_enabled=True,
+        ce_backfill_top_k=10,
+        ce_backfill_min_score=0.30,
+        cross_encoder_model="fake-model",
+        cross_encoder_text_limit=512,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.fixture
+def install_fake(monkeypatch):
+    """Force CROSS_ENCODER_AVAILABLE=True and stub the loader to return the given fake."""
+
+    def _install(fake: FakeModel):
+        # Both modules cache CROSS_ENCODER_AVAILABLE as an imported constant.
+        monkeypatch.setattr(reranker_mod, "CROSS_ENCODER_AVAILABLE", True)
+        monkeypatch.setattr(br, "CROSS_ENCODER_AVAILABLE", True)
+        monkeypatch.setattr(reranker_mod, "_load_cross_encoder", lambda name: fake)
+
+    return _install
+
+
+def _uuid(n: int) -> UUID:
+    return UUID(int=n)
+
+
+# ---------------------------------------------------------------------------
+# 1. Disabled passthrough
+# ---------------------------------------------------------------------------
+
+
+async def test_ce_rerank_disabled_passthrough(monkeypatch):
+    """ce_backfill_enabled=False → returns input unchanged."""
+    # Even if CE were available, disabled wins the short-circuit.
+    monkeypatch.setattr(reranker_mod, "CROSS_ENCODER_AVAILABLE", True)
+    settings = make_settings(ce_backfill_enabled=False)
+
+    rows = [(_uuid(1), 0.42), (_uuid(2), 0.33)]
+    out = await br.ce_rerank_backfill_candidates(
+        query_text="anything",
+        candidate_rows=rows,
+        content_map={_uuid(1): "alpha", _uuid(2): "beta"},
+        settings=settings,
+    )
+    assert out == rows  # list(candidate_rows) is a shallow copy w/ same tuples
+
+
+# ---------------------------------------------------------------------------
+# 2. Unavailable passthrough
+# ---------------------------------------------------------------------------
+
+
+async def test_ce_rerank_unavailable_passthrough(monkeypatch):
+    """CROSS_ENCODER_AVAILABLE=False → input returned unchanged."""
+    monkeypatch.setattr(reranker_mod, "CROSS_ENCODER_AVAILABLE", False)
+    monkeypatch.setattr(br, "CROSS_ENCODER_AVAILABLE", False)
+    settings = make_settings()
+
+    rows = [(_uuid(1), 0.42), (_uuid(2), 0.33)]
+    out = await br.ce_rerank_backfill_candidates(
+        query_text="anything",
+        candidate_rows=rows,
+        content_map={_uuid(1): "alpha", _uuid(2): "beta"},
+        settings=settings,
+    )
+    assert out == rows
+
+
+# ---------------------------------------------------------------------------
+# 3. Empty candidates
+# ---------------------------------------------------------------------------
+
+
+async def test_ce_rerank_empty_candidates(install_fake):
+    """[] in → [] out (short-circuit before any model load)."""
+    fake = FakeModel()
+    install_fake(fake)
+    settings = make_settings()
+
+    out = await br.ce_rerank_backfill_candidates(
+        query_text="anything",
+        candidate_rows=[],
+        content_map={},
+        settings=settings,
+    )
+    assert out == []
+    assert fake.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 4. Empty query
+# ---------------------------------------------------------------------------
+
+
+async def test_ce_rerank_empty_query(install_fake):
+    """Empty query_text → input returned unchanged."""
+    fake = FakeModel()
+    install_fake(fake)
+    settings = make_settings()
+
+    rows = [(_uuid(1), 0.4), (_uuid(2), 0.3)]
+    out = await br.ce_rerank_backfill_candidates(
+        query_text="",
+        candidate_rows=rows,
+        content_map={_uuid(1): "alpha", _uuid(2): "beta"},
+        settings=settings,
+    )
+    assert out == rows
+    assert fake.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 5. Drops rows with missing / empty content
+# ---------------------------------------------------------------------------
+
+
+async def test_ce_rerank_drops_empty_content(install_fake):
+    """Rows whose content is missing from content_map are dropped before reranking."""
+    fake = FakeModel(score_fn=lambda pairs: [2.0] * len(pairs))
+    install_fake(fake)
+    settings = make_settings()
+
+    rows = [(_uuid(1), 0.4), (_uuid(2), 0.3), (_uuid(3), 0.2)]
+    content_map = {_uuid(1): "alpha", _uuid(2): "beta"}  # _uuid(3) missing
+
+    out = await br.ce_rerank_backfill_candidates(
+        query_text="q",
+        candidate_rows=rows,
+        content_map=content_map,
+        settings=settings,
+    )
+    # Only 2 rows reached the reranker.
+    assert len(fake.pairs_seen) == 2
+    # And output has at most 2 survivors.
+    out_ids = {cid for cid, _ in out}
+    assert _uuid(3) not in out_ids
+    assert len(out) == 2
+
+
+# ---------------------------------------------------------------------------
+# 6. Respects top_k
+# ---------------------------------------------------------------------------
+
+
+async def test_ce_rerank_respects_top_k(install_fake):
+    """20 candidates with top_k=5 → returns exactly 5 survivors."""
+    # Fake emits raw logits 20,19,...1 so sigmoid is near 1.0 for all (all above floor).
+    fake = FakeModel(score_fn=lambda pairs: [float(20 - i) for i in range(len(pairs))])
+    install_fake(fake)
+    settings = make_settings(ce_backfill_top_k=5, ce_backfill_min_score=0.1)
+
+    rows = [(_uuid(i), 0.5) for i in range(1, 21)]
+    content_map = {_uuid(i): f"doc{i}" for i in range(1, 21)}
+
+    out = await br.ce_rerank_backfill_candidates(
+        query_text="q",
+        candidate_rows=rows,
+        content_map=content_map,
+        settings=settings,
+    )
+    assert len(out) == 5
+
+
+# ---------------------------------------------------------------------------
+# 7. Min score floor
+# ---------------------------------------------------------------------------
+
+
+async def test_ce_rerank_applies_min_score_floor(install_fake):
+    """Raw logits that sigmoid to ~[0.8,0.7,0.4,0.2,0.1] with floor=0.5 → keep top 2."""
+    import math
+
+    # Compute inverse sigmoid (logit) of target sigmoid values.
+    def logit(p: float) -> float:
+        return math.log(p / (1 - p))
+
+    targets = [0.8, 0.7, 0.4, 0.2, 0.1]
+    raw_logits = [logit(p) for p in targets]
+
+    fake = FakeModel(score_fn=lambda pairs: list(raw_logits))
+    install_fake(fake)
+    settings = make_settings(ce_backfill_top_k=10, ce_backfill_min_score=0.5)
+
+    rows = [(_uuid(i + 1), 0.5) for i in range(5)]
+    content_map = {_uuid(i + 1): f"doc{i+1}" for i in range(5)}
+
+    out = await br.ce_rerank_backfill_candidates(
+        query_text="q",
+        candidate_rows=rows,
+        content_map=content_map,
+        settings=settings,
+    )
+    assert len(out) == 2
+    # All survivors above the floor.
+    for _, score in out:
+        assert score >= 0.5
+
+
+# ---------------------------------------------------------------------------
+# 8. Preserves RRF when short-circuited
+# ---------------------------------------------------------------------------
+
+
+async def test_ce_rerank_preserves_rrf_when_short_circuited(monkeypatch):
+    """Short-circuit path does NOT mutate the RRF score."""
+    monkeypatch.setattr(reranker_mod, "CROSS_ENCODER_AVAILABLE", False)
+    monkeypatch.setattr(br, "CROSS_ENCODER_AVAILABLE", False)
+    settings = make_settings()
+
+    rows = [(_uuid(1), 0.42)]
+    out = await br.ce_rerank_backfill_candidates(
+        query_text="q",
+        candidate_rows=rows,
+        content_map={_uuid(1): "alpha"},
+        settings=settings,
+    )
+    assert out == [(_uuid(1), 0.42)]
+    # RRF preserved exactly
+    assert out[0][1] == 0.42
+
+
+# ---------------------------------------------------------------------------
+# 9. Replaces RRF with sigmoid score
+# ---------------------------------------------------------------------------
+
+
+async def test_ce_rerank_replaces_score_with_sigmoid(install_fake):
+    """When CE actually runs, output tuples carry sigmoid(raw) NOT the input RRF."""
+    # Two candidates so F042 does NOT short-circuit on len<=1; both raw=2.0.
+    fake = FakeModel(score_fn=lambda pairs: [2.0] * len(pairs))
+    install_fake(fake)
+    settings = make_settings(ce_backfill_min_score=0.0)
+
+    rows = [(_uuid(1), 0.42), (_uuid(2), 0.11)]
+    content_map = {_uuid(1): "alpha", _uuid(2): "beta"}
+
+    out = await br.ce_rerank_backfill_candidates(
+        query_text="q",
+        candidate_rows=rows,
+        content_map=content_map,
+        settings=settings,
+    )
+    expected_sig = 1.0 / (1.0 + pow(2.718281828, -2.0))
+    assert len(out) == 2
+    for _, score in out:
+        assert abs(score - expected_sig) < 1e-3
+        assert score != 0.42
+        assert score != 0.11
+
+
+# ---------------------------------------------------------------------------
+# 10. Single candidate bypass (F042 len<=1 short-circuit)
+# ---------------------------------------------------------------------------
+
+
+async def test_ce_rerank_single_candidate_bypass(install_fake):
+    """With one candidate, F042 short-circuits → fake model never called; tuple passes through."""
+    fake = FakeModel()
+    install_fake(fake)
+    settings = make_settings(ce_backfill_min_score=0.0)
+
+    rows = [(_uuid(1), 0.42)]
+    out = await br.ce_rerank_backfill_candidates(
+        query_text="q",
+        candidate_rows=rows,
+        content_map={_uuid(1): "alpha"},
+        settings=settings,
+    )
+    # F042 short-circuits for len<=1 → adapter never invokes model.predict.
+    assert fake.call_count == 0
+    # Output contains the sole candidate with its original RRF score intact.
+    assert len(out) == 1
+    assert out[0][0] == _uuid(1)
+    assert out[0][1] == 0.42
+
+
+# ---------------------------------------------------------------------------
+# 11. Under-filled top_k
+# ---------------------------------------------------------------------------
+
+
+async def test_ce_rerank_under_filled_top_k(install_fake):
+    """3 candidates, top_k=10, all above floor → returns 3 (not padded)."""
+    fake = FakeModel(score_fn=lambda pairs: [3.0] * len(pairs))
+    install_fake(fake)
+    settings = make_settings(ce_backfill_top_k=10, ce_backfill_min_score=0.1)
+
+    rows = [(_uuid(1), 0.5), (_uuid(2), 0.5), (_uuid(3), 0.5)]
+    content_map = {_uuid(1): "a", _uuid(2): "b", _uuid(3): "c"}
+
+    out = await br.ce_rerank_backfill_candidates(
+        query_text="q",
+        candidate_rows=rows,
+        content_map=content_map,
+        settings=settings,
+    )
+    assert len(out) == 3
+
+
+# ---------------------------------------------------------------------------
+# 12. Duplicate candidate IDs — dedup is not the adapter's job
+# ---------------------------------------------------------------------------
+
+
+async def test_ce_rerank_duplicate_candidate_ids_in_input(install_fake):
+    """Same UUID appearing twice in candidate_rows is NOT deduped by the adapter."""
+    fake = FakeModel(score_fn=lambda pairs: [2.0] * len(pairs))
+    install_fake(fake)
+    settings = make_settings(ce_backfill_min_score=0.0)
+
+    dup = _uuid(1)
+    rows = [(dup, 0.5), (dup, 0.3)]
+    content_map = {dup: "alpha"}
+
+    out = await br.ce_rerank_backfill_candidates(
+        query_text="q",
+        candidate_rows=rows,
+        content_map=content_map,
+        settings=settings,
+    )
+    # Both entries wrapped and scored.
+    assert len(fake.pairs_seen) == 2
+    assert len(out) == 2
+    assert all(cid == dup for cid, _ in out)
+
+
+# ---------------------------------------------------------------------------
+# 13. fetch_candidate_content agent_id filter
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_candidate_content_agent_id_filter():
+    """fetch_candidate_content passes agent_id as a bound param (defense-in-depth)."""
+    id_a = uuid4()
+    id_b = uuid4()
+
+    # Synthetic row class with .id / .content attributes.
+    def make_row(rid, content):
+        return SimpleNamespace(id=rid, content=content)
+
+    # Mock session: capture params; return only the agent=A row.
+    captured = {}
+
+    class FakeResult:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def __iter__(self):
+            return iter(self._rows)
+
+    async def fake_execute(sql, params):
+        captured["sql"] = str(sql)
+        captured["params"] = params
+        # Simulate the DB returning ONLY agent A's row.
+        return FakeResult([make_row(id_a, "shared content")])
+
+    session = SimpleNamespace(execute=fake_execute)
+
+    out = await br.fetch_candidate_content(
+        session=session,
+        agent_id="agent-A",
+        entity_type="fact",
+        candidate_ids=[id_a, id_b],
+    )
+
+    assert out == {id_a: "shared content"}
+    # agent_id bound into params (defense-in-depth) and SQL carries the filter.
+    assert captured["params"]["agent_id"] == "agent-A"
+    assert "agent_id" in captured["sql"]
+
+
+# ---------------------------------------------------------------------------
+# 14. fetch_candidate_content drops whitespace-only content
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_candidate_content_drops_whitespace():
+    """Rows with NULL / empty / whitespace-only content are omitted from the result map."""
+    id_keep = uuid4()
+    id_ws = uuid4()
+    id_none = uuid4()
+
+    def make_row(rid, content):
+        return SimpleNamespace(id=rid, content=content)
+
+    class FakeResult:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def __iter__(self):
+            return iter(self._rows)
+
+    async def fake_execute(sql, params):
+        return FakeResult(
+            [
+                make_row(id_keep, "hello"),
+                make_row(id_ws, "   "),
+                make_row(id_none, None),
+            ]
+        )
+
+    session = SimpleNamespace(execute=fake_execute)
+
+    out = await br.fetch_candidate_content(
+        session=session,
+        agent_id="agent-A",
+        entity_type="fact",
+        candidate_ids=[id_keep, id_ws, id_none],
+    )
+    assert out == {id_keep: "hello"}

--- a/tests/test_graph_densifier.py
+++ b/tests/test_graph_densifier.py
@@ -367,7 +367,10 @@ async def test_backfill_same_type_with_ce_rerank(
         await session.commit()
 
     ce_stats = {"survived": 0, "pruned": 0}
-    edges = await densifier.backfill_orphan_facts(max_count=10, ce_stats=ce_stats)
+    # max_count=1: process exactly one orphan so ce_stats reflects a single CE call.
+    # With max_count>1, every near-duplicate becomes its own orphan and ce_stats
+    # accumulates across all of them (5 orphans × 2 survivors = 10, not 2).
+    edges = await densifier.backfill_orphan_facts(max_count=1, ce_stats=ce_stats)
     # 2 survivors above floor, 2 pruned below floor.
     assert ce_stats["survived"] == 2
     assert ce_stats["pruned"] == 2

--- a/tests/test_graph_densifier.py
+++ b/tests/test_graph_densifier.py
@@ -301,3 +301,150 @@ async def test_run_backfill_cycle_returns_all_types(db, settings, mock_embedding
     assert "decisions" in results
     assert "episodes" in results
     assert "procedures" in results
+
+
+# ---------------------------------------------------------------------------
+# F043: CE rerank integration with backfill (require Postgres)
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_ce(monkeypatch, fake):
+    """Force CE availability and install fake loader on both reranker + adapter modules."""
+    import nous.heart.reranker as reranker_mod
+    from nous.brain import backfill_rerank as br
+
+    monkeypatch.setattr(reranker_mod, "CROSS_ENCODER_AVAILABLE", True)
+    monkeypatch.setattr(br, "CROSS_ENCODER_AVAILABLE", True)
+    monkeypatch.setattr(reranker_mod, "_load_cross_encoder", lambda name: fake)
+
+
+class _FakeCE:
+    """Fake CrossEncoder; predict returns a precomputed list of raw logits."""
+
+    def __init__(self, scores):
+        self._scores = scores
+        self.calls = 0
+
+    def predict(self, pairs):
+        self.calls += 1
+        # Return scores aligned with however many pairs we got.
+        n = len(list(pairs))
+        if n <= len(self._scores):
+            return self._scores[:n]
+        # Pad with very high logits so extras pass.
+        return list(self._scores) + [10.0] * (n - len(self._scores))
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_backfill_same_type_with_ce_rerank(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint, monkeypatch
+):
+    """CE rerank prunes low-score candidates; only above-floor survivors get edges."""
+    agent_id = f"test-ce-rerank-{uuid4().hex[:8]}"
+    s = settings.model_copy(update={
+        "graph_threshold_fact_fact": 0.01,
+        "graph_threshold_fact_decision": 0.01,
+        "ce_backfill_enabled": True,
+        "ce_backfill_top_k": 10,
+        "ce_backfill_min_score": 0.5,
+    })
+    # 2 high logits (sigmoid >> 0.5), 2 low logits (sigmoid < 0.5).
+    fake = _FakeCE(scores=[5.0, 5.0, -5.0, -5.0])
+    _install_fake_ce(monkeypatch, fake)
+
+    linker = GraphLinker(db, mock_embeddings, s, agent_id)
+    densifier = GraphDensifier(db, linker, mock_embeddings, s, agent_id)
+
+    async with db.session() as session:
+        base_emb = await mock_embeddings.embed("Python is great for data science")
+        await _insert_fact(session, agent_id, "Python orphan seed", base_emb)
+        for i in range(4):
+            near = await mock_embeddings.embed_near(
+                "Python is great for data science", noise=0.005
+            )
+            await _insert_fact(session, agent_id, f"candidate {i}", near)
+        await session.commit()
+
+    ce_stats = {"survived": 0, "pruned": 0}
+    edges = await densifier.backfill_orphan_facts(max_count=10, ce_stats=ce_stats)
+    # 2 survivors above floor, 2 pruned below floor.
+    assert ce_stats["survived"] == 2
+    assert ce_stats["pruned"] == 2
+    # At most as many edges as survivors (cosine gate may drop further).
+    assert edges <= 2
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_backfill_ce_disabled_matches_baseline(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint
+):
+    """ce_backfill_enabled=False → ce_stats stays zero AND edges still get created."""
+    agent_id = f"test-ce-disabled-{uuid4().hex[:8]}"
+    s = settings.model_copy(update={
+        "graph_threshold_fact_fact": 0.01,
+        "graph_threshold_fact_decision": 0.01,
+        "ce_backfill_enabled": False,
+    })
+    linker = GraphLinker(db, mock_embeddings, s, agent_id)
+    densifier = GraphDensifier(db, linker, mock_embeddings, s, agent_id)
+
+    async with db.session() as session:
+        base_emb = await mock_embeddings.embed("Identical fact text")
+        await _insert_fact(session, agent_id, "Identical fact text", base_emb)
+        near = await mock_embeddings.embed_near("Identical fact text", noise=0.005)
+        await _insert_fact(session, agent_id, "Identical fact text v2", near)
+        await session.commit()
+
+    ce_stats = {"survived": 0, "pruned": 0}
+    edges = await densifier.backfill_orphan_facts(max_count=10, ce_stats=ce_stats)
+    # CE disabled → counters never incremented.
+    assert ce_stats == {"survived": 0, "pruned": 0}
+    # Baseline behavior: low threshold + near-identical embeddings → at least one edge.
+    assert edges >= 1
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_run_backfill_cycle_returns_ce_stats(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint
+):
+    """run_backfill_cycle includes a `_ce_stats` dict with int survived/pruned."""
+    agent_id = f"test-ce-stats-{uuid4().hex[:8]}"
+    linker = GraphLinker(db, mock_embeddings, settings, agent_id)
+    densifier = GraphDensifier(db, linker, mock_embeddings, settings, agent_id)
+
+    result = await densifier.run_backfill_cycle()
+    assert "_ce_stats" in result
+    assert isinstance(result["_ce_stats"], dict)
+    assert isinstance(result["_ce_stats"].get("survived"), int)
+    assert isinstance(result["_ce_stats"].get("pruned"), int)
+    # Per-type counts remain ints.
+    for k in ("facts", "decisions", "episodes", "procedures"):
+        assert isinstance(result[k], int)
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_run_backfill_cycle_sum_values_unchanged(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint
+):
+    """Regression guard for P1: summing edge counts must EXCLUDE _ce_stats."""
+    agent_id = f"test-ce-sum-{uuid4().hex[:8]}"
+    linker = GraphLinker(db, mock_embeddings, settings, agent_id)
+    densifier = GraphDensifier(db, linker, mock_embeddings, settings, agent_id)
+
+    result = await densifier.run_backfill_cycle()
+
+    # Mimic the sleep_handler aggregation rule.
+    edge_sum = sum(v for k, v in result.items() if not k.startswith("_"))
+    expected = (
+        result["facts"]
+        + result["decisions"]
+        + result["episodes"]
+        + result["procedures"]
+    )
+    assert edge_sum == expected
+    # And the dict still carries the underscored key.
+    assert "_ce_stats" in result

--- a/tests/test_sleep_densification.py
+++ b/tests/test_sleep_densification.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
@@ -29,21 +31,40 @@ def handler(settings, bus):
 
 
 @pytest.mark.asyncio
-async def test_graph_densification_phase_runs(handler):
-    """Graph densification phase runs backfill and cluster discovery when densifier is wired."""
+async def test_graph_densification_phase_runs(handler, caplog):
+    """Graph densification phase runs backfill and cluster discovery when densifier is wired.
+
+    F043 regression guard: the orphan_edges_created total MUST equal the sum of
+    per-type edge counts and MUST NOT include the _ce_stats counters (which would
+    double-count). With facts=3, decisions=2, ce survived=5 + pruned=3, the
+    correct total is 5 — NOT 13.
+    """
     densifier = MagicMock()
-    densifier.run_backfill_cycle = AsyncMock(return_value={"facts": 3, "decisions": 2, "episodes": 0, "procedures": 0})
+    densifier.run_backfill_cycle = AsyncMock(return_value={
+        "facts": 3,
+        "decisions": 2,
+        "episodes": 0,
+        "procedures": 0,
+        "_ce_stats": {"survived": 5, "pruned": 3},
+    })
     densifier.discover_clusters = AsyncMock(return_value=3)
     handler._graph_densifier = densifier
 
     sleep_stats = {}
-    result = await handler._phase_graph_densification(sleep_stats)
+    with caplog.at_level(logging.INFO, logger="nous.handlers.sleep_handler"):
+        result = await handler._phase_graph_densification(sleep_stats)
 
     assert result is True
     densifier.run_backfill_cycle.assert_awaited_once()
     densifier.discover_clusters.assert_awaited_once_with(max_bridges=20)
-    assert sleep_stats["orphan_edges_created"] == 5  # sum(3+2+0+0)
+    # Regression guard: 5 (3+2+0+0), NOT 13 (which would mean _ce_stats leaked in).
+    assert sleep_stats["orphan_edges_created"] == 5
     assert sleep_stats["bridge_edges_created"] == 3
+    # F043: CE counters surfaced into sleep_stats.
+    assert sleep_stats["ce_backfill_survived"] == 5
+    assert sleep_stats["ce_backfill_pruned"] == 3
+    # F043: log line carries the CE survived/pruned summary.
+    assert "CE survived=5 pruned=3" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Apply F042's cross-encoder reranker as a precision pre-filter inside F040 graph densification. CE inserts between `hybrid_search`'s RRF-merged candidates and the existing per-relation cosine threshold gate in `GraphDensifier._backfill_same_type` / `_backfill_cross_type`, so candidates that are topically close but semantically unrelated get pruned before edge creation. The cosine gate stays intact as the correctness floor — F043 is purely additive precision.

## Why sleep, not just recall
F042 put CE in `recall_deep` where latency is user-visible. Sleep is genuinely async (idle timer, batched, no one waiting), so CE is free of latency concerns. Sleep is also where the eventual outcome-feedback signal for fine-tuning lives (F042 Phase 2 territory).

## Changes
- **New:** `nous/brain/_entity_config.py`, `nous/brain/backfill_rerank.py` (~175 LOC, `RerankCandidate` dataclass + `fetch_candidate_content` with `agent_id` defense-in-depth + `async ce_rerank_backfill_candidates` reusing F042)
- **Modified:** `graph_densifier.py` (CE insertion via `ce_stats` kwarg threaded through all `backfill_orphan_*` methods, `run_backfill_cycle` returns `_ce_stats` under underscore-prefixed key), `sleep_handler.py` (pops `_ce_stats` before sum, updated log), `config.py` (3 settings default OFF)
- **Tests:** 14 deterministic unit tests + 4 new `@pytest.mark.postgres_only` integration tests + extended sleep-phase test
- **Docs:** CLAUDE.md env vars + shipped row, INDEX.md row, spec Status → Shipped

## Universal P1 caught by plan review
All 3 review agents converged on the same bug: `sum(result.values())` in `sleep_handler._phase_graph_densification` would silently double-count new CE counters into `orphan_edges_created`, and the existing `test_graph_densification_phase_runs` assertion (`== 5`) would break. **Fix is double-protected**: `graph_densifier.run_backfill_cycle` filters `_`-prefixed keys from its internal sum AND `sleep_handler` pops `_ce_stats` before its sum. A new regression guard test `test_run_backfill_cycle_sum_values_unchanged` fails loudly if anyone re-introduces the bug.

## Process
- Plan v2 reviewed by 3-agent team: arch `2ae17477`, impl `1c8eed8a`, devil `65b4a55c` — APPROVE WITH REVISIONS. All P1 + P2 findings addressed in plan v2 before implementation began.
- Implementation via subagent pipeline: python-eng-043 → test-eng-043 + docs-eng-043 (parallel).
- Code review (`code-reviewer-043`, `12fb934d`): APPROVE, 0 P1, 0 P2, 3 P3. Interrupt-path log gap addressed inline; cosmetic nits skipped.
- 14/14 F043 unit tests pass; 30/30 relevant tests pass (13 postgres_only tests skipped in CI without live PG).

## Test plan
- [x] 14 unit tests in `tests/test_backfill_rerank.py` (deterministic FakeModel, no real torch import)
- [x] 5 sleep-handler tests including regression guard
- [ ] 4 integration tests gated `@pytest.mark.postgres_only` — run against real PG before merge
- [ ] Staging: `NOUS_CE_BACKFILL_ENABLED=true`, trigger sleep cycle, verify `F040 graph densification: N backfill edges (CE survived=X pruned=Y)` log
- [ ] Monitor `ce_backfill_pruned / (survived + pruned)` — expect 20-50% prune rate once tuned

## Out of scope (future phases per spec)
- Contradiction-detection candidate filtering (Phase 2 — different CE semantics)
- Contradiction subject-expansion via CE (Phase 3)
- Outcome-based fine-tuning (Phase 4, feeds F042 Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)