### PR TITLE
fix(tools): surface entity IDs in recall_deep + broaden anti-hallucination prompt

### DIFF
--- a/nous/api/tools.py
+++ b/nous/api/tools.py
@@ -355,7 +355,8 @@ def create_nous_tools(brain: Brain, heart: Heart, settings: Settings | None = No
                         results_text.append("=== Heart Memory ===")
                         for i, result in enumerate(heart_results, 1):
                             results_text.append(
-                                f"{i}. [{result.type}] {result.summary} (score: {result.score:.3f})"
+                                f"{i}. [{result.type}] {result.summary} "
+                                f"(id: {result.id}, score: {result.score:.3f})"
                             )
                     else:
                         results_text.append("=== Heart Memory ===\nNo results found.")
@@ -384,7 +385,8 @@ def create_nous_tools(brain: Brain, heart: Heart, settings: Settings | None = No
                     for i, n in enumerate(heart_graph_decisions, 1):
                         decayed = n.edge_weight * settings.graph_recall_decay
                         results_text.append(
-                            f"{i}. [via {n.edge_relation}] {n.description} (score: {decayed:.3f})"
+                            f"{i}. [via {n.edge_relation}] {n.description} "
+                            f"(id: {n.id}, score: {decayed:.3f})"
                         )
 
             # Search Brain decisions
@@ -461,16 +463,17 @@ def create_nous_tools(brain: Brain, heart: Heart, settings: Settings | None = No
                 if decision_results or graph_expanded:
                     results_text.append("\n=== Brain Decisions ===")
                     for i, dec in enumerate(decision_results, 1):
-                        score_str = f" (score: {dec.score:.3f})" if dec.score else ""
+                        score_str = f", score: {dec.score:.3f}" if dec.score else ""
                         results_text.append(
                             f"{i}. {dec.description} | {dec.category} | {dec.stakes} | "
-                            f"confidence: {dec.confidence:.2f}{score_str}"
+                            f"confidence: {dec.confidence:.2f} "
+                            f"(id: {dec.id}{score_str})"
                         )
                     for j, n in enumerate(graph_expanded, len(decision_results) + 1):
                         decayed_score = n.edge_weight * settings.graph_recall_decay
                         results_text.append(
                             f"{j}. [via graph: {n.edge_relation}] {n.description} "
-                            f"(score: {decayed_score:.3f})"
+                            f"(id: {n.id}, score: {decayed_score:.3f})"
                         )
                 else:
                     results_text.append("\n=== Brain Decisions ===\nNo results found.")

--- a/nous/cognitive/context.py
+++ b/nous/cognitive/context.py
@@ -209,7 +209,13 @@ class ContextEngine:
                 'Instead, say "I\'d need to re-read that file" or "Let me fetch '
                 'that again" and call the tool again. Results marked with '
                 '"re-fetchable" can be retrieved by calling the same tool '
-                "with the same arguments."
+                "with the same arguments.\n\n"
+                "Never fabricate identifiers, UUIDs, file paths, URLs, or exact "
+                "strings that were not present in a prior tool result or in this "
+                "system prompt. If you need one and don't have it, call a search "
+                "or list tool first to obtain it. A tool error from a real ID "
+                "is always better than a plausible-looking guess — guessed IDs "
+                "waste turns and can trigger wrong actions."
             )
             sections.append(
                 ContextSection(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ include = ["nous*"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 asyncio_default_test_loop_scope = "session"
+markers = [
+    "integration: requires live PostgreSQL (run with --integration)",
+]
 
 [tool.ruff]
 target-version = "py312"

--- a/tests/test_anti_hallucination.py
+++ b/tests/test_anti_hallucination.py
@@ -73,3 +73,25 @@ class TestAntiHallucinationPrompt:
         )
         labels = [sec.label for sec in result.sections]
         assert "Context Safety" in labels
+
+    @pytest.mark.asyncio
+    async def test_prompt_forbids_fabricated_identifiers(self):
+        """Extended anti-hallucination clause: never fabricate IDs/UUIDs/paths.
+
+        Prevents the failure mode where the LLM invents a plausible-looking UUID
+        for get_procedure / get_fact / etc. when the ID was not present in context.
+        """
+        s = Settings(anti_hallucination_prompt=True)
+        engine = _make_engine(s)
+
+        result = await engine.build(
+            agent_id="test",
+            session_id="test-session",
+            input_text="test",
+            frame=_make_frame(),
+        )
+        prompt = result.system_prompt
+        assert "fabricate" in prompt.lower()
+        assert "identifiers" in prompt.lower() or "UUIDs" in prompt
+        # Both original and extended clauses must coexist
+        assert "re-read that file" in prompt or "re-fetch" in prompt

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -272,6 +272,68 @@ class TestRecallDeep:
         text = result["content"][0]["text"]
         assert "No results found" in text
 
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_recall_deep_surfaces_fact_id(self, tools):
+        """Heart fact results include an 'id: <uuid>' so get_procedure/get_fact callers
+        can reference them without fabricating UUIDs (anti-hallucination contract).
+
+        Integration-only: requires live PostgreSQL for pgvector <=> operator.
+        """
+        import re
+
+        await tools["learn_fact"](
+            content="Id surfacing test fact about quantum widgets",
+            category="technical",
+            subject="id-surface",
+        )
+
+        result = await tools["recall_deep"](
+            query="quantum widgets",
+            memory_types=["fact"],
+        )
+
+        text = result["content"][0]["text"]
+        assert "Heart Memory" in text
+        assert "id: " in text, "recall_deep must surface entity IDs for get_procedure/detail callers"
+        # Verify the id is a real UUID format, not a placeholder
+        uuid_match = re.search(
+            r"id: ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})",
+            text,
+        )
+        assert uuid_match is not None, f"Expected UUID in output, got: {text}"
+
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_recall_deep_surfaces_decision_id(self, tools):
+        """Brain decision results include an 'id: <uuid>' so follow-up tools
+        can reference the decision without fabricating UUIDs.
+
+        Integration-only: requires live PostgreSQL for pgvector <=> operator.
+        """
+        import re
+
+        await tools["record_decision"](
+            description="Id surfacing decision about deployment topology",
+            confidence=0.8,
+            category="architecture",
+            stakes="medium",
+            tags=["id-surface"],
+        )
+
+        result = await tools["recall_deep"](
+            query="deployment topology",
+            memory_types=["decision"],
+        )
+
+        text = result["content"][0]["text"]
+        assert "Brain Decisions" in text
+        uuid_match = re.search(
+            r"id: ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})",
+            text,
+        )
+        assert uuid_match is not None, f"Expected decision UUID in output, got: {text}"
+
 
 # ---------------------------------------------------------------------------
 # create_censor tests


### PR DESCRIPTION
## Why

Production trace showed the LLM fabricating a procedure UUID (`b1f742e1-4be0-4f86-babd-e7a1809f1e1c`) and calling `get_procedure` with it, getting back "not found". Root cause analysis:

- `recall_deep` output format at `api/tools.py:358` was `[type] summary (score)` — **no ID**.
- `get_procedure` requires a real UUID from a prior recall result.
- Tool description says "UUID of the procedure (from recall_deep results)" — promising something `recall_deep` never emits.
- The LLM had no path to obtain the ID it was being asked to provide, so it guessed a plausible-looking one.

This is a **broken tool contract**, not a model failure. The existing F016 anti-hallucination prompt only covers cleared/compacted tool results — it does not cover fabricated identifiers generally, so it couldn't help here.

Follows the lesson from decision `f935574c` (2026-03-11): "When adding a detail-fetch tool, always also improve the search/summary view to make the detail worth fetching." That earlier fix added the procedure description to the summary but missed the ID.

## What

**1. `nous/api/tools.py` — surface IDs in `recall_deep` output (4 format strings).**

Added `id: <uuid>` to all four code paths:
- Heart results (facts, episodes, procedures, censors)
- Graph-connected decisions (cross-type expansion from Heart seeds)
- Brain decisions (direct search)
- Graph-expanded decisions (1-hop + spreading activation neighbors)

Purely additive — existing substring-based callers and tests are unaffected. Uses `RecallResult.id` (guaranteed `UUID`) and `DecisionResult.id` / `NeighborResult.id` (both `UUID`).

**2. `nous/cognitive/context.py` — broaden the F016 anti-hallucination prompt.**

Extended the existing clause with a general rule:

> Never fabricate identifiers, UUIDs, file paths, URLs, or exact strings that were not present in a prior tool result or in this system prompt. If you need one and don't have it, call a search or list tool first to obtain it. A tool error from a real ID is always better than a plausible-looking guess — guessed IDs waste turns and can trigger wrong actions.

The original cleared-tool-result clause is preserved verbatim. Existing tests that check for "re-read that file" / "re-fetch" substrings keep passing.

## Tests

- `tests/test_anti_hallucination.py` — new unit test `test_prompt_forbids_fabricated_identifiers` verifies both the original and extended clauses coexist. **4/4 tests pass.**
- `tests/test_tools.py` — two new `@pytest.mark.integration` tests (`test_recall_deep_surfaces_fact_id`, `test_recall_deep_surfaces_decision_id`) assert a real UUID regex appears in output. Marked integration because they need live Postgres for pgvector `<=>`.
- `pyproject.toml` — registers the `integration` pytest marker to silence `PytestUnknownMarkWarning`.

**Pre-existing `test_tools.py` failures** (4 tests: `test_learn_fact_*`, `test_recall_deep_all`, `test_recall_deep_decisions_only`) are sqlite/pgvector incompatibilities unrelated to this PR. They fail on `main` too and need `--integration` + live Postgres regardless.

## Context

- Forge decision: `3faa7a40`
- Observed in live trace after compacting `agent_identity.preferences` section from 9,696 → 1,350 chars (separate work today).
- Related to broader cleanup — the procedures table also has near-duplicates (same symptom as the preferences bloat we just fixed), which is filed as a separate followup.

## Test plan

- [x] `uv run pytest tests/test_anti_hallucination.py -v` — 4/4 pass
- [x] `uv run pytest tests/test_tools.py -v` — no new regressions (2 new tests skipped via integration marker)
- [ ] Deploy to live Nous container, retry the "send me file via email" flow, verify `recall_deep` now returns `id: <uuid>` and `get_procedure` is called with a real ID instead of a fabricated one.
- [ ] Run `uv run pytest --integration` against a live Postgres to verify the two new integration tests pass end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)