### PR TITLE
fix(config): remove redundant validation_alias from subtask timeout fields

### DIFF
--- a/nous/config.py
+++ b/nous/config.py
@@ -234,14 +234,8 @@ class Settings(BaseSettings):
     subtask_enabled: bool = True
     subtask_workers: int = 2
     subtask_poll_interval: float = 2.0
-    subtask_default_timeout: int = Field(
-        default=120,
-        validation_alias="NOUS_SUBTASK_DEFAULT_TIMEOUT",
-    )
-    subtask_max_timeout: int = Field(
-        default=900,
-        validation_alias="NOUS_SUBTASK_MAX_TIMEOUT",
-    )
+    subtask_default_timeout: int = 120
+    subtask_max_timeout: int = 900
     subtask_max_concurrent: int = 3
     schedule_enabled: bool = True
     schedule_check_interval: int = 60

--- a/nous/storage/models.py
+++ b/nous/storage/models.py
@@ -665,7 +665,7 @@ class Subtask(Base):
     frame_type: Mapped[str | None] = mapped_column(String(30), nullable=True)
     model: Mapped[str | None] = mapped_column(String(100), nullable=True)
     notify: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
-    delivered: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
+    delivered: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/tests/sqlite_compat.py
+++ b/tests/sqlite_compat.py
@@ -132,6 +132,14 @@ def _rewrite_sql_for_sqlite(sql_text: str) -> str:
         sql_text,
         flags=re.IGNORECASE
     )
+    # Rewrite PG interval arithmetic: X.started_at + X.timeout_seconds * interval '1 second'
+    # SQLite equivalent: datetime(X.started_at, '+' || CAST(X.timeout_seconds AS TEXT) || ' seconds')
+    sql_text = re.sub(
+        r"(?:\w+\.)?subtasks\.started_at\s*\+\s*(?:\w+\.)?subtasks\.timeout_seconds\s*\*\s*interval\s*'1 second'",
+        "datetime(subtasks.started_at, '+' || CAST(subtasks.timeout_seconds AS TEXT) || ' seconds')",
+        sql_text,
+        flags=re.IGNORECASE
+    )
     return sql_text
 
 


### PR DESCRIPTION
## Problem

PR #259 added `validation_alias="NOUS_SUBTASK_DEFAULT_TIMEOUT"` and `"NOUS_SUBTASK_MAX_TIMEOUT"` to the two subtask timeout fields in `Settings`. In Pydantic v2, when `validation_alias` is set, the alias becomes the **only** accepted key during model construction — the field name itself is rejected unless `populate_by_name=True` is also configured.

This silently broke every test that constructs `Settings(subtask_default_timeout=..., ...)` directly:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
subtask_default_timeout
  Extra inputs are not permitted [type=extra_forbidden, input_value=120, input_type=int]
```

**19 tests** failed (8 outright failures + 11 setup errors across `TestWorkerEnhancements`, `TestSubtaskWorkerPool`, etc.).

## Root Cause

`Settings` already has `env_prefix="NOUS_"` via `SettingsConfigDict`, which automatically maps `NOUS_SUBTASK_DEFAULT_TIMEOUT` → `subtask_default_timeout` from the environment. The `validation_alias` was **redundant** and conflicted with direct kwarg construction.

## Fixes (2 commits)

### 1. Remove redundant validation_alias (restores 13 tests)
Remove the `Field(validation_alias=...)` wrappers from both fields, reverting them to plain `int` literals. The 900s default is preserved. `env_prefix` continues to handle env var overrides correctly.

### 2. Fix 6 remaining SQLite-compat failures

**`Subtask.delivered` missing Python default:**
- `server_default="false"` works for PostgreSQL but SQLite's Boolean processor coerces the raw string `"false"` (non-empty) to `True`
- Fix: add `default=False` alongside the existing `server_default` (matches pattern used by `notify` column)

**`reclaim_stale()` uses `interval '1 second'` (PostgreSQL-only syntax):**
- SQLite raises `OperationalError` on this expression  
- Fix: add SQL rewrite rule in `sqlite_compat._rewrite_sql_for_sqlite()`
- Rewrites: `X.started_at + X.timeout_seconds * interval '1 second'`
- To: `datetime(subtasks.started_at, '+' || CAST(...) || ' seconds')`

## Test Results

| | Before PR | After fix | 
|---|---|---|
| test_subtasks.py passed | 51 | **70 (all)** |
| test_subtasks.py errors/failures | 19 | **0** |

No regressions in other test files.