### PR TITLE
feat(F047): Phase 1 — Goal/Project Registry & Resolver

### DIFF
--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -49,12 +49,12 @@ _OPTIONAL_DECISION_FRAMES = frozenset({"task", "debug"})
 
 # Frame-gated tool access (D5)
 FRAME_TOOLS: dict[str, list[str]] = {
-    "conversation": ["record_decision", "learn_fact", "learn_skill", "recall_deep", "recall_recent", "get_procedure", "create_censor", "bash", "read_file", "write_file", "web_search", "web_fetch", "cache_retrieve", "spawn_task", "schedule_task", "list_tasks", "cancel_task", "run_python", "send_file", "heartbeat_check_create", "heartbeat_check_manage", "dag_create", "dag_manage"],
-    "question": ["recall_deep", "recall_recent", "get_procedure", "bash", "read_file", "write_file", "record_decision", "learn_fact", "learn_skill", "create_censor", "web_search", "web_fetch", "cache_retrieve", "list_tasks", "cancel_task", "run_python", "dag_manage"],
-    "decision": ["record_decision", "recall_deep", "recall_recent", "get_procedure", "create_censor", "bash", "read_file", "web_search", "web_fetch", "cache_retrieve", "list_tasks", "cancel_task", "dag_manage"],
+    "conversation": ["record_decision", "learn_fact", "learn_skill", "recall_deep", "recall_recent", "get_procedure", "create_censor", "bash", "read_file", "write_file", "web_search", "web_fetch", "cache_retrieve", "spawn_task", "schedule_task", "list_tasks", "cancel_task", "run_python", "send_file", "heartbeat_check_create", "heartbeat_check_manage", "dag_create", "dag_manage", "project_register", "project_update", "project_note", "project_list"],
+    "question": ["recall_deep", "recall_recent", "get_procedure", "bash", "read_file", "write_file", "record_decision", "learn_fact", "learn_skill", "create_censor", "web_search", "web_fetch", "cache_retrieve", "list_tasks", "cancel_task", "run_python", "dag_manage", "project_list"],
+    "decision": ["record_decision", "recall_deep", "recall_recent", "get_procedure", "create_censor", "bash", "read_file", "web_search", "web_fetch", "cache_retrieve", "list_tasks", "cancel_task", "dag_manage", "project_list"],
     "creative": ["learn_fact", "recall_deep", "recall_recent", "get_procedure", "write_file", "web_search", "cache_retrieve"],
     "task": ["*"],  # All tools
-    "debug": ["record_decision", "recall_deep", "recall_recent", "get_procedure", "bash", "read_file", "learn_fact", "web_search", "web_fetch", "cache_retrieve", "spawn_task", "schedule_task", "list_tasks", "cancel_task", "run_python", "send_file", "heartbeat_check_create", "heartbeat_check_manage", "dag_create", "dag_manage"],
+    "debug": ["record_decision", "recall_deep", "recall_recent", "get_procedure", "bash", "read_file", "learn_fact", "web_search", "web_fetch", "cache_retrieve", "spawn_task", "schedule_task", "list_tasks", "cancel_task", "run_python", "send_file", "heartbeat_check_create", "heartbeat_check_manage", "dag_create", "dag_manage", "project_register", "project_update", "project_note", "project_list"],
     "initiation": ["store_identity", "complete_initiation"],
 }
 

--- a/nous/api/tools.py
+++ b/nous/api/tools.py
@@ -2007,3 +2007,208 @@ async def _resolve_dag(store: "Any", dag_id_str: str) -> "Any | None":
         raise ValueError(f"Prefix '{dag_id_str}' is ambiguous, matches: {ids}")
 
     return None
+
+
+# ---------------------------------------------------------------------------
+# F047: Project Registry tools
+# ---------------------------------------------------------------------------
+
+_PROJECT_REGISTER_SCHEMA = {
+    "description": "Register a new project/workstream. Use this when starting work on a new initiative that should be tracked across sessions.",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Short slug identifier (e.g. 'F047-project-registry', 'voice-output')",
+        },
+        "title": {
+            "type": "string",
+            "description": "Human-readable title",
+        },
+        "description": {
+            "type": "string",
+            "description": "1-3 sentences describing the goal/intent of this project",
+        },
+        "priority": {
+            "type": "number",
+            "description": "Priority from 0.0 to 1.0 (default 0.5). Higher = more prominent in context.",
+        },
+        "tags": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Keywords for filtering and matching",
+        },
+    },
+    "required": ["name", "title"],
+}
+
+_PROJECT_UPDATE_SCHEMA = {
+    "description": "Update an existing project's status, priority, description, or tags.",
+    "type": "object",
+    "properties": {
+        "name_or_id": {
+            "type": "string",
+            "description": "Project name or UUID",
+        },
+        "status": {
+            "type": "string",
+            "enum": ["active", "paused", "completed", "abandoned"],
+            "description": "New status",
+        },
+        "priority": {
+            "type": "number",
+            "description": "New priority (0.0-1.0)",
+        },
+        "description": {
+            "type": "string",
+            "description": "Updated description",
+        },
+        "title": {
+            "type": "string",
+            "description": "Updated title",
+        },
+        "tags": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Updated tags",
+        },
+    },
+    "required": ["name_or_id"],
+}
+
+_PROJECT_NOTE_SCHEMA = {
+    "description": "Add a note or event to a project's log. Use for milestones, blockers, status updates, or general notes.",
+    "type": "object",
+    "properties": {
+        "name_or_id": {
+            "type": "string",
+            "description": "Project name or UUID",
+        },
+        "summary": {
+            "type": "string",
+            "description": "1-2 line summary of the event or note",
+        },
+        "event_type": {
+            "type": "string",
+            "enum": ["note", "milestone", "blocker", "session"],
+            "description": "Type of event (default: note)",
+        },
+    },
+    "required": ["name_or_id", "summary"],
+}
+
+_PROJECT_LIST_SCHEMA = {
+    "description": "List registered projects, optionally filtered by status.",
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["active", "paused", "completed", "abandoned"],
+            "description": "Filter by status (default: active). Pass null/omit for all.",
+        },
+        "limit": {
+            "type": "integer",
+            "description": "Max results (default: 10)",
+        },
+    },
+    "required": [],
+}
+
+
+def register_project_tools(
+    dispatcher: ToolDispatcher,
+    registry: "Any",
+) -> None:
+    """F047: Register project registry tools."""
+    from nous.projects.schemas import (
+        ProjectInput,
+        ProjectNoteInput,
+        ProjectUpdateInput,
+    )
+
+    async def project_register(**kwargs: Any) -> dict:
+        try:
+            inp = ProjectInput(
+                name=kwargs["name"],
+                title=kwargs["title"],
+                description=kwargs.get("description", ""),
+                priority=kwargs.get("priority", 0.5),
+                tags=kwargs.get("tags", []),
+            )
+            detail = await registry.register(inp)
+            events_text = ""
+            if detail.recent_events:
+                events_text = f"\nEvents: {detail.recent_events[0].summary}"
+            text = (
+                f"Registered project '{detail.name}' ({str(detail.id)[:8]})\n"
+                f"  Title: {detail.title}\n"
+                f"  Status: {detail.status}, Priority: {detail.priority:.1f}\n"
+                f"  Tags: {', '.join(detail.tags) if detail.tags else 'none'}"
+                f"{events_text}"
+            )
+            return {"content": [{"type": "text", "text": text}]}
+        except Exception as e:
+            return {"content": [{"type": "text", "text": f"Error registering project: {e}"}]}
+
+    async def project_update(**kwargs: Any) -> dict:
+        try:
+            name_or_id = kwargs["name_or_id"]
+            inp = ProjectUpdateInput(
+                status=kwargs.get("status"),
+                priority=kwargs.get("priority"),
+                description=kwargs.get("description"),
+                title=kwargs.get("title"),
+                tags=kwargs.get("tags"),
+            )
+            detail = await registry.update(name_or_id, inp)
+            text = (
+                f"Updated project '{detail.name}' ({str(detail.id)[:8]})\n"
+                f"  Status: {detail.status}, Priority: {detail.priority:.1f}\n"
+                f"  Title: {detail.title}"
+            )
+            return {"content": [{"type": "text", "text": text}]}
+        except Exception as e:
+            return {"content": [{"type": "text", "text": f"Error updating project: {e}"}]}
+
+    async def project_note(**kwargs: Any) -> dict:
+        try:
+            name_or_id = kwargs["name_or_id"]
+            inp = ProjectNoteInput(
+                summary=kwargs["summary"],
+                event_type=kwargs.get("event_type", "note"),
+            )
+            event_detail = await registry.add_note(name_or_id, inp)
+            text = (
+                f"Added {event_detail.event_type} to project: {event_detail.summary}\n"
+                f"  Event ID: {str(event_detail.id)[:8]}"
+            )
+            return {"content": [{"type": "text", "text": text}]}
+        except Exception as e:
+            return {"content": [{"type": "text", "text": f"Error adding note: {e}"}]}
+
+    async def project_list(**kwargs: Any) -> dict:
+        try:
+            status = kwargs.get("status", "active")
+            limit = kwargs.get("limit", 10)
+            projects = await registry.list_projects(status=status, limit=limit)
+            if not projects:
+                return {"content": [{"type": "text", "text": f"No projects with status '{status}'."}]}
+
+            lines = [f"Projects ({len(projects)}, status={status or 'all'}):"]
+            for p in projects:
+                touched = p.last_touched_at.strftime("%Y-%m-%d %H:%M") if p.last_touched_at else "never"
+                line = f"  {p.name} | {p.status} | priority {p.priority:.1f} | touched {touched}"
+                if p.title:
+                    line += f" | {p.title}"
+                lines.append(line)
+                if p.recent_events:
+                    latest = p.recent_events[0]
+                    lines.append(f"    Last: [{latest.event_type}] {latest.summary}")
+            return {"content": [{"type": "text", "text": "\n".join(lines)}]}
+        except Exception as e:
+            return {"content": [{"type": "text", "text": f"Error listing projects: {e}"}]}
+
+    dispatcher.register("project_register", project_register, _PROJECT_REGISTER_SCHEMA)
+    dispatcher.register("project_update", project_update, _PROJECT_UPDATE_SCHEMA)
+    dispatcher.register("project_note", project_note, _PROJECT_NOTE_SCHEMA)
+    dispatcher.register("project_list", project_list, _PROJECT_LIST_SCHEMA)

--- a/nous/config.py
+++ b/nous/config.py
@@ -456,6 +456,11 @@ class Settings(BaseSettings):
     # F038: DAG Orchestration
     dag_enabled: bool = True
 
+    # F047: Goal / Project Registry
+    project_registry_enabled: bool = True
+    project_context_limit: int = 5  # Max active projects injected into context
+    project_context_max_tokens: int = 400  # Token budget for Active Projects section
+
     # F039: Correction Learning Pipeline
     correction_extraction_enabled: bool = True
 

--- a/nous/projects/__init__.py
+++ b/nous/projects/__init__.py
@@ -1,0 +1,27 @@
+"""F047: Goal / Project Registry — Phase 1.
+
+Provides persistent project tracking, pre-turn resolution, and
+context injection for active workstreams.
+"""
+
+from nous.projects.registry import ProjectRegistry
+from nous.projects.resolver import ProjectResolver
+from nous.projects.context import ProjectContextInjector
+from nous.projects.schemas import (
+    ProjectDetail,
+    ProjectEventDetail,
+    ProjectInput,
+    ProjectNoteInput,
+    ProjectUpdateInput,
+)
+
+__all__ = [
+    "ProjectRegistry",
+    "ProjectResolver",
+    "ProjectContextInjector",
+    "ProjectDetail",
+    "ProjectEventDetail",
+    "ProjectInput",
+    "ProjectNoteInput",
+    "ProjectUpdateInput",
+]

--- a/nous/projects/context.py
+++ b/nous/projects/context.py
@@ -1,0 +1,118 @@
+"""ProjectContextInjector — surfaces Active Projects in working memory (F047).
+
+Generates a markdown block listing active projects for injection into the
+context engine's working memory section. Capped at ~400 tokens.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from nous.projects.registry import ProjectRegistry
+from nous.projects.schemas import ProjectDetail
+
+logger = logging.getLogger(__name__)
+
+
+def _relative_time(dt: datetime) -> str:
+    """Format a datetime as a human-readable relative time string."""
+    now = datetime.now(timezone.utc)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    diff = now - dt
+    seconds = int(diff.total_seconds())
+    if seconds < 60:
+        return "just now"
+    minutes = seconds // 60
+    if minutes < 60:
+        return f"{minutes}m ago"
+    hours = minutes // 60
+    if hours < 24:
+        return f"{hours}h ago"
+    days = hours // 24
+    if days == 1:
+        return "yesterday"
+    return f"{days}d ago"
+
+
+class ProjectContextInjector:
+    """Builds the Active Projects context block for injection."""
+
+    CHARS_PER_TOKEN = 4
+
+    def __init__(
+        self,
+        registry: ProjectRegistry,
+        max_projects: int = 5,
+        max_tokens: int = 400,
+    ) -> None:
+        self._registry = registry
+        self._max_projects = max_projects
+        self._max_tokens = max_tokens
+
+    async def build_context_block(
+        self,
+        session: AsyncSession | None = None,
+    ) -> str | None:
+        """Build the Active Projects markdown block.
+
+        Returns None if no active projects exist.
+        """
+        try:
+            projects = await self._registry.list_active_for_context(
+                limit=self._max_projects,
+                session=session,
+            )
+        except Exception:
+            logger.warning("F047: Failed to load active projects for context")
+            return None
+
+        if not projects:
+            return None
+
+        return self._format_projects(projects)
+
+    def _format_projects(self, projects: list[ProjectDetail]) -> str:
+        """Format projects as a compact markdown block."""
+        max_chars = self._max_tokens * self.CHARS_PER_TOKEN
+        lines: list[str] = []
+        char_count = 0
+        shown = 0
+
+        for project in projects:
+            touched = _relative_time(project.last_touched_at)
+            status_str = project.status
+            priority_str = f"priority {project.priority:.1f}"
+
+            # Build the bullet line
+            line = f"- **{project.name}** ({status_str}, {priority_str}, last touched {touched})"
+
+            # Add description snippet if available
+            desc = project.description
+            if desc:
+                desc_snippet = desc[:120]
+                if len(desc) > 120:
+                    desc_snippet = desc_snippet.rsplit(" ", 1)[0] + "..."
+                line += f"\n  {desc_snippet}"
+
+            # Add most recent event if available
+            if project.recent_events:
+                latest = project.recent_events[0]
+                event_time = _relative_time(latest.created_at)
+                line += f"\n  Last event: {latest.summary} ({event_time})"
+
+            line_chars = len(line) + 1  # +1 for newline
+            if char_count + line_chars > max_chars and shown > 0:
+                remaining = len(projects) - shown
+                if remaining > 0:
+                    lines.append(f"- +{remaining} more project(s)")
+                break
+
+            lines.append(line)
+            char_count += line_chars
+            shown += 1
+
+        return "\n".join(lines)

--- a/nous/projects/registry.py
+++ b/nous/projects/registry.py
@@ -1,0 +1,431 @@
+"""Project Registry — CRUD operations for projects and events.
+
+Follows the Brain/Heart manager pattern: public methods handle session
+creation/commit, private methods work with injected sessions (P1-1).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy import select, update as sa_update, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from nous.brain.embeddings import EmbeddingProvider
+from nous.projects.schemas import (
+    ProjectDetail,
+    ProjectEventDetail,
+    ProjectInput,
+    ProjectNoteInput,
+    ProjectStatus,
+    ProjectUpdateInput,
+)
+from nous.storage.database import Database
+from nous.storage.models import Project, ProjectEvent
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_tags(raw: list | str | None) -> list[str]:
+    """Safely parse tags from DB — handles Postgres ARRAY and SQLite JSON."""
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, list):
+                return [str(t) for t in parsed]
+        except (json.JSONDecodeError, TypeError):
+            pass
+        return []
+    if isinstance(raw, list):
+        # SQLite compat: if ARRAY was stored as JSON and read back char-by-char
+        if raw and all(len(str(x)) == 1 for x in raw):
+            joined = "".join(str(x) for x in raw)
+            try:
+                parsed = json.loads(joined)
+                if isinstance(parsed, list):
+                    return [str(t) for t in parsed]
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return [str(t) for t in raw]
+    return []
+
+
+class ProjectRegistry:
+    """CRUD manager for the project registry (F047)."""
+
+    def __init__(
+        self,
+        db: Database,
+        agent_id: str,
+        embeddings: EmbeddingProvider | None = None,
+    ) -> None:
+        self.db = db
+        self.agent_id = agent_id
+        self._embeddings = embeddings
+
+    # ------------------------------------------------------------------
+    # register
+    # ------------------------------------------------------------------
+
+    async def register(
+        self,
+        inp: ProjectInput,
+        session: AsyncSession | None = None,
+    ) -> ProjectDetail:
+        """Register a new project. Raises ValueError if name already exists."""
+        if session is None:
+            async with self.db.session() as session:
+                result = await self._register(inp, session)
+                await session.commit()
+                return result
+        return await self._register(inp, session)
+
+    async def _register(self, inp: ProjectInput, session: AsyncSession) -> ProjectDetail:
+        # Check uniqueness
+        existing = await self._get_by_name(inp.name, session)
+        if existing is not None:
+            raise ValueError(f"Project '{inp.name}' already exists for this agent")
+
+        embedding = None
+        if self._embeddings and inp.description:
+            try:
+                embedding = await self._embeddings.embed(inp.description)
+            except Exception:
+                logger.warning("Failed to embed project description for '%s'", inp.name)
+
+        project = Project(
+            agent_id=self.agent_id,
+            name=inp.name,
+            title=inp.title,
+            description=inp.description,
+            priority=inp.priority,
+            tags=inp.tags or [],
+            embedding=embedding,
+        )
+        session.add(project)
+        await session.flush()
+
+        # Append 'created' event
+        event = ProjectEvent(
+            project_id=project.id,
+            agent_id=self.agent_id,
+            event_type="created",
+            summary=f"Project registered: {inp.title}",
+        )
+        session.add(event)
+        await session.flush()
+
+        return self._to_detail(project, events=[event])
+
+    # ------------------------------------------------------------------
+    # update
+    # ------------------------------------------------------------------
+
+    async def update(
+        self,
+        name_or_id: str,
+        inp: ProjectUpdateInput,
+        session: AsyncSession | None = None,
+    ) -> ProjectDetail:
+        """Update project fields. Raises ValueError if not found."""
+        if session is None:
+            async with self.db.session() as session:
+                result = await self._update(name_or_id, inp, session)
+                await session.commit()
+                return result
+        return await self._update(name_or_id, inp, session)
+
+    async def _update(
+        self,
+        name_or_id: str,
+        inp: ProjectUpdateInput,
+        session: AsyncSession,
+    ) -> ProjectDetail:
+        project = await self._resolve(name_or_id, session)
+        if project is None:
+            raise ValueError(f"Project '{name_or_id}' not found")
+
+        old_status = project.status
+        changes: list[str] = []
+
+        if inp.status is not None and inp.status != project.status:
+            project.status = inp.status
+            changes.append(f"status: {old_status} → {inp.status}")
+        if inp.priority is not None and inp.priority != project.priority:
+            changes.append(f"priority: {project.priority} → {inp.priority}")
+            project.priority = inp.priority
+        if inp.description is not None and inp.description != project.description:
+            project.description = inp.description
+            changes.append("description updated")
+            # Re-embed
+            if self._embeddings and inp.description:
+                try:
+                    project.embedding = await self._embeddings.embed(inp.description)
+                except Exception:
+                    logger.warning("Failed to re-embed project description")
+        if inp.title is not None and inp.title != project.title:
+            project.title = inp.title
+            changes.append(f"title → {inp.title}")
+        if inp.tags is not None:
+            project.tags = inp.tags
+            changes.append("tags updated")
+
+        now = datetime.now(timezone.utc)
+        project.updated_at = now
+        project.last_touched_at = now
+        await session.flush()
+
+        # Log status change event if status changed
+        if inp.status is not None and inp.status != old_status:
+            event = ProjectEvent(
+                project_id=project.id,
+                agent_id=self.agent_id,
+                event_type="status_change",
+                summary=f"Status changed: {old_status} → {inp.status}",
+            )
+            session.add(event)
+            await session.flush()
+
+        return await self._load_detail(project, session)
+
+    # ------------------------------------------------------------------
+    # add_note
+    # ------------------------------------------------------------------
+
+    async def add_note(
+        self,
+        name_or_id: str,
+        inp: ProjectNoteInput,
+        session: AsyncSession | None = None,
+    ) -> ProjectEventDetail:
+        """Add a note/event to a project."""
+        if session is None:
+            async with self.db.session() as session:
+                result = await self._add_note(name_or_id, inp, session)
+                await session.commit()
+                return result
+        return await self._add_note(name_or_id, inp, session)
+
+    async def _add_note(
+        self,
+        name_or_id: str,
+        inp: ProjectNoteInput,
+        session: AsyncSession,
+    ) -> ProjectEventDetail:
+        project = await self._resolve(name_or_id, session)
+        if project is None:
+            raise ValueError(f"Project '{name_or_id}' not found")
+
+        event = ProjectEvent(
+            project_id=project.id,
+            agent_id=self.agent_id,
+            event_type=inp.event_type,
+            summary=inp.summary,
+            episode_id=inp.episode_id,
+        )
+        session.add(event)
+
+        # Touch the project
+        now = datetime.now(timezone.utc)
+        project.last_touched_at = now
+        project.updated_at = now
+        await session.flush()
+
+        return self._event_to_detail(event)
+
+    # ------------------------------------------------------------------
+    # list_projects
+    # ------------------------------------------------------------------
+
+    async def list_projects(
+        self,
+        status: ProjectStatus | None = "active",
+        limit: int = 10,
+        session: AsyncSession | None = None,
+    ) -> list[ProjectDetail]:
+        """List projects, optionally filtered by status."""
+        if session is None:
+            async with self.db.session() as session:
+                return await self._list_projects(status, limit, session)
+        return await self._list_projects(status, limit, session)
+
+    async def _list_projects(
+        self,
+        status: ProjectStatus | None,
+        limit: int,
+        session: AsyncSession,
+    ) -> list[ProjectDetail]:
+        stmt = (
+            select(Project)
+            .where(Project.agent_id == self.agent_id)
+        )
+        if status is not None:
+            stmt = stmt.where(Project.status == status)
+        stmt = stmt.order_by(Project.last_touched_at.desc()).limit(limit)
+
+        result = await session.execute(stmt)
+        projects = result.scalars().all()
+
+        details = []
+        for p in projects:
+            detail = await self._load_detail(p, session)
+            details.append(detail)
+        return details
+
+    # ------------------------------------------------------------------
+    # get
+    # ------------------------------------------------------------------
+
+    async def get(
+        self,
+        name_or_id: str,
+        session: AsyncSession | None = None,
+    ) -> ProjectDetail | None:
+        """Get a project by name or ID."""
+        if session is None:
+            async with self.db.session() as session:
+                project = await self._resolve(name_or_id, session)
+                if project is None:
+                    return None
+                return await self._load_detail(project, session)
+        project = await self._resolve(name_or_id, session)
+        if project is None:
+            return None
+        return await self._load_detail(project, session)
+
+    # ------------------------------------------------------------------
+    # touch
+    # ------------------------------------------------------------------
+
+    async def touch(
+        self,
+        project_id: UUID,
+        session: AsyncSession | None = None,
+    ) -> None:
+        """Update last_touched_at timestamp."""
+        if session is None:
+            async with self.db.session() as session:
+                await self._touch(project_id, session)
+                await session.commit()
+                return
+        await self._touch(project_id, session)
+
+    async def _touch(self, project_id: UUID, session: AsyncSession) -> None:
+        await session.execute(
+            sa_update(Project)
+            .where(Project.id == project_id)
+            .where(Project.agent_id == self.agent_id)
+            .values(last_touched_at=func.now())
+        )
+        await session.flush()
+
+    # ------------------------------------------------------------------
+    # list_active_for_context
+    # ------------------------------------------------------------------
+
+    async def list_active_for_context(
+        self,
+        limit: int = 5,
+        session: AsyncSession | None = None,
+    ) -> list[ProjectDetail]:
+        """List active projects ordered by priority * recency for context injection."""
+        if session is None:
+            async with self.db.session() as session:
+                return await self._list_active_for_context(limit, session)
+        return await self._list_active_for_context(limit, session)
+
+    async def _list_active_for_context(
+        self, limit: int, session: AsyncSession
+    ) -> list[ProjectDetail]:
+        stmt = (
+            select(Project)
+            .where(Project.agent_id == self.agent_id)
+            .where(Project.status == "active")
+            .order_by(Project.priority.desc(), Project.last_touched_at.desc())
+            .limit(limit)
+        )
+        result = await session.execute(stmt)
+        projects = result.scalars().all()
+
+        details = []
+        for p in projects:
+            detail = await self._load_detail(p, session)
+            details.append(detail)
+        return details
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    async def _resolve(self, name_or_id: str, session: AsyncSession) -> Project | None:
+        """Resolve a project by name or UUID string."""
+        # Try UUID first
+        try:
+            uid = UUID(name_or_id)
+            result = await session.execute(
+                select(Project)
+                .where(Project.id == uid)
+                .where(Project.agent_id == self.agent_id)
+            )
+            project = result.scalars().first()
+            if project is not None:
+                return project
+        except (ValueError, AttributeError):
+            pass
+
+        # Fall back to name lookup
+        return await self._get_by_name(name_or_id, session)
+
+    async def _get_by_name(self, name: str, session: AsyncSession) -> Project | None:
+        result = await session.execute(
+            select(Project)
+            .where(Project.agent_id == self.agent_id)
+            .where(Project.name == name)
+        )
+        return result.scalars().first()
+
+    async def _load_detail(self, project: Project, session: AsyncSession) -> ProjectDetail:
+        """Load project detail with recent events."""
+        stmt = (
+            select(ProjectEvent)
+            .where(ProjectEvent.project_id == project.id)
+            .order_by(ProjectEvent.created_at.desc())
+            .limit(5)
+        )
+        result = await session.execute(stmt)
+        events = result.scalars().all()
+        return self._to_detail(project, events=events)
+
+    def _to_detail(
+        self, project: Project, events: list[ProjectEvent] | None = None
+    ) -> ProjectDetail:
+        return ProjectDetail(
+            id=project.id,
+            agent_id=project.agent_id,
+            name=project.name,
+            title=project.title,
+            description=project.description,
+            status=project.status,
+            priority=project.priority,
+            tags=_parse_tags(project.tags),
+            source_decision_id=project.source_decision_id,
+            created_at=project.created_at,
+            updated_at=project.updated_at,
+            last_touched_at=project.last_touched_at,
+            recent_events=[self._event_to_detail(e) for e in (events or [])],
+        )
+
+    def _event_to_detail(self, event: ProjectEvent) -> ProjectEventDetail:
+        return ProjectEventDetail(
+            id=event.id,
+            project_id=event.project_id,
+            event_type=event.event_type,
+            summary=event.summary,
+            episode_id=event.episode_id,
+            created_at=event.created_at,
+        )

--- a/nous/projects/resolver.py
+++ b/nous/projects/resolver.py
@@ -1,0 +1,129 @@
+"""ProjectResolver — pre-turn project matcher (F047 Phase 1).
+
+Detects whether a user message references an existing project via:
+1. Explicit F\\d{3} mention matching project.name
+2. Exact name mention (case-insensitive substring)
+3. Tag overlap
+
+On match: touches last_touched_at so the project stays active in context.
+Phase 2 will add embedding-based matching and auto-creation.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from nous.projects.registry import ProjectRegistry, _parse_tags
+from nous.storage.database import Database
+from nous.storage.models import Project
+
+logger = logging.getLogger(__name__)
+
+# Matches F### patterns (e.g. F047, F011)
+_FCODE_RE = re.compile(r"\bF(\d{3})\b", re.IGNORECASE)
+
+
+class ProjectResolver:
+    """Detects project references in user messages and touches them."""
+
+    def __init__(
+        self,
+        registry: ProjectRegistry,
+        db: Database,
+        agent_id: str,
+    ) -> None:
+        self._registry = registry
+        self._db = db
+        self._agent_id = agent_id
+
+    async def resolve(
+        self,
+        user_input: str,
+        session: AsyncSession | None = None,
+    ) -> list[UUID]:
+        """Detect referenced projects and touch them.
+
+        Returns list of matched project IDs.
+        """
+        if session is None:
+            async with self._db.session() as session:
+                result = await self._resolve(user_input, session)
+                await session.commit()
+                return result
+        return await self._resolve(user_input, session)
+
+    async def _resolve(
+        self,
+        user_input: str,
+        session: AsyncSession,
+    ) -> list[UUID]:
+        # Load active projects for this agent
+        stmt = (
+            select(Project)
+            .where(Project.agent_id == self._agent_id)
+            .where(Project.status.in_(["active", "paused"]))
+        )
+        result = await session.execute(stmt)
+        projects = result.scalars().all()
+
+        if not projects:
+            return []
+
+        matched_ids: list[UUID] = []
+        input_lower = user_input.lower()
+
+        # Extract F-codes from input
+        fcodes = {m.group(0).upper() for m in _FCODE_RE.finditer(user_input)}
+
+        for project in projects:
+            if self._matches(project, input_lower, fcodes):
+                matched_ids.append(project.id)
+
+        # Touch all matched projects
+        for pid in matched_ids:
+            try:
+                await self._registry.touch(pid, session=session)
+            except Exception:
+                logger.debug("Failed to touch project %s", pid)
+
+        if matched_ids:
+            logger.info("F047 resolver: matched %d projects from input", len(matched_ids))
+
+        return matched_ids
+
+    def _matches(
+        self,
+        project: Project,
+        input_lower: str,
+        fcodes: set[str],
+    ) -> bool:
+        """Check if a project matches the user input."""
+        name = project.name or ""
+
+        # 1. F-code match (e.g. name starts with "F047")
+        name_upper = name.upper()
+        for fcode in fcodes:
+            if name_upper.startswith(fcode) or fcode in name_upper:
+                return True
+
+        # 2. Exact name mention (case-insensitive)
+        if name.lower() in input_lower and len(name) >= 3:
+            return True
+
+        # 3. Title mention (case-insensitive, only if title is >= 5 chars to avoid noise)
+        title = project.title or ""
+        if title and len(title) >= 5 and title.lower() in input_lower:
+            return True
+
+        # 4. Tag overlap
+        tags = _parse_tags(project.tags)
+        for tag in tags:
+            if tag and len(tag) >= 3 and tag.lower() in input_lower:
+                return True
+
+        return False

--- a/nous/projects/schemas.py
+++ b/nous/projects/schemas.py
@@ -1,0 +1,69 @@
+"""Pydantic DTOs for the Project Registry (F047)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+ProjectStatus = Literal["active", "paused", "completed", "abandoned"]
+ProjectEventType = Literal["created", "session", "milestone", "blocker", "status_change", "note"]
+
+
+class ProjectInput(BaseModel):
+    """Input for registering a new project."""
+
+    name: str
+    title: str
+    description: str = ""
+    priority: float = Field(default=0.5, ge=0.0, le=1.0)
+    tags: list[str] = Field(default_factory=list)
+
+
+class ProjectUpdateInput(BaseModel):
+    """Input for updating an existing project."""
+
+    status: ProjectStatus | None = None
+    priority: float | None = Field(default=None, ge=0.0, le=1.0)
+    description: str | None = None
+    title: str | None = None
+    tags: list[str] | None = None
+
+
+class ProjectNoteInput(BaseModel):
+    """Input for adding a note/event to a project."""
+
+    summary: str
+    event_type: ProjectEventType = "note"
+    episode_id: UUID | None = None
+
+
+class ProjectDetail(BaseModel):
+    """Full project with all fields."""
+
+    id: UUID
+    agent_id: str
+    name: str
+    title: str
+    description: str
+    status: ProjectStatus
+    priority: float
+    tags: list[str]
+    source_decision_id: UUID | None = None
+    created_at: datetime
+    updated_at: datetime
+    last_touched_at: datetime
+    recent_events: list[ProjectEventDetail] = Field(default_factory=list)
+
+
+class ProjectEventDetail(BaseModel):
+    """Project event log entry."""
+
+    id: UUID
+    project_id: UUID
+    event_type: ProjectEventType
+    summary: str
+    episode_id: UUID | None = None
+    created_at: datetime

--- a/nous/storage/models.py
+++ b/nous/storage/models.py
@@ -615,6 +615,78 @@ class WorkingMemory(Base):
     updated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
 
+# ---------------------------------------------------------------------------
+# F047: Goal / Project Registry
+# ---------------------------------------------------------------------------
+
+
+class Project(Base):
+    """Persistent project/workstream registry entry."""
+
+    __tablename__ = "projects"
+    __table_args__ = (
+        UniqueConstraint("agent_id", "name", name="uq_projects_agent_name"),
+        CheckConstraint(
+            "status IN ('active', 'paused', 'completed', 'abandoned')",
+            name="ck_projects_status",
+        ),
+        CheckConstraint(
+            "priority >= 0.0 AND priority <= 1.0",
+            name="ck_projects_priority",
+        ),
+        {"schema": "heart"},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
+    agent_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+    status: Mapped[str] = mapped_column(String(20), nullable=False, server_default="active")
+    priority: Mapped[float] = mapped_column(Float, nullable=False, server_default="0.5")
+    tags = mapped_column(ARRAY(Text), nullable=True, server_default="{}")
+    source_decision_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("brain.decisions.id"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    last_touched_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    embedding = mapped_column(Vector(1536), nullable=True)
+
+    events: Mapped[list["ProjectEvent"]] = relationship(
+        back_populates="project", cascade="all, delete-orphan", order_by="ProjectEvent.created_at.desc()"
+    )
+
+
+class ProjectEvent(Base):
+    """Append-only event log entry for a project."""
+
+    __tablename__ = "project_events"
+    __table_args__ = (
+        CheckConstraint(
+            "event_type IN ('created', 'session', 'milestone', 'blocker', 'status_change', 'note')",
+            name="ck_project_events_type",
+        ),
+        {"schema": "heart"},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("heart.projects.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    agent_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    event_type: Mapped[str] = mapped_column(String(30), nullable=False)
+    summary: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+    episode_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("heart.episodes.id"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
+
+    project: Mapped["Project"] = relationship(back_populates="events")
+
+
 class ConversationState(Base):
     __tablename__ = "conversation_state"
     __table_args__ = (

--- a/sql/migrations/034_projects.sql
+++ b/sql/migrations/034_projects.sql
@@ -1,0 +1,48 @@
+-- F047: Goal / Project Registry — Phase 1 (Registry & Resolver)
+-- Two new tables in the heart schema for tracking active projects and their event log.
+
+-- 1. projects — persistent registry of active workstreams
+CREATE TABLE IF NOT EXISTS heart.projects (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_id VARCHAR(100) NOT NULL,
+    name VARCHAR(200) NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    status VARCHAR(20) NOT NULL DEFAULT 'active',
+    priority REAL NOT NULL DEFAULT 0.5,
+    tags TEXT[] DEFAULT '{}',
+    source_decision_id UUID REFERENCES brain.decisions(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_touched_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    embedding vector(1536),
+    CONSTRAINT ck_projects_status CHECK (status IN ('active', 'paused', 'completed', 'abandoned')),
+    CONSTRAINT ck_projects_priority CHECK (priority >= 0.0 AND priority <= 1.0)
+);
+
+-- Unique name per agent
+CREATE UNIQUE INDEX IF NOT EXISTS uq_projects_agent_name ON heart.projects (agent_id, name);
+
+-- Index for listing active projects
+CREATE INDEX IF NOT EXISTS idx_projects_agent_status ON heart.projects (agent_id, status);
+
+-- HNSW index for embedding search
+CREATE INDEX IF NOT EXISTS idx_projects_embedding ON heart.projects
+    USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64);
+
+-- 2. project_events — append-only event log per project
+CREATE TABLE IF NOT EXISTS heart.project_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id UUID NOT NULL REFERENCES heart.projects(id) ON DELETE CASCADE,
+    agent_id VARCHAR(100) NOT NULL,
+    event_type VARCHAR(30) NOT NULL,
+    summary TEXT NOT NULL DEFAULT '',
+    episode_id UUID REFERENCES heart.episodes(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT ck_project_events_type CHECK (
+        event_type IN ('created', 'session', 'milestone', 'blocker', 'status_change', 'note')
+    )
+);
+
+-- Index for fetching events by project
+CREATE INDEX IF NOT EXISTS idx_project_events_project ON heart.project_events (project_id, created_at DESC);

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,26 @@
+"""Test fixtures for F047 project registry unit tests.
+
+Reuses the session-scoped db and function-scoped session from the
+parent conftest.py (tests/conftest.py).
+"""
+
+import pytest
+import pytest_asyncio
+
+from nous.config import Settings
+from nous.projects.registry import ProjectRegistry
+
+
+@pytest_asyncio.fixture
+async def registry(db, settings):
+    """ProjectRegistry instance for testing."""
+    return ProjectRegistry(
+        db=db,
+        agent_id=settings.agent_id,
+        embeddings=None,
+    )
+
+
+@pytest.fixture
+def agent_id(settings) -> str:
+    return settings.agent_id

--- a/tests/unit/test_projects_context.py
+++ b/tests/unit/test_projects_context.py
@@ -1,0 +1,197 @@
+"""Tests for ProjectContextInjector — Active Projects block (F047 Phase 1).
+
+Tests use the SAVEPOINT fixture from tests/conftest.py.
+"""
+
+from datetime import datetime, timezone
+
+from nous.projects.context import ProjectContextInjector, _relative_time
+from nous.projects.schemas import ProjectInput, ProjectNoteInput, ProjectUpdateInput
+
+
+# ---------------------------------------------------------------------------
+# _relative_time helper
+# ---------------------------------------------------------------------------
+
+
+def test_relative_time_just_now():
+    """Times within 60 seconds show 'just now'."""
+    now = datetime.now(timezone.utc)
+    assert _relative_time(now) == "just now"
+
+
+def test_relative_time_minutes():
+    """Times within an hour show minutes."""
+    from datetime import timedelta
+    t = datetime.now(timezone.utc) - timedelta(minutes=15)
+    result = _relative_time(t)
+    assert "m ago" in result
+
+
+def test_relative_time_hours():
+    """Times within a day show hours."""
+    from datetime import timedelta
+    t = datetime.now(timezone.utc) - timedelta(hours=3)
+    result = _relative_time(t)
+    assert "h ago" in result
+
+
+def test_relative_time_days():
+    """Times beyond a day show days."""
+    from datetime import timedelta
+    t = datetime.now(timezone.utc) - timedelta(days=5)
+    result = _relative_time(t)
+    assert "5d ago" in result
+
+
+# ---------------------------------------------------------------------------
+# Context block building
+# ---------------------------------------------------------------------------
+
+
+async def test_build_context_empty(registry, session):
+    """No active projects returns None."""
+    injector = ProjectContextInjector(registry=registry)
+    block = await injector.build_context_block(session=session)
+    assert block is None
+
+
+async def test_build_context_single_project(registry, session):
+    """Single active project appears in context block."""
+    await registry.register(
+        ProjectInput(
+            name="F047-ctx",
+            title="Context Test",
+            description="Testing context injection",
+            priority=0.8,
+        ),
+        session=session,
+    )
+    injector = ProjectContextInjector(registry=registry)
+    block = await injector.build_context_block(session=session)
+
+    assert block is not None
+    assert "F047-ctx" in block
+    assert "active" in block
+    assert "0.8" in block
+    assert "Testing context injection" in block
+
+
+async def test_build_context_includes_recent_event(registry, session):
+    """Context block includes a recent event summary."""
+    await registry.register(
+        ProjectInput(name="F047-evt", title="Event Test"),
+        session=session,
+    )
+    await registry.add_note(
+        "F047-evt",
+        ProjectNoteInput(summary="Phase 1 shipped"),
+        session=session,
+    )
+
+    injector = ProjectContextInjector(registry=registry)
+    block = await injector.build_context_block(session=session)
+
+    assert block is not None
+    # Should include at least one event (either the note or the created event)
+    assert "Last event:" in block
+    # The block should mention the project
+    assert "F047-evt" in block
+
+
+async def test_build_context_multiple_projects(registry, session):
+    """Multiple active projects all appear."""
+    for i in range(3):
+        await registry.register(
+            ProjectInput(
+                name=f"F047-multi-{i}",
+                title=f"Multi {i}",
+                priority=0.5 + i * 0.1,
+            ),
+            session=session,
+        )
+
+    injector = ProjectContextInjector(registry=registry, max_projects=5)
+    block = await injector.build_context_block(session=session)
+
+    assert block is not None
+    for i in range(3):
+        assert f"F047-multi-{i}" in block
+
+
+async def test_build_context_excludes_paused(registry, session):
+    """Paused projects do not appear in context."""
+    await registry.register(
+        ProjectInput(name="F047-paused-ctx", title="Paused Ctx"),
+        session=session,
+    )
+    await registry.update(
+        "F047-paused-ctx",
+        ProjectUpdateInput(status="paused"),
+        session=session,
+    )
+
+    injector = ProjectContextInjector(registry=registry)
+    block = await injector.build_context_block(session=session)
+
+    # Should be None since the only project is paused
+    assert block is None
+
+
+async def test_build_context_respects_limit(registry, session):
+    """Context respects max_projects limit."""
+    for i in range(10):
+        await registry.register(
+            ProjectInput(name=f"F047-lim-ctx-{i}", title=f"Limit {i}"),
+            session=session,
+        )
+
+    injector = ProjectContextInjector(registry=registry, max_projects=3)
+    block = await injector.build_context_block(session=session)
+
+    assert block is not None
+    # Count bullet points
+    bullets = [line for line in block.split("\n") if line.startswith("- **")]
+    # Should have at most 3 project bullets (maybe +1 for the "more" line)
+    assert len(bullets) <= 4
+
+
+async def test_build_context_truncates_description(registry, session):
+    """Long descriptions are truncated."""
+    long_desc = "A " * 200  # 400 chars
+    await registry.register(
+        ProjectInput(
+            name="F047-long-desc",
+            title="Long Description",
+            description=long_desc,
+        ),
+        session=session,
+    )
+
+    injector = ProjectContextInjector(registry=registry)
+    block = await injector.build_context_block(session=session)
+
+    assert block is not None
+    # Description should be truncated with ellipsis
+    assert "..." in block
+
+
+async def test_build_context_priority_ordering(registry, session):
+    """Higher priority projects appear first."""
+    await registry.register(
+        ProjectInput(name="F047-low-pri", title="Low", priority=0.1),
+        session=session,
+    )
+    await registry.register(
+        ProjectInput(name="F047-high-pri", title="High", priority=0.9),
+        session=session,
+    )
+
+    injector = ProjectContextInjector(registry=registry)
+    block = await injector.build_context_block(session=session)
+
+    assert block is not None
+    # High priority should appear before low priority
+    high_pos = block.index("F047-high-pri")
+    low_pos = block.index("F047-low-pri")
+    assert high_pos < low_pos

--- a/tests/unit/test_projects_registry.py
+++ b/tests/unit/test_projects_registry.py
@@ -1,0 +1,342 @@
+"""Tests for ProjectRegistry — CRUD operations (F047 Phase 1).
+
+Tests use the SAVEPOINT fixture from tests/conftest.py.
+"""
+
+import uuid
+
+import pytest
+
+from nous.projects.registry import ProjectRegistry
+from nous.projects.schemas import (
+    ProjectDetail,
+    ProjectEventDetail,
+    ProjectInput,
+    ProjectNoteInput,
+    ProjectUpdateInput,
+)
+
+
+# ---------------------------------------------------------------------------
+# register
+# ---------------------------------------------------------------------------
+
+
+async def test_register_creates_project(registry, session):
+    """Registering a project creates it with correct fields."""
+    inp = ProjectInput(
+        name="F047-test",
+        title="Test Project",
+        description="A test project for unit testing",
+        priority=0.7,
+        tags=["test", "f047"],
+    )
+    detail = await registry.register(inp, session=session)
+
+    assert isinstance(detail, ProjectDetail)
+    assert detail.name == "F047-test"
+    assert detail.title == "Test Project"
+    assert detail.description == "A test project for unit testing"
+    assert detail.priority == 0.7
+    assert detail.status == "active"
+    assert detail.tags == ["test", "f047"]
+    assert detail.id is not None
+
+
+async def test_register_creates_event(registry, session):
+    """Registering a project also creates a 'created' event."""
+    inp = ProjectInput(name="F047-events", title="Events Test")
+    detail = await registry.register(inp, session=session)
+
+    assert len(detail.recent_events) == 1
+    event = detail.recent_events[0]
+    assert event.event_type == "created"
+    assert "Events Test" in event.summary
+
+
+async def test_register_duplicate_name_raises(registry, session):
+    """Registering a project with a duplicate name raises ValueError."""
+    inp = ProjectInput(name="F047-dup", title="First")
+    await registry.register(inp, session=session)
+
+    with pytest.raises(ValueError, match="already exists"):
+        await registry.register(
+            ProjectInput(name="F047-dup", title="Second"),
+            session=session,
+        )
+
+
+async def test_register_default_priority(registry, session):
+    """Default priority is 0.5."""
+    inp = ProjectInput(name="F047-default", title="Default Priority")
+    detail = await registry.register(inp, session=session)
+    assert detail.priority == 0.5
+
+
+# ---------------------------------------------------------------------------
+# update
+# ---------------------------------------------------------------------------
+
+
+async def test_update_status(registry, session):
+    """Updating status changes it and logs a status_change event."""
+    inp = ProjectInput(name="F047-upd-status", title="Status Test")
+    detail = await registry.register(inp, session=session)
+    assert detail.status == "active"
+
+    updated = await registry.update(
+        "F047-upd-status",
+        ProjectUpdateInput(status="paused"),
+        session=session,
+    )
+    assert updated.status == "paused"
+
+    # Should have a status_change event
+    status_events = [e for e in updated.recent_events if e.event_type == "status_change"]
+    assert len(status_events) >= 1
+    assert "paused" in status_events[0].summary
+
+
+async def test_update_priority(registry, session):
+    """Updating priority changes it."""
+    inp = ProjectInput(name="F047-upd-pri", title="Priority Test", priority=0.3)
+    await registry.register(inp, session=session)
+
+    updated = await registry.update(
+        "F047-upd-pri",
+        ProjectUpdateInput(priority=0.9),
+        session=session,
+    )
+    assert updated.priority == 0.9
+
+
+async def test_update_description(registry, session):
+    """Updating description changes it."""
+    inp = ProjectInput(name="F047-upd-desc", title="Desc Test", description="old")
+    await registry.register(inp, session=session)
+
+    updated = await registry.update(
+        "F047-upd-desc",
+        ProjectUpdateInput(description="new description"),
+        session=session,
+    )
+    assert updated.description == "new description"
+
+
+async def test_update_not_found_raises(registry, session):
+    """Updating a non-existent project raises ValueError."""
+    with pytest.raises(ValueError, match="not found"):
+        await registry.update(
+            "nonexistent-project",
+            ProjectUpdateInput(status="paused"),
+            session=session,
+        )
+
+
+async def test_update_by_uuid(registry, session):
+    """Can update by UUID string."""
+    inp = ProjectInput(name="F047-uuid-upd", title="UUID Update Test")
+    detail = await registry.register(inp, session=session)
+
+    updated = await registry.update(
+        str(detail.id),
+        ProjectUpdateInput(title="Updated Title"),
+        session=session,
+    )
+    assert updated.title == "Updated Title"
+
+
+# ---------------------------------------------------------------------------
+# add_note
+# ---------------------------------------------------------------------------
+
+
+async def test_add_note(registry, session):
+    """Adding a note creates an event."""
+    inp = ProjectInput(name="F047-note", title="Note Test")
+    await registry.register(inp, session=session)
+
+    event = await registry.add_note(
+        "F047-note",
+        ProjectNoteInput(summary="Phase 1 shipped"),
+        session=session,
+    )
+    assert isinstance(event, ProjectEventDetail)
+    assert event.event_type == "note"
+    assert event.summary == "Phase 1 shipped"
+
+
+async def test_add_milestone(registry, session):
+    """Adding a milestone event works."""
+    inp = ProjectInput(name="F047-milestone", title="Milestone Test")
+    await registry.register(inp, session=session)
+
+    event = await registry.add_note(
+        "F047-milestone",
+        ProjectNoteInput(summary="PR merged", event_type="milestone"),
+        session=session,
+    )
+    assert event.event_type == "milestone"
+
+
+async def test_add_note_not_found_raises(registry, session):
+    """Adding a note to a non-existent project raises ValueError."""
+    with pytest.raises(ValueError, match="not found"):
+        await registry.add_note(
+            "nonexistent",
+            ProjectNoteInput(summary="test"),
+            session=session,
+        )
+
+
+# ---------------------------------------------------------------------------
+# list_projects
+# ---------------------------------------------------------------------------
+
+
+async def test_list_active_projects(registry, session):
+    """Listing active projects returns only active ones."""
+    await registry.register(
+        ProjectInput(name="F047-list-a", title="Active 1"),
+        session=session,
+    )
+    await registry.register(
+        ProjectInput(name="F047-list-b", title="Active 2"),
+        session=session,
+    )
+    # Create and pause one
+    await registry.register(
+        ProjectInput(name="F047-list-p", title="Paused"),
+        session=session,
+    )
+    await registry.update(
+        "F047-list-p",
+        ProjectUpdateInput(status="paused"),
+        session=session,
+    )
+
+    active = await registry.list_projects(status="active", session=session)
+    active_names = {p.name for p in active}
+    assert "F047-list-a" in active_names
+    assert "F047-list-b" in active_names
+    assert "F047-list-p" not in active_names
+
+
+async def test_list_all_projects(registry, session):
+    """Listing with status=None returns all projects."""
+    await registry.register(
+        ProjectInput(name="F047-all-1", title="All 1"),
+        session=session,
+    )
+    await registry.register(
+        ProjectInput(name="F047-all-2", title="All 2"),
+        session=session,
+    )
+    await registry.update(
+        "F047-all-2",
+        ProjectUpdateInput(status="completed"),
+        session=session,
+    )
+
+    all_projects = await registry.list_projects(status=None, session=session)
+    all_names = {p.name for p in all_projects}
+    assert "F047-all-1" in all_names
+    assert "F047-all-2" in all_names
+
+
+async def test_list_respects_limit(registry, session):
+    """Listing with limit caps the results."""
+    for i in range(5):
+        await registry.register(
+            ProjectInput(name=f"F047-lim-{i}", title=f"Limit {i}"),
+            session=session,
+        )
+
+    projects = await registry.list_projects(status="active", limit=3, session=session)
+    assert len(projects) <= 3
+
+
+# ---------------------------------------------------------------------------
+# get
+# ---------------------------------------------------------------------------
+
+
+async def test_get_by_name(registry, session):
+    """Get a project by name."""
+    inp = ProjectInput(name="F047-get", title="Get Test")
+    created = await registry.register(inp, session=session)
+
+    fetched = await registry.get("F047-get", session=session)
+    assert fetched is not None
+    assert fetched.id == created.id
+    assert fetched.name == "F047-get"
+
+
+async def test_get_by_uuid(registry, session):
+    """Get a project by UUID string."""
+    inp = ProjectInput(name="F047-get-uuid", title="UUID Get")
+    created = await registry.register(inp, session=session)
+
+    fetched = await registry.get(str(created.id), session=session)
+    assert fetched is not None
+    assert fetched.name == "F047-get-uuid"
+
+
+async def test_get_not_found(registry, session):
+    """Get returns None for non-existent project."""
+    fetched = await registry.get("nonexistent", session=session)
+    assert fetched is None
+
+
+# ---------------------------------------------------------------------------
+# touch
+# ---------------------------------------------------------------------------
+
+
+async def test_touch_updates_timestamp(registry, session):
+    """Touch updates last_touched_at."""
+    inp = ProjectInput(name="F047-touch", title="Touch Test")
+    detail = await registry.register(inp, session=session)
+
+    original_touched = detail.last_touched_at
+    await registry.touch(detail.id, session=session)
+
+    fetched = await registry.get("F047-touch", session=session)
+    assert fetched is not None
+    # The timestamp should be >= original (may be equal in fast tests)
+    assert fetched.last_touched_at >= original_touched
+
+
+# ---------------------------------------------------------------------------
+# list_active_for_context
+# ---------------------------------------------------------------------------
+
+
+async def test_list_active_for_context(registry, session):
+    """Context listing returns active projects ordered by priority."""
+    await registry.register(
+        ProjectInput(name="F047-ctx-low", title="Low", priority=0.3),
+        session=session,
+    )
+    await registry.register(
+        ProjectInput(name="F047-ctx-high", title="High", priority=0.9),
+        session=session,
+    )
+    await registry.register(
+        ProjectInput(name="F047-ctx-paused", title="Paused", priority=1.0),
+        session=session,
+    )
+    await registry.update(
+        "F047-ctx-paused",
+        ProjectUpdateInput(status="paused"),
+        session=session,
+    )
+
+    context_projects = await registry.list_active_for_context(limit=5, session=session)
+    names = [p.name for p in context_projects]
+
+    # Paused should not appear
+    assert "F047-ctx-paused" not in names
+    # High priority should come first
+    if len(names) >= 2:
+        assert names[0] == "F047-ctx-high"

--- a/tests/unit/test_projects_resolver.py
+++ b/tests/unit/test_projects_resolver.py
@@ -1,0 +1,221 @@
+"""Tests for ProjectResolver — pre-turn project matcher (F047 Phase 1).
+
+Tests use the SAVEPOINT fixture from tests/conftest.py.
+"""
+
+from nous.projects.registry import ProjectRegistry
+from nous.projects.resolver import ProjectResolver
+from nous.projects.schemas import ProjectInput
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+async def _setup_projects(registry, session):
+    """Create a set of test projects."""
+    await registry.register(
+        ProjectInput(
+            name="F047-goal-project-registry",
+            title="Goal Project Registry",
+            description="Give Nous persistent project tracking",
+            tags=["registry", "memory"],
+        ),
+        session=session,
+    )
+    await registry.register(
+        ProjectInput(
+            name="F041-snn-sleep",
+            title="SNN Sleep Densification",
+            description="Sleep-phase graph densification from tinyHippo",
+            tags=["sleep", "graph"],
+        ),
+        session=session,
+    )
+    await registry.register(
+        ProjectInput(
+            name="voice-output",
+            title="Voice Output via TTS",
+            description="TTS via Chromecast",
+            tags=["voice", "tts", "chromecast"],
+        ),
+        session=session,
+    )
+
+
+# ---------------------------------------------------------------------------
+# F-code matching
+# ---------------------------------------------------------------------------
+
+
+async def test_fcode_match(registry, session, agent_id, db):
+    """F### codes in user input match project names."""
+    await _setup_projects(registry, session)
+    resolver = ProjectResolver(registry=registry, db=db, agent_id=agent_id)
+
+    matched = await resolver.resolve("Let's work on F047 next", session=session)
+    assert len(matched) == 1
+
+    # Verify it matched the right project
+    project = await registry.get("F047-goal-project-registry", session=session)
+    assert project is not None
+    assert project.id in matched
+
+
+async def test_fcode_match_case_insensitive(registry, session, agent_id, db):
+    """F-code matching is case-insensitive."""
+    await _setup_projects(registry, session)
+    resolver = ProjectResolver(registry=registry, db=db, agent_id=agent_id)
+
+    matched = await resolver.resolve("What about f041?", session=session)
+    assert len(matched) == 1
+
+
+async def test_multiple_fcode_matches(registry, session, agent_id, db):
+    """Multiple F-codes match multiple projects."""
+    await _setup_projects(registry, session)
+    resolver = ProjectResolver(registry=registry, db=db, agent_id=agent_id)
+
+    matched = await resolver.resolve("F047 and F041 are both in progress", session=session)
+    assert len(matched) == 2
+
+
+# ---------------------------------------------------------------------------
+# Name matching
+# ---------------------------------------------------------------------------
+
+
+async def test_name_match(registry, session, agent_id, db):
+    """Exact project name in user input matches."""
+    await _setup_projects(registry, session)
+    resolver = ProjectResolver(registry=registry, db=db, agent_id=agent_id)
+
+    matched = await resolver.resolve(
+        "Let me check on voice-output progress",
+        session=session,
+    )
+    assert len(matched) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Title matching
+# ---------------------------------------------------------------------------
+
+
+async def test_title_match(registry, session, agent_id, db):
+    """Project title in user input matches."""
+    await _setup_projects(registry, session)
+    resolver = ProjectResolver(registry=registry, db=db, agent_id=agent_id)
+
+    matched = await resolver.resolve(
+        "What's the status of Voice Output via TTS?",
+        session=session,
+    )
+    assert len(matched) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Tag matching
+# ---------------------------------------------------------------------------
+
+
+async def test_tag_match(registry, session, agent_id, db):
+    """Tags in user input match."""
+    await _setup_projects(registry, session)
+    resolver = ProjectResolver(registry=registry, db=db, agent_id=agent_id)
+
+    matched = await resolver.resolve(
+        "I want to work on chromecast stuff",
+        session=session,
+    )
+    assert len(matched) >= 1
+
+
+# ---------------------------------------------------------------------------
+# No match
+# ---------------------------------------------------------------------------
+
+
+async def test_no_match(registry, session, agent_id, db):
+    """Unrelated input returns empty list."""
+    await _setup_projects(registry, session)
+    resolver = ProjectResolver(registry=registry, db=db, agent_id=agent_id)
+
+    matched = await resolver.resolve("What's the weather like?", session=session)
+    assert matched == []
+
+
+async def test_no_projects_returns_empty(registry, session, agent_id, db):
+    """No projects at all returns empty list."""
+    resolver = ProjectResolver(registry=registry, db=db, agent_id=agent_id)
+
+    matched = await resolver.resolve("F047 test", session=session)
+    assert matched == []
+
+
+# ---------------------------------------------------------------------------
+# Touch on match
+# ---------------------------------------------------------------------------
+
+
+async def test_match_touches_project(registry, session, agent_id, db):
+    """Matching a project updates its last_touched_at."""
+    await _setup_projects(registry, session)
+    resolver = ProjectResolver(registry=registry, db=db, agent_id=agent_id)
+
+    project_before = await registry.get("F047-goal-project-registry", session=session)
+    assert project_before is not None
+    original_touched = project_before.last_touched_at
+
+    await resolver.resolve("Working on F047", session=session)
+
+    project_after = await registry.get("F047-goal-project-registry", session=session)
+    assert project_after is not None
+    assert project_after.last_touched_at >= original_touched
+
+
+# ---------------------------------------------------------------------------
+# Paused projects are still matched
+# ---------------------------------------------------------------------------
+
+
+async def test_paused_projects_matched(registry, session, agent_id, db):
+    """Paused projects are still detected by the resolver."""
+    await registry.register(
+        ProjectInput(name="F099-paused-test", title="Paused Test"),
+        session=session,
+    )
+    from nous.projects.schemas import ProjectUpdateInput
+    await registry.update(
+        "F099-paused-test",
+        ProjectUpdateInput(status="paused"),
+        session=session,
+    )
+    resolver = ProjectResolver(registry=registry, db=db, agent_id=agent_id)
+
+    matched = await resolver.resolve("Check F099", session=session)
+    assert len(matched) == 1
+
+
+# ---------------------------------------------------------------------------
+# Completed/abandoned projects are NOT matched
+# ---------------------------------------------------------------------------
+
+
+async def test_completed_projects_not_matched(registry, session, agent_id, db):
+    """Completed projects are not detected by the resolver."""
+    await registry.register(
+        ProjectInput(name="F098-done", title="Done Test"),
+        session=session,
+    )
+    from nous.projects.schemas import ProjectUpdateInput
+    await registry.update(
+        "F098-done",
+        ProjectUpdateInput(status="completed"),
+        session=session,
+    )
+    resolver = ProjectResolver(registry=registry, db=db, agent_id=agent_id)
+
+    matched = await resolver.resolve("Check F098", session=session)
+    assert len(matched) == 0

--- a/tests/unit/test_projects_schemas.py
+++ b/tests/unit/test_projects_schemas.py
@@ -1,0 +1,100 @@
+"""Tests for F047 project schemas — Pydantic validation."""
+
+import pytest
+from pydantic import ValidationError
+
+from nous.projects.schemas import (
+    ProjectDetail,
+    ProjectEventDetail,
+    ProjectInput,
+    ProjectNoteInput,
+    ProjectUpdateInput,
+)
+
+
+# ---------------------------------------------------------------------------
+# ProjectInput
+# ---------------------------------------------------------------------------
+
+
+def test_project_input_minimal():
+    """Minimal ProjectInput requires name and title."""
+    inp = ProjectInput(name="test", title="Test")
+    assert inp.name == "test"
+    assert inp.priority == 0.5
+    assert inp.tags == []
+    assert inp.description == ""
+
+
+def test_project_input_full():
+    """Full ProjectInput with all fields."""
+    inp = ProjectInput(
+        name="F047-full",
+        title="Full Test",
+        description="A test",
+        priority=0.8,
+        tags=["a", "b"],
+    )
+    assert inp.priority == 0.8
+    assert inp.tags == ["a", "b"]
+
+
+def test_project_input_priority_bounds():
+    """Priority must be between 0.0 and 1.0."""
+    with pytest.raises(ValidationError):
+        ProjectInput(name="x", title="X", priority=-0.1)
+    with pytest.raises(ValidationError):
+        ProjectInput(name="x", title="X", priority=1.1)
+
+
+# ---------------------------------------------------------------------------
+# ProjectUpdateInput
+# ---------------------------------------------------------------------------
+
+
+def test_project_update_all_none():
+    """Update with all None fields is valid (no-op update)."""
+    inp = ProjectUpdateInput()
+    assert inp.status is None
+    assert inp.priority is None
+
+
+def test_project_update_status():
+    """Update with valid status."""
+    inp = ProjectUpdateInput(status="completed")
+    assert inp.status == "completed"
+
+
+def test_project_update_invalid_status():
+    """Update with invalid status raises."""
+    with pytest.raises(ValidationError):
+        ProjectUpdateInput(status="invalid")
+
+
+def test_project_update_priority_bounds():
+    """Priority update must be between 0.0 and 1.0."""
+    with pytest.raises(ValidationError):
+        ProjectUpdateInput(priority=2.0)
+
+
+# ---------------------------------------------------------------------------
+# ProjectNoteInput
+# ---------------------------------------------------------------------------
+
+
+def test_project_note_default_type():
+    """Default event_type is 'note'."""
+    inp = ProjectNoteInput(summary="test note")
+    assert inp.event_type == "note"
+
+
+def test_project_note_milestone():
+    """Can create milestone event."""
+    inp = ProjectNoteInput(summary="shipped", event_type="milestone")
+    assert inp.event_type == "milestone"
+
+
+def test_project_note_invalid_type():
+    """Invalid event_type raises."""
+    with pytest.raises(ValidationError):
+        ProjectNoteInput(summary="test", event_type="invalid_type")

--- a/tests/unit/test_projects_tools.py
+++ b/tests/unit/test_projects_tools.py
@@ -1,0 +1,180 @@
+"""Tests for F047 project tools — tool handler functions.
+
+Tests use the SAVEPOINT fixture from tests/conftest.py.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from nous.api.tools import ToolDispatcher, register_project_tools
+from nous.projects.registry import ProjectRegistry
+from nous.projects.schemas import ProjectInput
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dispatcher():
+    """Fresh ToolDispatcher for testing."""
+    return ToolDispatcher(tool_schema_cache_enabled=False)
+
+
+@pytest.fixture
+def registered_dispatcher(dispatcher, registry):
+    """Dispatcher with project tools registered."""
+    register_project_tools(dispatcher, registry)
+    return dispatcher
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_tools_registered(registered_dispatcher):
+    """All four project tools are registered."""
+    assert "project_register" in registered_dispatcher._handlers
+    assert "project_update" in registered_dispatcher._handlers
+    assert "project_note" in registered_dispatcher._handlers
+    assert "project_list" in registered_dispatcher._handlers
+
+
+def test_schemas_registered(registered_dispatcher):
+    """All four tool schemas are registered."""
+    assert "project_register" in registered_dispatcher._schemas
+    assert "project_update" in registered_dispatcher._schemas
+    assert "project_note" in registered_dispatcher._schemas
+    assert "project_list" in registered_dispatcher._schemas
+
+
+# ---------------------------------------------------------------------------
+# project_register tool
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_project_register(registered_dispatcher, session, registry):
+    """project_register tool creates a project and returns info."""
+    result, is_error = await registered_dispatcher.dispatch(
+        "project_register",
+        {"name": "F047-tool-test", "title": "Tool Test", "description": "testing tools"},
+    )
+    assert not is_error
+    assert "F047-tool-test" in result
+    assert "Tool Test" in result
+
+    # Verify project was actually created
+    project = await registry.get("F047-tool-test", session=session)
+    assert project is not None
+
+
+async def test_tool_project_register_duplicate(registered_dispatcher, registry):
+    """project_register tool returns error for duplicate name."""
+    await registered_dispatcher.dispatch(
+        "project_register",
+        {"name": "F047-dup-tool", "title": "First"},
+    )
+    result, is_error = await registered_dispatcher.dispatch(
+        "project_register",
+        {"name": "F047-dup-tool", "title": "Second"},
+    )
+    assert "Error" in result or "already exists" in result
+
+
+# ---------------------------------------------------------------------------
+# project_update tool
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_project_update(registered_dispatcher, registry):
+    """project_update tool updates status."""
+    await registered_dispatcher.dispatch(
+        "project_register",
+        {"name": "F047-upd-tool", "title": "Update Tool"},
+    )
+    result, is_error = await registered_dispatcher.dispatch(
+        "project_update",
+        {"name_or_id": "F047-upd-tool", "status": "paused"},
+    )
+    assert not is_error
+    assert "paused" in result.lower()
+
+
+async def test_tool_project_update_not_found(registered_dispatcher):
+    """project_update returns error for non-existent project."""
+    result, is_error = await registered_dispatcher.dispatch(
+        "project_update",
+        {"name_or_id": "nonexistent", "status": "paused"},
+    )
+    assert "Error" in result or "not found" in result
+
+
+# ---------------------------------------------------------------------------
+# project_note tool
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_project_note(registered_dispatcher, registry):
+    """project_note tool adds a note."""
+    await registered_dispatcher.dispatch(
+        "project_register",
+        {"name": "F047-note-tool", "title": "Note Tool"},
+    )
+    result, is_error = await registered_dispatcher.dispatch(
+        "project_note",
+        {"name_or_id": "F047-note-tool", "summary": "Phase 1 done"},
+    )
+    assert not is_error
+    assert "Phase 1 done" in result
+
+
+async def test_tool_project_note_milestone(registered_dispatcher, registry):
+    """project_note with event_type=milestone."""
+    await registered_dispatcher.dispatch(
+        "project_register",
+        {"name": "F047-ms-tool", "title": "Milestone Tool"},
+    )
+    result, is_error = await registered_dispatcher.dispatch(
+        "project_note",
+        {"name_or_id": "F047-ms-tool", "summary": "PR merged", "event_type": "milestone"},
+    )
+    assert not is_error
+    assert "milestone" in result
+
+
+# ---------------------------------------------------------------------------
+# project_list tool
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_project_list_empty(registered_dispatcher):
+    """project_list returns empty message when no projects."""
+    result, is_error = await registered_dispatcher.dispatch(
+        "project_list",
+        {},
+    )
+    assert not is_error
+    assert "No projects" in result or "0" in result
+
+
+async def test_tool_project_list_with_projects(registered_dispatcher, registry):
+    """project_list shows registered projects."""
+    await registered_dispatcher.dispatch(
+        "project_register",
+        {"name": "F047-list-tool-1", "title": "List 1"},
+    )
+    await registered_dispatcher.dispatch(
+        "project_register",
+        {"name": "F047-list-tool-2", "title": "List 2"},
+    )
+    result, is_error = await registered_dispatcher.dispatch(
+        "project_list",
+        {"status": "active"},
+    )
+    assert not is_error
+    assert "F047-list-tool-1" in result
+    assert "F047-list-tool-2" in result


### PR DESCRIPTION
## Summary

Implements **Phase 1** of F047 (Goal/Project Registry) — the schema, tools, resolver, and context injector that give Nous persistent tracking of active workstreams across sessions.

**Scope (Phase 1 only):**
- SQL migration `034_projects.sql`: `heart.projects` + `heart.project_events` tables with embedding column, HNSW index, status/priority constraints
- ORM models `Project` and `ProjectEvent` in `storage/models.py`
- `nous/projects/` module:
  - `ProjectRegistry`: CRUD for projects and events (session injection pattern P1-1)
  - `ProjectResolver`: pre-turn matcher via F-code, name, title, and tag detection; touches `last_touched_at` on match
  - `ProjectContextInjector`: builds Active Projects markdown block for working memory (priority-ordered, token-capped at ~400 tokens)
- Four tools: `project_register`, `project_update`, `project_note`, `project_list` — registered in `FRAME_TOOLS` for conversation, question, decision, debug frames
- Config: `project_registry_enabled`, `project_context_limit`, `project_context_max_tokens`

**Not in scope (deferred to Phase 2/3):**
- No sleep hooks or SessionCloser
- No retrieval boost / GoalSignal
- No auto-creation from high-confidence new-work detection

## Test plan

- [x] 63 unit tests across 5 files — all passing
  - `test_projects_registry.py` (20 tests): register, update, add_note, list, get, touch
  - `test_projects_resolver.py` (11 tests): F-code matching, name/title/tag matching, no-match, paused/completed filtering
  - `test_projects_context.py` (12 tests): context block building, priority ordering, token capping, paused exclusion
  - `test_projects_schemas.py` (10 tests): Pydantic validation, bounds checking
  - `test_projects_tools.py` (10 tests): tool registration, dispatch, error handling
- [x] Existing tests unaffected (verified `test_models.py`, `test_config_search.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)