### PR TITLE
fix(heartbeat): suppress identity/contact facts and broaden resolved patterns

### DIFF
--- a/nous/heartbeat/checks.py
+++ b/nous/heartbeat/checks.py
@@ -173,6 +173,18 @@ _OBSERVATION_PATTERNS = [
     "showed that",
     "need both a",  # "need both X and Y" is descriptive, not a task
     "tasks need both",
+    # Contact info / identity facts (not actionable tasks)
+    "email address is",       # person/contact facts about email
+    "linkedin.com/in/",       # LinkedIn profile URL facts
+    "two email addresses",    # dual-email identity facts
+    "profile url is",         # social profile URL facts
+    # Broader resolved/encoded patterns
+    "resolved —",             # facts starting with RESOLVED —
+    "encoded as censors",     # architecture facts about censor encoding
+    "failure modes encoded",  # resolved architecture findings
+    "are stale and should no",  # stale-fact cleanup notes
+    "is a false positive",    # explicit false-positive labeling
+    "recurring false alarm",  # recurring false alarm documentation
 ]
 
 PENDING_PROTOTYPES = [
@@ -255,6 +267,12 @@ class SelfInitiatedCheck(BaseCheck):
                     if fid in seen_fact_ids:
                         continue
                     seen_fact_ids.add(fid)
+
+                    # Skip person/identity category facts — never actionable
+                    fact_category = getattr(fact, "category", None) or ""
+                    fact_tags = getattr(fact, "tags", None) or []
+                    if fact_category == "person" or "resolved" in fact_tags or "identity" in fact_tags:
+                        continue
 
                     # Check recency using fact score as proxy (hybrid search)
                     # and content relevance via _looks_like_pending


### PR DESCRIPTION
## Problem
SelfInitiatedCheck repeatedly flags these as pending actions (recurring false positives):
- Tim's email address fact (`51215e2e`)
- Tim's LinkedIn profile fact (`6ec6cf9e`)
- Task completion signal lessons (encoded as censors, now stale as standalone facts)
- Long-running failure mode docs (architecture lessons, not tasks)

These are facts about identity/contact info or resolved architecture decisions — not actionable pending items.

## Root Cause
Two issues in `_embedding_search`:
1. Prototype "Tim asked me to do this and I haven't yet" has high cosine similarity with any Tim-related fact
2. No category/tag filter — `person` category facts and facts tagged `resolved` were treated identically to task facts

## Fix
1. **10 new `_OBSERVATION_PATTERNS`** covering:
   - Contact info patterns: `email address is`, `linkedin.com/in/`, `two email addresses`, `profile url is`
   - Resolved/encoded: `resolved —`, `encoded as censors`, `failure modes encoded`
   - False-positive labels: `is a false positive`, `recurring false alarm`, `are stale and should no`

2. **Category/tag skip** in `_embedding_search`: skip facts where `category='person'` or tags include `resolved` or `identity`

## Decision
Resolves decision `589259aa` (expand _OBSERVATION_PATTERNS, expand to >32 patterns — done).

Tested: syntax passes, patterns verified.