### PR TITLE
fix(dag): check-type nodes with completion_check now honour shell poll (awaiting_check)

### DIFF
--- a/nous/dag/orchestrator.py
+++ b/nous/dag/orchestrator.py
@@ -290,25 +290,44 @@ class DAGOrchestrator:
         if check is None:
             # Check was unregistered — for DAG-managed checks this means
             # self-disable completed (DynamicCheckLoader unregisters on disable).
-            # Treat as successful completion, not failure.
-            await self._store.update_node(
-                node.id,
-                status="completed",
-                result="Check completed (self-disabled)",
-                completed_at=datetime.now(UTC),
-            )
-            node.status = "completed"
+            if node.completion_check and node.completion_check.strip():
+                # Heartbeat check finished — now poll the shell completion_check
+                now = datetime.now(UTC)
+                await self._store.update_node(
+                    node.id,
+                    status="awaiting_check",
+                    awaiting_check_at=now,
+                )
+                node.status = "awaiting_check"
+            else:
+                await self._store.update_node(
+                    node.id,
+                    status="completed",
+                    result="Check completed (self-disabled)",
+                    completed_at=datetime.now(UTC),
+                )
+                node.status = "completed"
             return
 
         # Use check.active to detect disabled checks (review fix)
         if not check.active:
-            await self._store.update_node(
-                node.id,
-                status="completed",
-                result="Check completed (disabled itself)",
-                completed_at=datetime.now(UTC),
-            )
-            node.status = "completed"
+            if node.completion_check and node.completion_check.strip():
+                # Heartbeat check disabled itself — now poll the shell completion_check
+                now = datetime.now(UTC)
+                await self._store.update_node(
+                    node.id,
+                    status="awaiting_check",
+                    awaiting_check_at=now,
+                )
+                node.status = "awaiting_check"
+            else:
+                await self._store.update_node(
+                    node.id,
+                    status="completed",
+                    result="Check completed (disabled itself)",
+                    completed_at=datetime.now(UTC),
+                )
+                node.status = "completed"
 
     async def _poll_awaiting_checks(self, dag: ExecutionDAG) -> None:
         """Poll completion_check commands for nodes in awaiting_check status."""

--- a/tests/test_dag_orchestrator.py
+++ b/tests/test_dag_orchestrator.py
@@ -1020,3 +1020,123 @@ class TestDAGEdgeCases:
         await orchestrator.start_dag(dag.id)
         with pytest.raises(ValueError, match="expected pending"):
             await orchestrator.start_dag(dag.id)
+
+
+class TestCheckNodeCompletionCheck:
+    """Test that check-type nodes honour completion_check after heartbeat finishes."""
+
+    def _check_node_request(self, completion_check: str = "test -f /tmp/done.flag") -> DAGCreateRequest:
+        return DAGCreateRequest(
+            name="check-node-cc-test",
+            nodes=[
+                DAGNodeSpec(
+                    name="monitor",
+                    type=DAGNodeType.check,
+                    instructions="Monitor something",
+                    completion_check=completion_check,
+                ),
+                DAGNodeSpec(
+                    name="use-result",
+                    type=DAGNodeType.subtask,
+                    instructions="Use the result",
+                ),
+            ],
+            edges=[
+                DAGEdgeSpec(from_node="monitor", to_node="use-result", edge_type="dependency"),
+            ],
+        )
+
+    @pytest.mark.asyncio
+    async def test_check_node_unregistered_no_completion_check_completes(
+        self, store, orchestrator, dynamic_loader
+    ):
+        """check-type node with no completion_check: unregistered → completed directly."""
+        request = DAGCreateRequest(
+            name="check-no-cc",
+            nodes=[DAGNodeSpec(name="monitor", type=DAGNodeType.check, instructions="Monitor")],
+            edges=[],
+        )
+        dag = await store.create(request)
+        await orchestrator.start_dag(dag.id)
+        # Simulate check launched (running)
+        fetched = await store.get_dag(dag.id)
+        monitor = next(n for n in fetched.nodes if n.name == "monitor")
+        await store.update_node(monitor.id, status="running", check_name="dag-test-monitor")
+        # Registry returns None → check unregistered
+        dynamic_loader._registry.get_check.return_value = None
+        await orchestrator.tick()
+        fetched2 = await store.get_dag(dag.id)
+        monitor2 = next(n for n in fetched2.nodes if n.name == "monitor")
+        assert monitor2.status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_check_node_unregistered_with_completion_check_transitions_to_awaiting(
+        self, store, orchestrator, dynamic_loader
+    ):
+        """check-type node: when heartbeat check unregisters and completion_check defined
+        → should transition to awaiting_check (not immediately completed)."""
+        dag = await store.create(self._check_node_request())
+        await orchestrator.start_dag(dag.id)
+        fetched = await store.get_dag(dag.id)
+        monitor = next(n for n in fetched.nodes if n.name == "monitor")
+        await store.update_node(monitor.id, status="running", check_name="dag-test-monitor")
+        # Registry returns None → heartbeat check unregistered (finished)
+        dynamic_loader._registry.get_check.return_value = None
+        # Prevent shell command from actually running
+        orchestrator._run_completion_check = AsyncMock(return_value=CheckResult("pending"))
+        await orchestrator.tick()
+        fetched2 = await store.get_dag(dag.id)
+        monitor2 = next(n for n in fetched2.nodes if n.name == "monitor")
+        # BUG FIX: must be awaiting_check, not completed
+        assert monitor2.status == "awaiting_check", (
+            f"Expected awaiting_check, got {monitor2.status}. "
+            "completion_check was ignored — check-type node skipped directly to completed."
+        )
+        assert monitor2.awaiting_check_at is not None
+
+    @pytest.mark.asyncio
+    async def test_check_node_disabled_with_completion_check_transitions_to_awaiting(
+        self, store, orchestrator, dynamic_loader
+    ):
+        """check-type node: when heartbeat check disables itself and completion_check defined
+        → should transition to awaiting_check."""
+        dag = await store.create(self._check_node_request())
+        await orchestrator.start_dag(dag.id)
+        fetched = await store.get_dag(dag.id)
+        monitor = next(n for n in fetched.nodes if n.name == "monitor")
+        await store.update_node(monitor.id, status="running", check_name="dag-test-monitor")
+        # Registry returns an inactive check → check disabled itself
+        inactive_check = MagicMock()
+        inactive_check.active = False
+        dynamic_loader._registry.get_check.return_value = inactive_check
+        orchestrator._run_completion_check = AsyncMock(return_value=CheckResult("pending"))
+        await orchestrator.tick()
+        fetched2 = await store.get_dag(dag.id)
+        monitor2 = next(n for n in fetched2.nodes if n.name == "monitor")
+        assert monitor2.status == "awaiting_check", (
+            f"Expected awaiting_check, got {monitor2.status}."
+        )
+        assert monitor2.awaiting_check_at is not None
+
+    @pytest.mark.asyncio
+    async def test_check_node_completion_check_passes_unblocks_dependent(
+        self, store, orchestrator, subtask_mgr, dynamic_loader
+    ):
+        """Full flow: heartbeat check unregisters → awaiting_check → shell passes → dependent launches."""
+        dag = await store.create(self._check_node_request())
+        await orchestrator.start_dag(dag.id)
+        fetched = await store.get_dag(dag.id)
+        monitor = next(n for n in fetched.nodes if n.name == "monitor")
+        await store.update_node(monitor.id, status="running", check_name="dag-test-monitor")
+        # Tick 1: heartbeat unregisters → awaiting_check
+        dynamic_loader._registry.get_check.return_value = None
+        orchestrator._run_completion_check = AsyncMock(return_value=CheckResult("pending"))
+        await orchestrator.tick()
+        # Tick 2: completion_check passes → completed → dependent launches
+        orchestrator._run_completion_check = AsyncMock(return_value=CheckResult("success"))
+        await orchestrator.tick()
+        fetched2 = await store.get_dag(dag.id)
+        monitor2 = next(n for n in fetched2.nodes if n.name == "monitor")
+        use_result = next(n for n in fetched2.nodes if n.name == "use-result")
+        assert monitor2.status == "completed"
+        assert use_result.status == "running"


### PR DESCRIPTION
## Problem

`_sync_check_node()` was immediately marking check-type DAG nodes as `completed` when the underlying heartbeat check unregistered or disabled itself. This meant any `completion_check` shell command defined on the node was **silently skipped**.

## Root Cause

The `awaiting_check` transition was only wired in `_sync_subtask_node()`:

```python
# _sync_subtask_node — correct
if node.completion_check and node.completion_check.strip():
    await self._store.update_node(node.id, status="awaiting_check", ...)
```

But `_sync_check_node()` went straight to `completed`, bypassing the poll loop entirely.

## Fix

In both completion branches of `_sync_check_node()` (check unregistered, check inactive), gate on `node.completion_check`:
- **If set** → transition to `awaiting_check` with `awaiting_check_at` timestamp; `_poll_awaiting_checks()` takes it from there on the next tick.
- **If not set** → mark completed immediately (existing behaviour, now guarded).

## Tests

4 new tests in `TestCheckNodeCompletionCheck`:
1. No `completion_check` → completes directly (regression guard)
2. Heartbeat check unregisters + `completion_check` defined → `awaiting_check`
3. Heartbeat check disables itself + `completion_check` defined → `awaiting_check`
4. Full E2E: unregistered → awaiting → shell passes → dependent node launches

All 38 orchestrator tests pass.