### PR TITLE
fix(heartbeat): case-insensitive tag skip + 17 regression tests for PR #323

### DIFF
--- a/nous/heartbeat/checks.py
+++ b/nous/heartbeat/checks.py
@@ -268,10 +268,11 @@ class SelfInitiatedCheck(BaseCheck):
                         continue
                     seen_fact_ids.add(fid)
 
-                    # Skip person/identity category facts — never actionable
+                    # Skip person/identity category facts — never actionable.
+                    # Lowercase tags for comparison; schema doesn't enforce casing.
                     fact_category = getattr(fact, "category", None) or ""
-                    fact_tags = getattr(fact, "tags", None) or []
-                    if fact_category == "person" or "resolved" in fact_tags or "identity" in fact_tags:
+                    fact_tags_lower = {t.lower() for t in (getattr(fact, "tags", None) or [])}
+                    if fact_category == "person" or fact_tags_lower & {"resolved", "identity"}:
                         continue
 
                     # Check recency using fact score as proxy (hybrid search)

--- a/tests/test_heartbeat_intelligent.py
+++ b/tests/test_heartbeat_intelligent.py
@@ -282,6 +282,101 @@ class TestSelfInitiatedPromiseTracking:
 
 
 # ===========================================================================
+# TestObservationPatternSuppression — coverage for the 10 patterns added in
+# PR #323 (identity/contact facts, resolved/encoded notes, false-positive
+# meta-docs). Guards against accidental pattern removal.
+# ===========================================================================
+
+
+class TestObservationPatternSuppression:
+    """Regression guard for PR #323 identity/resolved _OBSERVATION_PATTERNS."""
+
+    @pytest.mark.parametrize("content", [
+        # Contact info / identity facts
+        "Tim's email address is tim@example.com",
+        "Profile: linkedin.com/in/tfatykhov",
+        "He has two email addresses for different accounts",
+        "His profile url is example.com/tim",
+        # Resolved / encoded patterns
+        "Resolved — admission guardrails now block stale facts",
+        "Task completion signals encoded as censors",
+        "Long-running failure modes encoded in the heart module",
+        "These facts are stale and should no longer surface",
+        "That flag is a false positive from last week",
+        "Recurring false alarm from Tuesday's heartbeat run",
+    ])
+    def test_pattern_triggers_is_observation(self, content: str):
+        """Each PR #323 pattern makes _is_observation return True."""
+        assert SelfInitiatedCheck._is_observation(content)
+
+
+# ===========================================================================
+# TestTagCasingSkip — tag membership must be case-insensitive.
+# Fact schema does not enforce tag casing; comparison must lowercase.
+# ===========================================================================
+
+
+class TestTagCasingSkip:
+    """Embedding-search tag skip ignores case for 'resolved' and 'identity'."""
+
+    @staticmethod
+    def _make_fact(tags: list[str], category: str | None = None) -> MagicMock:
+        f = MagicMock()
+        f.id = "fact-tag"
+        # Actionable-looking content so only the tag skip can suppress it.
+        f.content = "TODO: need to follow up on this pending action"
+        f.score = 0.9
+        f.category = category
+        f.tags = tags
+        return f
+
+    @staticmethod
+    def _wire_heart(heart: MagicMock, fact: MagicMock) -> None:
+        heart.facts.search = AsyncMock(return_value=[fact])
+        heart.search_episodes = AsyncMock(return_value=[])
+        heart.schedules.get_due = AsyncMock(return_value=[])
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tag_variant", ["resolved", "Resolved", "RESOLVED"])
+    async def test_resolved_tag_skipped_case_insensitively(self, tag_variant: str):
+        heart, brain = MagicMock(), MagicMock()
+        self._wire_heart(heart, self._make_fact(tags=[tag_variant]))
+        embeddings = MagicMock()
+        embeddings.embed_batch = AsyncMock(return_value=[[0.1] * 10] * 5)
+
+        check = SelfInitiatedCheck(heart, brain, _mock_settings(), embeddings=embeddings)
+        result = await check.run()
+
+        assert [f for f in result.findings if f.raw_data.get("detection") == "embedding"] == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tag_variant", ["identity", "Identity", "IDENTITY"])
+    async def test_identity_tag_skipped_case_insensitively(self, tag_variant: str):
+        heart, brain = MagicMock(), MagicMock()
+        self._wire_heart(heart, self._make_fact(tags=[tag_variant]))
+        embeddings = MagicMock()
+        embeddings.embed_batch = AsyncMock(return_value=[[0.1] * 10] * 5)
+
+        check = SelfInitiatedCheck(heart, brain, _mock_settings(), embeddings=embeddings)
+        result = await check.run()
+
+        assert [f for f in result.findings if f.raw_data.get("detection") == "embedding"] == []
+
+    @pytest.mark.asyncio
+    async def test_person_category_still_skipped(self):
+        """Regression guard: category='person' skip survives the tag-casing refactor."""
+        heart, brain = MagicMock(), MagicMock()
+        self._wire_heart(heart, self._make_fact(tags=[], category="person"))
+        embeddings = MagicMock()
+        embeddings.embed_batch = AsyncMock(return_value=[[0.1] * 10] * 5)
+
+        check = SelfInitiatedCheck(heart, brain, _mock_settings(), embeddings=embeddings)
+        result = await check.run()
+
+        assert [f for f in result.findings if f.raw_data.get("detection") == "embedding"] == []
+
+
+# ===========================================================================
 # TestEmailLLMClassification — 4 tests
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

- `SelfInitiatedCheck._embedding_search` tag skip was case-sensitive: `"resolved" in fact_tags` misses `["Resolved"]` and `["RESOLVED"]`. `FactInput.tags` schema does not enforce lowercase, so drift is a matter of time.
- PR #323 shipped with zero tests for the 10 new `_OBSERVATION_PATTERNS` or the category/tag skip. This PR closes both gaps.

## Fix

`nous/heartbeat/checks.py:272-274` — lowercase the tag set before intersecting with `{"resolved", "identity"}`. Two lines of runtime change, plus a comment noting the schema caveat.

## Tests

Two new test classes, 17 cases total:

| Class | Cases | Purpose |
|---|---|---|
| `TestObservationPatternSuppression` | 10 | Parametrized over each PR #323 pattern — guards against accidental pattern removal |
| `TestTagCasingSkip` | 7 | Case variants of `resolved`/`identity` (6) + `category='person'` regression guard (1) |

**Bug-exercise verified:** stashed the fix, re-ran `TestTagCasingSkip::test_resolved_tag_skipped_case_insensitively[Resolved]` and `[IDENTITY]` — both fail without the fix, confirming the tests differentiate.

## Scope

Surgical: two files changed, +99/-3 lines. No refactor of adjacent code, no new test directory, no schema change.

## Test plan

- [x] `uv run pytest tests/test_heartbeat_intelligent.py -q` — 37 pass (20 existing + 17 new)
- [x] Stash-and-reapply confirms the 2 case-variant tests fail on the pre-fix code

## Follow-up (not in this PR)

A separate issue will propose a spike to decide whether the `_OBSERVATION_PATTERNS` arms race (40+ entries) warrants a systemic fix (per-fact `actionable` classifier at learn time). Per Karpathy §1: measure before building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)