### PR TITLE
fix(migrator): strip -- comments before splitting on ; (unblocks F047 migration 034)

### DIFF
--- a/nous/storage/migrator.py
+++ b/nous/storage/migrator.py
@@ -27,6 +27,24 @@ CREATE TABLE IF NOT EXISTS nous_system.schema_migrations (
 """
 
 
+def _split_sql_statements(sql: str) -> list[str]:
+    """Split a migration file into individual SQL statements.
+
+    Strips `-- ...` line comments BEFORE splitting on `;` so a semicolon
+    inside a comment does not break the splitter (see bug: migration 034
+    had "-- legacy rows; backfill..." that was mis-split into "backfill..."
+    and executed as SQL).
+
+    Block comments `/* ... */` are NOT handled — our migrations don't use
+    them. Dollar-quoted strings `$$...$$` would also need care; current
+    migrations don't use those either.
+    """
+    stripped = "\n".join(
+        ln for ln in sql.splitlines() if not ln.lstrip().startswith("--")
+    )
+    return [stmt.strip() for stmt in stripped.split(";") if stmt.strip()]
+
+
 async def run_migrations(engine: AsyncEngine) -> list[str]:
     """Apply pending SQL migrations and return list of newly applied names."""
     if not _MIGRATIONS_DIR.is_dir():
@@ -60,16 +78,8 @@ async def run_migrations(engine: AsyncEngine) -> list[str]:
 
             logger.info("Applying migration %s ...", path.name)
             # asyncpg doesn't support multiple statements in one execute(),
-            # so split on semicolons and run each statement individually.
-            for raw_stmt in sql.split(";"):
-                # Strip SQL comments (-- ...) before checking if empty
-                lines = [
-                    ln for ln in raw_stmt.splitlines()
-                    if ln.strip() and not ln.strip().startswith("--")
-                ]
-                stmt = "\n".join(lines).strip()
-                if not stmt:
-                    continue
+            # so split and run each statement individually.
+            for stmt in _split_sql_statements(sql):
                 await conn.execute(text(stmt))
             await conn.execute(
                 text(

--- a/sql/migrations/034_fact_actionability.sql
+++ b/sql/migrations/034_fact_actionability.sql
@@ -1,6 +1,6 @@
 -- F047: Actionability classification at learn time.
 -- Adds two nullable columns and a partial index on heart.facts.
--- NULL = not yet classified (legacy rows; backfill handler will populate).
+-- NULL = not yet classified (legacy rows, backfilled by the handler).
 -- Partial index optimizes the "find actionable facts" query used by heartbeat.
 
 ALTER TABLE heart.facts

--- a/tests/test_migrator_split.py
+++ b/tests/test_migrator_split.py
@@ -1,0 +1,117 @@
+"""Unit tests for nous.storage.migrator._split_sql_statements.
+
+Regression coverage for the bug where a semicolon inside a `-- ...` line
+comment broke the statement splitter and leaked comment prose into an
+executable SQL statement (migration 034 / F047).
+"""
+
+from __future__ import annotations
+
+from nous.storage.migrator import _split_sql_statements
+
+
+def test_split_simple_statements():
+    sql = "CREATE TABLE t (id INT); CREATE INDEX idx ON t(id);"
+    assert _split_sql_statements(sql) == [
+        "CREATE TABLE t (id INT)",
+        "CREATE INDEX idx ON t(id)",
+    ]
+
+
+def test_split_strips_leading_line_comments():
+    sql = """
+-- A comment.
+CREATE TABLE t (id INT);
+-- Another comment.
+CREATE INDEX idx ON t(id);
+"""
+    stmts = _split_sql_statements(sql)
+    assert len(stmts) == 2
+    assert stmts[0].startswith("CREATE TABLE")
+    assert stmts[1].startswith("CREATE INDEX")
+
+
+def test_split_handles_semicolon_inside_line_comment():
+    """Regression for migration 034: semicolon inside a -- comment must
+    not cause the splitter to leak the tail of the comment into the next
+    statement as bogus SQL."""
+    sql = """
+-- NULL = not yet classified (legacy rows; backfill handler will populate).
+ALTER TABLE heart.facts
+    ADD COLUMN IF NOT EXISTS actionable BOOLEAN DEFAULT NULL;
+"""
+    stmts = _split_sql_statements(sql)
+    assert len(stmts) == 1
+    assert stmts[0].startswith("ALTER TABLE")
+    # The comment tail must NOT have leaked into executable SQL.
+    for stmt in stmts:
+        assert "backfill handler" not in stmt
+        assert "legacy rows" not in stmt
+
+
+def test_split_handles_indented_comments():
+    sql = """
+ALTER TABLE t
+    ADD COLUMN x INT,
+    -- inline indented comment; with a semicolon
+    ADD COLUMN y INT;
+"""
+    stmts = _split_sql_statements(sql)
+    assert len(stmts) == 1
+    assert "ADD COLUMN x INT" in stmts[0]
+    assert "ADD COLUMN y INT" in stmts[0]
+    assert "inline indented" not in stmts[0]
+
+
+def test_split_preserves_comment_on_column_strings():
+    """`COMMENT ON COLUMN ... IS '...'` is valid SQL — it must survive
+    splitting (the string literal is not a -- comment)."""
+    sql = """
+COMMENT ON COLUMN heart.facts.actionable IS
+    'F047: True=pending action, False=observation/resolved, NULL=unclassified';
+"""
+    stmts = _split_sql_statements(sql)
+    assert len(stmts) == 1
+    assert stmts[0].startswith("COMMENT ON COLUMN")
+    assert "F047" in stmts[0]
+
+
+def test_split_drops_empty_chunks():
+    assert _split_sql_statements(";;;") == []
+    assert _split_sql_statements("   ;   ;  ") == []
+    assert _split_sql_statements("") == []
+    assert _split_sql_statements("\n\n-- just a comment\n\n") == []
+
+
+def test_split_full_migration_034():
+    """End-to-end: feed the exact content of migration 034 and assert
+    that the three expected statements come out (ALTER TABLE, CREATE
+    INDEX, COMMENT ON COLUMN × 2). The ORIGINAL buggy version of this
+    file would produce a 4th bogus statement starting with "backfill"."""
+    sql = """-- F047: Actionability classification at learn time.
+-- Adds two nullable columns and a partial index on heart.facts.
+-- NULL = not yet classified (legacy rows; backfill handler will populate).
+-- Partial index optimizes the "find actionable facts" query used by heartbeat.
+
+ALTER TABLE heart.facts
+    ADD COLUMN IF NOT EXISTS actionable BOOLEAN DEFAULT NULL,
+    ADD COLUMN IF NOT EXISTS actionable_confidence REAL DEFAULT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_facts_actionable_agent
+    ON heart.facts(agent_id, actionable)
+    WHERE actionable = TRUE;
+
+COMMENT ON COLUMN heart.facts.actionable IS
+    'F047: True=pending action, False=observation/resolved, NULL=unclassified';
+COMMENT ON COLUMN heart.facts.actionable_confidence IS
+    'F047: Classifier confidence 0.0-1.0';
+"""
+    stmts = _split_sql_statements(sql)
+    # Exactly 4: ALTER + CREATE INDEX + 2× COMMENT ON COLUMN.
+    assert len(stmts) == 4, f"expected 4 statements, got {len(stmts)}: {stmts}"
+    assert stmts[0].startswith("ALTER TABLE")
+    assert stmts[1].startswith("CREATE INDEX")
+    assert stmts[2].startswith("COMMENT ON COLUMN")
+    assert stmts[3].startswith("COMMENT ON COLUMN")
+    # No bogus chunk starts with "backfill".
+    assert not any(s.lower().startswith("backfill") for s in stmts)


### PR DESCRIPTION
## Summary

Hotfix: fresh \`docker compose up\` fails on the F047 migration
(\`034_fact_actionability.sql\`) with:

\`\`\`
asyncpg.exceptions.PostgresSyntaxError: syntax error at or near \"backfill\"
\`\`\`

## Root cause

Migration 034 line 3:

\`\`\`sql
-- NULL = not yet classified (legacy rows; backfill handler will populate).
\`\`\`

The migrator (\`nous/storage/migrator.py\`) ran \`sql.split(\";\")\` **before** stripping \`-- ...\` line comments. So:

1. Split happens mid-comment at the \`;\`.
2. Right-hand chunk starts with \`backfill handler will populate).\` — no longer has a \`--\` prefix.
3. Comment-line filter (which only removes lines starting with \`--\`) no longer recognizes it.
4. Postgres receives \`backfill handler will populate).\nALTER TABLE heart.facts...\` → syntax error.

## Fix

- Extract \`_split_sql_statements(sql)\` helper that strips \`-- ...\` line comments **first**, then splits on \`;\`. Strip-then-split is commutative; split-then-strip is not.
- Reword migration 034's comment to not contain a semicolon — defensive, unblocks anyone running older migrator code.

## Test plan

- [x] \`uv run pytest tests/test_migrator_split.py -v\` — 7 new unit tests pass
- [x] Regression test \`test_split_full_migration_034\` feeds the ORIGINAL buggy content of migration 034 through the new splitter and asserts exactly 4 statements (ALTER, CREATE INDEX, 2× COMMENT ON COLUMN) with zero \"backfill\" ghosts
- [x] Existing migration tests unaffected

## Risk

Low. The helper behavior is unchanged for migrations without semicolons-in-comments (which is all of them except 034 — verified by \`grep -n \"^[[:space:]]*--\" sql/migrations/*.sql | grep ';'\`).

Forge decision: \`d5264bb1\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)