### PR TITLE
feat(F047): symmetric INFO logging + backfill tier summary

### DIFF
--- a/nous/handlers/actionability_backfill.py
+++ b/nous/handlers/actionability_backfill.py
@@ -118,6 +118,7 @@ class ActionabilityBackfillHandler:
         total = 0
         classified = 0
         errors = 0
+        tier_counts: dict[str, int] = {}
         start = time.monotonic()
 
         while True:
@@ -132,6 +133,7 @@ class ActionabilityBackfillHandler:
                     )
                     if tier == "llm":
                         self._llm_calls_used += 1
+                    tier_counts[tier] = tier_counts.get(tier, 0) + 1
                     await self._update_actionable(fact_id, actionable, conf)
                     classified += 1
                 except asyncio.CancelledError:
@@ -155,8 +157,21 @@ class ActionabilityBackfillHandler:
             "classified": classified,
             "errors": errors,
             "elapsed_s": round(elapsed, 2),
+            "tiers": tier_counts,
+            "llm_calls_used": self._llm_calls_used,
+            "llm_budget": self._max_llm_calls,
         }
         logger.info("F047 backfill complete: %s", summary)
+        if self._llm_calls_used >= self._max_llm_calls and tier_counts.get("default", 0) > 0:
+            logger.warning(
+                "F047 backfill: LLM budget exhausted (%d/%d calls) — %d fact(s) "
+                "fell through to the default path. Raise "
+                "NOUS_ACTIONABILITY_BACKFILL_TOKEN_BUDGET to cover them on the "
+                "next run.",
+                self._llm_calls_used,
+                self._max_llm_calls,
+                tier_counts.get("default", 0),
+            )
         return summary
 
     async def _fetch_batch(self) -> list[tuple[UUID, str, str | None, list[str]]]:

--- a/nous/heart/actionability.py
+++ b/nous/heart/actionability.py
@@ -236,8 +236,12 @@ class ActionabilityClassifier:
             )
             return (self._default_when_unknown, 0.3, "default")
 
-        return (
-            bool(result["actionable"]),
-            float(result.get("confidence", 0.5)),
-            "llm",
+        actionable = bool(result["actionable"])
+        confidence = float(result.get("confidence", 0.5))
+        logger.info(
+            "F047: LLM classified actionable=%s confidence=%.2f for %r",
+            actionable,
+            confidence,
+            content[:80],
         )
+        return (actionable, confidence, "llm")

--- a/tests/test_actionability.py
+++ b/tests/test_actionability.py
@@ -201,6 +201,39 @@ class TestLLMTier:
         assert tier == "default"
 
     @pytest.mark.asyncio
+    async def test_llm_success_emits_info_log(self, monkeypatch, caplog):
+        """Successful LLM classifications must log at INFO so operators have
+        symmetric visibility with the default-path log, not silent success."""
+        import logging as _logging
+
+        async def fake_call(**kwargs):
+            return {"actionable": True, "confidence": 0.82, "reason": "explicit ask"}
+
+        monkeypatch.setattr(
+            "nous.handlers.call_background_llm_structured",
+            fake_call,
+        )
+
+        fake_llm = MagicMock()
+        c = ActionabilityClassifier(llm=fake_llm)
+
+        with caplog.at_level(_logging.INFO, logger="nous.heart.actionability"):
+            actionable, conf, tier = await c.classify("TODO is resolved")
+
+        assert tier == "llm" and actionable is True and conf == 0.82
+        success_logs = [
+            r for r in caplog.records
+            if r.levelno == _logging.INFO and "LLM classified" in r.getMessage()
+        ]
+        assert success_logs, (
+            "expected an INFO log on successful LLM classification; "
+            f"got records: {[(r.levelname, r.getMessage()) for r in caplog.records]}"
+        )
+        msg = success_logs[0].getMessage()
+        assert "actionable=True" in msg
+        assert "0.82" in msg
+
+    @pytest.mark.asyncio
     async def test_no_llm_no_heuristic_returns_default(self):
         c = ActionabilityClassifier(llm=None, default_when_unknown=False)
         # "banana" matches nothing

--- a/tests/test_actionability_backfill.py
+++ b/tests/test_actionability_backfill.py
@@ -264,3 +264,164 @@ class TestClassifierErrorHandling:
         assert result["total"] == 2
         assert result["classified"] == 1
         assert result["errors"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Summary / observability (INFO log tier breakdown + budget-exhausted WARNING)
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillSummary:
+    @pytest.mark.asyncio
+    async def test_summary_includes_tier_counts(self, monkeypatch):
+        """run_once return value has per-tier counts and LLM budget usage."""
+        class LockSession:
+            async def __aenter__(self_inner):
+                m = MagicMock()
+                res = MagicMock(); res.scalar = MagicMock(return_value=True)
+                m.execute = AsyncMock(return_value=res)
+                return m
+            async def __aexit__(self_inner, *a): return False
+
+        class UpdateSession:
+            async def __aenter__(self_inner):
+                m = MagicMock(); m.execute = AsyncMock(); m.commit = AsyncMock()
+                return m
+            async def __aexit__(self_inner, *a): return False
+
+        db = MagicMock()
+        db.session = MagicMock(side_effect=[
+            LockSession(),
+            UpdateSession(), UpdateSession(), UpdateSession(),
+        ])
+
+        classifier = MagicMock()
+        classifier._budget_check = None
+        tiers = iter(["llm", "heuristic_action", "default"])
+
+        async def classify(content, cat, tags):
+            return (True, 0.7, next(tiers))
+
+        classifier.classify = AsyncMock(side_effect=classify)
+        h = ActionabilityBackfillHandler(db, classifier, "agent-x", token_budget=10_000)
+
+        batches = iter([
+            [(uuid4(), "a", None, []), (uuid4(), "b", None, []), (uuid4(), "c", None, [])],
+            [],
+        ])
+
+        async def fake_fetch():
+            return next(batches)
+
+        monkeypatch.setattr(h, "_fetch_batch", fake_fetch)
+        summary = await h.run_once()
+
+        assert summary["total"] == 3
+        assert summary["classified"] == 3
+        assert summary["errors"] == 0
+        assert summary["tiers"] == {"llm": 1, "heuristic_action": 1, "default": 1}
+        assert summary["llm_calls_used"] == 1
+        assert summary["llm_budget"] == 40
+
+    @pytest.mark.asyncio
+    async def test_budget_exhausted_emits_warning(self, monkeypatch, caplog):
+        """When LLM budget hits cap AND defaults happened, operator sees a
+        WARNING pointing at NOUS_ACTIONABILITY_BACKFILL_TOKEN_BUDGET."""
+        import logging as _logging
+
+        class LockSession:
+            async def __aenter__(self_inner):
+                m = MagicMock()
+                res = MagicMock(); res.scalar = MagicMock(return_value=True)
+                m.execute = AsyncMock(return_value=res)
+                return m
+            async def __aexit__(self_inner, *a): return False
+
+        class UpdateSession:
+            async def __aenter__(self_inner):
+                m = MagicMock(); m.execute = AsyncMock(); m.commit = AsyncMock()
+                return m
+            async def __aexit__(self_inner, *a): return False
+
+        db = MagicMock()
+        # token_budget=250 → _max_llm_calls=1. Two facts: 1st LLM (budget
+        # consumed), 2nd defaulted.
+        db.session = MagicMock(side_effect=[LockSession(), UpdateSession(), UpdateSession()])
+        classifier = MagicMock()
+        classifier._budget_check = None
+        tiers = iter(["llm", "default"])
+
+        async def classify(content, cat, tags):
+            return (False, 0.5, next(tiers))
+
+        classifier.classify = AsyncMock(side_effect=classify)
+        h = ActionabilityBackfillHandler(db, classifier, "agent-x", token_budget=250)
+
+        batches = iter([
+            [(uuid4(), "a", None, []), (uuid4(), "b", None, [])],
+            [],
+        ])
+
+        async def fake_fetch():
+            return next(batches)
+
+        monkeypatch.setattr(h, "_fetch_batch", fake_fetch)
+
+        with caplog.at_level(_logging.WARNING, logger="nous.handlers.actionability_backfill"):
+            summary = await h.run_once()
+
+        assert summary["llm_calls_used"] == 1
+        assert summary["llm_budget"] == 1
+        assert summary["tiers"].get("default", 0) == 1
+
+        warns = [r for r in caplog.records if r.levelno == _logging.WARNING]
+        assert any(
+            "budget exhausted" in r.getMessage()
+            and "NOUS_ACTIONABILITY_BACKFILL_TOKEN_BUDGET" in r.getMessage()
+            for r in warns
+        ), f"expected budget-exhausted WARNING; got: {[r.getMessage() for r in warns]}"
+
+    @pytest.mark.asyncio
+    async def test_budget_exhausted_without_defaults_no_warning(self, monkeypatch, caplog):
+        """If budget is fully used but every fact was LLM-classified (no
+        defaults), no warning — there was nothing missed."""
+        import logging as _logging
+
+        class LockSession:
+            async def __aenter__(self_inner):
+                m = MagicMock()
+                res = MagicMock(); res.scalar = MagicMock(return_value=True)
+                m.execute = AsyncMock(return_value=res)
+                return m
+            async def __aexit__(self_inner, *a): return False
+
+        class UpdateSession:
+            async def __aenter__(self_inner):
+                m = MagicMock(); m.execute = AsyncMock(); m.commit = AsyncMock()
+                return m
+            async def __aexit__(self_inner, *a): return False
+
+        db = MagicMock()
+        db.session = MagicMock(side_effect=[LockSession(), UpdateSession()])
+        classifier = MagicMock()
+        classifier._budget_check = None
+
+        async def classify(content, cat, tags):
+            return (True, 0.9, "llm")
+
+        classifier.classify = AsyncMock(side_effect=classify)
+        h = ActionabilityBackfillHandler(db, classifier, "agent-x", token_budget=250)
+
+        batches = iter([[(uuid4(), "a", None, [])], []])
+
+        async def fake_fetch():
+            return next(batches)
+
+        monkeypatch.setattr(h, "_fetch_batch", fake_fetch)
+        with caplog.at_level(_logging.WARNING, logger="nous.handlers.actionability_backfill"):
+            await h.run_once()
+
+        assert not any(
+            "budget exhausted" in r.getMessage()
+            for r in caplog.records if r.levelno == _logging.WARNING
+        )


### PR DESCRIPTION
## Summary

Fixes observability asymmetry in the F047 actionability classifier. Previously a backfill that LLM-classified 40 facts and defaulted 1437 would emit **only 1437 INFO lines** (the default path) — making it look like the LLM never fired when it actually did.

## Changes

- \`ActionabilityClassifier._llm_classify\` now emits an INFO log on **successful** LLM classification with verdict + confidence + content preview. Symmetric with the existing default-path INFO log.
- \`ActionabilityBackfillHandler._run_batches\` summary now carries per-tier counts plus \`llm_calls_used\` and \`llm_budget\`. One-line summary at the end of the backfill tells ops the full breakdown (hard_filter / heuristic_action / heuristic_observation / llm / default) instead of just \"X classified, Y errors\".
- Budget-exhausted + defaulted → **WARNING** pointing at \`NOUS_ACTIONABILITY_BACKFILL_TOKEN_BUDGET\`. Operators get actionable guidance instead of having to infer the cause.

## Test plan

- [x] \`uv run pytest tests/test_actionability.py tests/test_actionability_backfill.py -v\` — 43 pass (4 new, 39 existing)
- [x] \`test_llm_success_emits_info_log\` — asserts the new INFO log text + fields
- [x] \`test_summary_includes_tier_counts\` — per-tier breakdown in the summary dict
- [x] \`test_budget_exhausted_emits_warning\` — WARNING fires only when budget exhausted **and** defaults happened
- [x] \`test_budget_exhausted_without_defaults_no_warning\` — no spurious warning when budget is fully used but every fact was classified

## Expected operator view after merge

On a healthy backfill with enough budget:
\`\`\`
INFO F047: LLM classified actionable=False confidence=0.92 for 'Knowledge graph has 35 edges...'
INFO F047: LLM classified actionable=True confidence=0.88 for 'Draft the F048 review...'
...
INFO F047 backfill complete: {'total': 1477, 'classified': 1477, 'errors': 0, 'elapsed_s': 2340.5, 'tiers': {'llm': 1200, 'heuristic_observation': 200, 'heuristic_action': 60, 'default': 17}, 'llm_calls_used': 1200, 'llm_budget': 1600}
\`\`\`

On a budget-starved backfill:
\`\`\`
INFO F047 backfill complete: {..., 'tiers': {'llm': 40, 'default': 1437}, 'llm_calls_used': 40, 'llm_budget': 40}
WARNING F047 backfill: LLM budget exhausted (40/40 calls) — 1437 fact(s) fell through to the default path. Raise NOUS_ACTIONABILITY_BACKFILL_TOKEN_BUDGET to cover them on the next run.
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)