### PR TITLE
fix(F048): strip SDK helper-only fields from aggregated Message (parsed_output 400)

### DIFF
--- a/nous/api/anthropic_client.py
+++ b/nous/api/anthropic_client.py
@@ -1028,11 +1028,60 @@ class SdkAnthropicClient:
 
     @staticmethod
     def _message_to_content(message: Any) -> list[dict[str, Any]]:
-        """Convert SDK Message.content blocks to raw dicts matching API format."""
+        """Convert SDK Message.content blocks to raw dicts matching the API's
+        wire format.
+
+        The SDK's `messages.stream()` helper (used by call_streaming_aggregated)
+        attaches helper-only fields (e.g. `parsed_output`) to some blocks that
+        the server will reject on the next request as
+        "Extra inputs are not permitted". model_dump() emits every field, so
+        we explicitly build each block from the allow-listed set of fields
+        per block type and drop anything else.
+        """
         content: list[dict[str, Any]] = []
         for block in message.content:
-            block_dict = block.model_dump() if hasattr(block, "model_dump") else block.dict()
-            content.append(block_dict)
+            block_type = getattr(block, "type", None)
+
+            if block_type == "text":
+                out: dict[str, Any] = {
+                    "type": "text",
+                    "text": getattr(block, "text", "") or "",
+                }
+                citations = getattr(block, "citations", None)
+                if citations:
+                    out["citations"] = [
+                        c.model_dump() if hasattr(c, "model_dump") else dict(c)
+                        for c in citations
+                    ]
+            elif block_type == "tool_use":
+                out = {
+                    "type": "tool_use",
+                    "id": getattr(block, "id", ""),
+                    "name": getattr(block, "name", ""),
+                    "input": getattr(block, "input", {}) or {},
+                }
+            elif block_type == "thinking":
+                out = {
+                    "type": "thinking",
+                    "thinking": getattr(block, "thinking", "") or "",
+                    "signature": getattr(block, "signature", "") or "",
+                }
+            elif block_type == "redacted_thinking":
+                out = {
+                    "type": "redacted_thinking",
+                    "data": getattr(block, "data", "") or "",
+                }
+            else:
+                # Unknown block type — model_dump but strip known helper-only
+                # fields as a defensive fallback.
+                raw = (
+                    block.model_dump() if hasattr(block, "model_dump")
+                    else dict(block)
+                )
+                raw.pop("parsed_output", None)
+                out = raw
+
+            content.append(out)
         return content
 
     @staticmethod

--- a/tests/test_api_streaming_aggregated.py
+++ b/tests/test_api_streaming_aggregated.py
@@ -484,3 +484,80 @@ async def test_sdk_aggregator_matches_call_for_same_message():
     assert resp_call.content == resp_stream.content
     assert resp_call.stop_reason == resp_stream.stop_reason
     assert resp_call.usage == resp_stream.usage
+
+
+# ---------------------------------------------------------------------------
+# F048 regression: SdkAnthropicClient._message_to_content must strip SDK
+# helper-only fields (parsed_output etc.) so they don't round-trip back to
+# the API as "Extra inputs are not permitted" 400s.
+# ---------------------------------------------------------------------------
+
+
+def test_sdk_message_to_content_strips_parsed_output_from_text():
+    """messages.stream() helper sets `parsed_output` on text blocks; the
+    server rejects it on the NEXT request. _message_to_content must
+    whitelist fields, not model_dump everything."""
+    block = SimpleNamespace(type="text", text="hello world", citations=None)
+    # The SDK helper attaches this; Anthropic server rejects it.
+    block.parsed_output = {"should": "be-stripped"}
+
+    msg = SimpleNamespace(content=[block])
+    result = SdkAnthropicClient._message_to_content(msg)
+
+    assert result == [{"type": "text", "text": "hello world"}]
+    assert "parsed_output" not in result[0]
+
+
+def test_sdk_message_to_content_strips_parsed_output_from_tool_use():
+    block = SimpleNamespace(type="tool_use", id="toolu_abc", name="recall", input={"q": 1})
+    block.parsed_output = "helper-only"
+
+    msg = SimpleNamespace(content=[block])
+    result = SdkAnthropicClient._message_to_content(msg)
+
+    assert result == [{"type": "tool_use", "id": "toolu_abc", "name": "recall", "input": {"q": 1}}]
+    assert "parsed_output" not in result[0]
+
+
+def test_sdk_message_to_content_strips_parsed_output_from_thinking():
+    block = SimpleNamespace(type="thinking", thinking="Let me think.", signature="sig-1")
+    block.parsed_output = "helper-only"
+
+    msg = SimpleNamespace(content=[block])
+    result = SdkAnthropicClient._message_to_content(msg)
+
+    assert result == [{"type": "thinking", "thinking": "Let me think.", "signature": "sig-1"}]
+    assert "parsed_output" not in result[0]
+
+
+def test_sdk_message_to_content_strips_parsed_output_from_unknown_block():
+    """Unknown block types fall back to model_dump — that path must also
+    strip parsed_output defensively."""
+    raw = MagicMock()
+    raw.type = "future_new_block_type"
+    raw.model_dump.return_value = {
+        "type": "future_new_block_type",
+        "payload": "x",
+        "parsed_output": "strip-me",
+    }
+
+    msg = SimpleNamespace(content=[raw])
+    result = SdkAnthropicClient._message_to_content(msg)
+
+    assert result[0]["type"] == "future_new_block_type"
+    assert result[0]["payload"] == "x"
+    assert "parsed_output" not in result[0]
+
+
+def test_sdk_message_to_content_preserves_citations_on_text():
+    """If the block has citations, they must survive the whitelist (they
+    are valid Anthropic API content)."""
+    citation = SimpleNamespace(type="char_location", cited_text="q")
+    citation.model_dump = lambda: {"type": "char_location", "cited_text": "q"}
+
+    block = SimpleNamespace(type="text", text="answer", citations=[citation])
+    msg = SimpleNamespace(content=[block])
+    result = SdkAnthropicClient._message_to_content(msg)
+
+    assert result[0]["text"] == "answer"
+    assert result[0]["citations"] == [{"type": "char_location", "cited_text": "q"}]


### PR DESCRIPTION
## Summary

Heartbeat triage (and any other background path that uses \`call_streaming_aggregated\`) started failing with:

\`\`\`
anthropic.BadRequestError: 400 invalid_request_error:
messages.19.content.1.text.parsed_output: Extra inputs are not permitted
\`\`\`

## Root cause

The Anthropic SDK's \`messages.stream()\` helper (the one F048 uses for aggregated streaming) attaches helper-only fields to aggregated content blocks — most visibly \`parsed_output\` on text blocks from the structured-output helper. Our \`_message_to_content\` dumped the whole block with \`model_dump()\`, so those helper fields rode back to the server as part of the assistant message on the next turn → 400.

This was latent before F048. The non-streaming \`call()\` path uses \`messages.create()\` which doesn't set \`parsed_output\`. F048 switched background paths to \`messages.stream()\` and exposed it.

## Fix

Explicit field allow-list in \`_message_to_content\` per block type:
- \`text\` → \`{type, text, citations?}\`
- \`tool_use\` → \`{type, id, name, input}\`
- \`thinking\` → \`{type, thinking, signature}\`
- \`redacted_thinking\` → \`{type, data}\`
- Unknown → \`model_dump()\` with defensive \`parsed_output\` pop

## Test plan

- [x] \`uv run pytest tests/test_api_streaming_aggregated.py\` — 18 pass (5 new)
- [x] \`test_sdk_message_to_content_strips_parsed_output_from_text\` — regression
- [x] Same for \`tool_use\`, \`thinking\`, and \`unknown_block\` (fallback path)
- [x] \`test_sdk_message_to_content_preserves_citations_on_text\` — whitelist doesn't accidentally drop legit fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)