### PR TITLE
feat(F030.1): skip MMR when CE just reordered (preserves rerank's value)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,6 +385,7 @@ DB connection vars are **unprefixed** (shared with docker-compose). All others u
 | `NOUS_PROCEDURE_SCORE_FLOOR` | `0.40` | Minimum score for procedures when embeddings enabled (F038) |
 | `NOUS_MMR_ENABLED` | `false` | Enable MMR diversity re-ranking in recall_deep |
 | `NOUS_MMR_DIVERSITY_WEIGHT` | `0.7` | MMR relevance vs diversity weight (1.0=pure relevance, 0.0=pure diversity) |
+| `NOUS_MMR_SKIP_AFTER_CE` | `true` | F030.1: skip MMR when CE rerank just reordered the head. F051 harness measured +30% MRR (0.372 -> 0.484, +190% on jargon-drift) when MMR is gated this way. Set `false` to restore pre-F030.1 chained CE-then-MMR behavior. |
 | `NOUS_CROSS_ENCODER_ENABLED` | `false` | Enable F042 cross-encoder reranking in recall_deep (requires sentence-transformers) |
 | `NOUS_CROSS_ENCODER_MODEL` | `cross-encoder/ms-marco-MiniLM-L-6-v2` | Cross-encoder model name for F042 reranking |
 | `NOUS_CROSS_ENCODER_MAX_CANDIDATES` | `30` | Max candidates to rerank (head-truncation, tail untouched) |

--- a/nous/config.py
+++ b/nous/config.py
@@ -420,6 +420,12 @@ class Settings(BaseSettings):
         default=0.7, ge=0.0, le=1.0,
         description="MMR relevance vs diversity weight (1.0=pure relevance, 0.0=pure diversity)",
     )
+    # F030.1: Skip MMR when cross-encoder rerank just reordered the head.
+    # F051 retrieval-eval harness measured +30% MRR (0.372 -> 0.484, +190% on
+    # jargon-drift) when MMR is gated off after CE fires — MMR's diversity
+    # selection over CE's reordered top-20 neutralizes CE's relevance signal.
+    # Default True; set False to restore pre-F030.1 behavior (chain CE then MMR).
+    mmr_skip_after_ce: bool = True
 
     # F042: Cross-encoder reranking
     cross_encoder_enabled: bool = False

--- a/nous/heart/heart.py
+++ b/nous/heart/heart.py
@@ -825,6 +825,11 @@ class Heart:
         # otherwise let later memory types be excluded from reranking even
         # when their scores are higher than earlier types').
         ce_enabled = RuntimeConfig.get().get_cross_encoder_enabled(self.settings)
+        # F030.1: Track whether CE actually reordered the head; the MMR gate
+        # below uses this to skip diversity re-ranking when CE has already
+        # produced a relevance-ordered head. Default False so that CE-disabled
+        # / CE-failed paths still get MMR's cold-path diversity.
+        ce_reordered = False
         if ce_enabled and len(merged) > 1 and CROSS_ENCODER_AVAILABLE:
             merged.sort(key=lambda r: r.score, reverse=True)
             try:
@@ -852,9 +857,20 @@ class Heart:
                     "Cross-encoder rerank failed, keeping RRF order: %s", exc
                 )
 
-        # F030: MMR diversity re-ranking
+        # F030: MMR diversity re-ranking.
+        # F030.1: Skip MMR when CE just reordered the head — the F051 harness
+        # measured a +30% MRR uplift (and +190% on jargon-drift) by gating
+        # MMR off in this case. MMR's diversity selection over CE's reordered
+        # top-20 otherwise neutralizes CE's relevance signal. Set
+        # NOUS_MMR_SKIP_AFTER_CE=false to restore pre-F030.1 chained behavior.
+        mmr_blocked_by_ce = ce_reordered and self.settings.mmr_skip_after_ce
+        if mmr_blocked_by_ce:
+            logger.info(
+                "MMR: skipped (F030.1 — CE reordered head, mmr_skip_after_ce=True)"
+            )
         if (
             self.settings.mmr_enabled
+            and not mmr_blocked_by_ce
             and len(merged) > 1
             and self._embeddings is not None
         ):

--- a/tests/test_f030_1_mmr_skip.py
+++ b/tests/test_f030_1_mmr_skip.py
@@ -1,0 +1,185 @@
+"""F030.1 — Skip MMR when cross-encoder rerank just reordered the head.
+
+The F051 retrieval-eval harness measured that chaining MMR after CE neutralizes
+CE's relevance gains (MMR's diversity selection re-picks the top-K from CE's
+reordered top-20 by diversity, blowing away the CE order). This test module
+verifies the gate logic in `Heart._recall`:
+
+  - CE reordered + flag on  -> MMR is NOT invoked.
+  - CE off                  -> MMR IS invoked (cold-path diversity preserved).
+  - CE reordered + flag off -> MMR IS invoked (legacy chained behavior).
+  - Default Settings has    -> mmr_skip_after_ce = True.
+
+Test pattern mirrors tests/test_mmr_integration.py: mock the four sub-searches,
+patch `cross_encoder_rerank`, `CROSS_ENCODER_AVAILABLE`, `mmr_rerank`, and
+`batch_fetch_embeddings` at the `nous.heart.heart` module path.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from nous.config import Settings
+from nous.heart.heart import Heart
+from nous.heart.schemas import FactSummary, RecallResult
+from nous.runtime_config import RuntimeConfig
+
+
+def _make_heart(
+    *,
+    mmr_enabled: bool = True,
+    mmr_skip_after_ce: bool = True,
+    cross_encoder_enabled: bool = True,
+) -> Heart:
+    """Construct a Heart with mocked DB + embeddings and overridden flags."""
+    db = MagicMock()
+    db.session = MagicMock()
+    # _env_file=None bypasses the dev .env (which carries unrelated keys).
+    settings = Settings(_env_file=None)
+    object.__setattr__(settings, "mmr_enabled", mmr_enabled)
+    object.__setattr__(settings, "mmr_skip_after_ce", mmr_skip_after_ce)
+    object.__setattr__(settings, "cross_encoder_enabled", cross_encoder_enabled)
+    embeddings = AsyncMock()
+    embeddings.embed = AsyncMock(return_value=[1.0, 0.0, 0.0])
+    return Heart(db, settings, embeddings)
+
+
+def _two_facts():
+    """Two FactSummary fixtures with distinct IDs and scores."""
+    r1 = FactSummary(
+        id=uuid4(), content="fact1", subject="s1", category="c1",
+        confidence=0.8, active=True, score=0.9,
+    )
+    r2 = FactSummary(
+        id=uuid4(), content="fact2", subject="s2", category="c2",
+        confidence=0.7, active=True, score=0.5,
+    )
+    return r1, r2
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime_config():
+    """Ensure RuntimeConfig overrides don't leak between tests."""
+    RuntimeConfig.reset()
+    yield
+    RuntimeConfig.reset()
+
+
+class TestF030_1MMRSkipAfterCE:
+    @pytest.mark.asyncio
+    async def test_mmr_skipped_when_ce_reordered(self):
+        """CE on + reorders head + skip flag on -> MMR is NOT invoked."""
+        heart = _make_heart(
+            mmr_enabled=True,
+            mmr_skip_after_ce=True,
+            cross_encoder_enabled=True,
+        )
+        session = AsyncMock()
+        r1, r2 = _two_facts()
+
+        heart.facts.search = AsyncMock(return_value=[r1, r2])
+        heart.episodes.search = AsyncMock(return_value=[])
+        heart.procedures.search = AsyncMock(return_value=[])
+        heart.censors.search = AsyncMock(return_value=[])
+
+        # Fake CE: swap order so pre_ce_head != post_ce_head -> ce_reordered=True.
+        async def fake_ce_rerank(query, candidates, text_fn, **kw):
+            reordered = list(reversed(candidates))
+            for c in reordered:
+                c.score = 0.42  # mutate to simulate sigmoid score
+            return reordered
+
+        with patch("nous.heart.heart.CROSS_ENCODER_AVAILABLE", True), \
+             patch("nous.heart.heart.cross_encoder_rerank",
+                   new=AsyncMock(side_effect=fake_ce_rerank)) as mock_ce, \
+             patch("nous.heart.heart.mmr_rerank") as mock_mmr, \
+             patch("nous.heart.heart.batch_fetch_embeddings") as mock_fetch:
+            results = await heart._recall("test query", 10, None, session)
+
+            mock_ce.assert_awaited_once()
+            mock_mmr.assert_not_called()
+            mock_fetch.assert_not_called()
+            assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_mmr_runs_when_ce_disabled(self):
+        """CE off + MMR on -> MMR IS invoked (cold-path diversity preserved)."""
+        heart = _make_heart(
+            mmr_enabled=True,
+            mmr_skip_after_ce=True,
+            cross_encoder_enabled=False,
+        )
+        session = AsyncMock()
+        r1, r2 = _two_facts()
+
+        heart.facts.search = AsyncMock(return_value=[r1, r2])
+        heart.episodes.search = AsyncMock(return_value=[])
+        heart.procedures.search = AsyncMock(return_value=[])
+        heart.censors.search = AsyncMock(return_value=[])
+
+        with patch("nous.heart.heart.CROSS_ENCODER_AVAILABLE", True), \
+             patch("nous.heart.heart.cross_encoder_rerank") as mock_ce, \
+             patch("nous.heart.heart.mmr_rerank") as mock_mmr, \
+             patch("nous.heart.heart.batch_fetch_embeddings",
+                   new=AsyncMock(return_value={
+                       r1.id: [1.0, 0.0, 0.0],
+                       r2.id: [0.0, 1.0, 0.0],
+                   })) as mock_fetch:
+            mock_mmr.return_value = [
+                RecallResult(type="fact", id=r1.id, summary="fact1", score=0.9),
+                RecallResult(type="fact", id=r2.id, summary="fact2", score=0.5),
+            ]
+            await heart._recall("test query", 10, None, session)
+
+            mock_ce.assert_not_called()
+            mock_mmr.assert_called_once()
+            mock_fetch.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_mmr_runs_when_skip_flag_off(self):
+        """CE on + reorders + skip flag OFF -> legacy chained behavior, MMR runs."""
+        heart = _make_heart(
+            mmr_enabled=True,
+            mmr_skip_after_ce=False,  # opt out of F030.1
+            cross_encoder_enabled=True,
+        )
+        session = AsyncMock()
+        r1, r2 = _two_facts()
+
+        heart.facts.search = AsyncMock(return_value=[r1, r2])
+        heart.episodes.search = AsyncMock(return_value=[])
+        heart.procedures.search = AsyncMock(return_value=[])
+        heart.censors.search = AsyncMock(return_value=[])
+
+        async def fake_ce_rerank(query, candidates, text_fn, **kw):
+            reordered = list(reversed(candidates))
+            for c in reordered:
+                c.score = 0.42
+            return reordered
+
+        with patch("nous.heart.heart.CROSS_ENCODER_AVAILABLE", True), \
+             patch("nous.heart.heart.cross_encoder_rerank",
+                   new=AsyncMock(side_effect=fake_ce_rerank)) as mock_ce, \
+             patch("nous.heart.heart.mmr_rerank") as mock_mmr, \
+             patch("nous.heart.heart.batch_fetch_embeddings",
+                   new=AsyncMock(return_value={
+                       r1.id: [1.0, 0.0, 0.0],
+                       r2.id: [0.0, 1.0, 0.0],
+                   })) as mock_fetch:
+            mock_mmr.return_value = [
+                RecallResult(type="fact", id=r2.id, summary="fact2", score=0.42),
+                RecallResult(type="fact", id=r1.id, summary="fact1", score=0.42),
+            ]
+            await heart._recall("test query", 10, None, session)
+
+            mock_ce.assert_awaited_once()
+            mock_mmr.assert_called_once()  # legacy chain preserved
+            mock_fetch.assert_awaited_once()
+
+    def test_mmr_skip_default_is_true(self):
+        """Default Settings ships with mmr_skip_after_ce=True (F051 finding)."""
+        s = Settings(_env_file=None)
+        assert s.mmr_skip_after_ce is True


### PR DESCRIPTION
## Summary

Adds `NOUS_MMR_SKIP_AFTER_CE` (default `true`). After CE rerank actually reorders the top-20 head, MMR is now skipped — the F051 retrieval-eval harness measured that chaining MMR after CE neutralizes CE's relevance gains because MMR's diversity selection over CE-reordered candidates blows away the CE order.

**F051 harness baseline (v2, 27 probes)**:
| config | MRR |
|---|---:|
| baseline (CE on, MMR on) | 0.372 |
| **ce_on_mmr_off** | **0.484 (+30%)** |
| jargon-drift category alone | **0.071 → 0.206 (+190%)** |

This unblocks operators who want to re-enable `NOUS_MMR_ENABLED=true` for the CE-disabled cold path while keeping CE's relevance signal intact when CE fires.

## Changes

- `nous/config.py` — new `mmr_skip_after_ce: bool = True` field in F030 block.
- `nous/heart/heart.py` — initialize `ce_reordered=False` before CE block; gate MMR with `mmr_blocked_by_ce = ce_reordered and self.settings.mmr_skip_after_ce`. When the gate fires, MMR is skipped and the existing fall-through `else` re-sorts by `.score` DESC (which is the CE sigmoid score on the head — preserving CE order).
- `tests/test_f030_1_mmr_skip.py` — 4 unit tests: skip-when-CE-reordered, run-when-CE-disabled, run-when-skip-flag-off, default-is-true.
- `CLAUDE.md` — `NOUS_MMR_SKIP_AFTER_CE` env-var row.

## Behavior matrix

| CE enabled | CE reordered | mmr_skip_after_ce | mmr_enabled | MMR runs? |
|---|---|---|---|---|
| true | true | true | true | NO (new — F030.1) |
| true | true | false | true | yes (legacy chain) |
| true | false | true | true | yes (CE didn't actually move anything) |
| false | n/a | n/a | true | yes (cold-path diversity preserved) |

## Pre-existing concern surfaced (not fixed in this PR)

When MMR is skipped (whether by F030.1 gate, embeddings=None, or single-result), `heart.py` falls through to `merged.sort(key=lambda r: r.score, reverse=True)`. CE only mutates head scores to sigmoid (0,1); tail items retain their RRF scores (also ~0-1). A high-RRF tail item could leapfrog a low-CE head item after re-sort. This already existed for the embeddings-None case in F042 — F030.1 just exposes it on the new code path. Worth a follow-up but out of scope here.

## Test plan

- [x] `uv run pytest tests/test_f030_1_mmr_skip.py -v` → 4 passed
- [x] `uv run pytest tests/test_retrieval_pipeline.py tests/eval/ -v` → 72 passed, no regressions
- [ ] CI: Lint + Tests