### PR TITLE
feat(F052): multi-embedding seed for graph densification backfill (Phase 1, default-off)

### DIFF
--- a/docs/features/F052-multi-embedding-backfill-seed.md
+++ b/docs/features/F052-multi-embedding-backfill-seed.md
@@ -1,0 +1,284 @@
+# F052 — Multi-Embedding Seed for Graph Densification Backfill
+
+**Status:** 📝 Proposed v2 (2026-04-26 — incorporates 3-agent spec review fixes)
+**Proposed by:** Tim
+**Date:** 2026-04-26
+**Depends on:** F040 (graph densification — shipped), F042 (CE rerank — shipped), F043 (CE in backfill — shipped), F045 (CE-aware thresholds — shipped), F050 (multi-query expansion — shipped Phase 1), F051 (eval harness — shipped)
+**Blocks:** none
+**Related:** F040 backfill orphan rate, `/dashboard/density`
+
+---
+
+## Problem
+
+`F040` graph densification backfill walks orphan facts/decisions/episodes/procedures and links each to similar nodes via hybrid search + cosine verification. The orphan is encoded **once** — single embedding from the orphan's stored content — and used to seed both candidate generation (`hybrid_search` at `nous/brain/graph_densifier.py:195`) and threshold gating (cosine verification at `:244-256`).
+
+**The miss**: orphans whose nearest semantic neighbor sits **just below** the per-relation cosine threshold (e.g., 0.81 vs the F045 fact↔fact gate at 0.82, or 0.64 vs CE-mode 0.65) never get an edge — even when a real relationship exists. A single embedding samples one point in the orphan's semantic neighborhood; the actual neighbor may be reachable from a slightly different paraphrase.
+
+Cumulative effect across cycles: orphan rate plateaus, density grows slowly, the densification dashboard shows a long tail of nodes that "should" be linked but aren't.
+
+### What this is not
+
+Not a CE precision tweak (F045 already covers that). Not a threshold relaxation (would inflate edge count without precision evidence). Not a new graph-traversal mechanism (F022 spreading activation handles that at read time). F052 is specifically about **widening candidate generation in `_backfill_same_type` at backfill time** without sacrificing precision, by reusing F050's expander to seed N alternate query embeddings per orphan.
+
+---
+
+## Goals
+
+1. **Reduce orphan rate** — measurable per-type drop in `/dashboard/density` orphan-percent after one sleep cycle, attributable solely to the new candidate-gen seed.
+2. **Preserve edge precision** — LLM-judged sample of new edges (≥30 per type) must show no statistically significant precision regression vs F040+F043+F045 baseline.
+3. **Pre-deploy validation only** — every gate decision happens on the eval corpus via the F051 harness; **no flag flip in prod until eval shows positive lift**. Explicit user requirement: *"test before deploying to live instance — there it is harder to catch things."*
+4. **Reuse, don't fork** — F050 `QueryExpander`, `hybrid_search_multi` (already RRF-fuses N variant embeddings via the `queries` parameter), F042 `ce_rerank_backfill_candidates`, F045 `_get_threshold` — all unchanged. F052 is a wedge between expander and existing densifier, not a parallel pipeline.
+5. **Default-off ship** — feature flag `NOUS_GRAPH_BACKFILL_MULTI_EMBEDDING_ENABLED=false` lands disabled. Eval harness flips it via the same `RuntimeConfig.reset()` mechanism F051 uses.
+6. **Singleton expander reuse** — F052 reuses `Heart`'s already-wired `_query_expander`; never instantiates a second `QueryExpander`. Preserves F050's `_warned_once` semantics + shared budget accounting.
+
+## Non-goals
+
+- **Phase 1 is `_backfill_same_type` ONLY.** Cross-type backfill (`_backfill_cross_type` at `graph_densifier.py:276-440`) uses common-template re-embedding + raw vector SQL + keyword-only hybrid_search — three different retrieval paths. The "cosine verification uses original `orphan_embedding`" precision invariant **does not hold** for cross-type (cross-type compares re-embedded `source_embedding` against re-embedded `target_embedding` at `:394-395`). Adding multi-embedding seed to cross-type without addressing the re-embed asymmetry would break the precision-safe invariant. **Cross-type extension deferred to F052.4** — see §Deferred.
+- **No production A/B in Phase 1** — eval harness only. If eval shows lift, *then* a separate decision opens production rollout.
+- **No change to F040's threshold logic** — variants widen candidate **generation**; cosine verification still uses the **original orphan embedding** against the existing per-relation threshold (F045 if CE backfill enabled, else F040 base).
+- **No change to F040's traversal scope** — same `NOUS_GRAPH_BACKFILL_MAX_*` per-cycle caps. F052 doesn't enlarge the orphan walk; it enriches what each walk attempt sees.
+- **No new sleep-cycle cadence** — runs inside the existing `sleep_handler.py` backfill phase, no new scheduler.
+- **No spreading-activation interaction** — F052 affects edge **creation** during backfill; F022 reads edges at recall time. Independent layers.
+- **No re-embedding of stored content** — orphan's stored embedding is untouched. We compute *additional* embeddings for paraphrases, but do not write them back to the row.
+
+## Deferred (with rationale)
+
+- **F052.1 — Production shadow mode.** Mirror F050's "compute but don't act" pattern: log what edges *would* be created with multi-embedding seed enabled, without writing them. Useful only if eval signal is ambiguous and we need prod-traffic data before flipping. Not needed for clear pos/neg eval results.
+- **F052.2 — Adaptive variant count per orphan.** Cheap orphans (already linked-adjacent, short content) use 1 variant; semantically dense or long orphans use 3. Current spec uses fixed 3.
+- **F052.3 — Variant-embedding caching.** Reuse `heart.query_expansions` cache table from F050 to avoid re-embedding identical orphan content across cycles. Likely low-value (each orphan walked at most once before becoming non-orphan).
+- **F052.4 — Cross-type backfill extension.** Apply multi-embedding seed to `_backfill_cross_type`. Requires deciding whether variants get re-encoded through `common_template_text(source_type, variant)` (changes the semantic meaning of the variant) and how the re-embedded source/target cosine gate composes with the wider candidate net. Non-trivial design — needs its own spec + eval methodology.
+
+---
+
+## Mechanism (same-type only — Phase 1)
+
+### Today (F040 + F043 + F045) — `_backfill_same_type`
+
+```
+orphan
+  ├─ orphan_embedding ◄── stored once at write time
+  ├─ orphan_content   ◄── stored at write time
+  │
+  ├─ hybrid_search(query_text=orphan_content, embedding=orphan_embedding) → candidates [up to 10]
+  ├─ if F043: ce_rerank_backfill_candidates(query=orphan_content, candidates=...) → survived [0..N]
+  └─ for each survived: cosine(orphan_embedding, candidate.embedding) > threshold → edge
+```
+
+### With F052 (multi-embedding seed) — `_backfill_same_type` only
+
+```
+orphan
+  ├─ orphan_embedding   ◄── stored once at write time
+  ├─ orphan_content     ◄── stored at write time
+  │
+  ├─ queries = await heart.expand_query_pairs(orphan_content)
+  │     # F050-gated:
+  │     # - if expansion disabled / short content / budget exhausted / expander is None / Haiku fails / embed fails:
+  │     #     returns [(orphan_content, orphan_embedding)]   ← single-pair byte-identical fallback (NEVER None)
+  │     # - else: returns [(orphan_content, orphan_embedding), (variant_1, vec_1), (variant_2, vec_2)]
+  │
+  ├─ hybrid_search_multi(queries=queries)
+  │     # Existing F050 RRF fusion across N searches.
+  │     # When len(queries)==1, search.py:319-332 delegates to single-query hybrid_search → byte-identical to today.
+  │     # When len(queries)>1, RRF-fuses ranked lists, returns deduped union.
+  │
+  ├─ if F043: ce_rerank_backfill_candidates(query=orphan_content, candidates=...) → survived [0..N]
+  │     # Unchanged. CE keys on ORIGINAL orphan_content for relevance signal — variants never reach CE.
+  │
+  └─ for each survived: cosine(orphan_embedding, candidate.embedding) > threshold → edge
+       # Unchanged. Original embedding gates precision. Variants influence candidate gen only.
+       # weight = float(sim_row.similarity) is original-embedding cosine — preserved by construction.
+```
+
+**Invariant**: when `multi_embedding_enabled=False` OR the F050 gate skips expansion (short content, budget exhausted, expander unset), `expand_query_pairs` returns `[(orphan_content, orphan_embedding)]` and `hybrid_search_multi` short-circuits at `search.py:319-332` to a single-query path *byte-identical* to today's `hybrid_search`.
+
+**Why this is precision-safe (same-type)**:
+- Candidate generation widens (more shots on goal).
+- CE rerank still keys on the original `orphan_content` — variants don't bias relevance scoring downstream.
+- Cosine verification still uses the original `orphan_embedding` — the precision gate is unchanged.
+- Net effect: same precision floor, more candidates that *can* clear it.
+
+**Why this is precision-safe-not-yet-proven (cross-type — Phase 1 excludes)**:
+- `_backfill_cross_type` re-embeds both source and target with `common_template_text` (`graph_densifier.py:300-303, 388-390`).
+- Cosine gate compares `source_embedding` (re-embedded common-template) to `target_embedding` (also re-embedded), not the orphan's stored embedding.
+- The clean precision proof above doesn't compose. Cross-type extension is F052.4.
+
+---
+
+## Eval methodology (gate before code)
+
+This section ships **before** implementation. Numbers below are the success criteria; if eval doesn't hit them, F052 doesn't merge.
+
+### Determinism guarantee
+
+Haiku is non-deterministic at default `temperature=0.4`. For density_eval re-runs to produce reproducible numbers:
+
+- `density_eval.py` overrides `Settings.query_expansion_temperature = 0.0` for the duration of the run.
+- Eval cache (`heart.query_expansions`) is **not** truncated between configs — variants for the same orphan_content are deterministic across runs after the first.
+- For paranoid noise check: harness supports `--n-runs 3` flag; report `mean ± stddev` per metric and gate on `mean - stddev` (lower-bound CI).
+
+(`temperature=0.0` requires adding `Settings.query_expansion_temperature: float = Field(default=0.4)` if not already present; F050's expander currently inherits Anthropic defaults. Plan handles this.)
+
+### Pre-condition: zero-edge state for BOTH configs
+
+Before *any* config runs, the harness asserts a clean baseline:
+
+1. `SELECT count(*) FROM brain.graph_edges WHERE agent_id = $eval_agent_id` must equal 0. If not, harness DELETEs and creates `eval_baseline_edges_snapshot` — a transient table holding the **intentionally empty** zero-edge state. The snapshot is the transactional anchor for step 6's restore on crash; an empty INSERT-from-snapshot is the correct no-op restore back to verified-clean state.
+2. Both configs (`baseline`, `f052_on`) start from this snapshot. Without this, the *first* config silently inherits any pre-existing edges and the comparison is meaningless. (Reviewer P1 caught this in v1.)
+
+### New harness mode: `nous_eval/density_eval.py` (~100 LOC)
+
+```bash
+uv run python -m nous_eval.density_eval --configs baseline,f052_on [--n-runs 1]
+```
+
+Behavior per config:
+
+1. **Restore baseline** — `DELETE FROM brain.graph_edges WHERE agent_id = $eval_agent_id` (no-op if already empty after prior config's restore).
+2. **Snapshot pre-state** — record per-relation: edge count = 0, distinct source/target IDs, per-type orphan count via `find_orphans()`. Verified-empty baseline.
+3. **Apply config** — set `RuntimeConfig` overrides (`graph_backfill_multi_embedding_enabled`, `query_expansion_temperature=0.0`, etc.) using F051's existing `RuntimeConfig.reset()` between configs.
+4. **Run densifier** — invoke `GraphDensifier.run_backfill_cycle()` directly, then **also** invoke `discover_clusters(max_bridges=20)` to mirror prod's full sleep_handler backfill phase (`nous/handlers/sleep_handler.py:886-911`). Without `discover_clusters`, eval measures backfill in isolation while prod runs both. (Reviewer P1.)
+5. **Snapshot post-state** — re-run step 2 measurements.
+6. **Transactional reset on failure** — wrap each config in `try/except`. If a config crashes mid-cycle (Haiku timeout cascade, OAT 401 burst), `INSERT INTO brain.graph_edges SELECT * FROM eval_baseline_edges_snapshot` to restore zero-edge state and log the failure as a config result, not a harness crash.
+7. **Repeat for next config**.
+8. **Output** — `reports/density-eval-<timestamp>.md`:
+
+| metric                        | baseline | f052_on | Δ      | gate-eligible |
+|-------------------------------|----------|---------|--------|---------------|
+| edges_created (total)         | 412      | 489     | +18.7% | ✅            |
+| edges_created (fact_fact)     | 218      | 261     | +19.7% | ✅            |
+| edges_created (decision_dec.) | 38       | 41      | +7.9%  | ✅ (N=15+)   |
+| edges_created (procedure_*)   | 4        | 5       | +25%   | ⚠ underpowered (N<15) |
+| orphans_remaining (fact)      | 47       | 31      | −34.0% | ✅            |
+| orphans_remaining (procedure) | 3        | 2       | −33.3% | ⚠ underpowered |
+| ce_pruned_total               | 134      | 218     | +62.7% | (info)        |
+| union_size_p95                | 10       | 22      | +120%  | (info)        |
+| haiku_calls                   | 0        | 117     | +∞     | (cost)        |
+| openai_embed_calls            | 0        | 117     | +∞     | (cost)        |
+| wall_seconds                  | 22       | 47      | +114%  | (cost)        |
+
+(Numbers above are *target shape*, not predictions.)
+
+### Edge-precision audit (semi-manual)
+
+Density lift without precision is worthless. After each eval run:
+
+1. Sample 30 newly-created edges per relation type (only types where new ≥ 30; otherwise sample all new edges of that type).
+2. Render each edge as `(source_content, target_content, relation, weight)`.
+3. LLM-judge via `nous_eval/edge_judge.py` (NEW, ~60 LOC) — single Sonnet call per batch with cached prompt template `nous_eval/templates/edge_precision_prompt.md`. Returns YES/WEAK/NO per edge.
+4. Compute precision = `YES / (YES + WEAK + NO)` per type.
+
+(Reviewer P3-2 flagged that "manual LLM-judge" was hand-waved. v2 commits to a real module.)
+
+### Gate criteria
+
+F052 ships to prod-flippable status only if **all** are true:
+
+1. **Density lift** — `(orphans_remaining_baseline − orphans_remaining_f052) / orphans_remaining_baseline ≥ 0.10` for at least one **gate-eligible** entity type, no per-type regression worse than `−0.02` on any gate-eligible type.
+   - **Gate-eligible** = baseline orphan count for that type ≥ 15. Below that, ratios are dominated by noise (procedure_* often has N=2-5 in eval corpus). Underpowered types are reported but excluded from the gate verdict.
+2. **Edge precision floor** — ≥ 0.75 LLM-judged YES rate per type. Justification: F045 baseline empirically validated 80% on fact↔fact at 0.65 threshold (decision `7d6fdce9`); F052 widens candidate gen so a 5-percentage-point precision give-back is the explicit acceptable trade-off for the density lift. If user wants zero-regression, set `NOUS_F052_GATE_PRECISION_FLOOR=0.80`.
+3. **CE truncation safety** — `union_size_p95 < cross_encoder_max_candidates - 2`. If the 95th-percentile union size hits the CE cap (default 30), eval is measuring CE truncation behavior under wider input distribution, not the multi-embedding effect. Re-run with `NOUS_CROSS_ENCODER_MAX_CANDIDATES=50` and compare. (Reviewer P2-3.)
+4. **Cost ceiling** — `haiku_calls + openai_embed_calls` per cycle stays within the orphan-cap budget (`NOUS_GRAPH_BACKFILL_MAX_FACTS + decisions + episodes + procedures = 130`). No surprise multiplication.
+5. **Wall time** — sleep cycle stays under existing tolerances (currently bounded by `NOUS_SUBTASK_DEFAULT_TIMEOUT=600s` for the sleep handler subtask).
+
+If gate misses on a single criterion: spec marks F052 abandoned with the eval-run report attached. No prod deploy.
+
+### Cost estimate (eval run, not prod)
+
+- Eval corpus has ~50-130 max orphans/cycle (varies by snapshot).
+- F050 expansion: 1 Haiku call per orphan that passes the min_words gate. Assume 80% pass → ~80 Haiku calls.
+- Embedding: `embed_batch(3 variants)` per Haiku-expanded orphan → ~80 OpenAI calls.
+- Per-run total: ~$0.04 with Haiku 4.5 + text-embedding-3-small. Bounded.
+
+---
+
+## Implementation surface (after eval gate passes)
+
+### Files to modify
+
+| File | LOC | Change |
+|---|---|---|
+| `nous/brain/graph_densifier.py` | ~30 | `_backfill_same_type` only: replace `hybrid_search(...)` call (line 195) with `queries = await heart.expand_query_pairs(orphan_content)` followed by `hybrid_search_multi(queries=queries, ...)`. Add `import` of `hybrid_search_multi` from `nous.heart.search`. Densifier needs a `Heart` reference passed at construction; today it has `_embedder` + `_settings` + `_linker`. Plan handles wiring. **`_backfill_cross_type` UNCHANGED in Phase 1.** |
+| `nous/heart/heart.py` | ~30 | Extract reusable `async def expand_query_pairs(self, query: str) -> list[tuple[str, list[float] \| None]]` from `_recall:809-835` inline block. Drop `agent_id` from signature — block uses `self.agent_id`. **Returns `[(query, None)]` (single-pair fallback) on any failure, NEVER None** — caller never has to check. Refactor `_recall` to call `self.expand_query_pairs(query)` so existing behavior is preserved (the _recall body still treats single-pair-with-None-embedding as the "skip expansion" branch). |
+| `nous/config.py` | ~5 | One new `Field`: `graph_backfill_multi_embedding_enabled: bool = Field(default=False, description="F052 master switch...")`. Use F050's `query_expansion_max_variants=3` directly — no new variant-count knob (Reviewer P2-1). |
+| `nous/config.py` | ~3 | One new `Field`: `query_expansion_temperature: float = Field(default=0.4, description="F050/F052 — Haiku temp...")`. Allows density_eval to override to 0.0. (Today F050 inherits Anthropic default — making it explicit + tunable.) |
+| `nous/heart/query_expansion.py` | ~5 | Read `settings.query_expansion_temperature` instead of inheriting default. Mechanical change. |
+| `nous_eval/retrieval.py` | ~10 | New `f052_on` `RetrievalConfig` entry for paired A/B in the existing retrieval harness (optional — does multi-embedding seed at backfill time also help recall via richer graph? Curiosity test). |
+| `nous_eval/density_eval.py` | ~100 | NEW. Snapshot/zero-edge-precondition/run/snapshot loop + transactional restore + markdown writer. |
+| `nous_eval/edge_judge.py` | ~60 | NEW. Sonnet-judge wrapper for §Edge-precision audit. |
+| `nous_eval/templates/edge_precision_prompt.md` | ~40 | NEW. Persisted prompt template with cache_control hint. |
+| `nous_eval/_build_densifier_for_eval.py` | ~30 | NEW helper — mirrors `_build_heart_for_eval` pattern. Constructs `Heart` (with QueryExpander wired) + `GraphDensifier` (with the Heart reference passed). Eliminates the wiring gap reviewer P2-1 flagged. |
+| `tests/test_f052_multi_embedding_seed.py` | ~180 | Unit + integration. **Required cases** (Reviewer P1-4): (1) single-pair short-circuit byte-identity vs today's hybrid_search; (2) multi-pair candidate-set strictly widens (or equals on full overlap); (3) original-embedding still gates cosine — assert weight = orig-embedding-cosine even when candidate came from variant; (4) expander failure returns single pair (not None) — densifier never sees None; (5) all-variants-return-same-candidates — RRF doesn't double-count; (6) empty union → return 0 cleanly; (7) union > CE cap (30) — assert candidates truncated and behavior matches CE-only path; (8) CancelledError propagates through densifier wedge (does NOT get swallowed by F050 fail-open). |
+| `docs/features/INDEX.md` | +1 row | F052 entry (added when impl ships, not now). |
+
+### Files NOT touched
+
+- `nous/heart/query_expansion.py` interface — F050's expander used as-is (only the temperature read changes).
+- `nous/heart/search.py` — `hybrid_search_multi` already does N-way RRF via `queries=`; nothing to add.
+- `nous/brain/backfill_rerank.py` — F043 CE adapter unchanged.
+- `nous/brain/_entity_config.py` — relation/threshold mapping unchanged.
+- `nous/brain/graph_densifier.py::_backfill_cross_type` — explicitly out of Phase 1 scope (deferred to F052.4).
+- `sql/migrations/` — no schema change. Variant embeddings are ephemeral.
+- `nous/handlers/sleep_handler.py` — backfill is invoked via the densifier, which transparently picks up the new path.
+
+### Total: ~250 LOC impl + ~180 LOC tests + ~230 LOC harness mode + judge = **~660 LOC**, ~2-3 day spike.
+
+---
+
+## Risks
+
+1. **Wider candidate net → more wrong edges.** Mitigated by: CE rerank unchanged (F043), cosine verification unchanged (F045 thresholds), per-cycle orphan cap unchanged. Eval gate's edge-precision audit (≥0.75) catches this empirically before any prod flip.
+2. **Eval corpus orphan distribution may not match prod.** Eval corpus is ~50-130 orphans across 4 types vs prod's variable backlog. Necessary but not sufficient — *if eval shows lift and we eventually do prod-flip, monitor `/dashboard/density` orphan-rate trend for 1-2 sleep cycles before declaring success*.
+3. **F050 cache pollution.** F050's `heart.query_expansions` cache keys on `canonical_input_hash(query)`. Orphan content fed through `expand()` populates the same cache as user queries. Mitigated by F050's existing TTL (`NOUS_QUERY_EXPANSION_CACHE_TTL_DAYS=30`) + the F050.2 sweep handler when it lands.
+4. **Haiku budget burn during sleep — shared bucket starvation.** F050 enforces `query_expansion_max_per_hour=500` *process-wide*. Backfill cycle of ≤130 orphans + concurrent interactive recall could starve one or the other. Eval (cold cache, idle DB) will never see this — prod will. Mitigation options for prod-flip phase: (a) `NOUS_QUERY_EXPANSION_MAX_PER_HOUR=1000` raise, (b) document as known cross-feature interaction in §Rollout Phase 4 monitoring, (c) F052.5 separate backfill bucket. Phase 1 picks (b); spec flags it explicitly.
+5. **CE rerank candidate-pool growth.** Today CE sees up to 10 candidates per orphan. With 3-variant union, count can grow to 30. Cap is `cross_encoder_max_candidates=30`. Density_eval emits `union_size_p95`; gate criterion 3 explicitly invalidates eval results when p95 hits 28+ and requires a re-run with raised cap. (Reviewer P2-3 operationalized.)
+6. **Async error contract** — densifier wedge **must propagate `asyncio.CancelledError`**; only fail open on `Exception`. F050's expander already does this correctly (`query_expansion.py:221-224`). The new `expand_query_pairs` helper preserves this. Test #8 enforces.
+7. **Edge cleanup on rollback** — F052 creates graph edges. If a bad rollout creates wrong edges, flipping the flag off doesn't delete them. Asymmetric "create" vs "delete" lifecycle. Low-precision edges get filtered by F022 spreading-activation density gates and F045 thresholds at read time, so impact is bounded — but worth flagging. If a serious post-flip regression emerges, manual `DELETE FROM brain.graph_edges WHERE created_at >= '<flip-timestamp>' AND <quality criteria>` may be needed.
+
+---
+
+## Rollout
+
+| Phase | Trigger | Action |
+|---|---|---|
+| **0 — Spec lock (this doc)** | This v2 doc + 3-agent re-review confirm deltas | Spec frozen, impl plan can be written |
+| **1 — Impl + harness mode** | Plan approval | Branch `feat/F052-multi-embedding-backfill`, ship code default-off + density_eval harness mode + tests + edge_judge + prompt template. PR opens with eval-pending status. |
+| **2 — Eval gate** | Branch CI green | Run `uv run python -m nous_eval.density_eval --configs baseline,f052_on --n-runs 1` on eval DB. If borderline, re-run with `--n-runs 3`. Manual edge-precision audit on 30 edges per type via `edge_judge.py`. Attach report to PR. |
+| **3a — Pass** | Eval meets all 5 gate criteria | Merge PR with prod flag still off. Open follow-up issue for prod-flip decision (separate from merge). |
+| **3b — Fail** | Eval misses any gate | Mark F052 status `❌ Abandoned (eval-fail-yyyy-mm-dd)` with the report linked. PR closes without merge. Spec stays as decision record. |
+| **4 — Prod flip (separate decision)** | 3a only | Set `NOUS_GRAPH_BACKFILL_MULTI_EMBEDDING_ENABLED=true` in prod `.env`, restart. **Hard gate**: monitor `/dashboard/density` for 2 sleep cycles AND `query_expansions_per_hour` metric for budget contention. Roll back via env-var flip if either trends wrong. |
+
+---
+
+## Open questions
+
+1. **density_eval harness mode — separate CLI entry or sub-mode of existing `retrieval` CLI?** Cleaner as separate (different metric set, different output format). Lean separate. *Plan answers.*
+2. **Should `discover_clusters(max_bridges=20)` parameters in eval mirror prod exactly, or use a smaller `max_bridges` to keep eval fast?** Plan answers.
+3. **Future cross-type extension (F052.4)** — should it apply variants pre-template (variant text → common-template wrap → embed) or post-template (orphan_content → common-template wrap → variant embeddings of the templated text)? Affects what semantic neighborhood is sampled. Out of Phase 1 scope; documented for future spec author.
+
+These are answered in the impl plan, not here.
+
+---
+
+## Spec review history
+
+- **v1 (2026-04-26 morning):** Initial draft.
+- **v1 → v2 (this doc) review fixes (3-agent: arch / devil / python-pro):**
+  - **P1-fix:** Phase 1 scoped to `_backfill_same_type` only — cross-type cosine invariant doesn't compose under multi-embedding seed; deferred to F052.4 (devil P1-1, P1-2; arch P1-2).
+  - **P1-fix:** `hybrid_search_multi` parameter renamed throughout: `variant_pairs=` → `queries=` (arch P1-1).
+  - **P1-fix:** `expand_query_pairs(self, query)` returns single-pair `[(query, None)]` on failure, NEVER `None` — eliminates 4-site fallback duplication (devil P1-4).
+  - **P1-fix:** Helper signature drops `agent_id` parameter (uses `self.agent_id` like the source block at `heart.py:813-835`) (python-pro P1-1).
+  - **P1-fix:** Determinism — `query_expansion_temperature: float` field added; density_eval forces `0.0` for reproducibility (devil P1-3).
+  - **P1-fix:** Eval pre-condition — zero-edge state asserted before BOTH configs run, not just within the loop (devil P1-5 + arch P2-2 elevated).
+  - **P1-fix:** Eval invokes `discover_clusters` to mirror prod's full sleep_handler backfill phase (devil P1-5 second part).
+  - **P1-fix:** Test plan bumped from ~120 LOC / 4 cases to ~180 LOC / 8 cases including CE truncation, cosine-gate invariant, RRF double-count, empty union, CancelledError propagation (python-pro P1-4).
+  - **P1-fix:** Singleton expander reuse note added to §Goals #6 (python-pro P1-2).
+  - **P2-fix:** Per-type N-floor (≥15) for gate eligibility — procedure_* often has N<15 in eval corpus (devil P2-2).
+  - **P2-fix:** CE truncation gate criterion (#3) — invalidates eval if `union_size_p95 ≥ cross_encoder_max_candidates - 2` (devil P2-3).
+  - **P2-fix:** Transactional reset — try/except + restore from snapshot table on config-crash (devil P2-4).
+  - **P2-fix:** Shared budget bucket starvation flagged in §Risks #4 with prod-flip mitigation options (devil P2-1).
+  - **P2-fix:** `_build_densifier_for_eval` helper added to impl surface (arch P2-1).
+  - **P2-fix:** CancelledError propagation explicit in §Risks #6 + test #8 (python-pro P2-2).
+  - **P2-fix:** Drop TBD "default-bind to query_expansion_max_variants" — just default to F050's value at call site (python-pro P2-1).
+  - **P2-fix:** `edge_judge.py` + persisted prompt template — no more hand-wave (devil P3-2 elevated).

--- a/docs/superpowers/plans/2026-04-26-f052-multi-embedding-backfill.md
+++ b/docs/superpowers/plans/2026-04-26-f052-multi-embedding-backfill.md
@@ -1,0 +1,780 @@
+# F052 Implementation Plan v1 — Multi-Embedding Seed for `_backfill_same_type`
+
+**Spec:** `docs/features/F052-multi-embedding-backfill-seed.md` (v2 — approved by 3-agent review)
+**Branch:** `feat/F052-multi-embedding-backfill`
+**Total LOC:** ~660 (250 impl + 180 tests + 230 harness/judge)
+**Estimated effort:** 2-3 day spike, parallel-implementable across 3 subagents
+
+---
+
+## Pre-emptive corrections to spec text
+
+These spec wording details are corrected here so impl agents don't reproduce them:
+
+| # | Spec says | Reality | Action |
+|---|---|---|---|
+| C1 | `Heart.expand_query_pairs(query, agent_id)` referenced once in §Eval-determinism | Spec §Implementation surface row 2 already drops `agent_id` per python-pro P1-1 fix. Method is `expand_query_pairs(self, query: str)`. | Plan uses correct signature throughout. |
+| C2 | "F050 expansion temperature default 0.4" | Reading `query_expansion.py:280-292` — Anthropic SDK default actually applies (Haiku stock = 1.0, NOT 0.4 as v1 plan claimed). F050 doesn't currently set `temperature` at all. | Plan adds the field as `Field(default=1.0)` to match Anthropic's actual stock value (preserves current implicit behavior). density_eval still overrides to 0.0 for re-run determinism. |
+| C3 | `nous_eval/_build_densifier_for_eval.py` — NEW file | Existing F051 module pattern uses helper functions inside `nous_eval/retrieval_runner.py`, not standalone files. Helper belongs adjacent to `_build_heart_for_eval`. | Plan adds `_build_densifier_for_eval` to `retrieval_runner.py`, not a new file. (Reduces file count, keeps the wiring-helpers cohesive.) |
+| C4 | "GraphDensifier needs Heart reference at construction" | Verified via grep: GraphDensifier is constructed at `nous/main.py:300` and 14 test sites in `tests/test_graph_densifier.py`. Adding `heart: Heart | None = None` as 6th arg with default None keeps all existing constructions backward-compatible. | Plan uses `heart: Heart | None = None` keyword arg. Test sites unchanged unless they exercise F052. |
+| C5 | Spec §Implementation surface row 4 says `query_expansion.py` change is "5 LOC" | Realistic LOC: ~3 lines (one `temperature` parameter to `messages.create`, value sourced from settings). | Cosmetic — note in plan. |
+
+---
+
+## File ownership map (parallel-safe partition)
+
+Three subagents work on disjoint file sets. Sequence: A starts first; B + C dispatch in parallel after A's heart.py change is in.
+
+### Subagent A: heart-config (sequential, ~80 LOC)
+Owns:
+- `nous/config.py` — 2 new `Field` declarations
+- `nous/heart/query_expansion.py` — read `settings.query_expansion_temperature`, thread to `messages.create`
+- `nous/heart/heart.py` — extract `expand_query_pairs` from `_recall:809-835`, refactor `_recall` to call it
+
+**Why sequential first**: Subagent B (densifier) imports `Heart.expand_query_pairs` and Subagent C (tests) asserts on it. Method must exist before B/C can write final code.
+
+### Subagent B: densifier-wedge (parallel after A, ~70 LOC + main.py wiring)
+Owns:
+- `nous/brain/graph_densifier.py` — `_backfill_same_type` wedge + new `_heart` member + constructor signature change
+- `nous/main.py:300` — pass `heart=heart` to GraphDensifier construction
+- (no other handlers touched — `_backfill_cross_type` explicitly Phase 1 OUT)
+
+### Subagent C: harness + tests (parallel after A, ~510 LOC)
+Owns:
+- `nous_eval/density_eval.py` (NEW, ~110 LOC)
+- `nous_eval/edge_judge.py` (NEW, ~70 LOC)
+- `nous_eval/templates/edge_precision_prompt.md` (NEW, ~40 LOC)
+- `nous_eval/retrieval_runner.py` — add `_build_densifier_for_eval(...)` helper (~30 LOC)
+- `nous_eval/retrieval.py` — add `f052_on` `RetrievalConfig` (~10 LOC)
+- `tests/test_f052_multi_embedding_seed.py` (NEW, ~180 LOC, 8 cases per spec §Test plan)
+
+---
+
+## Subagent A — detailed task list
+
+### A.1: `nous/config.py`
+
+Insert AFTER existing `query_expansion_cache_ttl_days` field (currently the last F050 field at ~line 565):
+
+```python
+# F050/F052 — Haiku temperature for query expansion. Default 1.0 matches
+# Anthropic's stock value (preserves F050's implicit behavior — F050 didn't
+# set temperature, so Haiku used its default). density_eval overrides to
+# 0.0 for re-run determinism.
+query_expansion_temperature: float = Field(
+    default=1.0,
+    description="F050/F052 — Haiku temperature for query expansion. "
+                "Default 1.0 matches Anthropic stock; F052 density_eval "
+                "overrides to 0.0 for re-run determinism.",
+)
+
+# F052 — Multi-embedding seed for _backfill_same_type. Default-off ship.
+# When enabled, the densifier expands each orphan's content into N=K_50
+# variants via Heart.expand_query_pairs and routes through hybrid_search_multi.
+graph_backfill_multi_embedding_enabled: bool = Field(
+    default=False,
+    description="F052 master switch — multi-embedding seed for graph "
+                "densification backfill (_backfill_same_type only in Phase 1).",
+)
+```
+
+**Style match**: F050's existing fields use `Field(default=..., description=...)` (config.py:538-565). New fields follow that exact pattern. **Do NOT use `validation_alias`** — env_prefix="NOUS_" handles env mapping (decision 0f425a05).
+
+### A.2: `nous/heart/query_expansion.py`
+
+Find `_call_haiku` method (currently `:280-292`). Locate the `messages.create` call that lacks `temperature=`. Add:
+
+```python
+"temperature": self._settings.query_expansion_temperature,
+```
+
+(Pass via the `**kwargs` dict the call uses, or as direct kwarg — match existing call style.)
+
+**Verification**: after change, the value flows from `Settings.query_expansion_temperature` → `QueryExpander._call_haiku` → Anthropic API. Test C.5 asserts.
+
+### A.3: `nous/heart/heart.py`
+
+Extract `expand_query_pairs` as a public method on `Heart`. Current inline block at `:809-835`:
+
+```python
+# F050: Optionally expand the query into variants via Haiku, then embed
+# them in a single batch call. variant_pairs stays None on any failure
+# so sub-managers fall back to the existing single-query path
+# (byte-identical when variant_pairs is None — see plan v2 §invariant).
+variant_pairs: list[tuple[str, list[float] | None]] | None = None
+if (
+    self.settings.query_expansion_enabled
+    and self._query_expander is not None
+    and self._embeddings is not None
+):
+    try:
+        variants = await self._query_expander.expand(query, self.agent_id)
+    except Exception as exc:
+        logger.warning("F050: query_expander.expand raised, using [query]: %s", exc)
+        variants = [query]
+
+    if len(variants) > 1:
+        try:
+            embeddings = await self._embeddings.embed_batch(variants)
+            variant_pairs = list(zip(variants, embeddings))
+        except Exception as exc:
+            logger.warning(...)
+            variant_pairs = None
+```
+
+**Refactor in two steps:**
+
+**Step A.3a — Add the new method** (after `_recall`, near other private helpers):
+
+```python
+async def expand_query_pairs(
+    self, query: str
+) -> list[tuple[str, list[float] | None]]:
+    """F050+F052 — expand a query into (text, embedding) pairs for
+    hybrid_search_multi.
+
+    **Contract: NEVER raises, NEVER returns None or [].**
+
+    On any failure path (expansion disabled, no expander, no embeddings,
+    Haiku raises, embed_batch raises, gate trips), returns
+    ``[(query, None)]`` — a single pair with no precomputed embedding.
+    Callers route this through ``hybrid_search_multi(queries=...)``,
+    which short-circuits at search.py:319-332 to byte-identical behavior
+    vs single-query ``hybrid_search``.
+
+    F052 callers (graph_densifier._backfill_same_type) MUST NOT
+    catch ``asyncio.CancelledError`` from this call — task cancellation
+    must propagate. The implementation only catches ``Exception``,
+    which excludes ``CancelledError`` in Python 3.8+.
+
+    Edge case: if cancelled mid-``embed_batch`` after Haiku already
+    succeeded, the Haiku tokens are spent but the helper raises
+    ``CancelledError`` upward — accepted cost per spec §Risks #6.
+    """
+    if not (
+        self.settings.query_expansion_enabled
+        and self._query_expander is not None
+        and self._embeddings is not None
+    ):
+        return [(query, None)]
+
+    try:
+        variants = await self._query_expander.expand(query, self.agent_id)
+    except Exception as exc:
+        logger.warning(
+            "F050/F052: query_expander.expand raised for %s, falling back to [query]: %s",
+            self.agent_id, exc,
+        )
+        return [(query, None)]
+
+    if len(variants) <= 1:
+        return [(query, None)]
+
+    try:
+        embeddings = await self._embeddings.embed_batch(variants)
+    except Exception as exc:
+        logger.warning(
+            "F050/F052: embed_batch failed for %d variants (%s), falling back to [query]: %s",
+            len(variants), self.agent_id, exc,
+        )
+        return [(query, None)]
+
+    return list(zip(variants, embeddings))
+```
+
+**Step A.3b — Refactor `_recall` to call the new method.** Replace `:809-835` block with:
+
+```python
+# F050: Expand query via Haiku + embed variants. Helper guarantees a
+# non-empty list with single-pair fallback on any failure (NEVER None).
+pairs = await self.expand_query_pairs(query)
+# Translate single-pair-with-None-embedding back to "no expansion"
+# so sub-managers route through their existing hybrid_search fast path.
+variant_pairs: list[tuple[str, list[float] | None]] | None = (
+    pairs if len(pairs) > 1 else None
+)
+```
+
+**Behavior preservation check**: when expansion disabled, helper returns `[(query, None)]`, len=1 → variant_pairs becomes `None` → sub-managers skip the multi path. Byte-identical to today.
+
+When expansion succeeds with N variants, helper returns N pairs, len>1 → variant_pairs = pairs → sub-managers route to hybrid_search_multi. Byte-identical to today.
+
+---
+
+## Subagent B — detailed task list
+
+### B.1: `nous/brain/graph_densifier.py` constructor
+
+Modify `GraphDensifier.__init__` (currently `:103-115`):
+
+```python
+# BEFORE
+def __init__(
+    self,
+    db: Database,
+    graph_linker: GraphLinker,
+    embedder: EmbeddingProvider | None,
+    settings: Settings,
+    agent_id: str,
+) -> None:
+    ...
+    self._db = db
+    self._linker = graph_linker
+    self._embedder = embedder
+    self._settings = settings
+    self._agent_id = agent_id
+    ...
+```
+
+```python
+# AFTER
+def __init__(
+    self,
+    db: Database,
+    graph_linker: GraphLinker,
+    embedder: EmbeddingProvider | None,
+    settings: Settings,
+    agent_id: str,
+    heart: "Heart | None" = None,  # F052 — for expand_query_pairs in same-type backfill
+) -> None:
+    ...
+    self._db = db
+    self._linker = graph_linker
+    self._embedder = embedder
+    self._settings = settings
+    self._agent_id = agent_id
+    self._heart = heart  # F052
+    ...
+```
+
+Add forward-only TYPE_CHECKING import at top:
+
+```python
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from nous.heart.heart import Heart
+```
+
+(Avoid circular import — heart imports brain.embeddings; densifier importing heart would cycle. TYPE_CHECKING-only guards it.)
+
+### B.2: `nous/brain/graph_densifier.py` import addition
+
+Add at top with existing import block:
+
+```python
+from nous.heart.search import hybrid_search, hybrid_search_multi  # F052
+```
+
+### B.3: `nous/brain/graph_densifier.py::_backfill_same_type` wedge
+
+Locate `_backfill_same_type` at `:163-274`. Replace the `hybrid_search(...)` call at `:195-206`:
+
+```python
+# BEFORE
+candidates = await hybrid_search(
+    session=session,
+    table=table,
+    embedding=orphan_embedding,
+    query_text=orphan_content[:500] if orphan_content else "",
+    agent_id=self._agent_id,
+    extra_where=f"AND t.id != :orphan_id",
+    extra_params={"orphan_id": orphan_id},
+    limit=10,
+    vector_weight=0.6,
+    active_filter=has_active,
+)
+```
+
+```python
+# AFTER
+# F052: When enabled + Heart wired, expand orphan content into N (text, embedding)
+# variants and route through hybrid_search_multi. Single-pair fallback (from helper
+# OR when feature disabled) short-circuits at search.py:319-332 to byte-identical
+# single-query hybrid_search behavior.
+if (
+    self._settings.graph_backfill_multi_embedding_enabled
+    and self._heart is not None
+    and orphan_content
+):
+    queries_pairs = await self._heart.expand_query_pairs(orphan_content[:500])
+    # Helper returns [(content, None)] when expansion is unavailable —
+    # in that case substitute the orphan's stored embedding so the
+    # short-circuit path uses it (matches today's hybrid_search call).
+    # Note: orphan_embedding may itself be None if the row had no embedding
+    # at write time (graph_densifier.py:186-190). That's fine — the
+    # short-circuit then routes to hybrid_search(embedding=None, ...)
+    # which is the existing keyword-only fallback path; weight assignment
+    # at :259-260 already handles the None-embedding branch via RRF score.
+    if len(queries_pairs) == 1 and queries_pairs[0][1] is None:
+        queries_pairs = [(orphan_content[:500], orphan_embedding)]
+else:
+    queries_pairs = [(orphan_content[:500] if orphan_content else "", orphan_embedding)]
+
+candidates = await hybrid_search_multi(
+    session=session,
+    table=table,
+    queries=queries_pairs,
+    agent_id=self._agent_id,
+    extra_where=f"AND t.id != :orphan_id",
+    extra_params={"orphan_id": orphan_id},
+    limit=10,
+    vector_weight=0.6,
+    active_filter=has_active,
+)
+```
+
+**Invariants preserved** (from spec §Mechanism):
+- CE rerank at `:212-232` unchanged — still keys on `orphan_content`.
+- Cosine verification at `:244-256` unchanged — still uses `orphan_embedding`. Variants influence candidate-gen only.
+- `weight = float(sim_row.similarity)` at `:257` is original-embedding cosine — preserved.
+- When `multi_embedding_enabled=False`, queries_pairs has len 1 with the original embedding → search.py:319-332 fast-path → byte-identical.
+- `_backfill_cross_type` at `:276+` UNTOUCHED.
+
+### B.4: `nous/main.py` wiring
+
+At `:300` — pass `heart` to GraphDensifier construction:
+
+```python
+# BEFORE
+graph_densifier = GraphDensifier(
+    db=database, graph_linker=graph_linker,
+    embedder=embedding_provider, settings=settings,
+    agent_id=settings.agent_id,
+)
+```
+
+```python
+# AFTER
+graph_densifier = GraphDensifier(
+    db=database, graph_linker=graph_linker,
+    embedder=embedding_provider, settings=settings,
+    agent_id=settings.agent_id,
+    heart=heart,  # F052 — enables expand_query_pairs in _backfill_same_type
+)
+```
+
+`heart` is already in scope at `main.py:300` (constructed earlier in the same function).
+
+---
+
+## Subagent C — detailed task list
+
+### C.1: `nous_eval/retrieval_runner.py` — `_build_densifier_for_eval`
+
+Add helper near existing `_build_heart_for_eval` (search the file for that name):
+
+```python
+async def _build_densifier_for_eval(
+    settings: Settings,
+    db: Database,
+    agent_id: str,
+    heart: Heart,
+) -> "GraphDensifier":
+    """F052 eval helper — construct GraphDensifier with Heart reference wired.
+
+    Mirrors the wiring path at nous/main.py:300 so density_eval invokes the
+    same densifier the production sleep handler does.
+    """
+    from nous.brain.graph_densifier import GraphDensifier
+    from nous.brain.graph_linker import GraphLinker
+    from nous.brain.embeddings import EmbeddingProvider
+
+    embedder = EmbeddingProvider(settings) if settings.openai_api_key else None
+    linker = GraphLinker(db=db, embedder=embedder, settings=settings, agent_id=agent_id)
+    return GraphDensifier(
+        db=db,
+        graph_linker=linker,
+        embedder=embedder,
+        settings=settings,
+        agent_id=agent_id,
+        heart=heart,  # F052
+    )
+```
+
+### C.2: `nous_eval/retrieval.py` — new RetrievalConfig
+
+Add to `_DEFAULT_CONFIGS` dict (next to the other f050_* entries):
+
+```python
+"f052_on": RetrievalConfig(
+    name="f052_on",
+    flags={
+        "graph_backfill_multi_embedding_enabled": True,
+        "query_expansion_enabled": True,  # F052 depends on F050 expander
+        "query_expansion_temperature": 0.0,  # density determinism — see C.3
+    },
+    description=(
+        "F052 multi-embedding seed for _backfill_same_type. "
+        "Eval-only retrieval-side measurement; density-side is in density_eval."
+    ),
+),
+```
+
+### C.3: `nous_eval/density_eval.py` (NEW)
+
+Skeleton (~110 LOC):
+
+```python
+"""F052 density-eval harness mode.
+
+Measures graph_edges + orphan-rate deltas across baseline vs f052_on configs
+on the F051 eval DB, using a snapshot-reset-run-snapshot loop with
+transactional restore on per-config failure.
+
+Determinism: forces query_expansion_temperature=0.0 for the duration of the run.
+Reproducibility: heart.query_expansions cache is preserved across runs.
+
+Per-config behavior:
+  1. Restore baseline (DELETE graph_edges WHERE agent_id = $eval_agent_id)
+  2. Snapshot pre-state (orphan counts per type)
+  3. Apply RuntimeConfig overrides
+  4. Run GraphDensifier.run_backfill_cycle() + discover_clusters(max_bridges=20)
+  5. Snapshot post-state
+  6. On exception: restore from eval_baseline_edges_snapshot, log config FAIL
+  7. Cleanup: pop RuntimeConfig overrides
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+from nous_eval.config import EvalSettings
+from nous_eval.retrieval import _DEFAULT_CONFIGS, RetrievalConfig
+from nous_eval.retrieval_runner import (
+    RuntimeConfig,
+    _apply_config_flags,        # F051 Settings-overlay helper
+    _settings_for_eval_db,      # redirect Settings DB connection to the eval DB
+    _build_heart_for_eval,
+    _build_densifier_for_eval,  # NEW in this PR — see C.1
+)
+from nous.config import Settings
+from nous.storage.database import Database
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DensitySnapshot:
+    edge_count_total: int
+    edge_count_per_relation: dict[str, int]
+    orphan_count_per_type: dict[str, int]
+
+
+@dataclass
+class DensityRunResult:
+    config_name: str
+    pre: DensitySnapshot
+    post: DensitySnapshot | None
+    edges_created: int
+    ce_pruned: int
+    union_size_p95: float | None
+    haiku_calls: int
+    openai_embed_calls: int
+    wall_seconds: float
+    failure: str | None = None  # set on exception
+
+
+async def _ensure_zero_edge_baseline(db: Database, agent_id: str) -> None:
+    """Pre-condition: zero edges for agent_id; create persistent snapshot for restore.
+
+    NOTE: Uses a real (non-TEMP) table named ``brain.eval_baseline_edges_snapshot``
+    so the snapshot survives across the multiple connection-pool sessions that
+    a per-config run uses (TEMP tables are session-scoped in Postgres and would
+    silently disappear when SQLAlchemy returns a different pooled connection
+    on the next session). Table is created idempotently; TRUNCATE on each run.
+
+    The snapshot is intentionally empty — it anchors a restore-to-zero-edges
+    operation if a config crashes mid-cycle, so the next config starts clean.
+    """
+    async with db.session() as session:
+        await session.execute(text(
+            "DELETE FROM brain.graph_edges WHERE agent_id = :aid"
+        ), {"aid": agent_id})
+        await session.execute(text(
+            "CREATE TABLE IF NOT EXISTS brain.eval_baseline_edges_snapshot "
+            "(LIKE brain.graph_edges INCLUDING ALL)"
+        ))
+        await session.execute(text(
+            "TRUNCATE brain.eval_baseline_edges_snapshot"
+        ))  # intentionally empty — anchor for restore-on-crash
+        await session.commit()
+
+
+async def _snapshot(db: Database, agent_id: str) -> DensitySnapshot:
+    # SELECT count(*) FROM brain.graph_edges WHERE agent_id = ... GROUP BY relation
+    # SELECT type, count(*) FROM (... orphan finder ...) GROUP BY type
+    ...
+
+
+async def _restore_baseline(db: Database, agent_id: str) -> None:
+    async with db.session() as session:
+        await session.execute(text(
+            "DELETE FROM brain.graph_edges WHERE agent_id = :aid"
+        ), {"aid": agent_id})
+        # Empty snapshot → no-op INSERT, restoring zero-edge state.
+        await session.execute(text(
+            "INSERT INTO brain.graph_edges SELECT * FROM brain.eval_baseline_edges_snapshot"
+        ))
+        await session.commit()
+
+
+async def _run_one_config(
+    config: RetrievalConfig,
+    main_settings_template: Settings,
+    eval_settings: EvalSettings,
+    db: Database,
+) -> DensityRunResult:
+    # Pattern mirrors nous_eval/retrieval_runner.run_matrix:160-220 EXACTLY:
+    # 1. RuntimeConfig.reset()  ← clear any leakage from a prior config
+    # 2. overridden = _apply_config_flags(main_settings_template, config)  ← Settings overlay
+    # 3. eval_scoped = _settings_for_eval_db(eval_settings, overridden)  ← redirect to eval DB
+    # 4. _ensure_zero_edge_baseline(db, agent_id)
+    # 5. snapshot pre
+    # 6. async with _build_heart_for_eval(db, eval_scoped) as heart:
+    #        densifier = await _build_densifier_for_eval(eval_scoped, db, agent_id, heart)
+    #        try:
+    #            result = await densifier.run_backfill_cycle()
+    #            _ = await densifier.discover_clusters(max_bridges=20)
+    #        except Exception as exc:
+    #            await _restore_baseline(db, agent_id)
+    #            return DensityRunResult(..., failure=str(exc))
+    # 7. snapshot post
+    # NOTE: RuntimeConfig.reset() at top of NEXT config call clears state — same as F051.
+    ...
+
+
+async def run_density_eval(
+    config_names: list[str],
+    settings: EvalSettings,
+    n_runs: int = 1,
+) -> list[DensityRunResult]:
+    db = Database(settings.eval_db_url)
+    await db.connect()
+    try:
+        results = []
+        for run_idx in range(n_runs):
+            for name in config_names:
+                config = _DEFAULT_CONFIGS[name]
+                results.append(await _run_one_config(config, settings, db))
+        return results
+    finally:
+        await db.close()
+
+
+def _write_report(results: list[DensityRunResult], path: Path) -> None:
+    # markdown table per spec §Eval methodology output
+    ...
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(prog="python -m nous_eval.density_eval")
+    p.add_argument("--configs", default="baseline,f052_on")
+    p.add_argument("--n-runs", type=int, default=1)
+    args = p.parse_args(argv)
+
+    config_names = args.configs.split(",")
+    settings = EvalSettings()
+    results = asyncio.run(run_density_eval(config_names, settings, args.n_runs))
+
+    out = Path(settings.eval_report_dir) / f"density-eval-{datetime.now(tz=UTC):%Y%m%d-%H%M%S}.md"
+    _write_report(results, out)
+    logger.info("density_eval report written: %s", out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+### C.4: `nous_eval/edge_judge.py` (NEW, ~70 LOC)
+
+Sonnet-judge wrapper:
+
+```python
+"""F052 — LLM-judge for edge precision in density_eval reports.
+
+Loads prompt from nous_eval/templates/edge_precision_prompt.md, batches
+edges, calls Sonnet via existing AnthropicClient (OAT-supporting per
+F050 lessons — see decision ecf364d7 lessons), returns YES/WEAK/NO per edge.
+"""
+
+from __future__ import annotations
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from nous.api.anthropic_client import create_client
+from nous.config import Settings
+
+
+@dataclass
+class EdgeJudgment:
+    source_id: str
+    target_id: str
+    relation: str
+    verdict: str  # "YES" | "WEAK" | "NO"
+    reasoning: str
+
+
+async def judge_edges(
+    edges: list[dict],  # [{source_content, target_content, relation, weight}, ...]
+    settings: Settings,
+    model: str = "claude-sonnet-4-6",
+) -> list[EdgeJudgment]:
+    client = create_client(settings)
+    await client.start()
+    try:
+        prompt_template = (
+            Path(__file__).parent / "templates" / "edge_precision_prompt.md"
+        ).read_text(encoding="utf-8")
+        # Batch ≤30 edges per Sonnet call
+        ...
+        # Parse JSON-array response
+        ...
+    finally:
+        await client.close()
+```
+
+### C.5: `nous_eval/templates/edge_precision_prompt.md` (NEW, ~40 LOC)
+
+Cached prompt template. Operator-editable. Schema:
+
+```
+You are evaluating graph edges for semantic correctness.
+For each edge, decide: YES / WEAK / NO.
+
+YES = the source and target are semantically related per the relation type.
+WEAK = a tenuous or indirect link; would not be the first thing a reasoner reaches for.
+NO = unrelated or wrong-direction.
+
+Edges to evaluate (JSON array follows). Return JSON array of {source_id, target_id, verdict, reasoning} in same order.
+```
+
+### C.6: `tests/test_f052_multi_embedding_seed.py` (NEW, ~180 LOC, 8 cases)
+
+Per spec §Test plan exactly:
+
+```python
+"""F052 tests — multi-embedding seed for _backfill_same_type.
+
+8 mandatory cases per spec §Implementation surface row "tests".
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+# ... imports ...
+
+
+# 1. Single-pair short-circuit byte-identity
+async def test_disabled_path_byte_identical_to_hybrid_search(...):
+    """When graph_backfill_multi_embedding_enabled=False, the wedge calls
+    hybrid_search_multi(queries=[(orphan_content, orphan_embedding)]).
+    The len==1 short-circuit at search.py:319-332 delegates to hybrid_search
+    with byte-identical args. Test asserts:
+      - hybrid_search_multi is called once with queries len==1
+      - The candidate list returned matches a direct hybrid_search call with
+        the same orphan_embedding/orphan_content (control comparison)."""
+    ...
+
+# 2. Multi-pair candidate-set strictly widens (or equals on full overlap)
+async def test_multi_pair_widens_candidate_set(...):
+    """With 3 distinct variant embeddings, union of candidates ≥ single-query result."""
+    ...
+
+# 3. Original-embedding still gates cosine
+async def test_cosine_uses_original_orphan_embedding(...):
+    """Even when candidate came from variant_2 search, the cosine check at
+    graph_densifier.py:244-256 uses orphan_embedding, not variant embedding.
+    Verify weight matches original-embedding cosine."""
+    ...
+
+# 4. Expander failure → helper single-pair fallback (helper itself NEVER raises)
+async def test_expander_failure_helper_returns_single_pair(...):
+    """Mock query_expander.expand (the INTERNAL Haiku call) to raise.
+    Assert: Heart.expand_query_pairs returns [(query, None)] without raising
+    (helper's contract). Then assert the densifier wedge sees this single-pair
+    fallback and routes through the byte-identical short-circuit path —
+    NEVER sees None, never has to check for it."""
+    ...
+
+# 5. All-variants-return-same-candidates: RRF doesn't double-count
+async def test_rrf_no_double_count_on_identical_lists(...):
+    """3 variants returning identical candidate lists → final ranks are
+    correct (not inflated). Asserts via _rrf_merge_n contract."""
+    ...
+
+# 6. Empty union → return 0 cleanly
+async def test_empty_union_returns_zero_edges(...):
+    """All 3 variant searches return [] → candidates falsy →
+    _backfill_same_type returns 0 without raising."""
+    ...
+
+# 7. CE truncation at 30-cap
+async def test_union_above_ce_cap_truncated(...):
+    """3 variants × 10 candidates = 30 unique → CE sees exactly 30 (cap).
+    Verify behavior is well-defined (not a silent failure)."""
+    ...
+
+# 8. CancelledError propagates through wedge
+async def test_cancelled_error_propagates_not_swallowed(...):
+    """Mock query_expander.expand to raise asyncio.CancelledError.
+    Helper's `except Exception` MUST NOT catch it (CancelledError is
+    BaseException in 3.8+). Densifier wedge must let it propagate."""
+    ...
+```
+
+---
+
+## Migration plan: NONE
+
+Verified: `heart.query_expansions` exists from F050 migration 038. F052 adds no schema. No new migration file needed.
+
+---
+
+## Test commands (post-impl)
+
+```bash
+# Subagent A scope
+uv run pytest tests/test_f052_multi_embedding_seed.py::test_expander_failure -v
+uv run python -c "from nous.config import Settings; s = Settings(); print(s.query_expansion_temperature, s.graph_backfill_multi_embedding_enabled)"
+
+# Subagent B scope
+uv run pytest tests/test_graph_densifier.py -v  # NO regressions on existing 14 tests
+uv run pytest tests/test_f052_multi_embedding_seed.py -v  # All 8 new cases pass
+
+# Subagent C scope (smoke — no real Haiku calls; uses scratch DB)
+NOUS_GRAPH_BACKFILL_MULTI_EMBEDDING_ENABLED=true \
+NOUS_QUERY_EXPANSION_ENABLED=true \
+NOUS_QUERY_EXPANSION_TEMPERATURE=0.0 \
+uv run python -m nous_eval.density_eval --configs baseline,f052_on --n-runs 1
+```
+
+---
+
+## Definition of done (all must hold before PR)
+
+1. All 8 new tests pass.
+2. All 15 existing `test_graph_densifier.py` tests pass (no regression).
+3. `uv run pytest tests/test_f050_*.py -v` passes (F050 callers unaffected by helper extraction).
+4. `density_eval --configs baseline,f052_on` runs to completion on the F051 eval DB without crashing.
+5. The eval report is human-readable and shows the gate-eligibility column correctly.
+6. `edge_judge.py` produces YES/WEAK/NO output on a 30-edge sample (smoke test).
+7. `git diff main...HEAD --stat` shows ONLY the files listed in this plan's §File ownership map. No collateral edits.
+8. Manual scan of `_backfill_cross_type` confirms it is **completely unchanged** from main (Phase 1 invariant).
+
+---
+
+## Out of scope for this PR (deferred)
+
+- Cross-type backfill multi-embedding seed → F052.4 (separate spec)
+- Production shadow mode → F052.1
+- Adaptive variant count per orphan → F052.2
+- Variant-embedding caching → F052.3
+- Shared budget bucket vs separate backfill bucket → F052.5 (if prod-flip phase shows starvation)

--- a/nous/brain/graph_densifier.py
+++ b/nous/brain/graph_densifier.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from sqlalchemy import text
@@ -23,8 +24,12 @@ from nous.brain.backfill_rerank import (
 from nous.brain.embeddings import EmbeddingProvider
 from nous.brain.graph_linker import GraphLinker, common_template_text, edge_confidence
 from nous.config import Settings
-from nous.heart.search import hybrid_search
+from nous.heart.search import hybrid_search, hybrid_search_multi  # F052
 from nous.storage.database import Database
+
+if TYPE_CHECKING:
+    # F052 — forward-only to avoid the heart->brain.embeddings circular import.
+    from nous.heart.heart import Heart
 
 logger = logging.getLogger(__name__)
 
@@ -107,12 +112,14 @@ class GraphDensifier:
         embedder: EmbeddingProvider | None,
         settings: Settings,
         agent_id: str,
+        heart: "Heart | None" = None,  # F052 — for expand_query_pairs in same-type backfill
     ) -> None:
         self.db = db
         self._linker = graph_linker
         self._embedder = embedder
         self._settings = settings
         self._agent_id = agent_id
+        self._heart = heart  # F052 — None keeps pre-F052 behavior (single-query path)
         self._interrupted = False
         self._last_cluster_discovery: datetime | None = None
 
@@ -192,11 +199,45 @@ class GraphDensifier:
         # Hybrid search: vector + keyword via RRF
         # brain.decisions has no `active` column — disable active filter for it
         has_active = entity_type != "decision"
-        candidates = await hybrid_search(
+
+        # F052: When enabled + Heart wired + non-empty orphan content, expand the
+        # orphan into N (text, embedding) variants via Heart.expand_query_pairs and
+        # route through hybrid_search_multi. The helper guarantees a non-empty
+        # list and never raises (single-pair fallback on any internal failure).
+        # When the helper returns the single-pair fallback `[(content, None)]`,
+        # we substitute the orphan's stored embedding so the short-circuit at
+        # search.py:319-332 is byte-identical to today's hybrid_search call.
+        # When the feature flag is off OR heart is None OR orphan_content is
+        # empty, queries_pairs falls back to a single (content, orphan_embedding)
+        # pair that triggers the same short-circuit. Cosine verification at
+        # :244-256 still uses orphan_embedding (NOT variant embeddings) — variants
+        # only widen candidate generation. _backfill_cross_type is intentionally
+        # NOT wedged in Phase 1.
+        if (
+            self._settings.graph_backfill_multi_embedding_enabled
+            and self._heart is not None
+            and orphan_content
+        ):
+            queries_pairs = await self._heart.expand_query_pairs(orphan_content[:500])
+            # Helper contract: never None, never empty. Single-pair-with-None-
+            # embedding means expansion was unavailable (disabled / no expander /
+            # Haiku failed / embed_batch failed) — substitute orphan_embedding
+            # so we still get vector signal.  Note: orphan_embedding may itself
+            # be None for rows without an embedding — hybrid_search_multi's
+            # short-circuit then routes to hybrid_search(embedding=None, ...),
+            # which is the existing keyword-only path; the weight branch at
+            # :259-260 already handles that via the RRF score proxy.
+            if len(queries_pairs) == 1 and queries_pairs[0][1] is None:
+                queries_pairs = [(orphan_content[:500], orphan_embedding)]
+        else:
+            queries_pairs = [
+                (orphan_content[:500] if orphan_content else "", orphan_embedding)
+            ]
+
+        candidates = await hybrid_search_multi(
             session=session,
             table=table,
-            embedding=orphan_embedding,
-            query_text=orphan_content[:500] if orphan_content else "",
+            queries=queries_pairs,
             agent_id=self._agent_id,
             extra_where=f"AND t.id != :orphan_id",
             extra_params={"orphan_id": orphan_id},

--- a/nous/config.py
+++ b/nous/config.py
@@ -564,6 +564,26 @@ class Settings(BaseSettings):
         description="F050 — cache row retention; sweep handler ships in F050.2.",
     )
 
+    # F050/F052 — Haiku temperature for query expansion. Default 1.0 matches
+    # Anthropic's stock value (preserves F050's implicit behavior — F050 didn't
+    # set temperature, so Haiku used its default). density_eval overrides to
+    # 0.0 for re-run determinism.
+    query_expansion_temperature: float = Field(
+        default=1.0,
+        description="F050/F052 — Haiku temperature for query expansion. "
+                    "Default 1.0 matches Anthropic stock; F052 density_eval "
+                    "overrides to 0.0 for re-run determinism.",
+    )
+
+    # F052 — Multi-embedding seed for _backfill_same_type. Default-off ship.
+    # When enabled, the densifier expands each orphan's content into N=K_50
+    # variants via Heart.expand_query_pairs and routes through hybrid_search_multi.
+    graph_backfill_multi_embedding_enabled: bool = Field(
+        default=False,
+        description="F052 master switch — multi-embedding seed for graph "
+                    "densification backfill (_backfill_same_type only in Phase 1).",
+    )
+
     @model_validator(mode="after")
     def _detect_explicit_overrides(self) -> "Settings":
         object.__setattr__(self, '_compaction_threshold_explicit',

--- a/nous/heart/heart.py
+++ b/nous/heart/heart.py
@@ -1014,6 +1014,18 @@ class Heart:
             )
             return [(query, None)]
 
+        # SFH P2-3: defensive — embed_batch may return fewer items on partial
+        # OpenAI response. Without this guard, zip(variants, embeddings)
+        # silently truncates the variant list, masking a real provider quirk.
+        # NEVER returns []/None per contract — fall through to single-pair.
+        if len(embeddings) != len(variants):
+            logger.warning(
+                "F050/F052: embed_batch returned %d embeddings for %d variants (%s), "
+                "falling back to [query]",
+                len(embeddings), len(variants), self.agent_id,
+            )
+            return [(query, None)]
+
         return list(zip(variants, embeddings))
 
     def _to_recall_result(self, memory_type: str, item: object, score: float) -> RecallResult | None:

--- a/nous/heart/heart.py
+++ b/nous/heart/heart.py
@@ -806,33 +806,14 @@ class Heart:
         if not search_map:
             return []
 
-        # F050: Optionally expand the query into variants via Haiku, then embed
-        # them in a single batch call. variant_pairs stays None on any failure
-        # so sub-managers fall back to the existing single-query path
-        # (byte-identical when variant_pairs is None — see plan v2 §invariant).
-        variant_pairs: list[tuple[str, list[float] | None]] | None = None
-        if (
-            self.settings.query_expansion_enabled
-            and self._query_expander is not None
-            and self._embeddings is not None
-        ):
-            try:
-                variants = await self._query_expander.expand(query, self.agent_id)
-            except Exception as exc:
-                # Defensive — expand() should never raise per spec, but belt & braces.
-                logger.warning("F050: query_expander.expand raised, using [query]: %s", exc)
-                variants = [query]
-
-            if len(variants) > 1:
-                try:
-                    embeddings = await self._embeddings.embed_batch(variants)
-                    variant_pairs = list(zip(variants, embeddings))
-                except Exception as exc:
-                    logger.warning(
-                        "F050: embed_batch failed for %d variants, falling back to single-query: %s",
-                        len(variants), exc,
-                    )
-                    variant_pairs = None
+        # F050: Expand query via Haiku + embed variants. Helper guarantees a
+        # non-empty list with single-pair fallback on any failure (NEVER None).
+        pairs = await self.expand_query_pairs(query)
+        # Translate single-pair-with-None-embedding back to "no expansion"
+        # so sub-managers route through their existing hybrid_search fast path.
+        variant_pairs: list[tuple[str, list[float] | None]] | None = (
+            pairs if len(pairs) > 1 else None
+        )
 
         keys: list[str] = []
         results_list: list[object] = []
@@ -980,6 +961,60 @@ class Heart:
             merged = merged[:limit]
 
         return merged
+
+    async def expand_query_pairs(
+        self, query: str
+    ) -> list[tuple[str, list[float] | None]]:
+        """F050+F052 — expand a query into (text, embedding) pairs for
+        hybrid_search_multi.
+
+        **Contract: NEVER raises, NEVER returns None or [].**
+
+        On any failure path (expansion disabled, no expander, no embeddings,
+        Haiku raises, embed_batch raises, gate trips), returns
+        ``[(query, None)]`` — a single pair with no precomputed embedding.
+        Callers route this through ``hybrid_search_multi(queries=...)``,
+        which short-circuits at search.py:319-332 to byte-identical behavior
+        vs single-query ``hybrid_search``.
+
+        F052 callers (graph_densifier._backfill_same_type) MUST NOT
+        catch ``asyncio.CancelledError`` from this call — task cancellation
+        must propagate. The implementation only catches ``Exception``,
+        which excludes ``CancelledError`` in Python 3.8+.
+
+        Edge case: if cancelled mid-``embed_batch`` after Haiku already
+        succeeded, the Haiku tokens are spent but the helper raises
+        ``CancelledError`` upward — accepted cost per spec §Risks #6.
+        """
+        if not (
+            self.settings.query_expansion_enabled
+            and self._query_expander is not None
+            and self._embeddings is not None
+        ):
+            return [(query, None)]
+
+        try:
+            variants = await self._query_expander.expand(query, self.agent_id)
+        except Exception as exc:
+            logger.warning(
+                "F050/F052: query_expander.expand raised for %s, falling back to [query]: %s",
+                self.agent_id, exc,
+            )
+            return [(query, None)]
+
+        if len(variants) <= 1:
+            return [(query, None)]
+
+        try:
+            embeddings = await self._embeddings.embed_batch(variants)
+        except Exception as exc:
+            logger.warning(
+                "F050/F052: embed_batch failed for %d variants (%s), falling back to [query]: %s",
+                len(variants), self.agent_id, exc,
+            )
+            return [(query, None)]
+
+        return list(zip(variants, embeddings))
 
     def _to_recall_result(self, memory_type: str, item: object, score: float) -> RecallResult | None:
         """Convert a typed search result to a RecallResult."""

--- a/nous/heart/query_expansion.py
+++ b/nous/heart/query_expansion.py
@@ -280,6 +280,7 @@ class QueryExpander:
         payload: dict[str, Any] = {
             "model": self._model,
             "max_tokens": 256,
+            "temperature": self._settings.query_expansion_temperature,
             "system": _SYSTEM_PROMPT,
             "tools": [_TOOL],
             "tool_choice": _TOOL_CHOICE,

--- a/nous/main.py
+++ b/nous/main.py
@@ -301,6 +301,7 @@ async def create_components(settings: Settings) -> dict:
                     db=database, graph_linker=graph_linker,
                     embedder=embedding_provider, settings=settings,
                     agent_id=settings.agent_id,
+                    heart=heart,  # F052 — enables expand_query_pairs in _backfill_same_type
                 )
                 logger.debug("F040: GraphDensifier created")
         except ImportError:

--- a/nous_eval/density_eval.py
+++ b/nous_eval/density_eval.py
@@ -76,7 +76,7 @@ class DensitySnapshot:
     orphan_count_per_type: dict[str, int] = field(default_factory=dict)
 
 
-@dataclass
+@dataclass(frozen=True)
 class DensityRunResult:
     """Outcome of one config under one density-eval run."""
 
@@ -228,6 +228,15 @@ async def _run_one_config(
     logger.info("F052: running density config=%s", config.name)
     overridden = _apply_config_flags(main_settings_template, config)
     eval_scoped = _settings_for_eval_db(eval_settings, overridden)
+    # SFH P1-1: F051's _settings_for_eval_db forces graph_backfill_enabled=False
+    # to suppress the production sleep handler. density_eval invokes the densifier
+    # DIRECTLY, so we must re-enable backfill here or every config silently
+    # returns 0 edges. Same applies to event_bus (we want emission events from
+    # backfill to fire) and a few related toggles. We override only what we need.
+    eval_scoped = eval_scoped.model_copy(update={"graph_backfill_enabled": True})
+    assert eval_scoped.graph_backfill_enabled, (
+        "density_eval requires graph_backfill_enabled=True; check _settings_for_eval_db override"
+    )
     agent_id = eval_scoped.agent_id
 
     t0 = time.monotonic()
@@ -283,13 +292,17 @@ async def _run_one_config(
             post = await _snapshot(db, agent_id)
     except Exception as exc:
         logger.exception("F052: harness setup failed for config=%s", config.name)
+        restore_failure: str | None = None
         try:
             await _restore_baseline(db, agent_id)
-        except Exception:
+        except Exception as restore_exc:
             logger.exception(
                 "F052: _restore_baseline also failed for config=%s", config.name
             )
+            restore_failure = f"{type(restore_exc).__name__}: {restore_exc}"
         failure = f"{type(exc).__name__}: {exc}"
+        if restore_failure is not None:
+            failure = f"{failure} | restore_also_failed: {restore_failure}"
 
     wall = time.monotonic() - t0
     return DensityRunResult(

--- a/nous_eval/density_eval.py
+++ b/nous_eval/density_eval.py
@@ -1,0 +1,474 @@
+"""F052 density-eval harness mode.
+
+Measures graph_edges + orphan-rate deltas across baseline vs ``f052_on``
+configs on the F051 eval DB, using a snapshot-reset-run-snapshot loop with
+transactional restore on per-config failure.
+
+Determinism: forces ``query_expansion_temperature=0.0`` for the duration of
+the run (set on the ``f052_on`` ``RetrievalConfig`` in
+:mod:`nous_eval.retrieval`). Reproducibility: ``heart.query_expansions``
+cache rows are preserved across runs (no truncate).
+
+Per-config behavior:
+
+1. ``RuntimeConfig.reset()`` — clear leakage from the prior config.
+2. ``_apply_config_flags(template, cfg)`` — Settings overlay (NOT
+   ``RuntimeConfig.set``; mirrors :mod:`retrieval_runner`).
+3. ``_settings_for_eval_db(eval_settings, overridden)`` — redirect DB.
+4. ``_ensure_zero_edge_baseline`` — DELETE current edges; (re-)create the
+   ``brain.eval_baseline_edges_snapshot`` anchor table; TRUNCATE it. The
+   anchor is intentionally empty — it represents zero-edge state and is
+   used by ``_restore_baseline`` if a config crashes mid-cycle.
+5. Snapshot pre-state (orphan + edge counts).
+6. Build Heart + densifier (sharing the embedding provider, mirroring
+   :mod:`nous/main.py:300`).
+7. Run ``GraphDensifier.run_backfill_cycle()`` + ``discover_clusters``.
+8. On exception: ``_restore_baseline`` and tag the run as failed.
+9. Snapshot post-state.
+
+A real (non-TEMP) snapshot table is used because TEMP tables are
+session-scoped in Postgres — a per-config run uses several pooled
+connections, and a TEMP table would silently disappear on connection
+swap.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import text
+
+from nous.brain._entity_config import _ENTITY_CONFIG
+from nous.config import Settings
+from nous.runtime_config import RuntimeConfig
+from nous.storage.database import Database
+from nous_eval.config import EvalSettings
+from nous_eval.retrieval import _DEFAULT_CONFIGS, RetrievalConfig
+from nous_eval.retrieval_runner import (
+    _apply_config_flags,
+    _build_densifier_for_eval,
+    _build_heart_for_eval,
+    _settings_for_eval_db,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DensitySnapshot:
+    """Edge + orphan counts at one point in time, scoped to one ``agent_id``."""
+
+    edge_count_total: int
+    edge_count_per_relation: dict[str, int] = field(default_factory=dict)
+    orphan_count_per_type: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class DensityRunResult:
+    """Outcome of one config under one density-eval run."""
+
+    config_name: str
+    pre: DensitySnapshot
+    post: DensitySnapshot | None
+    edges_created: int
+    ce_pruned: int
+    wall_seconds: float
+    failure: str | None = None  # set on exception path
+
+
+# ---------------------------------------------------------------------------
+# Snapshot / restore helpers
+# ---------------------------------------------------------------------------
+
+
+_SNAPSHOT_TABLE = "brain.eval_baseline_edges_snapshot"
+
+
+async def _ensure_zero_edge_baseline(db: Database, agent_id: str) -> None:
+    """Pre-condition: zero edges for ``agent_id``; ensure persistent snapshot.
+
+    The snapshot table is REAL (not TEMP) so it survives across the multiple
+    pooled connections that one per-config run uses. It is intentionally
+    empty: it represents the "zero-edge baseline" anchor state, restored by
+    :func:`_restore_baseline` when a config crashes mid-cycle.
+
+    Idempotent: ``CREATE TABLE IF NOT EXISTS`` + ``TRUNCATE``.
+    """
+    async with db.session() as session:
+        await session.execute(
+            text("DELETE FROM brain.graph_edges WHERE agent_id = :aid"),
+            {"aid": agent_id},
+        )
+        await session.execute(
+            text(
+                f"CREATE TABLE IF NOT EXISTS {_SNAPSHOT_TABLE} "
+                "(LIKE brain.graph_edges INCLUDING ALL)"
+            )
+        )
+        await session.execute(text(f"TRUNCATE {_SNAPSHOT_TABLE}"))
+        await session.commit()
+
+
+async def _restore_baseline(db: Database, agent_id: str) -> None:
+    """Restore graph_edges to the empty-snapshot anchor state for ``agent_id``.
+
+    The snapshot table is intentionally empty, so the INSERT-from-snapshot
+    is a no-op; the DELETE alone returns to zero-edge state. Kept as
+    DELETE+INSERT so that if a future iteration of the harness wants to
+    snapshot a non-empty baseline, the restore semantics already match.
+    """
+    async with db.session() as session:
+        await session.execute(
+            text("DELETE FROM brain.graph_edges WHERE agent_id = :aid"),
+            {"aid": agent_id},
+        )
+        await session.execute(
+            text(
+                f"INSERT INTO brain.graph_edges "
+                f"SELECT * FROM {_SNAPSHOT_TABLE}"
+            )
+        )
+        await session.commit()
+
+
+async def _snapshot(db: Database, agent_id: str) -> DensitySnapshot:
+    """Capture edge count (per-relation + total) and orphan count per type.
+
+    Both counts are scoped to ``agent_id``. Orphans are computed via the
+    same NOT EXISTS clause :class:`GraphDensifier.find_orphans` uses so the
+    pre-state matches what the densifier sees on its first iteration.
+    """
+    async with db.session() as session:
+        edge_total_row = await session.execute(
+            text(
+                "SELECT COUNT(*) AS n FROM brain.graph_edges "
+                "WHERE agent_id = :aid"
+            ),
+            {"aid": agent_id},
+        )
+        edge_total = int(edge_total_row.scalar() or 0)
+
+        per_rel_rows = await session.execute(
+            text(
+                "SELECT relation, COUNT(*) AS n FROM brain.graph_edges "
+                "WHERE agent_id = :aid GROUP BY relation"
+            ),
+            {"aid": agent_id},
+        )
+        per_rel = {row.relation: int(row.n) for row in per_rel_rows}
+
+        orphan_per_type: dict[str, int] = {}
+        for entity_type, (table, type_name, _content_col, extra) in _ENTITY_CONFIG.items():
+            sql = text(
+                f"""
+                SELECT COUNT(*) AS n FROM {table} t
+                WHERE t.agent_id = :aid
+                  AND {extra}
+                  AND t.embedding IS NOT NULL
+                  AND NOT EXISTS (
+                      SELECT 1 FROM brain.graph_edges e
+                      WHERE e.agent_id = :aid
+                        AND (
+                            (e.source_id = t.id AND e.source_type = :type_name)
+                            OR (e.target_id = t.id AND e.target_type = :type_name)
+                        )
+                  )
+                """
+            )
+            row = await session.execute(
+                sql, {"aid": agent_id, "type_name": type_name}
+            )
+            orphan_per_type[entity_type] = int(row.scalar() or 0)
+
+    return DensitySnapshot(
+        edge_count_total=edge_total,
+        edge_count_per_relation=per_rel,
+        orphan_count_per_type=orphan_per_type,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-config runner
+# ---------------------------------------------------------------------------
+
+
+async def _run_one_config(
+    config: RetrievalConfig,
+    main_settings_template: Settings,
+    eval_settings: EvalSettings,
+    db: Database,
+) -> DensityRunResult:
+    """Run one config end-to-end. Mirrors ``retrieval_runner.run_matrix``.
+
+    Sequence (matches F051 pattern at retrieval_runner.py:160-220):
+
+    1. ``RuntimeConfig.reset()``
+    2. ``overridden = _apply_config_flags(template, cfg)``
+    3. ``eval_scoped = _settings_for_eval_db(eval_settings, overridden)``
+    4. snapshot baseline (zero-edge anchor)
+    5. snapshot pre-state
+    6. build Heart + densifier; run cycle
+    7. on exception: restore baseline; record failure
+    8. snapshot post-state
+    """
+    RuntimeConfig.reset()
+    logger.info("F052: running density config=%s", config.name)
+    overridden = _apply_config_flags(main_settings_template, config)
+    eval_scoped = _settings_for_eval_db(eval_settings, overridden)
+    agent_id = eval_scoped.agent_id
+
+    t0 = time.monotonic()
+    await _ensure_zero_edge_baseline(db, agent_id)
+    pre = await _snapshot(db, agent_id)
+
+    edges_created = 0
+    ce_pruned = 0
+    failure: str | None = None
+    post: DensitySnapshot | None = None
+
+    try:
+        async with _build_heart_for_eval(db, eval_scoped) as heart:
+            densifier = await _build_densifier_for_eval(
+                eval_scoped, db, agent_id, heart
+            )
+            try:
+                cycle_result = await densifier.run_backfill_cycle()
+            except Exception as exc:
+                logger.exception(
+                    "F052: run_backfill_cycle raised for config=%s", config.name
+                )
+                await _restore_baseline(db, agent_id)
+                wall = time.monotonic() - t0
+                return DensityRunResult(
+                    config_name=config.name,
+                    pre=pre,
+                    post=None,
+                    edges_created=0,
+                    ce_pruned=0,
+                    wall_seconds=wall,
+                    failure=f"{type(exc).__name__}: {exc}",
+                )
+
+            # cycle_result keys: facts/decisions/episodes/procedures + _ce_stats
+            edges_created = sum(
+                v for k, v in cycle_result.items() if not k.startswith("_")
+            )
+            ce_stats = cycle_result.get("_ce_stats") or {}
+            ce_pruned = int(ce_stats.get("pruned", 0))
+
+            try:
+                # Cluster discovery is best-effort; failure here doesn't
+                # invalidate the backfill cycle's edge counts.
+                await densifier.discover_clusters(max_bridges=20)
+            except Exception:
+                logger.warning(
+                    "F052: discover_clusters raised for config=%s; continuing",
+                    config.name,
+                    exc_info=True,
+                )
+
+            post = await _snapshot(db, agent_id)
+    except Exception as exc:
+        logger.exception("F052: harness setup failed for config=%s", config.name)
+        try:
+            await _restore_baseline(db, agent_id)
+        except Exception:
+            logger.exception(
+                "F052: _restore_baseline also failed for config=%s", config.name
+            )
+        failure = f"{type(exc).__name__}: {exc}"
+
+    wall = time.monotonic() - t0
+    return DensityRunResult(
+        config_name=config.name,
+        pre=pre,
+        post=post,
+        edges_created=edges_created,
+        ce_pruned=ce_pruned,
+        wall_seconds=wall,
+        failure=failure,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Top-level orchestration + reporting
+# ---------------------------------------------------------------------------
+
+
+async def run_density_eval(
+    config_names: list[str],
+    eval_settings: EvalSettings,
+    n_runs: int = 1,
+) -> list[DensityRunResult]:
+    """Run the density eval matrix and return results in run-order.
+
+    One ``Database`` is created and reused across all configs/runs to avoid
+    per-config asyncpg-pool churn. Each per-config call still gets a fresh
+    Heart + densifier (mirrors ``run_matrix`` semantics).
+    """
+    main_settings_template = Settings()
+    db = Database(_settings_for_eval_db(eval_settings, main_settings_template))
+    await db.connect()
+    try:
+        results: list[DensityRunResult] = []
+        for run_idx in range(n_runs):
+            for name in config_names:
+                if name not in _DEFAULT_CONFIGS:
+                    raise ValueError(
+                        f"Unknown config: {name!r}. "
+                        f"Known: {sorted(_DEFAULT_CONFIGS)}"
+                    )
+                config = _DEFAULT_CONFIGS[name]
+                logger.info(
+                    "F052: density-eval run %d/%d config=%s",
+                    run_idx + 1, n_runs, name,
+                )
+                results.append(
+                    await _run_one_config(
+                        config, main_settings_template, eval_settings, db
+                    )
+                )
+        return results
+    finally:
+        await db.engine.dispose()
+
+
+def _format_snapshot(label: str, snap: DensitySnapshot | None) -> str:
+    if snap is None:
+        return f"  {label}: <none — config failed>\n"
+    parts = [f"  {label}: total={snap.edge_count_total}"]
+    if snap.edge_count_per_relation:
+        rels = ", ".join(
+            f"{k}={v}" for k, v in sorted(snap.edge_count_per_relation.items())
+        )
+        parts.append(f"    per_relation: {rels}")
+    if snap.orphan_count_per_type:
+        orphs = ", ".join(
+            f"{k}={v}" for k, v in sorted(snap.orphan_count_per_type.items())
+        )
+        parts.append(f"    orphans:      {orphs}")
+    return "\n".join(parts) + "\n"
+
+
+def _write_report(results: list[DensityRunResult], path: Path) -> None:
+    """Write a human-readable Markdown report.
+
+    Each config gets a section with pre/post snapshots, edges_created,
+    CE-rerank pruning count, wall-clock seconds, and failure tag (if any).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines: list[str] = []
+    lines.append("# F052 density-eval report\n")
+    lines.append(
+        f"_Generated: {datetime.now(tz=UTC):%Y-%m-%d %H:%M:%S UTC}_\n"
+    )
+    lines.append("")
+    lines.append(
+        "| config | edges_created | ce_pruned | wall_s | status |"
+    )
+    lines.append(
+        "|--------|---------------|-----------|--------|--------|"
+    )
+    for r in results:
+        status = "FAIL" if r.failure else "OK"
+        lines.append(
+            f"| {r.config_name} | {r.edges_created} | {r.ce_pruned} | "
+            f"{r.wall_seconds:.1f} | {status} |"
+        )
+    lines.append("")
+
+    for r in results:
+        lines.append(f"## {r.config_name}")
+        if r.failure:
+            lines.append(f"**FAILURE**: `{r.failure}`")
+        lines.append("")
+        lines.append(_format_snapshot("pre ", r.pre))
+        lines.append(_format_snapshot("post", r.post))
+        lines.append("")
+
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns process exit code."""
+    p = argparse.ArgumentParser(
+        prog="python -m nous_eval.density_eval",
+        description="F052 density-eval harness — backfill A/B on the eval DB.",
+    )
+    p.add_argument(
+        "--configs",
+        type=str,
+        default="baseline,f052_on",
+        help="Comma-separated config names (default: baseline,f052_on).",
+    )
+    p.add_argument(
+        "--n-runs",
+        type=int,
+        default=1,
+        help="Number of times to repeat the matrix (for variance).",
+    )
+    p.add_argument(
+        "--report-dir",
+        type=Path,
+        default=None,
+        help="Override EvalSettings.report_dir.",
+    )
+    p.add_argument(
+        "--log-level",
+        type=str,
+        default="info",
+        help="Logging verbosity (debug/info/warning).",
+    )
+    args = p.parse_args(argv)
+
+    logging.basicConfig(
+        level=args.log_level.upper(),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    eval_settings = EvalSettings()
+    eval_settings.warn_if_default_password()
+    if args.report_dir is not None:
+        eval_settings = eval_settings.model_copy(
+            update={"report_dir": args.report_dir}
+        )
+
+    config_names = [c.strip() for c in args.configs.split(",") if c.strip()]
+
+    try:
+        results = asyncio.run(
+            run_density_eval(config_names, eval_settings, args.n_runs)
+        )
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    out = (
+        eval_settings.report_dir
+        / f"density-eval-{datetime.now(tz=UTC):%Y%m%d-%H%M%S}.md"
+    )
+    _write_report(results, out)
+    print(f"Wrote: {out}")
+    logger.info("F052: density_eval report written: %s", out)
+
+    # Non-zero exit if any config failed — useful for CI signaling.
+    if any(r.failure for r in results):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nous_eval/edge_judge.py
+++ b/nous_eval/edge_judge.py
@@ -15,7 +15,9 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from dataclasses import dataclass
+from itertools import zip_longest
 from pathlib import Path
 from typing import Any
 
@@ -75,12 +77,11 @@ def _parse_response(content: list[dict[str, Any]]) -> list[dict[str, Any]]:
     raw = "".join(text_parts).strip()
     if not raw:
         raise ValueError("edge_judge: empty Sonnet response")
-    # Trim possible Markdown code fences
-    if raw.startswith("```"):
-        raw = raw.strip("`")
-        # Strip an optional leading "json\n" tag
-        if raw.lower().startswith("json"):
-            raw = raw[4:]
+    # Trim possible Markdown code fences. Surgical regex avoids stripping
+    # legitimate backticks inside JSON string payloads (the prior `.strip("`")`
+    # was over-broad and could chew into content).
+    raw = re.sub(r"^```(?:json)?\s*\n?", "", raw, flags=re.IGNORECASE)
+    raw = re.sub(r"\n?```\s*$", "", raw)
     parsed = json.loads(raw)
     if not isinstance(parsed, list):
         raise ValueError(
@@ -149,7 +150,32 @@ async def judge_edges(
                     )
                 continue
 
-            for src_edge, verdict_obj in zip(batch, parsed):
+            # SFH P1-2: zip would silently truncate when Sonnet returns fewer
+            # verdicts than the batch (max_tokens cutoff, ambiguous-skip). Use
+            # zip_longest + PARSE_ERROR pad so the precision denominator stays
+            # honest. Docstring promises one EdgeJudgment per input edge.
+            if len(parsed) < len(batch):
+                logger.warning(
+                    "edge_judge: short_response — Sonnet returned %d of %d verdicts in batch %d-%d; "
+                    "padding missing verdicts with PARSE_ERROR",
+                    len(parsed), len(batch), batch_start, batch_start + len(batch),
+                )
+            for src_edge, verdict_obj in zip_longest(batch, parsed, fillvalue=None):
+                if src_edge is None:
+                    # Sonnet returned MORE verdicts than we sent — log + drop the trailing extras.
+                    logger.warning("edge_judge: extra verdict beyond batch length — dropping")
+                    continue
+                if verdict_obj is None:
+                    judgments.append(
+                        EdgeJudgment(
+                            source_id=str(src_edge.get("source_id", "")),
+                            target_id=str(src_edge.get("target_id", "")),
+                            relation=str(src_edge.get("relation", "")),
+                            verdict="PARSE_ERROR",
+                            reasoning="short_response: Sonnet did not return a verdict for this edge",
+                        )
+                    )
+                    continue
                 judgments.append(
                     EdgeJudgment(
                         source_id=str(src_edge.get("source_id", "")),

--- a/nous_eval/edge_judge.py
+++ b/nous_eval/edge_judge.py
@@ -1,0 +1,165 @@
+"""F052 — LLM-judge for edge precision in density-eval reports.
+
+Loads a cached operator-editable prompt from
+``nous_eval/templates/edge_precision_prompt.md``, batches edges in chunks
+of ``BATCH_SIZE``, calls Sonnet via the existing OAT-supporting
+``AnthropicClient``, parses the JSON-array response, and returns one
+:class:`EdgeJudgment` per edge in input order.
+
+The harness is intentionally minimal — no caching, no retries, no
+streaming. Operators run it ad-hoc against a sampled edge set after a
+density-eval pass to estimate precision (YES / WEAK / NO ratios).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from nous.api.anthropic_client import create_client
+from nous.config import Settings
+
+logger = logging.getLogger(__name__)
+
+
+BATCH_SIZE = 30  # ≤30 edges per Sonnet call to keep prompts well under 8k tokens
+_TEMPLATE_PATH = Path(__file__).parent / "templates" / "edge_precision_prompt.md"
+
+
+@dataclass(frozen=True)
+class EdgeJudgment:
+    """One judge verdict per edge."""
+
+    source_id: str
+    target_id: str
+    relation: str
+    verdict: str  # "YES" | "WEAK" | "NO" | "PARSE_ERROR"
+    reasoning: str
+
+
+def _load_prompt_template() -> str:
+    """Read the operator-editable prompt template once per call.
+
+    Re-read on every call (rather than module-load) so operators can edit
+    the file between judge runs without restarting. The file is small
+    (<2KB) so the syscall cost is negligible.
+    """
+    return _TEMPLATE_PATH.read_text(encoding="utf-8")
+
+
+def _format_edge_payload(edges: list[dict[str, Any]]) -> str:
+    """Serialize an edge batch as a JSON array for the prompt body."""
+    return json.dumps(edges, ensure_ascii=False, indent=2)
+
+
+def _parse_response(content: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Extract the JSON array from a Sonnet text response.
+
+    Sonnet returns a list of content blocks; we concatenate ``text`` blocks
+    and parse the result as JSON. Anything else (tool-use, image) is
+    skipped. Raises ``ValueError`` if no JSON array is found.
+    """
+    text_parts: list[str] = []
+    for block in content:
+        # Both dict-style and attribute-style content blocks are tolerated
+        # so this works against either AnthropicClient backend.
+        btype = block.get("type") if isinstance(block, dict) else getattr(block, "type", None)
+        if btype != "text":
+            continue
+        bt = block.get("text") if isinstance(block, dict) else getattr(block, "text", "")
+        if bt:
+            text_parts.append(bt)
+    raw = "".join(text_parts).strip()
+    if not raw:
+        raise ValueError("edge_judge: empty Sonnet response")
+    # Trim possible Markdown code fences
+    if raw.startswith("```"):
+        raw = raw.strip("`")
+        # Strip an optional leading "json\n" tag
+        if raw.lower().startswith("json"):
+            raw = raw[4:]
+    parsed = json.loads(raw)
+    if not isinstance(parsed, list):
+        raise ValueError(
+            f"edge_judge: expected JSON array, got {type(parsed).__name__}"
+        )
+    return parsed
+
+
+async def judge_edges(
+    edges: list[dict[str, Any]],
+    settings: Settings,
+    model: str = "claude-sonnet-4-6",
+) -> list[EdgeJudgment]:
+    """Judge a list of edges. Each edge dict is shaped::
+
+        {
+            "source_id": str,
+            "target_id": str,
+            "source_content": str,
+            "target_content": str,
+            "relation": str,
+            "weight": float,    # optional
+        }
+
+    Returns one :class:`EdgeJudgment` per input edge in the same order.
+    Edges in batches that fail to parse are returned with
+    ``verdict="PARSE_ERROR"`` so the operator can spot-check rather than
+    silently lose precision data.
+    """
+    if not edges:
+        return []
+
+    template = _load_prompt_template()
+    client = create_client(settings)
+    await client.start()
+
+    judgments: list[EdgeJudgment] = []
+    try:
+        for batch_start in range(0, len(edges), BATCH_SIZE):
+            batch = edges[batch_start : batch_start + BATCH_SIZE]
+            prompt_body = template + "\n\n" + _format_edge_payload(batch)
+
+            try:
+                resp = await client.call(
+                    model=model,
+                    system=[{"type": "text", "text": "You are a careful precision judge. Return JSON only."}],
+                    messages=[{"role": "user", "content": prompt_body}],
+                    max_tokens=2048,
+                    temperature=0.0,
+                )
+                parsed = _parse_response(resp.content)
+            except Exception as exc:
+                logger.warning(
+                    "edge_judge: batch %d-%d failed (%s); marking PARSE_ERROR",
+                    batch_start, batch_start + len(batch), exc,
+                )
+                for e in batch:
+                    judgments.append(
+                        EdgeJudgment(
+                            source_id=str(e.get("source_id", "")),
+                            target_id=str(e.get("target_id", "")),
+                            relation=str(e.get("relation", "")),
+                            verdict="PARSE_ERROR",
+                            reasoning=str(exc),
+                        )
+                    )
+                continue
+
+            for src_edge, verdict_obj in zip(batch, parsed):
+                judgments.append(
+                    EdgeJudgment(
+                        source_id=str(src_edge.get("source_id", "")),
+                        target_id=str(src_edge.get("target_id", "")),
+                        relation=str(src_edge.get("relation", "")),
+                        verdict=str(verdict_obj.get("verdict", "PARSE_ERROR")).upper(),
+                        reasoning=str(verdict_obj.get("reasoning", "")),
+                    )
+                )
+    finally:
+        await client.close()
+
+    return judgments

--- a/nous_eval/edge_judge.py
+++ b/nous_eval/edge_judge.py
@@ -82,6 +82,9 @@ def _parse_response(content: list[dict[str, Any]]) -> list[dict[str, Any]]:
     # was over-broad and could chew into content).
     raw = re.sub(r"^```(?:json)?\s*\n?", "", raw, flags=re.IGNORECASE)
     raw = re.sub(r"\n?```\s*$", "", raw)
+    # Strip trailing commas before ] or } — Sonnet sometimes emits
+    # JSON5-style trailing commas which strict json.loads rejects.
+    raw = re.sub(r",(\s*[}\]])", r"\1", raw)
     parsed = json.loads(raw)
     if not isinstance(parsed, list):
         raise ValueError(
@@ -125,13 +128,20 @@ async def judge_edges(
             prompt_body = template + "\n\n" + _format_edge_payload(batch)
 
             try:
-                resp = await client.call(
-                    model=model,
-                    system=[{"type": "text", "text": "You are a careful precision judge. Return JSON only."}],
-                    messages=[{"role": "user", "content": prompt_body}],
-                    max_tokens=2048,
-                    temperature=0.0,
-                )
+                # AnthropicClient.call() takes a single payload dict, not kwargs.
+                # OAT auth requires the Claude Code preamble as system block 0
+                # (per project memory feedback_claude_code_preamble — without it,
+                # OAT returns 429 rate_limit_error). Mirrors hand_labels_draft.py.
+                resp = await client.call({
+                    "model": model,
+                    "system": [
+                        {"type": "text", "text": "You are Claude Code, Anthropic's official CLI for Claude.", "cache_control": {"type": "ephemeral"}},
+                        {"type": "text", "text": "You are a careful precision judge. Return JSON only."},
+                    ],
+                    "messages": [{"role": "user", "content": prompt_body}],
+                    "max_tokens": 8192,
+                    "temperature": 0.0,
+                })
                 parsed = _parse_response(resp.content)
             except Exception as exc:
                 logger.warning(

--- a/nous_eval/retrieval.py
+++ b/nous_eval/retrieval.py
@@ -66,6 +66,25 @@ _DEFAULT_CONFIGS: dict[str, RetrievalConfig] = {
         flags={"query_expansion_enabled": True},
         description="F050 multi-query expansion enabled.",
     ),
+    "f052_on": RetrievalConfig(
+        name="f052_on",
+        flags={
+            "graph_backfill_multi_embedding_enabled": True,
+            # F052 depends on the F050 expander being live — without it,
+            # Heart.expand_query_pairs returns the single-pair fallback
+            # and the densifier wedge collapses to byte-identical baseline.
+            "query_expansion_enabled": True,
+            # density_eval forces this to 0.0 for re-run determinism;
+            # the retrieval-side matrix gets the same override here so
+            # the two surfaces agree on the determinism contract.
+            "query_expansion_temperature": 0.0,
+        },
+        description=(
+            "F052 multi-embedding seed for _backfill_same_type. "
+            "Eval-only retrieval-side measurement; density-side lives in "
+            "`python -m nous_eval.density_eval`."
+        ),
+    ),
     "ce_off": RetrievalConfig(
         name="ce_off",
         flags={"cross_encoder_enabled": False},

--- a/nous_eval/retrieval_runner.py
+++ b/nous_eval/retrieval_runner.py
@@ -374,6 +374,54 @@ def _build_brain_for_eval(
     )
 
 
+async def _build_densifier_for_eval(
+    settings: Settings,
+    db: Database,
+    agent_id: str,
+    heart: Heart,
+):
+    """F052 eval helper — construct a GraphDensifier with Heart wired.
+
+    Mirrors the production wiring at ``nous/main.py:300`` so density_eval
+    invokes the same densifier the production sleep handler does.
+
+    The embedding provider is reused from ``heart._embeddings`` (rather than
+    re-constructed) so the per-config asyncpg/httpx pools don't double up
+    inside one eval run — same pattern as ``_build_brain_for_eval``.
+
+    Args:
+        settings: Eval-scoped Settings (after ``_settings_for_eval_db``).
+        db: Eval Database.
+        agent_id: Eval agent_id (typically ``settings.agent_id`` ==
+            ``eval_settings.agent_id``).
+        heart: The Heart constructed by ``_build_heart_for_eval`` —
+            must be inside its ``async with`` block so the wiring is alive
+            for the densifier's lifetime.
+
+    Returns:
+        Constructed ``GraphDensifier`` with ``heart=`` wired (F052).
+    """
+    # Late imports keep this module light when only the retrieval matrix runs.
+    from nous.brain.graph_densifier import GraphDensifier
+    from nous.brain.graph_linker import GraphLinker
+
+    embedder = heart._embeddings  # share with Heart — see docstring
+    linker = GraphLinker(
+        db=db,
+        embedder=embedder,
+        settings=settings,
+        agent_id=agent_id,
+    )
+    return GraphDensifier(
+        db=db,
+        graph_linker=linker,
+        embedder=embedder,
+        settings=settings,
+        agent_id=agent_id,
+        heart=heart,  # F052 — enables expand_query_pairs in _backfill_same_type
+    )
+
+
 # ---------------------------------------------------------------------------
 # Single-qrel scoring
 # ---------------------------------------------------------------------------

--- a/nous_eval/retrieval_runner.py
+++ b/nous_eval/retrieval_runner.py
@@ -406,6 +406,14 @@ async def _build_densifier_for_eval(
     from nous.brain.graph_linker import GraphLinker
 
     embedder = heart._embeddings  # share with Heart — see docstring
+    if embedder is None:
+        # SFH P2-6: density_eval depends on embeddings for both candidate generation
+        # AND the F052 wedge. Silent degradation here would collapse the F052
+        # measurement to a baseline-vs-baseline no-op. Fail loud so the operator
+        # sets OPENAI_API_KEY before re-running.
+        raise RuntimeError(
+            "density_eval requires an embedder (Heart._embeddings is None — set OPENAI_API_KEY)"
+        )
     linker = GraphLinker(
         db=db,
         embedder=embedder,

--- a/nous_eval/run_edge_audit.py
+++ b/nous_eval/run_edge_audit.py
@@ -1,0 +1,293 @@
+"""F052 edge-precision audit runner.
+
+Samples N newly-created edges per relation type from the eval DB, fetches
+source/target content, feeds to ``edge_judge.judge_edges`` for YES/WEAK/NO
+verdicts, and writes a precision report.
+
+Designed to run AFTER ``density_eval`` against the same eval DB. The
+``--since`` flag filters edges by ``created_at`` so you audit only the
+edges the most-recent density_eval run produced (not the cumulative graph).
+
+Typical workflow::
+
+    # 1. Note start timestamp
+    NOW=$(date -u +%Y-%m-%dT%H:%M:%S)
+
+    # 2. Run density_eval (creates new edges)
+    NOUS_EVAL_DB_NAME=nous_eval_scratch \\
+    NOUS_QUERY_EXPANSION_ENABLED=true \\
+    uv run python -m nous_eval.density_eval --configs baseline,f052_on
+
+    # 3. Audit only the edges from step 2
+    NOUS_EVAL_DB_NAME=nous_eval_scratch \\
+    uv run python -m nous_eval.run_edge_audit --since "$NOW"
+
+The audit writes ``reports/edge-audit-<timestamp>.md`` with per-relation
+precision (YES / (YES + WEAK + NO)). Spec gate criterion 2 is
+**precision >= 0.75 per type**.
+
+Cost: 1 Sonnet call per BATCH_SIZE (30) edges. With 4 relation types ×
+30 edges = ~4 calls per audit, so ~$0.05.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from collections import defaultdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import text
+
+from nous.config import Settings
+from nous.storage.database import Database
+from nous_eval.config import EvalSettings
+from nous_eval.edge_judge import EdgeJudgment, judge_edges
+from nous_eval.retrieval_runner import _settings_for_eval_db
+
+logger = logging.getLogger(__name__)
+
+# Per-type content fetch is structural — facts.content, decisions.context,
+# episodes.summary, procedures.steps_text. Mirrors fetch_candidate_content
+# in nous/brain/backfill_rerank.py but inline here to keep the audit tool
+# free of brain-internal imports.
+_CONTENT_BY_TYPE: dict[str, tuple[str, str]] = {
+    "fact": ("heart.facts", "content"),
+    "decision": ("brain.decisions", "context"),
+    "episode": ("heart.episodes", "summary"),
+    "procedure": ("heart.procedures", "name || ': ' || description"),
+}
+
+
+async def _sample_edges_per_type(
+    db: Database,
+    agent_id: str,
+    since: datetime | None,
+    limit_per_type: int,
+) -> dict[str, list[dict[str, Any]]]:
+    """Sample N edges per relation type, joining source+target content.
+
+    Returns ``{relation: [edge_dict, ...]}`` keyed by ``relation`` (e.g.
+    ``"related_to"``, ``"evidence_for"``). Edge dict has the shape
+    ``edge_judge.judge_edges`` expects.
+    """
+    out: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    async with db.session() as session:
+        rel_rows = await session.execute(text(
+            "SELECT DISTINCT relation FROM brain.graph_edges WHERE agent_id = :aid"
+        ), {"aid": agent_id})
+        relations = [r[0] for r in rel_rows]
+
+        for relation in relations:
+            params: dict[str, Any] = {
+                "aid": agent_id, "rel": relation, "lim": limit_per_type,
+            }
+            since_clause = ""
+            if since is not None:
+                since_clause = "AND e.created_at >= :since"
+                params["since"] = since
+            edge_rows = await session.execute(text(f"""
+                SELECT e.source_id, e.source_type, e.target_id, e.target_type,
+                       e.relation, e.weight
+                FROM brain.graph_edges e
+                WHERE e.agent_id = :aid AND e.relation = :rel {since_clause}
+                ORDER BY random()
+                LIMIT :lim
+            """), params)
+            for row in edge_rows:
+                out[relation].append({
+                    "source_id": str(row.source_id),
+                    "source_type": row.source_type,
+                    "target_id": str(row.target_id),
+                    "target_type": row.target_type,
+                    "relation": row.relation,
+                    "weight": float(row.weight) if row.weight is not None else None,
+                })
+
+        # Hydrate content per edge (one round-trip per type to keep SQL simple).
+        all_ids_by_type: dict[str, set[UUID]] = defaultdict(set)
+        for edges in out.values():
+            for e in edges:
+                if e["source_type"] in _CONTENT_BY_TYPE:
+                    all_ids_by_type[e["source_type"]].add(UUID(e["source_id"]))
+                if e["target_type"] in _CONTENT_BY_TYPE:
+                    all_ids_by_type[e["target_type"]].add(UUID(e["target_id"]))
+
+        content_map: dict[tuple[str, str], str] = {}
+        for entity_type, ids in all_ids_by_type.items():
+            if not ids:
+                continue
+            table, content_expr = _CONTENT_BY_TYPE[entity_type]
+            placeholders = ", ".join(f":id_{i}" for i in range(len(ids)))
+            id_list = list(ids)
+            params2 = {f"id_{i}": cid for i, cid in enumerate(id_list)}
+            rows = await session.execute(text(f"""
+                SELECT id, {content_expr} AS content
+                FROM {table}
+                WHERE id IN ({placeholders})
+            """), params2)
+            for row in rows:
+                content_map[(entity_type, str(row.id))] = row.content or ""
+
+        # Stitch content into edge dicts; skip edges where either side is missing.
+        for relation, edges in list(out.items()):
+            stitched: list[dict[str, Any]] = []
+            for e in edges:
+                src_content = content_map.get((e["source_type"], e["source_id"]))
+                tgt_content = content_map.get((e["target_type"], e["target_id"]))
+                if src_content is None or tgt_content is None:
+                    logger.debug("edge_audit: missing content for %s -> %s; skipping", e["source_id"], e["target_id"])
+                    continue
+                stitched.append({
+                    **e,
+                    "source_content": src_content,
+                    "target_content": tgt_content,
+                })
+            out[relation] = stitched
+
+    return dict(out)
+
+
+def _summarize(judgments: list[EdgeJudgment]) -> dict[str, int]:
+    counts = {"YES": 0, "WEAK": 0, "NO": 0, "PARSE_ERROR": 0}
+    for j in judgments:
+        counts[j.verdict] = counts.get(j.verdict, 0) + 1
+    return counts
+
+
+def _precision(counts: dict[str, int]) -> float:
+    yes = counts.get("YES", 0)
+    weak = counts.get("WEAK", 0)
+    no = counts.get("NO", 0)
+    denom = yes + weak + no
+    return yes / denom if denom > 0 else 0.0
+
+
+def _write_report(
+    per_relation: dict[str, list[EdgeJudgment]],
+    out_path: Path,
+    since: datetime | None,
+    limit_per_type: int,
+    threshold: float,
+) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# F052 edge-precision audit",
+        "",
+        f"_Generated: {datetime.now(tz=UTC):%Y-%m-%d %H:%M:%S} UTC_",
+        f"_since: {since.isoformat() if since else '(all edges)'}_  ",
+        f"_sample-limit-per-type: {limit_per_type}_  ",
+        f"_gate threshold (precision >= {threshold:.2f} per type)_",
+        "",
+        "| relation | n | YES | WEAK | NO | PARSE_ERROR | precision | gate |",
+        "|----------|---|-----|------|----|-------------|-----------|------|",
+    ]
+    overall_pass = True
+    for relation in sorted(per_relation.keys()):
+        judgments = per_relation[relation]
+        counts = _summarize(judgments)
+        n = len(judgments)
+        prec = _precision(counts)
+        passes = prec >= threshold and n >= 15  # spec N-floor
+        gate_marker = "PASS" if passes else ("UNDERPOWERED" if n < 15 else "FAIL")
+        if not passes and n >= 15:
+            overall_pass = False
+        lines.append(
+            f"| {relation} | {n} | {counts['YES']} | {counts['WEAK']} | {counts['NO']} | "
+            f"{counts['PARSE_ERROR']} | {prec:.2f} | {gate_marker} |"
+        )
+    lines.append("")
+    lines.append(f"**Overall gate**: {'PASS' if overall_pass else 'FAIL'} "
+                 f"(all gate-eligible relations meet precision >= {threshold:.2f})")
+    lines.append("")
+    lines.append("## Sample of NO + WEAK verdicts (for spot-check)")
+    lines.append("")
+    sample_count = 0
+    for relation, judgments in per_relation.items():
+        for j in judgments:
+            if j.verdict in ("NO", "WEAK") and sample_count < 10:
+                lines.append(f"- **{relation}** [{j.verdict}] {j.source_id} -> {j.target_id}: {j.reasoning[:200]}")
+                sample_count += 1
+    out_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+async def run(
+    settings: EvalSettings,
+    since: datetime | None,
+    limit_per_type: int,
+    threshold: float,
+    out_path: Path | None,
+) -> Path:
+    """Driver: build DB, sample edges, judge, write report. Returns the report path."""
+    main_settings = Settings()
+    eval_scoped = _settings_for_eval_db(settings, main_settings)
+    db = Database(eval_scoped)
+    await db.connect()
+    try:
+        agent_id = settings.agent_id
+        per_relation_edges = await _sample_edges_per_type(db, agent_id, since, limit_per_type)
+        if not per_relation_edges:
+            logger.warning("F052 audit: no edges sampled (since=%s, agent_id=%s)", since, agent_id)
+
+        per_relation_verdicts: dict[str, list[EdgeJudgment]] = {}
+        for relation, edges in per_relation_edges.items():
+            if not edges:
+                continue
+            logger.info("F052 audit: judging %d edges for relation=%s", len(edges), relation)
+            verdicts = await judge_edges(edges, eval_scoped)
+            per_relation_verdicts[relation] = verdicts
+
+        if out_path is None:
+            out_path = Path(settings.report_dir) / f"edge-audit-{datetime.now(tz=UTC):%Y%m%d-%H%M%S}.md"
+        _write_report(per_relation_verdicts, out_path, since, limit_per_type, threshold)
+        return out_path
+    finally:
+        await db.engine.dispose()
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="python -m nous_eval.run_edge_audit")
+    p.add_argument("--since", default=None,
+                   help="ISO-8601 timestamp; only audit edges created at/after this. Default: all edges.")
+    p.add_argument("--limit-per-type", type=int, default=30,
+                   help="Max edges to sample per relation type. Default: 30 (matches spec gate sample size).")
+    p.add_argument("--threshold", type=float, default=0.75,
+                   help="Precision floor per relation type. Default: 0.75 (spec gate criterion 2).")
+    p.add_argument("--output", type=Path, default=None,
+                   help="Output markdown path. Default: reports/edge-audit-<timestamp>.md.")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+    ns = _parse_args(argv)
+
+    since = None
+    if ns.since:
+        try:
+            since = datetime.fromisoformat(ns.since)
+            if since.tzinfo is None:
+                since = since.replace(tzinfo=UTC)
+        except ValueError:
+            logger.error("F052 audit: invalid --since value %r (expected ISO-8601)", ns.since)
+            return 2
+
+    settings = EvalSettings()
+    out = asyncio.run(run(
+        settings=settings,
+        since=since,
+        limit_per_type=ns.limit_per_type,
+        threshold=ns.threshold,
+        out_path=ns.output,
+    ))
+    print(f"Wrote: {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nous_eval/templates/edge_precision_prompt.md
+++ b/nous_eval/templates/edge_precision_prompt.md
@@ -1,0 +1,30 @@
+You are a precision judge for a knowledge-graph edge audit.
+
+The Nous agent's `GraphDensifier` (F040) creates edges between memory nodes
+(facts, decisions, episodes, procedures) based on embedding similarity.
+F052 widens the candidate-generation step with multi-embedding query
+expansion. We need to confirm the resulting edges still represent
+semantically valid relationships, not noise let in by the wider net.
+
+For each edge, decide:
+
+- **YES** — the source and target are semantically related per the relation
+  type. A reasoner would naturally consider them together.
+- **WEAK** — a tenuous or indirect link; technically related but would not
+  be the first thing a reasoner reaches for.
+- **NO** — unrelated, wrong-direction, or off-topic.
+
+Relation glossary (subset):
+
+- `related_to` — same-type associative link (fact↔fact, etc.).
+- `evidence_for` — fact supports a decision.
+- `extracted_from` — fact came from an episode.
+- `discussed_in` — decision was discussed in an episode.
+- `informed_by` — decision was informed by a procedure.
+
+Edges to evaluate (JSON array follows). Return a JSON array of objects with
+keys `{source_id, target_id, verdict, reasoning}` in the SAME ORDER as the
+input. `verdict` MUST be one of `"YES"`, `"WEAK"`, `"NO"`. `reasoning` is a
+single sentence — no chain-of-thought, no Markdown.
+
+Return JSON only. No prose preamble or postamble.

--- a/tests/test_f052_multi_embedding_seed.py
+++ b/tests/test_f052_multi_embedding_seed.py
@@ -31,11 +31,15 @@ try:
     from nous.config import Settings
     _settings_probe = Settings()
     if not hasattr(_settings_probe, "graph_backfill_multi_embedding_enabled"):
-        raise ImportError(
+        raise AttributeError(
             "Settings.graph_backfill_multi_embedding_enabled missing "
             "(F052 Subagent A not yet merged)"
         )
-except (ImportError, Exception) as exc:  # pragma: no cover - skip path
+except (ImportError, AttributeError) as exc:  # pragma: no cover - skip path
+    # SFH P2-1: narrow to (ImportError, AttributeError). The prior `except Exception`
+    # would silently mask any future Settings ValidationError / RuntimeError under
+    # the misleading "F052 Settings field not yet merged" banner — letting a real
+    # bug skip-pass in CI for weeks.
     pytest.skip(
         f"F052 Settings field not yet merged ({exc!r}) — skipping module",
         allow_module_level=True,

--- a/tests/test_f052_multi_embedding_seed.py
+++ b/tests/test_f052_multi_embedding_seed.py
@@ -1,0 +1,493 @@
+"""F052 — Multi-embedding seed for ``_backfill_same_type``.
+
+Eight mandatory unit-test cases per spec §Test plan, exercised against
+the wedge installed in ``nous/brain/graph_densifier.py``. Tests use mocks
+for ``Heart.expand_query_pairs`` and patch the imported
+``hybrid_search_multi`` symbol on ``nous.brain.graph_densifier`` so they
+run without a Postgres connection.
+
+Each test ALSO carries an ``ImportError`` skip-guard so the file remains
+collectable on a working tree where Subagent A or B has not yet landed
+the ``Heart.expand_query_pairs`` helper or the
+``graph_backfill_multi_embedding_enabled`` Settings field. In that
+scenario the test module is skipped at collection time with a
+diagnostic rather than crashing the test suite.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import gates — skip module cleanly if A or B hasn't merged yet.
+# ---------------------------------------------------------------------------
+
+try:
+    from nous.config import Settings
+    _settings_probe = Settings()
+    if not hasattr(_settings_probe, "graph_backfill_multi_embedding_enabled"):
+        raise ImportError(
+            "Settings.graph_backfill_multi_embedding_enabled missing "
+            "(F052 Subagent A not yet merged)"
+        )
+except (ImportError, Exception) as exc:  # pragma: no cover - skip path
+    pytest.skip(
+        f"F052 Settings field not yet merged ({exc!r}) — skipping module",
+        allow_module_level=True,
+    )
+
+try:
+    from nous.heart.heart import Heart
+    if not hasattr(Heart, "expand_query_pairs"):
+        raise ImportError(
+            "Heart.expand_query_pairs missing (F052 Subagent A not yet merged)"
+        )
+except ImportError as exc:  # pragma: no cover - skip path
+    pytest.skip(
+        f"Heart.expand_query_pairs not yet merged ({exc!r}) — skipping module",
+        allow_module_level=True,
+    )
+
+# Densifier import is below the gates so a missing wedge import (B not merged)
+# also short-circuits cleanly.
+try:
+    from nous.brain.graph_densifier import GraphDensifier
+    import inspect as _inspect
+    _gd_sig = _inspect.signature(GraphDensifier.__init__)
+    if "heart" not in _gd_sig.parameters:
+        raise ImportError(
+            "GraphDensifier(heart=...) kwarg missing (F052 Subagent B not yet merged)"
+        )
+except ImportError as exc:  # pragma: no cover - skip path
+    pytest.skip(
+        f"GraphDensifier wedge not yet merged ({exc!r}) — skipping module",
+        allow_module_level=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers — minimal Heart/Densifier construction without a real DB.
+# ---------------------------------------------------------------------------
+
+
+def _make_settings(**overrides) -> Settings:
+    """Settings copy with F052 enabled and graph thresholds dropped low.
+
+    The low thresholds let the cosine gate pass for synthetic candidates
+    without forcing real embeddings.
+    """
+    base = Settings()
+    update = {
+        "graph_backfill_multi_embedding_enabled": True,
+        "query_expansion_enabled": True,
+        "graph_backfill_enabled": True,
+        "graph_threshold_fact_fact": 0.0,
+        "ce_backfill_enabled": False,  # tests target the wedge, not CE
+    }
+    update.update(overrides)
+    return base.model_copy(update=update)
+
+
+def _make_densifier(
+    heart: object | None,
+    *,
+    settings: Settings | None = None,
+) -> GraphDensifier:
+    """Build a GraphDensifier with mocked deps and (optionally) a heart."""
+    settings = settings or _make_settings()
+    db = MagicMock()
+    linker = MagicMock()
+    linker.create_edge = AsyncMock(return_value=MagicMock())
+    embedder = MagicMock()
+    return GraphDensifier(
+        db=db,
+        graph_linker=linker,
+        embedder=embedder,
+        settings=settings,
+        agent_id="test-f052-agent",
+        heart=heart,
+    )
+
+
+def _fake_session_factory(
+    sim_value: float = 0.95,
+    orphan_embedding: list[float] | None = None,
+):
+    """Return a MagicMock session that responds to the densifier's SQL.
+
+    The densifier hits two SQL statements inside ``_backfill_same_type``:
+    1. SELECT embedding for the orphan (returns ``orphan_embedding``).
+    2. SELECT cosine similarity for each candidate (returns ``sim_value``).
+    """
+    if orphan_embedding is None:
+        orphan_embedding = [0.1] * 8
+
+    session = MagicMock()
+
+    # First SQL execute returns a row with an "embedding" attr; subsequent
+    # similarity SQLs return a row with a "similarity" attr. We discriminate
+    # by SQL contents — cleaner than counting calls.
+    async def _execute(sql, params=None):
+        sql_str = str(sql)
+        result = MagicMock()
+        if "FROM heart.facts WHERE id" in sql_str and "embedding::text" in sql_str:
+            row = SimpleNamespace(embedding=orphan_embedding)
+            result.first = MagicMock(return_value=row)
+        elif "1 - (embedding <=>" in sql_str:
+            row = SimpleNamespace(similarity=sim_value)
+            result.first = MagicMock(return_value=row)
+        else:
+            result.first = MagicMock(return_value=None)
+        return result
+
+    session.execute = AsyncMock(side_effect=_execute)
+    return session
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — single-pair short-circuit byte-identity (feature off)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_disabled_path_byte_identical_to_hybrid_search():
+    """When ``graph_backfill_multi_embedding_enabled=False``, the wedge must
+    construct a single ``(content, orphan_embedding)`` pair and route through
+    ``hybrid_search_multi`` — which short-circuits at search.py:319-332 to
+    a byte-identical ``hybrid_search`` call.
+    """
+    settings = _make_settings(graph_backfill_multi_embedding_enabled=False)
+    # heart=None to additionally prove the wedge does NOT consult the helper
+    # when the flag is off.
+    densifier = _make_densifier(heart=None, settings=settings)
+    session = _fake_session_factory()
+    orphan_id = uuid4()
+
+    fake_multi = AsyncMock(return_value=[(uuid4(), 0.9)])
+    with patch(
+        "nous.brain.graph_densifier.hybrid_search_multi", fake_multi
+    ):
+        await densifier._backfill_same_type(
+            entity_type="fact",
+            orphan_id=orphan_id,
+            orphan_content="orphan content here",
+            session=session,
+        )
+
+    # Critical assertion: queries len==1 → triggers the single-element
+    # fast-path in hybrid_search_multi.
+    assert fake_multi.await_count == 1
+    call_kwargs = fake_multi.await_args.kwargs
+    assert "queries" in call_kwargs
+    queries = call_kwargs["queries"]
+    assert len(queries) == 1, "Disabled path must produce exactly one query pair"
+    assert queries[0][0] == "orphan content here"
+    # Embedding is whatever _fake_session_factory returned for orphan
+    assert queries[0][1] is not None
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — multi-pair widens (or matches) candidate set
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_multi_pair_widens_candidate_set():
+    """With 3 distinct (text, embedding) variants, the wedge must call
+    ``hybrid_search_multi`` with a list of length 3 — letting RRF widen
+    the candidate set vs the single-query baseline.
+    """
+    heart = MagicMock()
+    heart.expand_query_pairs = AsyncMock(
+        return_value=[
+            ("variant 1 text", [0.1] * 8),
+            ("variant 2 text", [0.2] * 8),
+            ("variant 3 text", [0.3] * 8),
+        ]
+    )
+    densifier = _make_densifier(heart=heart)
+    session = _fake_session_factory()
+
+    # Two unique candidates from RRF fusion.
+    cand_a, cand_b = uuid4(), uuid4()
+    fake_multi = AsyncMock(return_value=[(cand_a, 0.9), (cand_b, 0.8)])
+    with patch(
+        "nous.brain.graph_densifier.hybrid_search_multi", fake_multi
+    ):
+        await densifier._backfill_same_type(
+            entity_type="fact",
+            orphan_id=uuid4(),
+            orphan_content="orphan content goes here",
+            session=session,
+        )
+
+    assert heart.expand_query_pairs.await_count == 1
+    queries = fake_multi.await_args.kwargs["queries"]
+    assert len(queries) == 3, "Multi-pair path must surface all 3 variants"
+    assert {q[0] for q in queries} == {
+        "variant 1 text", "variant 2 text", "variant 3 text",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — original embedding still gates cosine
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cosine_uses_original_orphan_embedding():
+    """Variants influence candidate-gen only. The cosine verification at
+    graph_densifier.py:284-298 must use the ORIGINAL ``orphan_embedding``,
+    so the edge weight must reflect the orphan↔candidate similarity, not
+    any variant↔candidate similarity.
+    """
+    orphan_emb = [0.7] * 8  # the embedding cosine SQL must use this
+    heart = MagicMock()
+    heart.expand_query_pairs = AsyncMock(
+        return_value=[
+            ("v1", [0.1] * 8),
+            ("v2", [0.2] * 8),
+        ]
+    )
+    settings = _make_settings()
+    densifier = _make_densifier(heart=heart, settings=settings)
+
+    captured_emb_params: list[dict] = []
+
+    async def _execute(sql, params=None):
+        sql_str = str(sql)
+        result = MagicMock()
+        if "embedding::text" in sql_str:
+            result.first = MagicMock(
+                return_value=SimpleNamespace(embedding=orphan_emb)
+            )
+        elif "1 - (embedding <=>" in sql_str:
+            captured_emb_params.append(params or {})
+            result.first = MagicMock(
+                return_value=SimpleNamespace(similarity=0.91)
+            )
+        else:
+            result.first = MagicMock(return_value=None)
+        return result
+
+    session = MagicMock()
+    session.execute = AsyncMock(side_effect=_execute)
+
+    cand = uuid4()
+    fake_multi = AsyncMock(return_value=[(cand, 0.5)])
+    with patch(
+        "nous.brain.graph_densifier.hybrid_search_multi", fake_multi
+    ):
+        await densifier._backfill_same_type(
+            entity_type="fact",
+            orphan_id=uuid4(),
+            orphan_content="long orphan text that drives expansion",
+            session=session,
+        )
+
+    # The cosine SQL must have been called with the orphan's stored embedding,
+    # NOT a variant embedding.
+    assert captured_emb_params, "cosine SQL was never called"
+    emb_param = captured_emb_params[0].get("emb", "")
+    assert "0.7" in emb_param, (
+        "Cosine gate used a non-orphan embedding — F052 invariant violated"
+    )
+    # And the create_edge weight must equal the cosine similarity (0.91).
+    densifier._linker.create_edge.assert_awaited_once()
+    weight = densifier._linker.create_edge.await_args.kwargs.get("weight")
+    assert weight == pytest.approx(0.91)
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — expander failure → helper single-pair fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_expander_failure_helper_returns_single_pair():
+    """If the helper itself returns ``[(query, None)]`` (its documented
+    fallback), the wedge must substitute the orphan's stored embedding
+    so the short-circuit path still has vector signal — and never sees
+    ``None`` flowing into ``hybrid_search_multi`` for the embedding slot.
+    """
+    heart = MagicMock()
+    heart.expand_query_pairs = AsyncMock(
+        return_value=[("orphan content", None)]  # helper's fallback shape
+    )
+    densifier = _make_densifier(heart=heart)
+    orphan_emb = [0.3] * 8
+    session = _fake_session_factory(orphan_embedding=orphan_emb)
+
+    fake_multi = AsyncMock(return_value=[])
+    with patch(
+        "nous.brain.graph_densifier.hybrid_search_multi", fake_multi
+    ):
+        await densifier._backfill_same_type(
+            entity_type="fact",
+            orphan_id=uuid4(),
+            orphan_content="orphan content",
+            session=session,
+        )
+
+    assert heart.expand_query_pairs.await_count == 1
+    queries = fake_multi.await_args.kwargs["queries"]
+    assert len(queries) == 1
+    text_q, emb_q = queries[0]
+    assert text_q == "orphan content"
+    assert emb_q == orphan_emb, (
+        "Helper single-pair fallback should be backfilled with orphan_embedding"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — RRF fusion handles identical-list inputs without double-counting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rrf_no_double_count_on_identical_lists():
+    """If 3 variant searches return identical candidate lists, the wedge
+    must hand all 3 to hybrid_search_multi — the RRF inside that function
+    is responsible for not double-counting. The wedge's own contract is
+    just to deliver N variants without de-duplicating them itself.
+    """
+    heart = MagicMock()
+    heart.expand_query_pairs = AsyncMock(
+        return_value=[
+            ("variant 1", [0.1] * 8),
+            ("variant 2", [0.2] * 8),
+            ("variant 3", [0.3] * 8),
+        ]
+    )
+    densifier = _make_densifier(heart=heart)
+    session = _fake_session_factory()
+
+    fake_multi = AsyncMock(return_value=[])
+    with patch(
+        "nous.brain.graph_densifier.hybrid_search_multi", fake_multi
+    ):
+        await densifier._backfill_same_type(
+            entity_type="fact",
+            orphan_id=uuid4(),
+            orphan_content="orphan content",
+            session=session,
+        )
+
+    queries = fake_multi.await_args.kwargs["queries"]
+    assert len(queries) == 3, (
+        "Wedge must hand all variants to hybrid_search_multi; RRF de-dupes"
+    )
+    # The wedge does NOT collapse duplicates itself — that's RRF's job.
+    assert len({q[0] for q in queries}) == 3
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — empty union returns 0 cleanly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_union_returns_zero_edges():
+    """``hybrid_search_multi`` returning ``[]`` must short-circuit the
+    method to ``return 0`` without raising or attempting cosine SQL.
+    """
+    heart = MagicMock()
+    heart.expand_query_pairs = AsyncMock(
+        return_value=[("v1", [0.1] * 8), ("v2", [0.2] * 8)]
+    )
+    densifier = _make_densifier(heart=heart)
+    session = _fake_session_factory()
+
+    fake_multi = AsyncMock(return_value=[])
+    with patch(
+        "nous.brain.graph_densifier.hybrid_search_multi", fake_multi
+    ):
+        edges_created = await densifier._backfill_same_type(
+            entity_type="fact",
+            orphan_id=uuid4(),
+            orphan_content="content",
+            session=session,
+        )
+
+    assert edges_created == 0
+    densifier._linker.create_edge.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — large union forwarded to (CE-disabled) cosine loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_union_above_ce_cap_truncated():
+    """With CE backfill disabled, a 30-candidate union (3 variants × 10) is
+    forwarded directly to the cosine-verification loop without truncation.
+    Behaviour is well-defined — we just iterate every candidate the RRF
+    surfaced. (When CE backfill IS enabled, the F042 reranker imposes its
+    own head-truncation cap; that is a separate code path with its own
+    tests in test_backfill_rerank.py.)
+    """
+    heart = MagicMock()
+    heart.expand_query_pairs = AsyncMock(
+        return_value=[
+            ("v1", [0.1] * 8),
+            ("v2", [0.2] * 8),
+            ("v3", [0.3] * 8),
+        ]
+    )
+    densifier = _make_densifier(heart=heart)
+    session = _fake_session_factory(sim_value=0.99)
+
+    candidates = [(uuid4(), 0.9 - i * 0.01) for i in range(30)]
+    fake_multi = AsyncMock(return_value=candidates)
+    with patch(
+        "nous.brain.graph_densifier.hybrid_search_multi", fake_multi
+    ):
+        edges_created = await densifier._backfill_same_type(
+            entity_type="fact",
+            orphan_id=uuid4(),
+            orphan_content="content",
+            session=session,
+        )
+
+    # Without CE rerank, every candidate above the (zeroed) threshold
+    # produces an edge. The number is deterministic and equals 30.
+    assert edges_created == 30
+    assert densifier._linker.create_edge.await_count == 30
+
+
+# ---------------------------------------------------------------------------
+# Test 8 — CancelledError propagates; never swallowed by the wedge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancelled_error_propagates_not_swallowed():
+    """If ``Heart.expand_query_pairs`` raises ``asyncio.CancelledError``,
+    the wedge must let it propagate (CancelledError is a BaseException in
+    Python 3.8+; ``except Exception`` does NOT catch it). The densifier
+    must not log-and-swallow.
+    """
+    heart = MagicMock()
+    heart.expand_query_pairs = AsyncMock(side_effect=asyncio.CancelledError())
+    densifier = _make_densifier(heart=heart)
+    session = _fake_session_factory()
+
+    fake_multi = AsyncMock(return_value=[])
+    with patch(
+        "nous.brain.graph_densifier.hybrid_search_multi", fake_multi
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await densifier._backfill_same_type(
+                entity_type="fact",
+                orphan_id=uuid4(),
+                orphan_content="content",
+                session=session,
+            )
+
+    fake_multi.assert_not_awaited()


### PR DESCRIPTION
## Summary

F052 widens orphan candidate generation in `_backfill_same_type` (only) by reusing F050's `QueryExpander` to seed N alternate query embeddings per orphan, then RRF-fusing the candidate sets via the existing `hybrid_search_multi`. CE rerank + cosine verification stay unchanged so the precision floor is preserved by construction.

**Phase 1 scope is `_backfill_same_type` ONLY.** Cross-type backfill is explicitly deferred to F052.4 because the cross-type cosine gate uses re-embedded common-template vectors (not the orphan's stored embedding), so the precision-safe invariant doesn't compose.

**Default-off ship**: `NOUS_GRAPH_BACKFILL_MULTI_EMBEDDING_ENABLED=false` in this PR. Prod flip is a SEPARATE decision after the eval gate passes.

## Eval-before-deploy gate (the whole point of F052)

This PR ships the impl + the new `nous_eval/density_eval.py` harness mode. Per spec §Rollout:

- **Phase 2 — Eval gate** (next): run `uv run python -m nous_eval.density_eval --configs baseline,f052_on` against the F051 eval DB. Manual edge-precision audit on 30 edges per type via `nous_eval/edge_judge.py`. Attach report to this PR.
- **Phase 3a — Pass** (5 gate criteria all met): merge with prod flag still off. Open separate follow-up issue for prod-flip.
- **Phase 3b — Fail**: mark spec abandoned, close PR.

The 5 gate criteria are defined in spec §Gate criteria; gist:
1. Density lift ≥10% per gate-eligible type (N≥15), no regression worse than -2%
2. Edge precision ≥0.75 LLM-judged YES rate per type
3. CE truncation safety: `union_size_p95 < cross_encoder_max_candidates - 2`
4. Cost ceiling within bounded orphan-cap budget
5. Wall time under `NOUS_SUBTASK_DEFAULT_TIMEOUT=600s`

## Review history

**Spec review** (3 agents: arch / devil / python-pro):
- v1 → v2 fixes: 11 P1 + 7 P2 addressed. Devil's REWORK verdict was load-bearing — caught the cross-type pipeline mismatch (precision invariant false there) → Phase 1 scoped to same-type only.
- v2 lightweight re-review: APPROVE, all 17 deltas confirmed.

**Plan review** (3-lens single agent):
- v1 → v1.1 fixes: 3 P1 + 4 P2 addressed. Critical: `RuntimeConfig.set()` doesn't exist — F051 uses Settings overlay via `_apply_config_flags`. TEMP table snapshot was session-scoped → switched to real persistent table.

**Impl review** (3 agents: code-reviewer / SFH / python-pro):
- code-reviewer: APPROVE (3 P3)
- python-pro: APPROVE_WITH_REVISIONS (3 P2 + 4 P3)
- SFH: REWORK (2 P1 + 4 P2 + 2 P3) — binding verdict
- All P1 + P2 fixes landed in commit `80d003d`. SFH P1s caught:
  1. `density_eval` was inheriting `graph_backfill_enabled=False` from F051's disable list → would silently produce 0 edges for every config, F052 measurement meaningless.
  2. `edge_judge` zip-truncation when Sonnet returns short responses → silent precision-denominator inflation.
- Re-review of fixes: APPROVE, 8/8 finding closures confirmed, 8/8 tests pass.

## Code surface

| File | Change | LOC |
|---|---|---|
| `nous/config.py` | +2 Field declarations (query_expansion_temperature, graph_backfill_multi_embedding_enabled) | +20 |
| `nous/heart/heart.py` | Extracted `expand_query_pairs` helper from `_recall:809-835`; refactored `_recall` to call it | +101/-27 |
| `nous/heart/query_expansion.py` | Thread `temperature` from settings into Haiku call | +1 |
| `nous/brain/graph_densifier.py` | `_backfill_same_type` wedge + heart kwarg; `_backfill_cross_type` UNTOUCHED | +49/-4 |
| `nous/main.py` | Pass `heart=heart` to GraphDensifier construction | +1 |
| `nous_eval/density_eval.py` | NEW — F052 eval harness mode | +487 |
| `nous_eval/edge_judge.py` | NEW — Sonnet edge-precision judge | +191 |
| `nous_eval/templates/edge_precision_prompt.md` | NEW — operator-editable judge prompt | +30 |
| `nous_eval/retrieval_runner.py` | `_build_densifier_for_eval` helper | +56 |
| `nous_eval/retrieval.py` | `f052_on` RetrievalConfig | +19 |
| `tests/test_f052_multi_embedding_seed.py` | NEW — 8 mandatory test cases per spec | +497 |
| `docs/features/F052-multi-embedding-backfill-seed.md` | NEW spec v2 | +284 |
| `docs/superpowers/plans/2026-04-26-f052-multi-embedding-backfill.md` | NEW impl plan v1.1 | +780 |

**Total**: 2485 insertions / 31 deletions across 13 files.

## Test plan

- [x] All 8 F052 unit/integration tests pass
- [x] No regression on existing `test_graph_densifier.py` (3 pre-existing F045 fails unrelated; same on main)
- [x] Smoke imports for all new modules resolve
- [ ] **Phase 2** — `uv run python -m nous_eval.density_eval --configs baseline,f052_on --n-runs 1` against F051 eval DB
- [ ] **Phase 2** — manual 30-edge precision audit per type via `edge_judge.py`
- [ ] Attach gate-report markdown to this PR

## Out of scope (deferred)

- F052.1 production shadow mode
- F052.2 adaptive variant count
- F052.3 variant-embedding caching
- F052.4 cross-type backfill extension
- F052.5 separate backfill budget bucket

🤖 Generated with [Claude Code](https://claude.com/claude-code)