### PR TITLE
feat(F053): density-eval harness + edge-precision audit (F040 ops, salvaged from F052)

### DIFF
--- a/docs/features/F053-density-ops-harness.md
+++ b/docs/features/F053-density-ops-harness.md
@@ -1,0 +1,188 @@
+# F053 — Density-Eval Harness + Edge Precision Audit
+
+**Status:** 📝 Proposed (2026-04-26 — salvaged from F052 abandonment)
+**Proposed by:** Tim
+**Date:** 2026-04-26
+**Depends on:** F040 (graph densification — shipped), F042/F043/F045 (CE rerank + thresholds — shipped), F051 (eval harness infrastructure — shipped)
+**Blocks:** F054 (selective CE-threshold relaxation — separate spec)
+**Related:** F052 (abandoned 2026-04-26 — `❌ eval-fail`)
+
+---
+
+## Problem
+
+F040 graph densification shipped without a way to A/B alternate parameter choices (CE thresholds, content-length guards, candidate-pool caps) against a stable corpus. The only feedback loop today is "ship to prod, watch `/dashboard/density` for two sleep cycles, hope the trend is right." That's slow, expensive, and doesn't surface threshold-bound precision regressions until they've already polluted the graph.
+
+The F052 work (multi-embedding seed for backfill, abandoned) revealed two things during its eval gate run:
+1. The F051 eval-harness infrastructure could be wired to drive `GraphDensifier.run_backfill_cycle()` directly against the eval DB and snapshot edge/orphan deltas across configs.
+2. The bigger F040 win wasn't candidate generation at all — it was relaxed CE thresholds (`baseline_loose_ce` produced +59.6% more edges than baseline at identical precision). That finding was only visible because the harness instrumented the cycle.
+
+F053 ships the harness as standalone F040 ops infrastructure, separated from the abandoned F052 wedge. F054 will then use F053 to validate the selective CE-threshold relaxation hypothesis empirically before merge.
+
+### What this is not
+
+- Not a F040 algorithm change — `GraphDensifier`, `_backfill_same_type`, `_backfill_cross_type`, `discover_clusters` are untouched.
+- Not a new retrieval metric — F051's `nous_eval.retrieval` matrix (MRR/P@K/R@K/nDCG) stays unchanged.
+- Not a F052 resurrection — the abandoned multi-embedding wedge is NOT in this PR.
+
+---
+
+## Goals
+
+1. **Reproducible density measurement** — `uv run python -m nous_eval.density_eval --configs <list>` runs each config against the F051 eval DB and emits a markdown report with edge counts, orphan counts, ce_pruned, wall time, and per-relation breakdown. Re-runnable on the same corpus.
+2. **Eval-before-deploy gate for F040 tuning** — any PR that touches F040 thresholds, candidate caps, or content-length guards must demonstrate density delta + precision delta on the eval corpus before merge. F053 is the gate mechanism.
+3. **LLM-judged edge-precision audit** — `uv run python -m nous_eval.run_edge_audit` samples N newly-created edges per relation type, fetches source/target content, asks Sonnet for YES/WEAK/NO verdicts, computes per-relation precision with PASS/FAIL/UNDERPOWERED gate markers (≥15 N-floor + ≥0.75 precision floor).
+4. **Diagnostic baseline_loose_ce config out of the box** — ship one diagnostic `RetrievalConfig` (`baseline_loose_ce`) so future F040 tuning specs (F054, F055, ...) start with a working comparison point.
+
+## Non-goals
+
+- **No automatic gate enforcement at PR-time** — manual operator invocation, manual report attachment to PRs (matches F051's no-CI posture).
+- **No per-edge embedding cost analysis** — wall time + ce_pruned counters only; finer instrumentation deferred.
+- **No prompt-cache for edge_judge** — single Sonnet call per BATCH_SIZE=30 edges, no caching. Audit is rare (~once per F040 tuning PR).
+- **No support for cross-corpus comparison** — each density_eval run is scoped to the F051 eval corpus's `agent_id`. Prod-corpus runs are out of scope (F051 already enforces "eval DB only at runtime").
+
+## Deferred (with rationale)
+
+- **F053.1 — Per-config edge_judge integration in `density_eval.py`.** Today the audit is a separate `run_edge_audit` invocation against whatever edges currently live in the eval DB (typically the LAST config that ran). A future enhancement: snapshot edges-per-config and audit each set independently. Useful when comparing >2 configs' precision side-by-side.
+- **F053.2 — Cost telemetry per config** — track Haiku/Sonnet/embed token usage per config, surface in markdown report.
+- **F053.3 — `--n-runs` averaging** — repeat each config N times, report mean ± stddev. Useful when configs invoke non-deterministic LLM calls (F052-style expansion); not needed for pure-threshold configs.
+
+---
+
+## Mechanism
+
+### `nous_eval/density_eval.py` — the harness mode
+
+```bash
+uv run python -m nous_eval.density_eval --configs baseline,baseline_loose_ce
+```
+
+Per config (mirrors `nous_eval.retrieval_runner.run_matrix`):
+
+1. `RuntimeConfig.reset()` — clear flag leakage from prior config.
+2. `_apply_config_flags(template, cfg)` — Settings overlay (NOT `RuntimeConfig.set` — that's the F051 lesson).
+3. `_settings_for_eval_db(eval_settings, overridden)` — redirect Settings DB connection to the eval DB.
+4. `eval_scoped.model_copy(update={"graph_backfill_enabled": True})` — F051's `_settings_for_eval_db` forces this False to suppress prod handlers; density_eval invokes the densifier *directly* so we re-enable. Without this every config silently returns 0 edges.
+5. `_ensure_zero_edge_baseline(db, agent_id)` — DELETE current edges; create persistent `brain.eval_baseline_edges_snapshot` table (REAL, not TEMP — survives connection-pool churn); TRUNCATE.
+6. Snapshot pre-state — orphan + edge counts per type/relation.
+7. Build Heart + densifier via `_build_densifier_for_eval(settings, db, agent_id)`. Raises loud if `OPENAI_API_KEY` is unset (no silent collapse to baseline-vs-baseline).
+8. Run `densifier.run_backfill_cycle()` + `densifier.discover_clusters(max_bridges=20)`. On any exception: `_restore_baseline` → record failure string in `DensityRunResult.failure`.
+9. Snapshot post-state.
+10. `RuntimeConfig.reset()` for the next config.
+
+Output: `reports/density-eval-<timestamp>.md` markdown table + per-config breakdown.
+
+### `nous_eval/edge_judge.py` — the LLM judge
+
+- Loads operator-editable prompt template from `nous_eval/templates/edge_precision_prompt.md`.
+- Batches edges in chunks of `BATCH_SIZE=30`.
+- Calls Sonnet via the existing OAT-supporting `AnthropicClient` with the **Claude Code preamble as system block 0** (without it, OAT returns 429 — per project memory).
+- Parses JSON response with `json5`-style trailing-comma tolerance + code-fence stripping.
+- Returns one `EdgeJudgment` per input edge in input order; uses `zip_longest` + `verdict="PARSE_ERROR"` padding when Sonnet returns short responses (max_tokens cutoff, ambiguous-skip).
+- `max_tokens=8192` (empirically necessary — 2048 truncates mid-string with 30 edges of reasoning).
+
+### `nous_eval/run_edge_audit.py` — the audit driver
+
+```bash
+uv run python -m nous_eval.run_edge_audit --since "$NOW" --limit-per-type 30
+```
+
+- Samples N edges per relation type from `brain.graph_edges` for the eval `agent_id`.
+- Joins source + target content via the right per-type table (`heart.facts.content`, `brain.decisions.context`, `heart.episodes.summary`, `heart.procedures.name || ': ' || description`).
+- Skips edges where either side has missing content (logs DEBUG; counts toward N).
+- Calls `edge_judge.judge_edges` per relation; computes per-relation precision = `YES / (YES + WEAK + NO)`.
+- Writes `reports/edge-audit-<timestamp>.md` with per-relation gate markers:
+  - **PASS** = N ≥ 15 AND precision ≥ 0.75
+  - **UNDERPOWERED** = N < 15 (excluded from gate verdict)
+  - **FAIL** = N ≥ 15 AND precision < 0.75
+- Spot-check section lists up to 10 NO + WEAK verdicts with the model's reasoning so operators can audit the audit.
+
+### `baseline_loose_ce` diagnostic config
+
+Lives in `nous_eval/retrieval.py::_DEFAULT_CONFIGS`. Six-knob CE-threshold relaxation:
+
+| threshold | strict | loose |
+|---|---|---|
+| `ce_backfill_threshold_fact_fact` | 0.65 | 0.55 |
+| `ce_backfill_threshold_decision_decision` | 0.60 | 0.50 |
+| `ce_backfill_threshold_fact_decision` | 0.55 | 0.45 |
+| `ce_backfill_threshold_fact_episode` | 0.55 | 0.45 |
+| `ce_backfill_threshold_episode_episode` | 0.58 | 0.50 |
+| `ce_backfill_threshold_procedure_any` | 0.55 | 0.45 |
+
+**Note**: this is a *diagnostic* config, not a recommended deployment. The 2026-04-26 audit on the F051 eval corpus showed `evidence_for` precision regresses from 0.57 → 0.47 with this blanket relaxation. F054 will propose a **selective** relaxation (loosen same-type only).
+
+---
+
+## Code surface
+
+### Files added
+| File | LOC | Purpose |
+|---|---|---|
+| `nous_eval/density_eval.py` | ~490 | F053 harness mode CLI + per-config snapshot/run/restore loop + markdown writer |
+| `nous_eval/edge_judge.py` | ~190 | Sonnet edge-precision judge with OAT preamble + JSON tolerance |
+| `nous_eval/run_edge_audit.py` | ~290 | Audit CLI driver + per-relation precision report |
+| `nous_eval/templates/edge_precision_prompt.md` | ~30 | Operator-editable judge prompt |
+
+### Files modified
+| File | LOC change | Change |
+|---|---|---|
+| `nous_eval/retrieval_runner.py` | +44 | Add `_build_densifier_for_eval(settings, db, agent_id)` helper |
+| `nous_eval/retrieval.py` | +25 | Add `baseline_loose_ce` diagnostic `RetrievalConfig` |
+| `docs/features/INDEX.md` | +1 row | F053 entry (added when impl ships) |
+
+### Files NOT touched
+- `nous/` — no production code changes. F040/F042/F043/F045 algorithms unchanged.
+- `nous_eval/retrieval_runner.py::run_matrix` — F051 retrieval harness unchanged.
+- `sql/migrations/` — no schema. The `brain.eval_baseline_edges_snapshot` table is created idempotently by the harness itself.
+
+**Total**: ~1070 LOC (mostly new module code, minimal touch on existing files).
+
+---
+
+## Tests
+
+This is operator tooling, not production code. Per F051's no-CI posture, F053 ships with smoke-test invocations rather than a unit test suite:
+
+- `uv run python -c "from nous_eval.density_eval import main; main(['--help'])"` — CLI parses cleanly.
+- `uv run python -c "from nous_eval.edge_judge import judge_edges; print('OK')"` — module imports.
+- Live smoke validated 2026-04-26 against `nous_eval_scratch` DB:
+  - `density_eval --configs baseline` → 240 edges, 105.8s wall.
+  - `density_eval --configs baseline,baseline_loose_ce,...` → 6-config matrix completed.
+  - `run_edge_audit --limit-per-type 30` → precision table for 3 relations.
+
+Future regression-prevention tests can land as F053.1 alongside the per-config edge_judge integration.
+
+---
+
+## Risks
+
+1. **Mutates the eval DB.** Each config DELETEs all edges before running. The snapshot table is empty by design (anchor for restore-on-crash), so a crash leaves zero-edge state. Operators must understand this is *not* a read-only harness — it modifies graph state.
+2. **OAT rate limits during edge_judge.** Heavy concurrent Sonnet usage on a single OAT can 429. The `Claude Code` preamble as system block 0 mitigates per project memory, but back-to-back audit runs may still hit limits.
+3. **JSON parser tolerance window.** The audit uses surgical regex to strip code fences + trailing commas before strict `json.loads`. Pathological Sonnet responses (deeply nested unquoted keys, unicode escapes) could still fail with `verdict="PARSE_ERROR"`. Logged as WARN; doesn't crash the audit.
+4. **`max_tokens=8192` cap.** 30 edges × ~250 chars reasoning = ~7500 chars ≈ 1900 tokens. Comfortable margin, but extreme verbosity could still truncate. Mitigated by zip_longest padding (truncated tail gets `PARSE_ERROR`).
+5. **Embedder requirement.** `_build_densifier_for_eval` raises `RuntimeError` if `OPENAI_API_KEY` is unset. This is intentional (silent collapse to baseline-vs-baseline would invalidate any A/B), but operators must export the key before running.
+
+---
+
+## Rollout
+
+| Phase | Trigger | Action |
+|---|---|---|
+| **0 — Spec lock (this doc)** | 3-agent review optional (low-risk operator tooling, no production code change). Plan-author judgment call. | Spec frozen. |
+| **1 — Ship as F053 PR** | Branch `feat/F053-density-ops-harness` with the files in §Code surface. Default-on (no flag — these are ad-hoc CLIs, not request-path code). | PR opens; merge after smoke-test confirmation. |
+| **2 — F054 spec uses F053** | F053 merged | F054 (selective CE-threshold relaxation) declares `Depends on: F053` and uses `density_eval` + `run_edge_audit` as its gate mechanism. |
+| **3 — Future tuning** | Any F040 PR | New convention: F040 changes touching thresholds, caps, or content guards must run `density_eval` + `run_edge_audit` against the eval corpus, attach reports to PR, demonstrate density Δ + precision Δ before merge. |
+
+---
+
+## Provenance
+
+This module was built during F052 implementation (PR #350) and validated by surfacing F052's negative result on 2026-04-26 (multi-embedding seed produced 0% density lift). When F052 was abandoned per its `§Rollout 3b`, the harness code was salvaged into this F053 spec because it's reusable infrastructure that paid for itself by enabling the abandonment decision.
+
+Concretely:
+- The diagnostic matrix (baseline / baseline_loose_ce / f052_on / f052_on_low_minwords / f052_on_loose_ce / f052_on_combo) revealed that F040's CE-mode cosine thresholds were the binding constraint, NOT candidate generation. This insight directly motivates F054.
+- The edge_judge precision audit revealed asymmetry between same-type relations (`related_to` precision 0.83 stable under loose CE) and cross-type relations (`evidence_for` precision degrades 0.57 → 0.47 under loose CE). This shapes F054's *selective* relaxation design.
+- Three SFH-grade bugs were caught and fixed during the live gate run: `SdkAnthropicClient.call()` payload-dict signature, OAT Claude-Code-preamble requirement, and JSON5 trailing-comma tolerance. Future Sonnet-judge code can reuse these patterns.
+
+The F052 spec stays at `docs/features/F052-multi-embedding-backfill-seed.md` as the abandonment decision record.

--- a/docs/features/F054-selective-ce-threshold-relaxation.md
+++ b/docs/features/F054-selective-ce-threshold-relaxation.md
@@ -1,0 +1,202 @@
+# F054 — Selective CE-Threshold Relaxation for F040 Backfill
+
+**Status:** 📝 Proposed (2026-04-26)
+**Proposed by:** Tim
+**Date:** 2026-04-26
+**Depends on:** F045 (CE-aware thresholds — shipped), F053 (density-eval harness — proposed PR #351)
+**Blocks:** none
+**Related:** F040 (graph densification — shipped), F052 (abandoned — provided the eval data motivating F054)
+
+---
+
+## Problem
+
+F045 ships per-relation CE-mode cosine thresholds for graph densification backfill, calibrated against a 2026-04-14 A/B that found `fact_fact=0.65` produced 80% LLM-judged precision. The other five thresholds (`decision_decision=0.60`, `fact_decision=0.55`, `fact_episode=0.55`, `episode_episode=0.58`, `procedure_any=0.55`) were histogram estimates, not empirically validated.
+
+The 2026-04-26 F053 density-eval harness run revealed:
+
+| relation | strict thresholds (today) | loose thresholds (`baseline_loose_ce`) | Δ edges | precision change |
+|---|---|---|---|---|
+| `related_to` (mostly same-type) | 159 edges | 272 edges | **+113 (+71%)** | **0.83 → 0.83 (no change)** |
+| `informed_by` (decision↔procedure) | 9 edges | 16 edges | +7 | 1.00 (n=9, underpowered) → 0.88 (n=16) |
+| `evidence_for` (decision↔fact) | 73 edges | 95 edges | +22 | **0.57 → 0.47 (worse)** |
+
+**Same-type relations are over-filtered.** Loosening their thresholds catches +113 high-precision edges per cycle on the F051 eval corpus at zero precision regression.
+
+**Cross-type `evidence_for` (fact↔decision) is fragile.** Already failing precision (0.57 < 0.75) with strict thresholds, and degrades further when loosened. The cause is corpus quality (~5 of 9 NO/WEAK verdicts cite "source content is empty" — `brain.decisions.context` is often null in the eval corpus), not algorithmic — but the threshold can't fix the corpus, so loosening it just adds more noise.
+
+F054 ships a *selective* relaxation: lower the same-type and one cross-type threshold, **leave fact↔fact at 0.55, fact↔decision at the strict 0.55**, and add a content-length guard for decisions to prevent empty-content edge creation.
+
+### What this is not
+
+- Not a F040 algorithm change — `_backfill_same_type` and `_backfill_cross_type` orchestration is untouched.
+- Not a F045 redesign — only the per-relation threshold *defaults* change; the `_get_threshold` routing logic stays the same.
+- Not a multi-embedding seed (that was F052 — abandoned). F054 doesn't generate new candidates; it lets more existing candidates clear cosine.
+
+---
+
+## Goals
+
+1. **Increase F040 backfill density on production** by ~50-70% (extrapolated from F051 eval-corpus measurement) at zero LLM-judged precision regression for same-type relations.
+2. **Eval-before-deploy gate** — every threshold change validated via F053 density_eval + run_edge_audit before merge. F054 implementation runs the same harness with the new defaults and demonstrates per-relation precision ≥ 0.75 (or unchanged from baseline) on a 30-edge audit per relation.
+3. **Add content-length guard for `brain.decisions.context`** mirroring F045's existing `NOUS_CE_BACKFILL_MIN_CONTENT_CHARS=80` for facts. Prevents empty-decision-content edges that the F053 audit identified as the root cause of `evidence_for` precision drops.
+4. **Default-on ship** (this is a tuning change, not a new feature). Old thresholds remain available via env-var overrides for operators who want to revert.
+
+## Non-goals
+
+- **No change to fact↔fact threshold** — already empirically validated at 0.65 → 80% precision (decision `7d6fdce9`). Don't fix what isn't broken.
+- **No change to `evidence_for` (fact↔decision) threshold** — F053 audit shows it's already under-precision; loosening makes it worse. Address via content guard, not threshold.
+- **No new metrics / dashboard panels** — `/dashboard/density` already shows orphan rate; F054 expects the rate to drop.
+- **No change to `_backfill_cross_type` candidate generation logic** — out of scope (would be F052.4 territory if anyone resurrects it).
+- **No F040 cycle-cap changes** — `NOUS_GRAPH_BACKFILL_MAX_FACTS=50` etc. stay where they are.
+
+## Deferred (with rationale)
+
+- **F054.1 — Per-corpus threshold calibration.** F054 ships defaults validated on the F051 eval corpus (~3000 nodes). Larger prod corpora may have different optimal thresholds. Deferred until F053's eval methodology has 30-day track record on prod density trends.
+- **F054.2 — Threshold annealing.** Lower thresholds during early backfill cycles (when graph is sparse), tighten as graph fills. Plausible but adds complexity; defer until baseline lift is measured.
+- **F054.3 — Content guards for episodes + procedures.** F045 has `NOUS_CE_BACKFILL_MIN_CONTENT_CHARS=80` for facts. F054 adds it for decisions. Episodes and procedures may also benefit but the F053 audit didn't surface evidence — defer until audit data shows similar empty-content patterns.
+
+---
+
+## Mechanism
+
+### Threshold changes
+
+Default values in `nous/config.py`:
+
+| Field | Current default (F045) | F054 default | Justification |
+|---|---|---|---|
+| `ce_backfill_threshold_fact_fact` | 0.65 | **0.55** | F053 measured: same-type fact↔fact at 0.55 produces +71% edges at 0.83 precision (no change) |
+| `ce_backfill_threshold_decision_decision` | 0.60 | **0.50** | Same lift pattern as fact↔fact (`related_to` precision unchanged) |
+| `ce_backfill_threshold_episode_episode` | 0.58 | **0.50** | Same pattern; conservative -8 since N=0 in eval corpus (extrapolated from same-type behavior) |
+| `ce_backfill_threshold_procedure_any` | 0.55 | **0.45** | Same pattern; same-type and procedure→fact catches more `related_to` edges |
+| `ce_backfill_threshold_fact_decision` | 0.55 | **0.55 (UNCHANGED)** | F053 measured: precision regresses 0.57 → 0.47 if loosened. KEEP STRICT. |
+| `ce_backfill_threshold_fact_episode` | 0.55 | **0.55 (UNCHANGED)** | No empirical lift data; default to KEEP STRICT until F053 audit shows otherwise |
+
+Mechanically: the values in `nous/brain/graph_densifier.py::_get_ce_mode_threshold` and `nous/config.py` change. `_get_threshold` routing logic is untouched.
+
+### Content-length guard for decisions
+
+Add a new Settings field:
+
+```python
+# F054 — minimum chars in brain.decisions.context for the decision to
+# participate in graph densification edges. Mirrors F045's
+# ce_backfill_min_content_chars for facts. F053 edge_judge audit showed
+# empty/near-empty decision context is the root cause of evidence_for
+# precision drops (~5 of 9 NO verdicts cited "source content is empty").
+ce_backfill_min_decision_chars: int = Field(
+    default=40,
+    description="F054 — drop decisions with context shorter than this from graph backfill",
+)
+```
+
+Apply in `_backfill_same_type` (decision-decision) and `_backfill_cross_type` (decision-fact, decision-episode, decision-procedure) candidate hydration: when fetching `brain.decisions.context`, exclude rows where `length(trim(context)) < min_decision_chars`. Symmetric to how F045's content guard works for `heart.facts.content`.
+
+### Backward compatibility
+
+All changes are pure default value tweaks. Operators who want the old behavior can revert via env vars:
+```bash
+NOUS_CE_BACKFILL_THRESHOLD_FACT_FACT=0.65 \
+NOUS_CE_BACKFILL_THRESHOLD_DECISION_DECISION=0.60 \
+NOUS_CE_BACKFILL_THRESHOLD_EPISODE_EPISODE=0.58 \
+NOUS_CE_BACKFILL_THRESHOLD_PROCEDURE_ANY=0.55 \
+NOUS_CE_BACKFILL_MIN_DECISION_CHARS=0 \
+```
+
+---
+
+## Eval methodology (gate before merge)
+
+Per F053's eval-before-deploy convention:
+
+### Required eval matrix
+
+```bash
+NOUS_EVAL_DB_NAME=nous_eval_scratch \
+  uv run python -m nous_eval.density_eval \
+    --configs baseline,f054_proposed,baseline_loose_ce
+```
+
+Where `f054_proposed` is added to `nous_eval/retrieval.py::_DEFAULT_CONFIGS`:
+
+```python
+"f054_proposed": RetrievalConfig(
+    name="f054_proposed",
+    flags={
+        "ce_backfill_threshold_fact_fact": 0.55,
+        "ce_backfill_threshold_decision_decision": 0.50,
+        "ce_backfill_threshold_episode_episode": 0.50,
+        "ce_backfill_threshold_procedure_any": 0.45,
+        # fact_decision, fact_episode UNCHANGED at 0.55
+        "ce_backfill_min_decision_chars": 40,
+    },
+    description=(
+        "F054 selective CE relaxation: same-type loosened, cross-type "
+        "fact_decision/fact_episode KEPT STRICT, +decision content guard."
+    ),
+),
+```
+
+### Required edge-precision audit
+
+```bash
+NOUS_EVAL_DB_NAME=nous_eval_scratch \
+  uv run python -m nous_eval.run_edge_audit --limit-per-type 30
+```
+
+### Gate criteria (all must pass)
+
+1. **Same-type density lift**: `f054_proposed.related_to_edges - baseline.related_to_edges >= +50`
+2. **Same-type precision floor**: `related_to` precision ≥ 0.75 (gate-eligible if N ≥ 15)
+3. **Cross-type precision floor (no regression)**: `evidence_for` precision change vs baseline ≤ -0.03 (i.e., max 3-percentage-point drop tolerated)
+4. **Cross-type density (informed_by, evidence_for)**: per-type Δ ≥ 0 (no regression)
+
+If any criterion fails: spec marked abandoned, defaults stay at F045 values.
+
+---
+
+## Code surface
+
+| File | LOC | Change |
+|---|---|---|
+| `nous/config.py` | ~10 | 4 default value tweaks (`Field(default=0.55)` etc.) + 1 new `ce_backfill_min_decision_chars` Field |
+| `nous/brain/graph_densifier.py` | ~5 | Apply `ce_backfill_min_decision_chars` filter in decision candidate hydration |
+| `nous_eval/retrieval.py` | ~15 | Add `f054_proposed` `RetrievalConfig` |
+| `tests/test_f054_threshold_relaxation.py` | ~80 | Unit tests for the threshold defaults + decision content guard |
+| `CLAUDE.md` | +5 lines | Update the env-var table with the new defaults + new `NOUS_CE_BACKFILL_MIN_DECISION_CHARS` row |
+| `docs/features/INDEX.md` | +1 row | F054 entry on ship |
+
+**Total**: ~115 LOC, ~half-day spike. No migration, no schema change.
+
+---
+
+## Risks
+
+1. **Eval corpus may not represent prod.** F051 eval corpus = ~3000 nodes from prior dev work. Prod corpus shape differs (likely more episodes, different fact/decision ratio). The +71% same-type lift is corpus-specific. Mitigation: monitor `/dashboard/density` orphan rate for 2 sleep cycles after merge; rollback via env-var override if trend is wrong.
+2. **Cross-type empty-content edges still possible for episodes/procedures.** F054.3 deferred. If `heart.episodes.summary` or `heart.procedures.description` is empty in prod, those will still create low-precision edges. Watch the next F053 audit cycle.
+3. **`fact_decision` precision is already failing (0.57 < 0.75).** F054 doesn't fix this — it's a corpus quality issue (empty `brain.decisions.context`). The content guard helps prevent NEW empty-decision edges but doesn't retroactively delete existing ones. Pre-existing `evidence_for` edges with empty source content will continue to score WEAK/NO in audits until cleaned up.
+4. **Threshold drift risk.** Default value changes cascade into any dashboard / report / test that hardcodes the old values. Search for `0.65` / `0.60` / `0.58` literals before merging; F045's existing tests assert specific threshold values and may need updates.
+
+---
+
+## Rollout
+
+| Phase | Trigger | Action |
+|---|---|---|
+| **0 — Spec lock** | This doc + optional 3-agent review (low-risk default-tweak; reviewer judgment) | Spec frozen; impl plan can be drafted (or skipped — change is small enough that direct PR is reasonable) |
+| **1 — Impl + eval** | Plan approval | Branch `feat/F054-selective-ce-relaxation`. Land config defaults + content guard + `f054_proposed` config + tests. Run `density_eval --configs baseline,f054_proposed,baseline_loose_ce` against eval DB. Run `run_edge_audit --limit-per-type 30`. |
+| **2 — Gate evaluation** | Branch CI green + eval reports attached to PR | Verify all 4 gate criteria from §Eval methodology pass. |
+| **3a — Pass** | All criteria met | Merge PR. Default takes effect on next prod restart. Monitor `/dashboard/density` for 2 sleep cycles. |
+| **3b — Fail** | Any gate criterion fails | Mark `❌ Abandoned (eval-fail-yyyy-mm-dd)`. Spec stays as decision record; defaults revert to F045 values. |
+| **4 — Post-merge monitoring** | Phase 3a only | Watch density dashboard. If orphan rate doesn't track eval prediction within 2 sleep cycles, env-var override the new thresholds back to F045 values and investigate corpus differences. |
+
+---
+
+## Open questions
+
+1. **Should `episode_episode` (0.58 → 0.50) be more conservative?** F053 corpus has 0 episode orphans, so the lift is extrapolated from same-type behavior. A first-merge could land at 0.55 (-3) instead of 0.50 (-8), then tighten/loosen based on prod data. Decided in impl plan.
+2. **Should the content guard apply to existing rows or only new edges?** F054 mechanism filters at backfill time so only NEW edges are gated. Existing low-content-source edges stay until manually cleaned. Decided: don't retroactively delete (F040 doesn't have a delete-low-quality-edges sweep).
+3. **Should F054 also raise `NOUS_CROSS_ENCODER_MAX_CANDIDATES` from 30 to 50?** With looser cosine, more candidates may pass CE rerank. If `union_size_p95` consistently hits 28+, raise the cap. Decided in impl plan after first eval run.
+
+These are answered in the impl plan, not here.

--- a/nous_eval/density_eval.py
+++ b/nous_eval/density_eval.py
@@ -1,0 +1,489 @@
+"""F053 density-eval harness mode.
+
+Measures graph_edges + orphan-rate deltas across configs on the F051 eval DB,
+using a snapshot-reset-run-snapshot loop with transactional restore on
+per-config failure. Designed to evaluate F040 graph-densification tuning
+hypotheses (CE thresholds, content-length guards) before live deployment.
+
+Includes the ``baseline_loose_ce`` diagnostic config (relaxed CE thresholds
+across all relation types — see :mod:`nous_eval.retrieval`).
+
+Per-config behavior:
+
+1. ``RuntimeConfig.reset()`` — clear leakage from the prior config.
+2. ``_apply_config_flags(template, cfg)`` — Settings overlay (NOT
+   ``RuntimeConfig.set``; mirrors :mod:`retrieval_runner`).
+3. ``_settings_for_eval_db(eval_settings, overridden)`` — redirect DB.
+4. ``_ensure_zero_edge_baseline`` — DELETE current edges; (re-)create the
+   ``brain.eval_baseline_edges_snapshot`` anchor table; TRUNCATE it. The
+   anchor is intentionally empty — it represents zero-edge state and is
+   used by ``_restore_baseline`` if a config crashes mid-cycle.
+5. Snapshot pre-state (orphan + edge counts).
+6. Build Heart + densifier (sharing the embedding provider, mirroring
+   :mod:`nous/main.py:300`).
+7. Run ``GraphDensifier.run_backfill_cycle()`` + ``discover_clusters``.
+8. On exception: ``_restore_baseline`` and tag the run as failed.
+9. Snapshot post-state.
+
+A real (non-TEMP) snapshot table is used because TEMP tables are
+session-scoped in Postgres — a per-config run uses several pooled
+connections, and a TEMP table would silently disappear on connection
+swap.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import text
+
+from nous.brain._entity_config import _ENTITY_CONFIG
+from nous.config import Settings
+from nous.runtime_config import RuntimeConfig
+from nous.storage.database import Database
+from nous_eval.config import EvalSettings
+from nous_eval.retrieval import _DEFAULT_CONFIGS, RetrievalConfig
+from nous_eval.retrieval_runner import (
+    _apply_config_flags,
+    _build_densifier_for_eval,
+    _build_heart_for_eval,
+    _settings_for_eval_db,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DensitySnapshot:
+    """Edge + orphan counts at one point in time, scoped to one ``agent_id``."""
+
+    edge_count_total: int
+    edge_count_per_relation: dict[str, int] = field(default_factory=dict)
+    orphan_count_per_type: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class DensityRunResult:
+    """Outcome of one config under one density-eval run."""
+
+    config_name: str
+    pre: DensitySnapshot
+    post: DensitySnapshot | None
+    edges_created: int
+    ce_pruned: int
+    wall_seconds: float
+    failure: str | None = None  # set on exception path
+
+
+# ---------------------------------------------------------------------------
+# Snapshot / restore helpers
+# ---------------------------------------------------------------------------
+
+
+_SNAPSHOT_TABLE = "brain.eval_baseline_edges_snapshot"
+
+
+async def _ensure_zero_edge_baseline(db: Database, agent_id: str) -> None:
+    """Pre-condition: zero edges for ``agent_id``; ensure persistent snapshot.
+
+    The snapshot table is REAL (not TEMP) so it survives across the multiple
+    pooled connections that one per-config run uses. It is intentionally
+    empty: it represents the "zero-edge baseline" anchor state, restored by
+    :func:`_restore_baseline` when a config crashes mid-cycle.
+
+    Idempotent: ``CREATE TABLE IF NOT EXISTS`` + ``TRUNCATE``.
+    """
+    async with db.session() as session:
+        await session.execute(
+            text("DELETE FROM brain.graph_edges WHERE agent_id = :aid"),
+            {"aid": agent_id},
+        )
+        await session.execute(
+            text(
+                f"CREATE TABLE IF NOT EXISTS {_SNAPSHOT_TABLE} "
+                "(LIKE brain.graph_edges INCLUDING ALL)"
+            )
+        )
+        await session.execute(text(f"TRUNCATE {_SNAPSHOT_TABLE}"))
+        await session.commit()
+
+
+async def _restore_baseline(db: Database, agent_id: str) -> None:
+    """Restore graph_edges to the empty-snapshot anchor state for ``agent_id``.
+
+    The snapshot table is intentionally empty, so the INSERT-from-snapshot
+    is a no-op; the DELETE alone returns to zero-edge state. Kept as
+    DELETE+INSERT so that if a future iteration of the harness wants to
+    snapshot a non-empty baseline, the restore semantics already match.
+    """
+    async with db.session() as session:
+        await session.execute(
+            text("DELETE FROM brain.graph_edges WHERE agent_id = :aid"),
+            {"aid": agent_id},
+        )
+        await session.execute(
+            text(
+                f"INSERT INTO brain.graph_edges "
+                f"SELECT * FROM {_SNAPSHOT_TABLE}"
+            )
+        )
+        await session.commit()
+
+
+async def _snapshot(db: Database, agent_id: str) -> DensitySnapshot:
+    """Capture edge count (per-relation + total) and orphan count per type.
+
+    Both counts are scoped to ``agent_id``. Orphans are computed via the
+    same NOT EXISTS clause :class:`GraphDensifier.find_orphans` uses so the
+    pre-state matches what the densifier sees on its first iteration.
+    """
+    async with db.session() as session:
+        edge_total_row = await session.execute(
+            text(
+                "SELECT COUNT(*) AS n FROM brain.graph_edges "
+                "WHERE agent_id = :aid"
+            ),
+            {"aid": agent_id},
+        )
+        edge_total = int(edge_total_row.scalar() or 0)
+
+        per_rel_rows = await session.execute(
+            text(
+                "SELECT relation, COUNT(*) AS n FROM brain.graph_edges "
+                "WHERE agent_id = :aid GROUP BY relation"
+            ),
+            {"aid": agent_id},
+        )
+        per_rel = {row.relation: int(row.n) for row in per_rel_rows}
+
+        orphan_per_type: dict[str, int] = {}
+        for entity_type, (table, type_name, _content_col, extra) in _ENTITY_CONFIG.items():
+            sql = text(
+                f"""
+                SELECT COUNT(*) AS n FROM {table} t
+                WHERE t.agent_id = :aid
+                  AND {extra}
+                  AND t.embedding IS NOT NULL
+                  AND NOT EXISTS (
+                      SELECT 1 FROM brain.graph_edges e
+                      WHERE e.agent_id = :aid
+                        AND (
+                            (e.source_id = t.id AND e.source_type = :type_name)
+                            OR (e.target_id = t.id AND e.target_type = :type_name)
+                        )
+                  )
+                """
+            )
+            row = await session.execute(
+                sql, {"aid": agent_id, "type_name": type_name}
+            )
+            orphan_per_type[entity_type] = int(row.scalar() or 0)
+
+    return DensitySnapshot(
+        edge_count_total=edge_total,
+        edge_count_per_relation=per_rel,
+        orphan_count_per_type=orphan_per_type,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-config runner
+# ---------------------------------------------------------------------------
+
+
+async def _run_one_config(
+    config: RetrievalConfig,
+    main_settings_template: Settings,
+    eval_settings: EvalSettings,
+    db: Database,
+) -> DensityRunResult:
+    """Run one config end-to-end. Mirrors ``retrieval_runner.run_matrix``.
+
+    Sequence (matches F051 pattern at retrieval_runner.py:160-220):
+
+    1. ``RuntimeConfig.reset()``
+    2. ``overridden = _apply_config_flags(template, cfg)``
+    3. ``eval_scoped = _settings_for_eval_db(eval_settings, overridden)``
+    4. snapshot baseline (zero-edge anchor)
+    5. snapshot pre-state
+    6. build Heart + densifier; run cycle
+    7. on exception: restore baseline; record failure
+    8. snapshot post-state
+    """
+    RuntimeConfig.reset()
+    logger.info("F053: running density config=%s", config.name)
+    overridden = _apply_config_flags(main_settings_template, config)
+    eval_scoped = _settings_for_eval_db(eval_settings, overridden)
+    # SFH P1-1: F051's _settings_for_eval_db forces graph_backfill_enabled=False
+    # to suppress the production sleep handler. density_eval invokes the densifier
+    # DIRECTLY, so we must re-enable backfill here or every config silently
+    # returns 0 edges. Same applies to event_bus (we want emission events from
+    # backfill to fire) and a few related toggles. We override only what we need.
+    eval_scoped = eval_scoped.model_copy(update={"graph_backfill_enabled": True})
+    assert eval_scoped.graph_backfill_enabled, (
+        "density_eval requires graph_backfill_enabled=True; check _settings_for_eval_db override"
+    )
+    agent_id = eval_scoped.agent_id
+
+    t0 = time.monotonic()
+    await _ensure_zero_edge_baseline(db, agent_id)
+    pre = await _snapshot(db, agent_id)
+
+    edges_created = 0
+    ce_pruned = 0
+    failure: str | None = None
+    post: DensitySnapshot | None = None
+
+    try:
+        async with _build_heart_for_eval(db, eval_scoped) as heart:
+            # heart context-manager keeps embedding provider alive for the
+            # densifier's lifetime; densifier is constructed independently.
+            _ = heart
+            densifier = await _build_densifier_for_eval(
+                eval_scoped, db, agent_id
+            )
+            try:
+                cycle_result = await densifier.run_backfill_cycle()
+            except Exception as exc:
+                logger.exception(
+                    "F053: run_backfill_cycle raised for config=%s", config.name
+                )
+                await _restore_baseline(db, agent_id)
+                wall = time.monotonic() - t0
+                return DensityRunResult(
+                    config_name=config.name,
+                    pre=pre,
+                    post=None,
+                    edges_created=0,
+                    ce_pruned=0,
+                    wall_seconds=wall,
+                    failure=f"{type(exc).__name__}: {exc}",
+                )
+
+            # cycle_result keys: facts/decisions/episodes/procedures + _ce_stats
+            edges_created = sum(
+                v for k, v in cycle_result.items() if not k.startswith("_")
+            )
+            ce_stats = cycle_result.get("_ce_stats") or {}
+            ce_pruned = int(ce_stats.get("pruned", 0))
+
+            try:
+                # Cluster discovery is best-effort; failure here doesn't
+                # invalidate the backfill cycle's edge counts.
+                await densifier.discover_clusters(max_bridges=20)
+            except Exception:
+                logger.warning(
+                    "F053: discover_clusters raised for config=%s; continuing",
+                    config.name,
+                    exc_info=True,
+                )
+
+            post = await _snapshot(db, agent_id)
+    except Exception as exc:
+        logger.exception("F053: harness setup failed for config=%s", config.name)
+        restore_failure: str | None = None
+        try:
+            await _restore_baseline(db, agent_id)
+        except Exception as restore_exc:
+            logger.exception(
+                "F053: _restore_baseline also failed for config=%s", config.name
+            )
+            restore_failure = f"{type(restore_exc).__name__}: {restore_exc}"
+        failure = f"{type(exc).__name__}: {exc}"
+        if restore_failure is not None:
+            failure = f"{failure} | restore_also_failed: {restore_failure}"
+
+    wall = time.monotonic() - t0
+    return DensityRunResult(
+        config_name=config.name,
+        pre=pre,
+        post=post,
+        edges_created=edges_created,
+        ce_pruned=ce_pruned,
+        wall_seconds=wall,
+        failure=failure,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Top-level orchestration + reporting
+# ---------------------------------------------------------------------------
+
+
+async def run_density_eval(
+    config_names: list[str],
+    eval_settings: EvalSettings,
+    n_runs: int = 1,
+) -> list[DensityRunResult]:
+    """Run the density eval matrix and return results in run-order.
+
+    One ``Database`` is created and reused across all configs/runs to avoid
+    per-config asyncpg-pool churn. Each per-config call still gets a fresh
+    Heart + densifier (mirrors ``run_matrix`` semantics).
+    """
+    main_settings_template = Settings()
+    db = Database(_settings_for_eval_db(eval_settings, main_settings_template))
+    await db.connect()
+    try:
+        results: list[DensityRunResult] = []
+        for run_idx in range(n_runs):
+            for name in config_names:
+                if name not in _DEFAULT_CONFIGS:
+                    raise ValueError(
+                        f"Unknown config: {name!r}. "
+                        f"Known: {sorted(_DEFAULT_CONFIGS)}"
+                    )
+                config = _DEFAULT_CONFIGS[name]
+                logger.info(
+                    "F053: density-eval run %d/%d config=%s",
+                    run_idx + 1, n_runs, name,
+                )
+                results.append(
+                    await _run_one_config(
+                        config, main_settings_template, eval_settings, db
+                    )
+                )
+        return results
+    finally:
+        await db.engine.dispose()
+
+
+def _format_snapshot(label: str, snap: DensitySnapshot | None) -> str:
+    if snap is None:
+        return f"  {label}: <none — config failed>\n"
+    parts = [f"  {label}: total={snap.edge_count_total}"]
+    if snap.edge_count_per_relation:
+        rels = ", ".join(
+            f"{k}={v}" for k, v in sorted(snap.edge_count_per_relation.items())
+        )
+        parts.append(f"    per_relation: {rels}")
+    if snap.orphan_count_per_type:
+        orphs = ", ".join(
+            f"{k}={v}" for k, v in sorted(snap.orphan_count_per_type.items())
+        )
+        parts.append(f"    orphans:      {orphs}")
+    return "\n".join(parts) + "\n"
+
+
+def _write_report(results: list[DensityRunResult], path: Path) -> None:
+    """Write a human-readable Markdown report.
+
+    Each config gets a section with pre/post snapshots, edges_created,
+    CE-rerank pruning count, wall-clock seconds, and failure tag (if any).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines: list[str] = []
+    lines.append("# F053 density-eval report\n")
+    lines.append(
+        f"_Generated: {datetime.now(tz=UTC):%Y-%m-%d %H:%M:%S UTC}_\n"
+    )
+    lines.append("")
+    lines.append(
+        "| config | edges_created | ce_pruned | wall_s | status |"
+    )
+    lines.append(
+        "|--------|---------------|-----------|--------|--------|"
+    )
+    for r in results:
+        status = "FAIL" if r.failure else "OK"
+        lines.append(
+            f"| {r.config_name} | {r.edges_created} | {r.ce_pruned} | "
+            f"{r.wall_seconds:.1f} | {status} |"
+        )
+    lines.append("")
+
+    for r in results:
+        lines.append(f"## {r.config_name}")
+        if r.failure:
+            lines.append(f"**FAILURE**: `{r.failure}`")
+        lines.append("")
+        lines.append(_format_snapshot("pre ", r.pre))
+        lines.append(_format_snapshot("post", r.post))
+        lines.append("")
+
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns process exit code."""
+    p = argparse.ArgumentParser(
+        prog="python -m nous_eval.density_eval",
+        description="F053 density-eval harness — backfill A/B on the eval DB.",
+    )
+    p.add_argument(
+        "--configs",
+        type=str,
+        default="baseline,f052_on",
+        help="Comma-separated config names (default: baseline,f052_on).",
+    )
+    p.add_argument(
+        "--n-runs",
+        type=int,
+        default=1,
+        help="Number of times to repeat the matrix (for variance).",
+    )
+    p.add_argument(
+        "--report-dir",
+        type=Path,
+        default=None,
+        help="Override EvalSettings.report_dir.",
+    )
+    p.add_argument(
+        "--log-level",
+        type=str,
+        default="info",
+        help="Logging verbosity (debug/info/warning).",
+    )
+    args = p.parse_args(argv)
+
+    logging.basicConfig(
+        level=args.log_level.upper(),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    eval_settings = EvalSettings()
+    eval_settings.warn_if_default_password()
+    if args.report_dir is not None:
+        eval_settings = eval_settings.model_copy(
+            update={"report_dir": args.report_dir}
+        )
+
+    config_names = [c.strip() for c in args.configs.split(",") if c.strip()]
+
+    try:
+        results = asyncio.run(
+            run_density_eval(config_names, eval_settings, args.n_runs)
+        )
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    out = (
+        eval_settings.report_dir
+        / f"density-eval-{datetime.now(tz=UTC):%Y%m%d-%H%M%S}.md"
+    )
+    _write_report(results, out)
+    print(f"Wrote: {out}")
+    logger.info("F053: density_eval report written: %s", out)
+
+    # Non-zero exit if any config failed — useful for CI signaling.
+    if any(r.failure for r in results):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nous_eval/edge_judge.py
+++ b/nous_eval/edge_judge.py
@@ -1,0 +1,201 @@
+"""F053 — LLM-judge for edge precision in density-eval reports.
+
+Loads a cached operator-editable prompt from
+``nous_eval/templates/edge_precision_prompt.md``, batches edges in chunks
+of ``BATCH_SIZE``, calls Sonnet via the existing OAT-supporting
+``AnthropicClient``, parses the JSON-array response, and returns one
+:class:`EdgeJudgment` per edge in input order.
+
+The harness is intentionally minimal — no caching, no retries, no
+streaming. Operators run it ad-hoc against a sampled edge set after a
+density-eval pass to estimate precision (YES / WEAK / NO ratios).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from itertools import zip_longest
+from pathlib import Path
+from typing import Any
+
+from nous.api.anthropic_client import create_client
+from nous.config import Settings
+
+logger = logging.getLogger(__name__)
+
+
+BATCH_SIZE = 30  # ≤30 edges per Sonnet call to keep prompts well under 8k tokens
+_TEMPLATE_PATH = Path(__file__).parent / "templates" / "edge_precision_prompt.md"
+
+
+@dataclass(frozen=True)
+class EdgeJudgment:
+    """One judge verdict per edge."""
+
+    source_id: str
+    target_id: str
+    relation: str
+    verdict: str  # "YES" | "WEAK" | "NO" | "PARSE_ERROR"
+    reasoning: str
+
+
+def _load_prompt_template() -> str:
+    """Read the operator-editable prompt template once per call.
+
+    Re-read on every call (rather than module-load) so operators can edit
+    the file between judge runs without restarting. The file is small
+    (<2KB) so the syscall cost is negligible.
+    """
+    return _TEMPLATE_PATH.read_text(encoding="utf-8")
+
+
+def _format_edge_payload(edges: list[dict[str, Any]]) -> str:
+    """Serialize an edge batch as a JSON array for the prompt body."""
+    return json.dumps(edges, ensure_ascii=False, indent=2)
+
+
+def _parse_response(content: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Extract the JSON array from a Sonnet text response.
+
+    Sonnet returns a list of content blocks; we concatenate ``text`` blocks
+    and parse the result as JSON. Anything else (tool-use, image) is
+    skipped. Raises ``ValueError`` if no JSON array is found.
+    """
+    text_parts: list[str] = []
+    for block in content:
+        # Both dict-style and attribute-style content blocks are tolerated
+        # so this works against either AnthropicClient backend.
+        btype = block.get("type") if isinstance(block, dict) else getattr(block, "type", None)
+        if btype != "text":
+            continue
+        bt = block.get("text") if isinstance(block, dict) else getattr(block, "text", "")
+        if bt:
+            text_parts.append(bt)
+    raw = "".join(text_parts).strip()
+    if not raw:
+        raise ValueError("edge_judge: empty Sonnet response")
+    # Trim possible Markdown code fences. Surgical regex avoids stripping
+    # legitimate backticks inside JSON string payloads (the prior `.strip("`")`
+    # was over-broad and could chew into content).
+    raw = re.sub(r"^```(?:json)?\s*\n?", "", raw, flags=re.IGNORECASE)
+    raw = re.sub(r"\n?```\s*$", "", raw)
+    # Strip trailing commas before ] or } — Sonnet sometimes emits
+    # JSON5-style trailing commas which strict json.loads rejects.
+    raw = re.sub(r",(\s*[}\]])", r"\1", raw)
+    parsed = json.loads(raw)
+    if not isinstance(parsed, list):
+        raise ValueError(
+            f"edge_judge: expected JSON array, got {type(parsed).__name__}"
+        )
+    return parsed
+
+
+async def judge_edges(
+    edges: list[dict[str, Any]],
+    settings: Settings,
+    model: str = "claude-sonnet-4-6",
+) -> list[EdgeJudgment]:
+    """Judge a list of edges. Each edge dict is shaped::
+
+        {
+            "source_id": str,
+            "target_id": str,
+            "source_content": str,
+            "target_content": str,
+            "relation": str,
+            "weight": float,    # optional
+        }
+
+    Returns one :class:`EdgeJudgment` per input edge in the same order.
+    Edges in batches that fail to parse are returned with
+    ``verdict="PARSE_ERROR"`` so the operator can spot-check rather than
+    silently lose precision data.
+    """
+    if not edges:
+        return []
+
+    template = _load_prompt_template()
+    client = create_client(settings)
+    await client.start()
+
+    judgments: list[EdgeJudgment] = []
+    try:
+        for batch_start in range(0, len(edges), BATCH_SIZE):
+            batch = edges[batch_start : batch_start + BATCH_SIZE]
+            prompt_body = template + "\n\n" + _format_edge_payload(batch)
+
+            try:
+                # AnthropicClient.call() takes a single payload dict, not kwargs.
+                # OAT auth requires the Claude Code preamble as system block 0
+                # (per project memory feedback_claude_code_preamble — without it,
+                # OAT returns 429 rate_limit_error). Mirrors hand_labels_draft.py.
+                resp = await client.call({
+                    "model": model,
+                    "system": [
+                        {"type": "text", "text": "You are Claude Code, Anthropic's official CLI for Claude.", "cache_control": {"type": "ephemeral"}},
+                        {"type": "text", "text": "You are a careful precision judge. Return JSON only."},
+                    ],
+                    "messages": [{"role": "user", "content": prompt_body}],
+                    "max_tokens": 8192,
+                    "temperature": 0.0,
+                })
+                parsed = _parse_response(resp.content)
+            except Exception as exc:
+                logger.warning(
+                    "edge_judge: batch %d-%d failed (%s); marking PARSE_ERROR",
+                    batch_start, batch_start + len(batch), exc,
+                )
+                for e in batch:
+                    judgments.append(
+                        EdgeJudgment(
+                            source_id=str(e.get("source_id", "")),
+                            target_id=str(e.get("target_id", "")),
+                            relation=str(e.get("relation", "")),
+                            verdict="PARSE_ERROR",
+                            reasoning=str(exc),
+                        )
+                    )
+                continue
+
+            # SFH P1-2: zip would silently truncate when Sonnet returns fewer
+            # verdicts than the batch (max_tokens cutoff, ambiguous-skip). Use
+            # zip_longest + PARSE_ERROR pad so the precision denominator stays
+            # honest. Docstring promises one EdgeJudgment per input edge.
+            if len(parsed) < len(batch):
+                logger.warning(
+                    "edge_judge: short_response — Sonnet returned %d of %d verdicts in batch %d-%d; "
+                    "padding missing verdicts with PARSE_ERROR",
+                    len(parsed), len(batch), batch_start, batch_start + len(batch),
+                )
+            for src_edge, verdict_obj in zip_longest(batch, parsed, fillvalue=None):
+                if src_edge is None:
+                    # Sonnet returned MORE verdicts than we sent — log + drop the trailing extras.
+                    logger.warning("edge_judge: extra verdict beyond batch length — dropping")
+                    continue
+                if verdict_obj is None:
+                    judgments.append(
+                        EdgeJudgment(
+                            source_id=str(src_edge.get("source_id", "")),
+                            target_id=str(src_edge.get("target_id", "")),
+                            relation=str(src_edge.get("relation", "")),
+                            verdict="PARSE_ERROR",
+                            reasoning="short_response: Sonnet did not return a verdict for this edge",
+                        )
+                    )
+                    continue
+                judgments.append(
+                    EdgeJudgment(
+                        source_id=str(src_edge.get("source_id", "")),
+                        target_id=str(src_edge.get("target_id", "")),
+                        relation=str(src_edge.get("relation", "")),
+                        verdict=str(verdict_obj.get("verdict", "PARSE_ERROR")).upper(),
+                        reasoning=str(verdict_obj.get("reasoning", "")),
+                    )
+                )
+    finally:
+        await client.close()
+
+    return judgments

--- a/nous_eval/retrieval.py
+++ b/nous_eval/retrieval.py
@@ -130,6 +130,31 @@ _DEFAULT_CONFIGS: dict[str, RetrievalConfig] = {
         flags={"graph_recall_enabled": False},
         description="F022 graph recall + spreading activation disabled.",
     ),
+    # ------------------------------------------------------------------
+    # F053 — density-eval diagnostic configs (used by
+    # `python -m nous_eval.density_eval`, not the retrieval matrix).
+    # ------------------------------------------------------------------
+    "baseline_loose_ce": RetrievalConfig(
+        name="baseline_loose_ce",
+        flags={
+            # F045 CE-mode thresholds, relaxed ~10% across the board.
+            # 2026-04-26 density-eval measured +59.6% edges over baseline
+            # at identical related_to precision (0.83 → 0.83).
+            "ce_backfill_threshold_fact_fact": 0.55,
+            "ce_backfill_threshold_decision_decision": 0.50,
+            "ce_backfill_threshold_fact_decision": 0.45,
+            "ce_backfill_threshold_fact_episode": 0.45,
+            "ce_backfill_threshold_episode_episode": 0.50,
+            "ce_backfill_threshold_procedure_any": 0.45,
+        },
+        description=(
+            "F053 diagnostic — F040+F043+F045 with CE-mode cosine thresholds "
+            "loosened ~10%. Empirically catches +59.6% more edges on the "
+            "F051 eval corpus at identical related_to precision (0.83). "
+            "Cross-type evidence_for precision degrades (0.57 → 0.47), so "
+            "any production tune-down should be selective per spec F054."
+        ),
+    ),
 }
 
 

--- a/nous_eval/retrieval_runner.py
+++ b/nous_eval/retrieval_runner.py
@@ -375,6 +375,47 @@ def _build_brain_for_eval(
 
 
 # ---------------------------------------------------------------------------
+# Density-eval helper (F053)
+# ---------------------------------------------------------------------------
+
+
+async def _build_densifier_for_eval(
+    settings: Settings,
+    db: Database,
+    agent_id: str,
+):
+    """F053 — construct ``GraphDensifier`` against the eval DB.
+
+    Mirrors the production wiring at ``nous/main.py:300`` so density_eval
+    invokes the same densifier the prod sleep handler does. ``EmbeddingProvider``
+    is required (raises ``RuntimeError`` if ``OPENAI_API_KEY`` is unset) since
+    backfill is meaningless without embeddings.
+    """
+    from nous.brain.graph_densifier import GraphDensifier
+    from nous.brain.graph_linker import GraphLinker
+    from nous.brain.embeddings import EmbeddingProvider
+
+    embedder = EmbeddingProvider(settings) if settings.openai_api_key else None
+    if embedder is None:
+        raise RuntimeError(
+            "F053 density_eval requires an embedder (set OPENAI_API_KEY)"
+        )
+    linker = GraphLinker(
+        db=db,
+        embedder=embedder,
+        settings=settings,
+        agent_id=agent_id,
+    )
+    return GraphDensifier(
+        db=db,
+        graph_linker=linker,
+        embedder=embedder,
+        settings=settings,
+        agent_id=agent_id,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Single-qrel scoring
 # ---------------------------------------------------------------------------
 

--- a/nous_eval/run_edge_audit.py
+++ b/nous_eval/run_edge_audit.py
@@ -1,0 +1,293 @@
+"""F053 edge-precision audit runner.
+
+Samples N newly-created edges per relation type from the eval DB, fetches
+source/target content, feeds to ``edge_judge.judge_edges`` for YES/WEAK/NO
+verdicts, and writes a precision report.
+
+Designed to run AFTER ``density_eval`` against the same eval DB. The
+``--since`` flag filters edges by ``created_at`` so you audit only the
+edges the most-recent density_eval run produced (not the cumulative graph).
+
+Typical workflow::
+
+    # 1. Note start timestamp
+    NOW=$(date -u +%Y-%m-%dT%H:%M:%S)
+
+    # 2. Run density_eval (creates new edges)
+    NOUS_EVAL_DB_NAME=nous_eval_scratch \\
+    NOUS_QUERY_EXPANSION_ENABLED=true \\
+    uv run python -m nous_eval.density_eval --configs baseline,f052_on
+
+    # 3. Audit only the edges from step 2
+    NOUS_EVAL_DB_NAME=nous_eval_scratch \\
+    uv run python -m nous_eval.run_edge_audit --since "$NOW"
+
+The audit writes ``reports/edge-audit-<timestamp>.md`` with per-relation
+precision (YES / (YES + WEAK + NO)). Spec gate criterion 2 is
+**precision >= 0.75 per type**.
+
+Cost: 1 Sonnet call per BATCH_SIZE (30) edges. With 4 relation types ×
+30 edges = ~4 calls per audit, so ~$0.05.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from collections import defaultdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import text
+
+from nous.config import Settings
+from nous.storage.database import Database
+from nous_eval.config import EvalSettings
+from nous_eval.edge_judge import EdgeJudgment, judge_edges
+from nous_eval.retrieval_runner import _settings_for_eval_db
+
+logger = logging.getLogger(__name__)
+
+# Per-type content fetch is structural — facts.content, decisions.context,
+# episodes.summary, procedures.steps_text. Mirrors fetch_candidate_content
+# in nous/brain/backfill_rerank.py but inline here to keep the audit tool
+# free of brain-internal imports.
+_CONTENT_BY_TYPE: dict[str, tuple[str, str]] = {
+    "fact": ("heart.facts", "content"),
+    "decision": ("brain.decisions", "context"),
+    "episode": ("heart.episodes", "summary"),
+    "procedure": ("heart.procedures", "name || ': ' || description"),
+}
+
+
+async def _sample_edges_per_type(
+    db: Database,
+    agent_id: str,
+    since: datetime | None,
+    limit_per_type: int,
+) -> dict[str, list[dict[str, Any]]]:
+    """Sample N edges per relation type, joining source+target content.
+
+    Returns ``{relation: [edge_dict, ...]}`` keyed by ``relation`` (e.g.
+    ``"related_to"``, ``"evidence_for"``). Edge dict has the shape
+    ``edge_judge.judge_edges`` expects.
+    """
+    out: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    async with db.session() as session:
+        rel_rows = await session.execute(text(
+            "SELECT DISTINCT relation FROM brain.graph_edges WHERE agent_id = :aid"
+        ), {"aid": agent_id})
+        relations = [r[0] for r in rel_rows]
+
+        for relation in relations:
+            params: dict[str, Any] = {
+                "aid": agent_id, "rel": relation, "lim": limit_per_type,
+            }
+            since_clause = ""
+            if since is not None:
+                since_clause = "AND e.created_at >= :since"
+                params["since"] = since
+            edge_rows = await session.execute(text(f"""
+                SELECT e.source_id, e.source_type, e.target_id, e.target_type,
+                       e.relation, e.weight
+                FROM brain.graph_edges e
+                WHERE e.agent_id = :aid AND e.relation = :rel {since_clause}
+                ORDER BY random()
+                LIMIT :lim
+            """), params)
+            for row in edge_rows:
+                out[relation].append({
+                    "source_id": str(row.source_id),
+                    "source_type": row.source_type,
+                    "target_id": str(row.target_id),
+                    "target_type": row.target_type,
+                    "relation": row.relation,
+                    "weight": float(row.weight) if row.weight is not None else None,
+                })
+
+        # Hydrate content per edge (one round-trip per type to keep SQL simple).
+        all_ids_by_type: dict[str, set[UUID]] = defaultdict(set)
+        for edges in out.values():
+            for e in edges:
+                if e["source_type"] in _CONTENT_BY_TYPE:
+                    all_ids_by_type[e["source_type"]].add(UUID(e["source_id"]))
+                if e["target_type"] in _CONTENT_BY_TYPE:
+                    all_ids_by_type[e["target_type"]].add(UUID(e["target_id"]))
+
+        content_map: dict[tuple[str, str], str] = {}
+        for entity_type, ids in all_ids_by_type.items():
+            if not ids:
+                continue
+            table, content_expr = _CONTENT_BY_TYPE[entity_type]
+            placeholders = ", ".join(f":id_{i}" for i in range(len(ids)))
+            id_list = list(ids)
+            params2 = {f"id_{i}": cid for i, cid in enumerate(id_list)}
+            rows = await session.execute(text(f"""
+                SELECT id, {content_expr} AS content
+                FROM {table}
+                WHERE id IN ({placeholders})
+            """), params2)
+            for row in rows:
+                content_map[(entity_type, str(row.id))] = row.content or ""
+
+        # Stitch content into edge dicts; skip edges where either side is missing.
+        for relation, edges in list(out.items()):
+            stitched: list[dict[str, Any]] = []
+            for e in edges:
+                src_content = content_map.get((e["source_type"], e["source_id"]))
+                tgt_content = content_map.get((e["target_type"], e["target_id"]))
+                if src_content is None or tgt_content is None:
+                    logger.debug("edge_audit: missing content for %s -> %s; skipping", e["source_id"], e["target_id"])
+                    continue
+                stitched.append({
+                    **e,
+                    "source_content": src_content,
+                    "target_content": tgt_content,
+                })
+            out[relation] = stitched
+
+    return dict(out)
+
+
+def _summarize(judgments: list[EdgeJudgment]) -> dict[str, int]:
+    counts = {"YES": 0, "WEAK": 0, "NO": 0, "PARSE_ERROR": 0}
+    for j in judgments:
+        counts[j.verdict] = counts.get(j.verdict, 0) + 1
+    return counts
+
+
+def _precision(counts: dict[str, int]) -> float:
+    yes = counts.get("YES", 0)
+    weak = counts.get("WEAK", 0)
+    no = counts.get("NO", 0)
+    denom = yes + weak + no
+    return yes / denom if denom > 0 else 0.0
+
+
+def _write_report(
+    per_relation: dict[str, list[EdgeJudgment]],
+    out_path: Path,
+    since: datetime | None,
+    limit_per_type: int,
+    threshold: float,
+) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# F053 edge-precision audit",
+        "",
+        f"_Generated: {datetime.now(tz=UTC):%Y-%m-%d %H:%M:%S} UTC_",
+        f"_since: {since.isoformat() if since else '(all edges)'}_  ",
+        f"_sample-limit-per-type: {limit_per_type}_  ",
+        f"_gate threshold (precision >= {threshold:.2f} per type)_",
+        "",
+        "| relation | n | YES | WEAK | NO | PARSE_ERROR | precision | gate |",
+        "|----------|---|-----|------|----|-------------|-----------|------|",
+    ]
+    overall_pass = True
+    for relation in sorted(per_relation.keys()):
+        judgments = per_relation[relation]
+        counts = _summarize(judgments)
+        n = len(judgments)
+        prec = _precision(counts)
+        passes = prec >= threshold and n >= 15  # spec N-floor
+        gate_marker = "PASS" if passes else ("UNDERPOWERED" if n < 15 else "FAIL")
+        if not passes and n >= 15:
+            overall_pass = False
+        lines.append(
+            f"| {relation} | {n} | {counts['YES']} | {counts['WEAK']} | {counts['NO']} | "
+            f"{counts['PARSE_ERROR']} | {prec:.2f} | {gate_marker} |"
+        )
+    lines.append("")
+    lines.append(f"**Overall gate**: {'PASS' if overall_pass else 'FAIL'} "
+                 f"(all gate-eligible relations meet precision >= {threshold:.2f})")
+    lines.append("")
+    lines.append("## Sample of NO + WEAK verdicts (for spot-check)")
+    lines.append("")
+    sample_count = 0
+    for relation, judgments in per_relation.items():
+        for j in judgments:
+            if j.verdict in ("NO", "WEAK") and sample_count < 10:
+                lines.append(f"- **{relation}** [{j.verdict}] {j.source_id} -> {j.target_id}: {j.reasoning[:200]}")
+                sample_count += 1
+    out_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+async def run(
+    settings: EvalSettings,
+    since: datetime | None,
+    limit_per_type: int,
+    threshold: float,
+    out_path: Path | None,
+) -> Path:
+    """Driver: build DB, sample edges, judge, write report. Returns the report path."""
+    main_settings = Settings()
+    eval_scoped = _settings_for_eval_db(settings, main_settings)
+    db = Database(eval_scoped)
+    await db.connect()
+    try:
+        agent_id = settings.agent_id
+        per_relation_edges = await _sample_edges_per_type(db, agent_id, since, limit_per_type)
+        if not per_relation_edges:
+            logger.warning("F053 audit: no edges sampled (since=%s, agent_id=%s)", since, agent_id)
+
+        per_relation_verdicts: dict[str, list[EdgeJudgment]] = {}
+        for relation, edges in per_relation_edges.items():
+            if not edges:
+                continue
+            logger.info("F053 audit: judging %d edges for relation=%s", len(edges), relation)
+            verdicts = await judge_edges(edges, eval_scoped)
+            per_relation_verdicts[relation] = verdicts
+
+        if out_path is None:
+            out_path = Path(settings.report_dir) / f"edge-audit-{datetime.now(tz=UTC):%Y%m%d-%H%M%S}.md"
+        _write_report(per_relation_verdicts, out_path, since, limit_per_type, threshold)
+        return out_path
+    finally:
+        await db.engine.dispose()
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="python -m nous_eval.run_edge_audit")
+    p.add_argument("--since", default=None,
+                   help="ISO-8601 timestamp; only audit edges created at/after this. Default: all edges.")
+    p.add_argument("--limit-per-type", type=int, default=30,
+                   help="Max edges to sample per relation type. Default: 30 (matches spec gate sample size).")
+    p.add_argument("--threshold", type=float, default=0.75,
+                   help="Precision floor per relation type. Default: 0.75 (spec gate criterion 2).")
+    p.add_argument("--output", type=Path, default=None,
+                   help="Output markdown path. Default: reports/edge-audit-<timestamp>.md.")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+    ns = _parse_args(argv)
+
+    since = None
+    if ns.since:
+        try:
+            since = datetime.fromisoformat(ns.since)
+            if since.tzinfo is None:
+                since = since.replace(tzinfo=UTC)
+        except ValueError:
+            logger.error("F053 audit: invalid --since value %r (expected ISO-8601)", ns.since)
+            return 2
+
+    settings = EvalSettings()
+    out = asyncio.run(run(
+        settings=settings,
+        since=since,
+        limit_per_type=ns.limit_per_type,
+        threshold=ns.threshold,
+        out_path=ns.output,
+    ))
+    print(f"Wrote: {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nous_eval/templates/edge_precision_prompt.md
+++ b/nous_eval/templates/edge_precision_prompt.md
@@ -1,0 +1,30 @@
+You are a precision judge for a knowledge-graph edge audit.
+
+The Nous agent's `GraphDensifier` (F040) creates edges between memory nodes
+(facts, decisions, episodes, procedures) based on embedding similarity.
+F052 widens the candidate-generation step with multi-embedding query
+expansion. We need to confirm the resulting edges still represent
+semantically valid relationships, not noise let in by the wider net.
+
+For each edge, decide:
+
+- **YES** — the source and target are semantically related per the relation
+  type. A reasoner would naturally consider them together.
+- **WEAK** — a tenuous or indirect link; technically related but would not
+  be the first thing a reasoner reaches for.
+- **NO** — unrelated, wrong-direction, or off-topic.
+
+Relation glossary (subset):
+
+- `related_to` — same-type associative link (fact↔fact, etc.).
+- `evidence_for` — fact supports a decision.
+- `extracted_from` — fact came from an episode.
+- `discussed_in` — decision was discussed in an episode.
+- `informed_by` — decision was informed by a procedure.
+
+Edges to evaluate (JSON array follows). Return a JSON array of objects with
+keys `{source_id, target_id, verdict, reasoning}` in the SAME ORDER as the
+input. `verdict` MUST be one of `"YES"`, `"WEAK"`, `"NO"`. `reasoning` is a
+single sentence — no chain-of-thought, no Markdown.
+
+Return JSON only. No prose preamble or postamble.


### PR DESCRIPTION
## Summary

Salvaged from PR #350 (F052 — closed 2026-04-26 per spec §Rollout 3b). Ships the F040 operator tooling that paid for itself by surfacing F052's negative result AND revealing that F040's CE-mode cosine thresholds (not candidate generation) were the binding constraint on density.

**No production code changes.** All edits are under `nous_eval/` + a new `docs/features/F053-*.md` spec.

## What ships

| File | Purpose |
|---|---|
| `nous_eval/density_eval.py` | Per-config snapshot/run/restore loop driving `GraphDensifier.run_backfill_cycle()` against eval DB |
| `nous_eval/edge_judge.py` | Sonnet edge-precision judge (Claude-Code preamble + JSON5 tolerance + max_tokens=8192) |
| `nous_eval/run_edge_audit.py` | Audit driver: samples N edges per relation, computes precision with PASS/FAIL/UNDERPOWERED |
| `nous_eval/templates/edge_precision_prompt.md` | Operator-editable judge prompt |
| `nous_eval/retrieval_runner.py` (+44) | `_build_densifier_for_eval(settings, db, agent_id)` helper |
| `nous_eval/retrieval.py` (+25) | `baseline_loose_ce` diagnostic `RetrievalConfig` |
| `docs/features/F053-density-ops-harness.md` | Spec |

## What does NOT ship (F052 abandonment carve-out)

The F052 multi-embedding wedge:
- ❌ `Heart.expand_query_pairs` extracted helper
- ❌ `graph_densifier._backfill_same_type` wedge
- ❌ `nous/main.py:300` heart= wiring
- ❌ `nous/config.py` F052 fields (`graph_backfill_multi_embedding_enabled`, `query_expansion_temperature`)
- ❌ F052 test suite

F052 spec stays at `docs/features/F052-multi-embedding-backfill-seed.md` as the abandonment decision record.

## Validation

Smoke-tested 2026-04-26 on `nous_eval_scratch` (1991 facts / 430 decisions / 479 episodes / 87 procedures):
- `density_eval --configs baseline` → 240 edges in 105.8s ✅
- `baseline_loose_ce` config registered ✅
- All imports resolve on clean main (no F052 deps) ✅

## How operators use it

```bash
# Densify A/B against eval DB
NOUS_EVAL_DB_NAME=nous_eval_scratch   uv run python -m nous_eval.density_eval --configs baseline,baseline_loose_ce
# → reports/density-eval-<timestamp>.md

# Audit precision of the resulting edges
NOUS_EVAL_DB_NAME=nous_eval_scratch   uv run python -m nous_eval.run_edge_audit --limit-per-type 30
# → reports/edge-audit-<timestamp>.md
```

## Why this unblocks F054

F054 (selective CE-threshold relaxation) needs an empirical gate. Without F053, F054 would either ship blind ("trust the diagnostic results from F052's PR comments") or re-build the harness from scratch. F053 makes the gate trivial: F054 declares `Depends on: F053` and runs `density_eval` + `run_edge_audit` to validate per-relation precision before merge.

## Test plan

- [x] `density_eval --configs baseline` runs to completion ✅
- [x] `baseline_loose_ce` config registered ✅
- [x] Imports resolve on clean main ✅
- [ ] Reviewer eye-test on harness code (operator tooling, no production impact)
- [ ] Optional: 3-agent review (low-risk, defer if reviewer agrees)

## Provenance trail

- 2026-04-25: F050 (multi-query expansion) shipped Phase 1 dark-launch (PR #348)
- 2026-04-26: F052 (multi-embedding backfill) opened (PR #350) → spec/plan/impl review cycle → live gate run → 0% density lift → diagnostic matrix revealed CE thresholds were the bottleneck → PR #350 closed per spec §Rollout 3b
- 2026-04-26: This PR (F053) salvages the harness for future F040 work

🤖 Generated with [Claude Code](https://claude.com/claude-code)