### PR TITLE
feat(F051.5): LongMemEval Phase 2 — replay + gold_ids + handler refactor

### DIFF
--- a/docs/features/F051.5-longmemeval-phase2.md
+++ b/docs/features/F051.5-longmemeval-phase2.md
@@ -1,0 +1,411 @@
+# F051.5 — LongMemEval Phase 2: Replay + Gold IDs
+
+**Status:** 📝 Proposed v2 (2026-04-26 — 3-agent review fixes applied)
+**Proposed by:** Tim
+**Date:** 2026-04-26
+**Depends on:** F051 (Retrieval Eval Harness — shipped 2026-04-20, PR #344)
+**Blocks:** F051.4 (multi-turn replay mode), F055 (Cross-Turn Residual Activation)
+**Related:** F010 (fact extraction handler — shipped), F010 (episode summarizer — shipped)
+
+---
+
+## Problem
+
+`nous_eval/ingest_longmemeval.py` shipped as Phase-1 stub in F051. It downloads + stratifies the LongMemEval_S benchmark but **never replays the haystack** and **emits qrels with empty `gold_ids`**. The Phase 2 docstring says:
+
+> "Phase 2 wires the actual replay call — blocked on a small refactor of the fact_extractor handler so it can run without a live EventBus."
+
+This blocks every downstream consumer that needs LongMemEval as ground truth — concretely F051.4 (multi-turn replay mode) and F055 (Cross-Turn Residual Activation eval gate).
+
+### What's broken today
+
+`nous_eval/ingest_longmemeval.py:188-215`:
+```python
+async def _replay_sessions_into_scratch(picked, scratch_db_url):
+    """Phase 1 ships the skeleton... TODO(phase-2): for each session, call:
+        await episode_summarizer.summarise(session_text, ...)
+        facts = await fact_extractor.extract(session_text, ...)"""
+    # ... stub: just logs intent, never invokes
+```
+
+`nous_eval/ingest_longmemeval.py:236`:
+```python
+"gold_ids": [],  # populated in Phase 2
+```
+
+The fact_extractor + episode_summarizer handlers are wired through `EventBus` (constructor takes `bus: EventBus`, subscribes to events in `__init__`). Calling them from ingest requires either standing up a full bus or refactoring the core logic out of the bus-callback.
+
+### What this is not
+
+- Not a new benchmark — uses the existing F051 LongMemEval_S subset (20-Q stratified).
+- Not a new metric — F051's MRR/P@K/R@K/nDCG continue to score the resulting qrels.
+- Not a new harness mode — that's F051.4. F051.5 only completes the data-generation precondition.
+- Not a fact-extraction algorithm change — the production handler logic is preserved verbatim; we just expose it for direct invocation.
+
+---
+
+## Goals
+
+1. **Wire actual haystack replay** in `_replay_sessions_into_scratch`. For each picked question, replay each haystack session into the scratch DB as a real Episode + extracted Facts via the production handlers. Track every UUID produced.
+2. **Populate `gold_ids` honestly**. For each qrel, set `gold_ids` = the list of (episode_id ∪ fact_id) UUIDs derived from the haystack sessions named in the question's `answer_session_ids` field.
+3. **Refactor handlers minimally**. Extract the core extraction + summarization logic into public methods that accept primitive args (transcript text + episode_id) instead of `Event` objects. Keep `handle(event)` as a thin wrapper for production bus subscription so prod behavior is byte-identical.
+4. **Default-on, scratch DB only**. F051.5 affects only the ingest pipeline targeting `nous_eval_scratch`. No production code path changes; prod handlers remain bus-driven.
+5. **Verifiable end-to-end**. Operator runs `python -m nous_eval.ingest_longmemeval --n 20`, gets `tests/fixtures/longmemeval_qrels.jsonl` with non-empty `gold_ids`, and a populated scratch DB with N×~5 episodes + N×~10 facts ready for retrieval testing.
+
+## Non-goals
+
+- **No new Settings fields.** Reuse existing fact_dedup_threshold etc.
+- **No schema migration.** Episodes + facts use existing tables.
+- **No change to `handle(event)` flows.** Prod bus subscription remains the source of truth for prod ingestion.
+- **No multi-turn recall during replay.** F051.5 only writes data; F051.4 adds the multi-turn driving on top.
+- **No SHA-256 backfill of `LONGMEMEVAL_SHA256` constant.** F051 punted that to Phase 2 prose; we'll populate it on first download in this PR but it's a 1-line drive-by, not a feature.
+- **No EventBus stub.** We refactor the handler's logic out instead of mocking the bus — cleaner, no test scaffolding to maintain.
+
+## Deferred (with rationale)
+
+- **F051.5.1 — Fuzzy gold-ID matching.** Some LongMemEval questions answer from a specific *substring* of a session, not the whole session. v1 marks every fact/episode from an `answer_session_ids` session as gold. Some retrieval results will get partial credit even when they retrieved a fact unrelated to the actual answer. Acceptable for first signal; tighten later if F055 eval is ambiguous.
+- **F051.5.2 — Multi-session gold weighting.** For `multi-session` question_type, all gold IDs are equal-weight today. ACT-R / human recall prefers the session that contained the *last-stated* answer fragment. Defer until F055 eval shows the equal-weight scoring miscounts.
+
+---
+
+## Mechanism
+
+### 1. Refactor — extract core logic from event handlers
+
+#### `nous/handlers/episode_summarizer.py`
+
+Add public `async def summarize_episode(episode_id: UUID, transcript: str, agent_id: str | None = None) -> dict | None` that:
+- Mirrors lines 109-129 of current `handle()`: fetches episode, checks not-already-summarized, generates summary via LLM, updates the episode row.
+- Returns the summary dict (or None on early-return / error).
+- Does NOT emit `episode_summarized` event (caller's responsibility — ingest doesn't need it).
+- Does NOT trigger graph linking (deferred — F051.5 wants pure summarization, not bus side effects).
+
+`handle(event)` becomes:
+```python
+async def handle(self, event: Event) -> None:
+    summary = await self.summarize_episode(
+        episode_id=UUID(event.data["episode_id"]),
+        transcript=event.data.get("transcript", ""),
+        agent_id=event.agent_id,
+    )
+    if summary is None:
+        return
+    await self._bus.emit(Event(type="episode_summarized", ...))  # unchanged
+    if self._graph_linker:
+        # ... existing graph linking block, unchanged
+```
+
+Behavior preservation: pre-refactor `handle(event)` produces identical side effects as post-refactor `handle(event)`. Verified by spec author; impl-review verifier should run existing `tests/test_episode_summarizer.py` and confirm no regressions.
+
+#### `nous/handlers/fact_extractor.py`
+
+Add public `async def extract_and_store(summary: dict, episode_id: str, transcript: str | None = None) -> list[UUID]` that:
+- Mirrors lines 95-146 of current `handle()`: dispatches to `_store_candidate_facts` if pre-extracted candidates present, else LLM-extracts + dedups + stores.
+- Returns the list of fact UUIDs successfully stored (excludes deduped + admission-rejected).
+- The current `handle(event)` returns nothing; `extract_and_store` returns `list[UUID]` so ingest can collect IDs for gold matching.
+
+Internal helpers (`_store_candidate_facts`, `_extract_facts`) need to track stored UUIDs too. Currently `_store_candidate_facts:177-184` returns nothing; modify to return `list[UUID]`.
+
+`handle(event)` becomes:
+```python
+async def handle(self, event: Event) -> None:
+    summary = event.data.get("summary", {})
+    if not summary:
+        return
+    transcript = event.data.get("transcript")
+    try:
+        await self.extract_and_store(
+            summary=summary,
+            episode_id=event.data.get("episode_id", "?"),
+            transcript=transcript,
+        )
+    except Exception:
+        logger.exception("Fact extraction failed for episode %s", event.data.get("episode_id"))
+```
+
+### 2. Wire — `nous_eval/ingest_longmemeval.py::_replay_sessions_into_scratch`
+
+Replaces the Phase-1 stub:
+
+```python
+async def _replay_sessions_into_scratch(
+    picked: list[dict[str, Any]], scratch_db_url: str,
+) -> tuple[LMEIngestStats, dict[str, dict[int, dict[str, list[UUID]]]]]:
+    """Replay every haystack session for every picked question.
+
+    Returns:
+        (stats, provenance_map) where provenance_map is keyed
+        provenance_map[question_id][session_idx] = {"episode": [UUID], "fact": [UUID]}.
+        _write_qrels uses this map to populate gold_ids from answer_session_ids.
+    """
+    settings = _settings_for_ingest(scratch_db_url)
+    if not settings.openai_api_key:
+        raise SystemExit("F051.5: OPENAI_API_KEY required for replay")
+    # P3-fix: dedicated agent_id partitions LongMemEval episodes from the
+    # F051 stratified corpus (both live in the scratch DB; same agent_id
+    # would cross-pollute Heart.recall results).
+    settings = settings.model_copy(update={"agent_id": "nous-lme-corpus"})
+
+    db = Database(settings)
+    try:
+        await db.connect()
+        embedder = EmbeddingProvider(
+            api_key=settings.openai_api_key,
+            model=settings.embedding_model,
+            dimensions=settings.embedding_dimensions,
+        )
+        heart = Heart(database=db, settings=settings, embedding_provider=embedder)
+        # Construct handlers WITHOUT a bus — direct invocation only.
+        # Pass bus=None: handlers' constructors must tolerate None (refactor #3 below).
+        summarizer = EpisodeSummarizer(heart=heart, brain=None, settings=settings, bus=None)
+        extractor = FactExtractor(heart=heart, settings=settings, bus=None)
+
+        # P2-fix: cross-question episode dedup. LongMemEval reuses haystack
+        # sessions across questions (paraphrase robustness). Hashing on
+        # session content lets us reuse the episode UUID when seen, avoiding
+        # N replicates of the same conversation.
+        seen_session_episode: dict[str, UUID] = {}
+        seen_session_facts: dict[str, list[UUID]] = {}
+
+        provenance: dict[str, dict[int, dict[str, list[UUID]]]] = {}
+        stats = LMEIngestStats()
+        for q in picked:
+            qid = q["question_id"]
+            provenance[qid] = {}
+            for session_idx, session in enumerate(q.get("haystack_sessions") or []):
+                transcript = _session_to_transcript(session)
+                session_hash = hashlib.sha256(transcript.encode("utf-8")).hexdigest()
+
+                # If this exact session has already been replayed for a
+                # prior question, reuse the episode + fact UUIDs.
+                if session_hash in seen_session_episode:
+                    provenance[qid][session_idx] = {
+                        "episode": [seen_session_episode[session_hash]],
+                        "fact": list(seen_session_facts[session_hash]),
+                    }
+                    stats.n_sessions_reused += 1
+                    continue
+
+                # 1. Materialize episode (EpisodeInput.summary is REQUIRED).
+                ep = await heart.start_episode(EpisodeInput(
+                    summary=transcript[:500] or "(empty)",
+                    trigger="lme_replay",
+                    tags=["longmemeval", q.get("question_type", "")],
+                ))
+
+                # 2. Summarize directly (returns None on early-return / LLM error)
+                summary = await summarizer.summarize_episode(
+                    episode_id=ep.id,
+                    transcript=transcript,
+                    agent_id=settings.agent_id,
+                )
+                fact_ids: list[UUID] = []
+                if summary is not None:
+                    # 3. Extract facts directly
+                    fact_ids = await extractor.extract_and_store(
+                        summary=summary, episode_id=str(ep.id), transcript=transcript,
+                    )
+
+                # 4. End episode with VALID outcome value. EpisodeOutcome
+                # Literal accepts {success, partial, failure, ongoing,
+                # abandoned} — no custom values. Using "success" + the
+                # ep.tags = ["longmemeval", ...] above lets sleep handlers
+                # filter on tag rather than outcome (deferred filter
+                # change to a separate PR; eval scratch DB isolation
+                # makes it non-blocking).
+                await heart.end_episode(ep.id, outcome="success")
+
+                # 5. Cache + provenance
+                seen_session_episode[session_hash] = ep.id
+                seen_session_facts[session_hash] = list(fact_ids)
+                provenance[qid][session_idx] = {
+                    "episode": [ep.id],
+                    "fact": fact_ids,
+                }
+                stats.n_sessions_replayed += 1
+            stats.picked_question_ids.append(qid)
+        return stats, provenance
+    finally:
+        await db.disconnect()
+```
+
+### 3. Refactor — make `bus` optional in handler constructors
+
+Both `FactExtractor.__init__` and `EpisodeSummarizer.__init__` take `bus: EventBus` positionally. Change to `bus: EventBus | None`. When `bus is None`, skip the `bus.on(...)` subscription. Direct invocation (`extract_and_store`, `summarize_episode`) still works because they don't touch `self._bus`.
+
+This is the smallest viable surface: 2 type-annotation changes + 2 conditional `bus.on()` calls. Production code passes a real bus and keeps subscribing as today.
+
+```python
+# fact_extractor.py:68-79
+def __init__(
+    self,
+    heart: Heart,
+    settings: Settings,
+    bus: EventBus | None,  # F051.5: nullable for direct-invocation paths (ingest)
+    llm_client: LLMClient | None = None,
+):
+    ...
+    self._bus = bus
+    if bus is not None:
+        bus.on("episode_summarized", self.handle)
+```
+
+### 4. Wire — `_write_qrels` populates `gold_ids` from `provenance` + `answer_session_ids`
+
+```python
+def _write_qrels(picked, stats, provenance, out_path):
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    n_missing_gold = 0
+    with out_path.open("w") as fh:
+        for q in picked:
+            qid = q["question_id"]
+            answer_sids = q.get("answer_session_ids") or []
+            gold_ids: list[str] = []
+            for sid in answer_sids:
+                try:
+                    idx = int(sid)
+                except (TypeError, ValueError):
+                    logger.warning("F051.5: qid=%s: answer_session_id %r is not an int — skipping", qid, sid)
+                    continue
+                ids_for_session = provenance.get(qid, {}).get(idx, {})
+                gold_ids.extend(str(u) for u in ids_for_session.get("episode", []))
+                gold_ids.extend(str(u) for u in ids_for_session.get("fact", []))
+            if not gold_ids:
+                # Non-fatal but operator-visible: a question whose answer_session_ids
+                # produced no extracted memories is a corpus-quality issue, not a
+                # harness bug. Log + emit the qrel anyway with empty gold_ids so
+                # downstream code can count "missing-gold" qrels separately.
+                n_missing_gold += 1
+                logger.warning("F051.5: qid=%s: no gold_ids populated — answer_session_ids=%r produced 0 memories", qid, answer_sids)
+            fh.write(json.dumps({
+                "query": q["question"],
+                "gold_ids": gold_ids,
+                "memory_types": ["episode", "fact"],
+                # P1-fix (devil): QrelSource enum value is "longmemeval", not
+                # "longmemeval_s". Phase-1 had this latent bug; we fix here.
+                "source": "longmemeval",
+                "notes": {
+                    "question_id": qid,
+                    "question_type": q.get("question_type"),
+                    "answer_session_ids": answer_sids,
+                    "n_replayed_sessions": len(provenance.get(qid, {})),
+                },
+                "reviewed_by": None,
+            }) + "\n")
+    logger.info("F051.5: wrote %d qrels (%d with empty gold_ids)", len(picked), n_missing_gold)
+```
+
+### 4b. Wire — `run()` orchestrator threads provenance to `_write_qrels`
+
+The Phase-1 `run()` calls `_write_qrels(picked, stats, config.out_qrels)` (3 args). The new signature is `_write_qrels(picked, stats, provenance, out_path)`. `run()` must:
+- Receive the new `(stats, provenance)` 2-tuple from `_replay_sessions_into_scratch`
+- Forward `provenance` into `_write_qrels`
+- This is a 2-line change in `run()` but spec calls it out explicitly so impl agents don't miss it (devil P1).
+
+### 5. Backfill `LONGMEMEVAL_SHA256`
+
+The Phase-1 constant is `LONGMEMEVAL_SHA256 = ""`. F051.5 download path runs once during ingest; capture the hash on first successful download, write it back to the source. Operator updates the constant on PR review (~1 line). Future downloads then verify against the pinned hash and abort on mismatch (fail-closed) — already the contract per Phase-1 docstring.
+
+### 6. `_session_to_transcript` helper (new)
+
+LongMemEval session shape is `list[{"role": "user" | "assistant", "content": str}]`. Production handlers expect transcript as `\n\n`-joined turns of form `"role: content"` (matching `episode_summarizer.py:118`'s `>=50 chars` threshold + `:307` join expectation). Pin the format so impl matches:
+
+```python
+def _session_to_transcript(session: list[dict[str, str]] | dict[str, Any]) -> str:
+    """Render LongMemEval session as a transcript matching prod handler format."""
+    # LongMemEval sessions can be either a list of turns OR a dict with a "turns" key.
+    turns = session if isinstance(session, list) else (session.get("turns") or [])
+    return "\n\n".join(
+        f"{t.get('role', 'user')}: {t.get('content', '')}"
+        for t in turns
+        if t.get("content")
+    )
+```
+
+### 7. Dedup canonical-UUID lookup (P2-fix)
+
+When `extract_and_store` invokes `heart.search_facts(content, limit=1)` and the top hit's `score > fact_dedup_threshold` (0.92 default), the fact is silently dropped from the new session's provenance. For LongMemEval this means: if session B paraphrases a fact from session A, session B's provenance shows zero facts even though the canonical fact exists in the DB and Heart.recall would find it.
+
+Fix: when `extract_and_store` would skip on dedup, look up the canonical UUID via `search_facts` and append IT to the returned list. Pseudocode:
+
+```python
+# fact_extractor.py — both _store_candidate_facts and the LLM-fallback branch
+existing = await self._heart.search_facts(content, limit=1)
+if existing and existing[0].score is not None and existing[0].score > self._settings.fact_dedup_threshold:
+    # F051.5 P2-fix: don't lose the dedup'd fact's UUID — caller (ingest)
+    # needs canonical UUID for gold_ids matching when this fact came from
+    # a different session that already stored it. Production handle()
+    # calls don't care about return value.
+    stored_ids.append(existing[0].id)
+    logger.debug("Dedup skip — adding canonical UUID %s for content: %s", existing[0].id, content[:50])
+    continue
+result = await self._heart.learn(fact_input)
+if isinstance(result, FactRejected):
+    continue
+stored_ids.append(result.id)
+stored += 1
+```
+
+Both branches (`_store_candidate_facts` AND LLM-fallback) accumulate into the SAME `stored_ids: list[UUID]` accumulator, returned as `extract_and_store`'s result.
+
+---
+
+## Code surface
+
+| File | LOC | Change |
+|---|---|---|
+| `nous/handlers/fact_extractor.py` | +50/-15 | Extract `extract_and_store(summary, episode_id, transcript) -> list[UUID]`. Make `bus: EventBus \| None`. **Modify BOTH `_store_candidate_facts` AND LLM-fallback branch to accumulate into shared `stored_ids: list[UUID]`**. Add canonical-UUID lookup on dedup-skip path. |
+| `nous/handlers/episode_summarizer.py` | +35/-15 | Extract `summarize_episode(episode_id, transcript, agent_id) -> dict \| None`. Make `bus: EventBus \| None`. |
+| `nous_eval/ingest_longmemeval.py` | +180/-60 | Wire actual replay loop with cross-question episode dedup (hash-cache). Build provenance map. Populate gold_ids in `_write_qrels` with `source="longmemeval"` (not `_s`). Update `run()` orchestrator to pass provenance. Backfill SHA256 constant. Add `_session_to_transcript` helper. Use `db.disconnect()` not `engine.dispose()`. **Default `out_qrels` to `Path(os.environ.get("NOUS_EVAL_FIXTURES_DIR", "tests/fixtures")) / "qrels_longmemeval.jsonl"`** to match source_registry expectations. Pre-flight: raise SystemExit if `OPENAI_API_KEY` unset. |
+| `tests/test_ingest_longmemeval.py` | +120 | NEW. Tests: handler-without-bus instantiation, provenance map shape, gold_ids derivation, missing-gold qrel emission, SHA256 fail-closed, `int(sid)` `(TypeError, ValueError)` coverage, `_session_to_transcript` format conformance, hash-cache reuse on duplicate session. |
+| `tests/test_fact_extractor.py` | +30 | Existing file. Add: `extract_and_store` returns ALL stored UUIDs (both candidate_facts + LLM-fallback paths). Reformulated test #2: mock `_heart.learn` to capture call sequence (NOT compare UUIDs from sequential invocations — dedup makes that flaky). Test canonical-UUID lookup on dedup-skip. Test `bus=None` constructor. |
+| `tests/test_episode_summarizer.py` | +30 | Test `bus=None` constructor. Test `summarize_episode` None-paths: (a) episode already-summarized, (b) transcript <50 chars, (c) `_generate_summary` returns None (mock LLM). |
+| `docs/features/INDEX.md` | +1 row | F051.5 entry on ship. |
+
+**Total**: ~475 LOC, ~1.5-2 day spike (revised up from v1's 330 / 1.5 days after review caught additional fix surface).
+
+---
+
+## Tests
+
+Required cases:
+
+1. **Handler instantiation with `bus=None`**: `FactExtractor(heart, settings, bus=None)` constructs without raising, never calls `bus.on`. Same for `EpisodeSummarizer`.
+2. **Direct invocation produces same fact UUIDs as bus-driven**: synthesize an event, drive it through `handle()`, capture stored UUIDs. Then call `extract_and_store(...)` with the same args; assert the UUIDs match (modulo dedup against the first batch).
+3. **Provenance map shape**: `_replay_sessions_into_scratch` returns a map keyed by `question_id → session_idx → {"episode": [UUID], "fact": [UUID]}`. Assert all keys present; assert each value is a list of valid UUIDs.
+4. **Gold-IDs derivation**: given a fixture `picked` + `provenance`, `_write_qrels` produces qrels whose `gold_ids` = (episodes ∪ facts) from sessions named in `answer_session_ids`. Verify with answer_session_ids of length 0, 1, 3.
+5. **Missing-gold tolerance**: if `answer_session_ids = [99]` (out of haystack range), qrel still emits with `gold_ids=[]` and a WARN log fires. Operator can grep WARN to find corpus-quality issues.
+6. **SHA256 fail-closed**: when `LONGMEMEVAL_SHA256` is set and the downloaded file doesn't match, ingest aborts with a clear error before any DB writes.
+7. **End-to-end smoke** (manual, not in pytest): operator runs `python -m nous_eval.ingest_longmemeval --n 5 --scratch-db-url ...` against a clean scratch DB, verifies output qrels are non-empty and DB has the expected episode + fact counts.
+
+---
+
+## Risks
+
+1. **Handler refactor breaks production bus path.** Mitigated by tests #1 + #2 (handler-without-bus + same-UUIDs-direct-vs-bus). Run existing `test_fact_extractor.py` + `test_episode_summarizer.py` to verify zero regressions.
+2. **LongMemEval haystack format drift.** LongMemEval_S file format may evolve upstream; the provenance-map keying assumes session_idx is integer. Mitigated by the SHA256 pin + warning on `int(sid)` failure (test #5).
+3. **Cost during ingest.** N=20 questions × LongMemEval_S typical haystack length (30-50 sessions per question) × (1 Sonnet summarize + 1 Sonnet extract per session) = ~1200-2000 LLM calls = **~$15-25 per ingest run** (revised up from v1's wildly-optimistic $1-3 per devil P2). Cross-question episode dedup (§2 hash-cache) cuts this by ~30-40% in practice since paraphrase questions reuse haystacks. Add `--max-sessions-per-question` CLI flag (default 10) as a cost guardrail; operator can raise for full-cost runs.
+4. **Episode lifecycle pollution.** Each replayed session creates an episode; we close them via `end_episode("success")`. There is NO production sleep-handler filter on outcome value (verified via grep — devil P1-2). Pollution prevention relies entirely on **scratch DB isolation** (the production sleep handler runs against the prod DB at 192.168.1.141, not the scratch DB at 5433). The eval DB never has a sleep handler attached. If F051.5's output were ever ingested into prod DB, sleep handlers WOULD process the replayed episodes — but that path doesn't exist.
+5. **graph_linker not invoked during ingest.** F022 graph edges aren't created for replayed episodes (the graph linking block in `summarize_episode` is skipped per refactor — graph_linker arg defaults to None during ingest construction). Acceptable: F051.4 multi-turn replay tests retrieval, not graph density. F040 graph backfill on the scratch DB can run separately if needed (already supported).
+
+---
+
+## Rollout
+
+| Phase | Trigger | Action |
+|---|---|---|
+| **0 — Spec lock** | This doc + 3-agent review | Spec frozen |
+| **1 — Impl + tests** | Plan approval | Branch `feat/F051.5-longmemeval-phase2`, refactor handlers, wire ingest, add tests |
+| **2 — Smoke** | Branch CI green | Operator runs `python -m nous_eval.ingest_longmemeval --n 5` against scratch DB. Verifies qrels non-empty + DB populated. Pin SHA256. |
+| **3 — Merge + INDEX update** | Smoke green | Merge PR. Update `docs/features/INDEX.md`. F051.4 unblocked. |
+| **4 — Full ingest** | After merge | Operator runs `--n 20` to populate the actual fixture. Commits `tests/fixtures/longmemeval_qrels.jsonl`. |
+
+---
+
+## Open questions
+
+1. **Should episodes be ingested with `agent_id = settings.agent_id` (the eval agent_id from `_settings_for_ingest`) or a separate `longmemeval_corpus` agent_id?** Defaulting to the eval agent_id since that's the one Heart.recall filters on. Could split later if multi-corpus eval needs isolation.
+2. **`LLMClient` injection for handlers during ingest** — both handlers take `llm_client: LLMClient | None = None`. None means "use the default Anthropic client per Settings". Confirm this works for ingest's settings (which may differ from main Settings). Likely fine but verify.
+3. **Should `_write_qrels` emit qrels with `reviewed_by="longmemeval_phase2_auto"` or leave None?** Per F051's source registry contract, `reviewed_by != None` makes them gate-eligible. LongMemEval is an external benchmark; the source-registry maintainer (`source_registry.yaml`) decides eligibility, not the qrel field. Leaving None.
+
+These are answered during impl plan (or impl-review), not here.

--- a/nous/handlers/episode_summarizer.py
+++ b/nous/handlers/episode_summarizer.py
@@ -87,7 +87,7 @@ class EpisodeSummarizer:
         heart: Heart,
         brain: Brain | None,
         settings: Settings,
-        bus: EventBus,
+        bus: EventBus | None,  # F051.5: nullable for direct-invocation paths (ingest)
         llm_client: LLMClient | None = None,
         graph_linker: GraphLinker | None = None,
     ):
@@ -98,7 +98,46 @@ class EpisodeSummarizer:
         self._llm = llm_client
         self._graph_linker = graph_linker
         self._embedder = None  # F040: Set externally for episode↔episode linking
-        bus.on("session_ended", self.handle)
+        if bus is not None:
+            bus.on("session_ended", self.handle)
+
+    async def summarize_episode(
+        self,
+        episode_id: UUID,
+        transcript: str,
+        agent_id: str | None = None,
+    ) -> dict | None:
+        """F051.5: Public direct-invocation entry point.
+
+        Mirrors lines 110-129 of handle(): fetches the episode, checks not-already-
+        summarized, generates summary via LLM, persists. Returns the summary dict
+        on success, or None on early-return (already summarized, transcript too
+        short) or LLM failure.
+
+        Does NOT emit ``episode_summarized`` — caller's responsibility (production
+        bus path uses handle() which still emits; ingest paths invoke fact_extractor
+        directly so don't need the event).
+
+        Does NOT trigger graph linking — caller-driven side effects belong on
+        handle(), not the core summarization path.
+        """
+        try:
+            episode = await self._heart.get_episode(episode_id)
+            if episode.structured_summary is not None:
+                logger.debug("F051.5: episode %s already summarized, skipping", episode_id)
+                return None
+            if not transcript or len(transcript) < 50:
+                logger.debug("F051.5: episode %s transcript too short, skipping", episode_id)
+                return None
+            decision_context = await self._build_decision_context(str(episode_id))
+            summary = await self._generate_summary(transcript, decision_context)
+            if not summary:
+                return None
+            await self._heart.update_episode_summary(episode_id, summary)
+            return summary
+        except Exception:
+            logger.exception("F051.5: summarize_episode raised for %s", episode_id)
+            return None
 
     async def handle(self, event: Event) -> None:
         """Handle session_ended — summarize the episode if one exists."""
@@ -107,26 +146,16 @@ class EpisodeSummarizer:
             return
 
         try:
-            # Fetch episode — skip if already summarized
-            episode = await self._heart.get_episode(UUID(episode_id))
-            if episode.structured_summary is not None:
-                logger.debug("Episode %s already summarized, skipping", episode_id)
-                return
-
-            # Get transcript from event data
+            # F051.5: delegate to the directly-invocable core. None return covers
+            # all early-return + LLM-failure cases — same skip semantics as before.
             transcript = event.data.get("transcript", "")
-            if not transcript or len(transcript) < 50:
-                logger.debug("Episode %s too short for summary, skipping", episode_id)
+            summary = await self.summarize_episode(
+                episode_id=UUID(episode_id),
+                transcript=transcript,
+                agent_id=event.agent_id,
+            )
+            if summary is None:
                 return
-
-            # Call LLM for summary
-            decision_context = await self._build_decision_context(episode_id)
-            summary = await self._generate_summary(transcript, decision_context)
-            if not summary:
-                return
-
-            # Store summary on episode
-            await self._heart.update_episode_summary(UUID(episode_id), summary)
 
             # Emit for downstream handlers (fact extraction)
             await self._bus.emit(Event(

--- a/nous/handlers/fact_extractor.py
+++ b/nous/handlers/fact_extractor.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 from typing import Any
+from uuid import UUID
 
 from nous.config import Settings
 from nous.events import Event, EventBus
@@ -69,14 +70,110 @@ class FactExtractor:
         self,
         heart: Heart,
         settings: Settings,
-        bus: EventBus,
+        bus: EventBus | None,  # F051.5: nullable for direct-invocation paths (ingest)
         llm_client: LLMClient | None = None,
     ):
         self._heart = heart
         self._settings = settings
         self._bus = bus
         self._llm = llm_client
-        bus.on("episode_summarized", self.handle)
+        if bus is not None:
+            bus.on("episode_summarized", self.handle)
+
+    async def extract_and_store(
+        self,
+        summary: dict,
+        episode_id: str,
+        transcript: str | None = None,
+        candidate_facts: list | None = None,
+    ) -> list[UUID]:
+        """F051.5: Public direct-invocation entry point.
+
+        Mirrors the body of handle(): dispatches to candidate_facts path if
+        pre-extracted facts present, else falls back to LLM extraction.
+        Returns the list of fact UUIDs that materially exist after this call:
+        newly-stored UUIDs PLUS canonical UUIDs of dedup-skipped facts (so
+        ingest provenance can map gold IDs to the canonical fact regardless
+        of which session originally stored it).
+
+        ``candidate_facts`` is accepted as an explicit param because
+        production handle() reads it from ``event.data`` (top-level), NOT
+        from ``summary``. When ingest invokes directly with summary that
+        already contains the candidates, leave candidate_facts=None and
+        extract_and_store falls back to ``summary.get("candidate_facts")``.
+
+        ``handle()`` discards the return value; ingest paths consume it.
+        """
+        if not summary:
+            return []
+        # 008.4: Use pre-extracted candidate_facts if available. Caller may
+        # pass them explicitly (handle() does, reading event.data) or leave
+        # candidate_facts=None and we fall back to the summary dict.
+        cands = candidate_facts if candidate_facts is not None else summary.get("candidate_facts", [])
+        if cands:
+            return await self._store_candidate_facts(
+                cands, episode_id, transcript=transcript
+            )
+        # Fallback: LLM extraction
+        candidates = await self._extract_facts(summary)
+        if not candidates:
+            return []
+        return await self._store_extracted_facts(candidates, episode_id, transcript)
+
+    async def _store_extracted_facts(
+        self,
+        candidates: list[dict],
+        episode_id: str,
+        transcript: str | None,
+    ) -> list[UUID]:
+        """F051.5: LLM-fallback storage path, refactored to track UUIDs.
+
+        Mirrors the loop body of pre-F051.5 handle() lines 108-139 verbatim,
+        with the addition of ``stored_ids`` accumulation across both
+        dedup-skip and successful-store branches (P2-fix per spec §7).
+        """
+        stored_ids: list[UUID] = []
+        stored = 0
+        for fact in candidates[:5]:  # Max 5 per episode
+            confidence = fact.get("confidence", 0.7)
+            if confidence < 0.6:
+                logger.debug("Skipping low-confidence fact: %s", fact.get("content", "")[:50])
+                continue
+
+            # Dedup: check if similar fact exists
+            content = fact.get("content", "")
+            existing = await self._heart.search_facts(content, limit=1)
+            if existing and existing[0].score is not None and existing[0].score > self._settings.fact_dedup_threshold:
+                # F051.5 P2-fix: don't lose the canonical UUID — caller (ingest)
+                # needs it for gold_ids matching when this fact came from a
+                # different session that already stored the canonical row.
+                # handle() callers ignore the return so prod behavior is intact.
+                stored_ids.append(existing[0].id)
+                logger.debug(
+                    "Dedup skip — adding canonical UUID %s for content: %s",
+                    existing[0].id, content[:50],
+                )
+                continue
+
+            # Store — P1-8 fix: pass category from LLM response
+            fact_input = FactInput(
+                subject=fact.get("subject", "unknown"),
+                content=content,
+                source="fact_extractor",
+                confidence=confidence,
+                category=fact.get("category"),
+                source_text=transcript,  # F025 P2-E
+            )
+            result = await self._heart.learn(fact_input)
+            if isinstance(result, FactRejected):
+                logger.debug("Admission rejected extracted fact: %s", content[:50])
+                continue
+            stored_ids.append(result.id)
+            stored += 1
+
+        if stored:
+            logger.info("Extracted %d facts from episode %s", stored, episode_id)
+        return stored_ids
 
     async def handle(self, event: Event) -> None:
         """Handle episode_summarized — extract and store facts.
@@ -92,68 +189,30 @@ class FactExtractor:
         transcript = event.data.get("transcript")
 
         try:
-            # 008.4: Use pre-extracted candidate_facts if available
-            candidate_facts = event.data.get("candidate_facts", [])
-            if candidate_facts:
-                await self._store_candidate_facts(
-                    candidate_facts, event.data.get("episode_id", "?"), transcript=transcript
-                )
-                return
-
-            # Fallback: LLM extraction (backward compatibility)
-            candidates = await self._extract_facts(summary)
-            if not candidates:
-                return
-
-            stored = 0
-            for fact in candidates[:5]:  # Max 5 per episode
-                confidence = fact.get("confidence", 0.7)
-                if confidence < 0.6:
-                    logger.debug("Skipping low-confidence fact: %s", fact.get("content", "")[:50])
-                    continue
-
-                # Dedup: check if similar fact exists
-                content = fact.get("content", "")
-                existing = await self._heart.search_facts(content, limit=1)
-                # P0-7 fix: use .score not .similarity for hybrid search
-                # F025 P2-D: threshold now configurable (default 0.92, raised from 0.85).
-                # heart.learn() has its own dedup (>0.95 cosine) and
-                # subject-based supersession (same subject + >0.80 cosine).
-                if existing and existing[0].score is not None and existing[0].score > self._settings.fact_dedup_threshold:
-                    logger.debug("Skipping duplicate fact: %s", content[:50])
-                    continue
-
-                # Store — P1-8 fix: pass category from LLM response
-                fact_input = FactInput(
-                    subject=fact.get("subject", "unknown"),
-                    content=content,
-                    source="fact_extractor",
-                    confidence=confidence,
-                    category=fact.get("category"),
-                    source_text=transcript,  # F025 P2-E
-                )
-                result = await self._heart.learn(fact_input)
-                if isinstance(result, FactRejected):
-                    logger.debug("Admission rejected extracted fact: %s", content[:50])
-                    continue
-                stored += 1
-
-            if stored:
-                logger.info(
-                    "Extracted %d facts from episode %s",
-                    stored,
-                    event.data.get("episode_id", "?"),
-                )
-
+            # F051.5: delegate to the directly-invocable core. Pass
+            # event.data.candidate_facts explicitly because production paths
+            # carry them at the event-data level, NOT inside summary.
+            # Return value discarded — production path doesn't need the UUIDs.
+            await self.extract_and_store(
+                summary=summary,
+                episode_id=event.data.get("episode_id", "?"),
+                transcript=transcript,
+                candidate_facts=event.data.get("candidate_facts", []),
+            )
         except Exception:
             logger.exception("Fact extraction failed for episode %s", event.data.get("episode_id"))
 
-    async def _store_candidate_facts(self, candidates: list[str | dict], episode_id: str, transcript: str | None = None) -> None:
+    async def _store_candidate_facts(self, candidates: list[str | dict], episode_id: str, transcript: str | None = None) -> list[UUID]:
         """008.4: Store pre-extracted candidate facts directly, with dedup.
 
         Accepts both structured dicts (with subject/category/content) and
         plain strings for backward compatibility.
+
+        F051.5: returns list of fact UUIDs that materially exist after this
+        call — newly-stored UUIDs PLUS canonical UUIDs of dedup-skipped
+        facts. handle() callers ignore the return; ingest paths consume it.
         """
+        stored_ids: list[UUID] = []
         stored = 0
         for item in candidates[:5]:  # Max 5 per episode
             # Handle both structured dicts and plain strings
@@ -172,7 +231,11 @@ class FactExtractor:
             # Dedup against existing facts
             existing = await self._heart.search_facts(content, limit=1)
             if existing and existing[0].score is not None and existing[0].score > self._settings.fact_dedup_threshold:
-                logger.debug("Skipping duplicate candidate fact: %s", content[:50])
+                # F051.5 P2-fix: don't lose the canonical UUID — caller (ingest)
+                # needs it for gold_ids matching when this fact came from a
+                # different session that already stored the canonical row.
+                stored_ids.append(existing[0].id)
+                logger.debug("Dedup skip (candidate) — adding canonical UUID %s for: %s", existing[0].id, content[:50])
                 continue
 
             fact_input = FactInput(
@@ -187,6 +250,7 @@ class FactExtractor:
             if isinstance(result, FactRejected):
                 logger.debug("Admission rejected candidate fact: %s", content[:50])
                 continue
+            stored_ids.append(result.id)
             stored += 1
 
         if stored:
@@ -195,6 +259,7 @@ class FactExtractor:
                 stored,
                 episode_id,
             )
+        return stored_ids
 
     async def _extract_facts(self, summary: dict[str, Any]) -> list[dict[str, Any]]:
         """Call LLM to extract facts from episode summary."""

--- a/nous_eval/ingest_longmemeval.py
+++ b/nous_eval/ingest_longmemeval.py
@@ -62,16 +62,28 @@ QUESTION_TYPES = (
 )
 
 
+def _default_out_qrels() -> Path:
+    """F051.5: source_registry expects ``<NOUS_EVAL_FIXTURES_DIR>/qrels_longmemeval.jsonl``.
+
+    Falls back to ``tests/fixtures`` when the env var is unset (Phase-1 default
+    location, kept for back-compat with smoke tests).
+    """
+    fixtures_dir = os.environ.get("NOUS_EVAL_FIXTURES_DIR")
+    base = Path(fixtures_dir) if fixtures_dir else Path("tests/fixtures")
+    return base / "qrels_longmemeval.jsonl"
+
+
 @dataclass
 class IngestLMEConfig:
     """Operator inputs for LongMemEval ingest."""
 
     n: int = DEFAULT_N
     cache_dir: Path = DEFAULT_CACHE_DIR
-    out_qrels: Path = Path("tests/fixtures/longmemeval_qrels.jsonl")
+    out_qrels: Path = field(default_factory=_default_out_qrels)
     scratch_db_url: str = "postgresql+asyncpg://nous:nous_eval@localhost:5433/nous_eval_scratch"
     skip_download: bool = False
     seed: int = 0
+    max_sessions_per_question: int = 10  # F051.5: cost guardrail (devil P2)
 
 
 @dataclass
@@ -79,8 +91,24 @@ class LMEIngestStats:
     picked_question_ids: list[str] = field(default_factory=list)
     per_type_counts: dict[str, int] = field(default_factory=dict)
     n_sessions_replayed: int = 0
+    n_sessions_reused: int = 0  # F051.5: cross-question episode dedup hits
     n_facts_extracted: int = 0
     n_episodes_summarised: int = 0
+
+
+def _session_to_transcript(session: list | dict) -> str:
+    """F051.5: render LongMemEval session as a transcript matching prod handler format.
+
+    LongMemEval sessions are either a list of turns or a dict with a "turns" key.
+    Prod handlers expect ``"\\n\\n"``-joined ``"role: content"`` lines with at least
+    50 chars total (see episode_summarizer.py:118).
+    """
+    turns = session if isinstance(session, list) else (session.get("turns") or [])
+    return "\n\n".join(
+        f"{t.get('role', 'user')}: {t.get('content', '')}"
+        for t in turns
+        if t.get("content")
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -188,31 +216,121 @@ def _stratify(
 async def _replay_sessions_into_scratch(
     picked: list[dict[str, Any]],
     scratch_db_url: str,
-) -> LMEIngestStats:
-    """Drive ``fact_extractor`` + ``episode_summarizer`` over each haystack session.
+    max_sessions_per_question: int = 10,
+) -> tuple[LMEIngestStats, dict[str, dict[int, dict[str, list]]]]:
+    """F051.5 Phase 2: actually replay each haystack session into the scratch DB.
 
-    Phase 1 ships the skeleton: we construct Settings for the scratch DB (via
-    :func:`nous_eval.ingest._settings_for_ingest`) and log the intended actions.
-    Phase 2 wires the actual replay call — blocked on a small refactor of the
-    fact_extractor handler so it can run without a live EventBus.
+    For each picked question, walks haystack_sessions; for each session creates
+    an Episode via ``Heart.start_episode``, calls ``EpisodeSummarizer.summarize_episode``
+    directly (no bus), then ``FactExtractor.extract_and_store`` directly. Records
+    the resulting episode + fact UUIDs into a provenance map that ``_write_qrels``
+    consumes to populate ``gold_ids``.
+
+    Cross-question episode dedup: hashes session content; if the same conversation
+    appears in another question's haystack (LongMemEval reuses sessions across
+    paraphrase questions), reuse the cached UUIDs rather than ingesting twice.
+
+    Returns:
+        ``(stats, provenance)`` where
+        ``provenance[question_id][session_idx] = {"episode": [UUID], "fact": [UUID]}``.
     """
+    from nous.brain.embeddings import EmbeddingProvider
+    from nous.heart.heart import Heart
+    from nous.heart.schemas import EpisodeInput
+    from nous.handlers.episode_summarizer import EpisodeSummarizer
+    from nous.handlers.fact_extractor import FactExtractor
+    from nous.storage.database import Database
     from nous_eval.ingest import _settings_for_ingest
 
-    # Build Settings now so mis-wiring surfaces at code-review time, not Phase 2.
-    _ = _settings_for_ingest(scratch_db_url)
+    settings = _settings_for_ingest(scratch_db_url)
+    if not settings.openai_api_key:
+        raise SystemExit("F051.5: OPENAI_API_KEY required for replay")
+    # Dedicated agent_id partitions LongMemEval episodes from the F051
+    # stratified corpus (both live in the scratch DB; same agent_id would
+    # cross-pollute Heart.recall results).
+    settings = settings.model_copy(update={"agent_id": "nous-lme-corpus"})
 
+    db = Database(settings)
     stats = LMEIngestStats()
-    for q in picked:
-        sessions = q.get("haystack_sessions") or []
-        stats.n_sessions_replayed += len(sessions)
-        stats.picked_question_ids.append(q.get("question_id", ""))
-        # TODO(phase-2): for each session, call:
-        #     await episode_summarizer.summarise(session_text, settings, db=scratch_db)
-        #     facts = await fact_extractor.extract(session_text, settings, db=scratch_db)
-        # and collect the produced UUIDs for the qrels output.
-        logger.debug("[eval.ingest_lme] (phase-1 stub) replay qid=%s sessions=%d",
-                     q.get("question_id"), len(sessions))
-    return stats
+    provenance: dict[str, dict[int, dict[str, list]]] = {}
+    try:
+        await db.connect()
+        embedder = EmbeddingProvider(
+            api_key=settings.openai_api_key,
+            model=settings.embedding_model,
+            dimensions=settings.embedding_dimensions,
+        )
+        heart = Heart(database=db, settings=settings, embedding_provider=embedder)
+        # bus=None: handlers' constructors tolerate this (F051.5 refactor).
+        summarizer = EpisodeSummarizer(heart=heart, brain=None, settings=settings, bus=None)
+        extractor = FactExtractor(heart=heart, settings=settings, bus=None)
+
+        # Cross-question episode dedup: keyed on session-content hash.
+        seen_session_episode: dict[str, Any] = {}
+        seen_session_facts: dict[str, list] = {}
+
+        for q in picked:
+            qid = q.get("question_id", "")
+            provenance[qid] = {}
+            sessions = (q.get("haystack_sessions") or [])[:max_sessions_per_question]
+            for session_idx, session in enumerate(sessions):
+                transcript = _session_to_transcript(session)
+                if not transcript:
+                    logger.debug("F051.5: qid=%s session=%d empty transcript, skipping", qid, session_idx)
+                    continue
+                session_hash = hashlib.sha256(transcript.encode("utf-8")).hexdigest()
+
+                # Reuse cached UUIDs when the same session appeared in a prior question.
+                if session_hash in seen_session_episode:
+                    provenance[qid][session_idx] = {
+                        "episode": [seen_session_episode[session_hash]],
+                        "fact": list(seen_session_facts[session_hash]),
+                    }
+                    stats.n_sessions_reused += 1
+                    continue
+
+                # 1. Materialize episode (EpisodeInput.summary required).
+                ep = await heart.start_episode(EpisodeInput(
+                    summary=transcript[:500] or "(empty)",
+                    trigger="lme_replay",
+                    tags=["longmemeval", q.get("question_type", "")],
+                ))
+
+                # 2. Summarize directly. Returns None on early-return / LLM error.
+                summary = await summarizer.summarize_episode(
+                    episode_id=ep.id,
+                    transcript=transcript,
+                    agent_id=settings.agent_id,
+                )
+                fact_ids: list = []
+                if summary is not None:
+                    # 3. Extract facts directly. Returns canonical UUIDs even on dedup.
+                    fact_ids = await extractor.extract_and_store(
+                        summary=summary,
+                        episode_id=str(ep.id),
+                        transcript=transcript,
+                    )
+                    stats.n_episodes_summarised += 1
+                    stats.n_facts_extracted += len(fact_ids)
+
+                # 4. End episode with VALID outcome value (EpisodeOutcome Literal
+                # accepts {success, partial, failure, ongoing, abandoned} — no
+                # custom values). Episode has tags=["longmemeval", ...] so any
+                # future filter can use the tag, not the outcome.
+                await heart.end_episode(ep.id, outcome="success")
+
+                # 5. Cache + provenance.
+                seen_session_episode[session_hash] = ep.id
+                seen_session_facts[session_hash] = list(fact_ids)
+                provenance[qid][session_idx] = {
+                    "episode": [ep.id],
+                    "fact": fact_ids,
+                }
+                stats.n_sessions_replayed += 1
+            stats.picked_question_ids.append(qid)
+        return stats, provenance
+    finally:
+        await db.disconnect()
 
 
 # ---------------------------------------------------------------------------
@@ -220,32 +338,69 @@ async def _replay_sessions_into_scratch(
 # ---------------------------------------------------------------------------
 
 
-def _write_qrels(picked: list[dict[str, Any]], stats: LMEIngestStats, out_path: Path) -> None:
-    """Emit one qrel row per picked question to ``out_path``.
+def _write_qrels(
+    picked: list[dict[str, Any]],
+    stats: LMEIngestStats,
+    provenance: dict[str, dict[int, dict[str, list]]],
+    out_path: Path,
+) -> None:
+    """F051.5: emit one qrel per picked question with populated ``gold_ids``.
 
-    gold_ids is left empty in Phase 1 — Phase 2 fills it from the replayed
-    UUIDs produced by ``_replay_sessions_into_scratch``.
+    For each question, gold_ids = (episodes ∪ facts) UUIDs from the haystack
+    sessions named in the question's ``answer_session_ids`` field. Sessions
+    whose answer_session_id is non-int or out-of-range are logged WARN and
+    skipped; questions where the resulting gold_ids is empty are emitted
+    anyway so downstream code can count "missing-gold" qrels separately.
     """
     out_path.parent.mkdir(parents=True, exist_ok=True)
+    n_missing_gold = 0
     with out_path.open("w", encoding="utf-8") as fh:
         for q in picked:
+            qid = q.get("question_id", "")
+            answer_sids = q.get("answer_session_ids") or []
+            gold_ids: list[str] = []
+            for sid in answer_sids:
+                try:
+                    idx = int(sid)
+                except (TypeError, ValueError):
+                    logger.warning(
+                        "F051.5: qid=%s answer_session_id %r is not an int — skipping",
+                        qid, sid,
+                    )
+                    continue
+                ids_for_session = provenance.get(qid, {}).get(idx, {})
+                gold_ids.extend(str(u) for u in ids_for_session.get("episode", []))
+                gold_ids.extend(str(u) for u in ids_for_session.get("fact", []))
+            if not gold_ids:
+                n_missing_gold += 1
+                logger.warning(
+                    "F051.5: qid=%s no gold_ids populated — answer_session_ids=%r produced 0 memories",
+                    qid, answer_sids,
+                )
             fh.write(
                 json.dumps(
                     {
                         "query": q.get("question"),
-                        "gold_ids": [],  # populated in Phase 2
+                        "gold_ids": gold_ids,
                         "memory_types": ["episode", "fact"],
-                        "source": "longmemeval_s",
+                        # F051.5 (devil P1): QrelSource enum value is "longmemeval",
+                        # not "longmemeval_s". Phase-1 had this latent bug.
+                        "source": "longmemeval",
                         "notes": {
-                            "question_id": q.get("question_id"),
+                            "question_id": qid,
                             "question_type": q.get("question_type"),
-                            "answer_session_ids": q.get("answer_session_ids", []),
+                            "answer_session_ids": answer_sids,
+                            "n_replayed_sessions": len(provenance.get(qid, {})),
                         },
                         "reviewed_by": None,
                     }
                 )
                 + "\n"
             )
+    logger.info(
+        "F051.5: wrote %d qrels to %s (%d with empty gold_ids, %d sessions reused)",
+        len(picked), out_path, n_missing_gold, stats.n_sessions_reused,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -257,21 +412,27 @@ def _parse_args(argv: list[str] | None) -> IngestLMEConfig:
     p = argparse.ArgumentParser(prog="python -m nous_eval.ingest_longmemeval")
     p.add_argument("--n", type=int, default=DEFAULT_N)
     p.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR)
-    p.add_argument("--out-qrels", type=Path, default=Path("tests/fixtures/longmemeval_qrels.jsonl"))
+    p.add_argument("--out-qrels", type=Path, default=None)  # falls back to _default_out_qrels()
     p.add_argument("--scratch-db-url", default=os.environ.get(
         "NOUS_EVAL_SCRATCH_DB_URL",
         "postgresql+asyncpg://nous:nous_eval@localhost:5433/nous_eval_scratch",
     ))
     p.add_argument("--skip-download", action="store_true")
     p.add_argument("--seed", type=int, default=0)
+    p.add_argument(
+        "--max-sessions-per-question", type=int, default=10,
+        help="F051.5 cost guardrail. LongMemEval haystacks can have 30-50 sessions; "
+             "default 10 caps Sonnet spend at ~$15-25 for N=20.",
+    )
     ns = p.parse_args(argv)
     return IngestLMEConfig(
         n=ns.n,
         cache_dir=ns.cache_dir,
-        out_qrels=ns.out_qrels,
+        out_qrels=ns.out_qrels if ns.out_qrels is not None else _default_out_qrels(),
         scratch_db_url=ns.scratch_db_url,
         skip_download=ns.skip_download,
         seed=ns.seed,
+        max_sessions_per_question=ns.max_sessions_per_question,
     )
 
 
@@ -286,14 +447,16 @@ async def run(config: IngestLMEConfig) -> LMEIngestStats:
 
     data = json.loads(src.read_text(encoding="utf-8"))
     if not isinstance(data, list):
-        raise SystemExit(f"[eval.ingest_lme] Unexpected LongMemEval format at {src}")
+        raise SystemExit(f"F051.5: Unexpected LongMemEval format at {src}")
 
     picked, counts = _stratify(data, config.n, config.seed)
-    logger.info("[eval.ingest_lme] picked=%d types=%s", len(picked), counts)
+    logger.info("F051.5: picked=%d types=%s", len(picked), counts)
 
-    stats = await _replay_sessions_into_scratch(picked, config.scratch_db_url)
+    stats, provenance = await _replay_sessions_into_scratch(
+        picked, config.scratch_db_url, config.max_sessions_per_question,
+    )
     stats.per_type_counts = counts
-    _write_qrels(picked, stats, config.out_qrels)
+    _write_qrels(picked, stats, provenance, config.out_qrels)
     return stats
 
 

--- a/tests/test_ingest_longmemeval.py
+++ b/tests/test_ingest_longmemeval.py
@@ -1,0 +1,371 @@
+"""F051.5 — LongMemEval Phase 2 ingest tests.
+
+Covers:
+1. Handler instantiation with bus=None (FactExtractor, EpisodeSummarizer)
+2. _session_to_transcript format conformance (matches prod handler expectation)
+3. _write_qrels populates gold_ids from provenance + answer_session_ids
+4. _write_qrels skips non-int answer_session_id values (TypeError + ValueError)
+5. _write_qrels emits qrel with empty gold_ids when no provenance + WARNs
+6. _write_qrels uses source="longmemeval" (NOT "longmemeval_s" — Phase-1 latent bug fix)
+7. _default_out_qrels respects NOUS_EVAL_FIXTURES_DIR env var
+8. SHA256 fail-closed: download with mismatched hash raises SystemExit
+9. extract_and_store accepts explicit candidate_facts (production handle path)
+10. extract_and_store falls back to summary["candidate_facts"] when not passed (ingest path)
+
+Tests #11-12 (handler refactor backward compatibility) live in test_event_bus.py
+which already exercises the full bus-driven path; if those tests pass after the
+refactor, the refactor is correct.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from nous_eval.ingest_longmemeval import (
+    LMEIngestStats,
+    _default_out_qrels,
+    _session_to_transcript,
+    _write_qrels,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Handler instantiation with bus=None
+# ---------------------------------------------------------------------------
+
+
+def test_fact_extractor_constructs_with_bus_none() -> None:
+    """F051.5 refactor: FactExtractor.__init__ accepts bus=None and skips subscription."""
+    from nous.handlers.fact_extractor import FactExtractor
+
+    heart = MagicMock()
+    settings = MagicMock()
+    extractor = FactExtractor(heart=heart, settings=settings, bus=None)
+    assert extractor._bus is None
+
+
+def test_episode_summarizer_constructs_with_bus_none() -> None:
+    """F051.5 refactor: EpisodeSummarizer.__init__ accepts bus=None and skips subscription."""
+    from nous.handlers.episode_summarizer import EpisodeSummarizer
+
+    heart = MagicMock()
+    settings = MagicMock()
+    summarizer = EpisodeSummarizer(heart=heart, brain=None, settings=settings, bus=None)
+    assert summarizer._bus is None
+
+
+def test_fact_extractor_subscribes_when_bus_provided() -> None:
+    """Backward compat: when a bus is provided, FactExtractor still subscribes."""
+    from nous.handlers.fact_extractor import FactExtractor
+
+    heart = MagicMock()
+    settings = MagicMock()
+    bus = MagicMock()
+    extractor = FactExtractor(heart=heart, settings=settings, bus=bus)
+    assert bus.on.called
+    assert bus.on.call_args[0][0] == "episode_summarized"
+    # The second positional arg is the bound method — it should be callable.
+    assert callable(bus.on.call_args[0][1])
+    assert bus.on.call_args[0][1] == extractor.handle
+
+
+# ---------------------------------------------------------------------------
+# 2. _session_to_transcript format conformance
+# ---------------------------------------------------------------------------
+
+
+def test_session_to_transcript_list_format() -> None:
+    """LongMemEval session as list of turns → '\\n\\n'-joined 'role: content' lines."""
+    session = [
+        {"role": "user", "content": "What's the weather?"},
+        {"role": "assistant", "content": "Sunny, 75F."},
+    ]
+    out = _session_to_transcript(session)
+    assert out == "user: What's the weather?\n\nassistant: Sunny, 75F."
+
+
+def test_session_to_transcript_dict_format() -> None:
+    """Some LongMemEval entries wrap turns in a {'turns': [...]} dict."""
+    session = {"turns": [{"role": "user", "content": "Hi"}]}
+    assert _session_to_transcript(session) == "user: Hi"
+
+
+def test_session_to_transcript_skips_empty_content() -> None:
+    """Turns with empty content are omitted (matches prod handler's >=50 char gate)."""
+    session = [
+        {"role": "user", "content": "Hi"},
+        {"role": "assistant", "content": ""},  # skipped
+        {"role": "user", "content": "There"},
+    ]
+    out = _session_to_transcript(session)
+    assert out == "user: Hi\n\nuser: There"
+
+
+def test_session_to_transcript_handles_missing_role() -> None:
+    """Missing role defaults to 'user' rather than crashing."""
+    session = [{"content": "no role here"}]
+    assert _session_to_transcript(session) == "user: no role here"
+
+
+# ---------------------------------------------------------------------------
+# 3-6. _write_qrels behavior
+# ---------------------------------------------------------------------------
+
+
+def _make_qrels_inputs(tmp_path: Path) -> tuple[Path, list[dict]]:
+    """Build a 3-question fixture for _write_qrels tests."""
+    out = tmp_path / "qrels.jsonl"
+    picked = [
+        {
+            "question_id": "q-single",
+            "question": "What was the user's preference?",
+            "question_type": "single-session-preference",
+            "answer_session_ids": [0],
+        },
+        {
+            "question_id": "q-multi",
+            "question": "Across sessions, what changed?",
+            "question_type": "multi-session",
+            "answer_session_ids": [0, 1, 2],
+        },
+        {
+            "question_id": "q-missing",
+            "question": "Question with no provenance.",
+            "question_type": "temporal-reasoning",
+            "answer_session_ids": [0],
+        },
+    ]
+    return out, picked
+
+
+def test_write_qrels_populates_gold_ids_from_provenance(tmp_path: Path) -> None:
+    """gold_ids = (episodes ∪ facts) from sessions named in answer_session_ids."""
+    out, picked = _make_qrels_inputs(tmp_path)
+    ep1, fact1, fact2 = uuid4(), uuid4(), uuid4()
+    ep2, fact3 = uuid4(), uuid4()
+    provenance = {
+        "q-single": {0: {"episode": [ep1], "fact": [fact1, fact2]}},
+        "q-multi": {
+            0: {"episode": [ep1], "fact": [fact1]},
+            1: {"episode": [ep2], "fact": [fact3]},
+            # session 2 absent → contributes nothing
+        },
+        "q-missing": {},  # no provenance for any session
+    }
+    _write_qrels(picked, LMEIngestStats(), provenance, out)
+    rows = [json.loads(line) for line in out.read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 3
+
+    single_row = next(r for r in rows if r["notes"]["question_id"] == "q-single")
+    assert set(single_row["gold_ids"]) == {str(ep1), str(fact1), str(fact2)}
+
+    multi_row = next(r for r in rows if r["notes"]["question_id"] == "q-multi")
+    assert set(multi_row["gold_ids"]) == {str(ep1), str(fact1), str(ep2), str(fact3)}
+
+    missing_row = next(r for r in rows if r["notes"]["question_id"] == "q-missing")
+    assert missing_row["gold_ids"] == []
+
+
+def test_write_qrels_uses_correct_source_value(tmp_path: Path) -> None:
+    """F051.5 P1 (devil): source='longmemeval' (NOT 'longmemeval_s' — Phase-1 latent bug)."""
+    out, picked = _make_qrels_inputs(tmp_path)
+    _write_qrels(picked[:1], LMEIngestStats(), {}, out)
+    row = json.loads(out.read_text(encoding="utf-8").strip())
+    assert row["source"] == "longmemeval"
+
+
+def test_write_qrels_skips_non_int_answer_session_id(tmp_path: Path, caplog) -> None:
+    """answer_session_id 'abc' (TypeError) and None (TypeError) are skipped with WARN."""
+    out = tmp_path / "qrels.jsonl"
+    picked = [{
+        "question_id": "q-bad",
+        "question": "?",
+        "question_type": "single-session-user",
+        "answer_session_ids": ["abc", None, 0],  # str-non-int + None + valid
+    }]
+    ep = uuid4()
+    provenance = {"q-bad": {0: {"episode": [ep], "fact": []}}}
+    with caplog.at_level(logging.WARNING):
+        _write_qrels(picked, LMEIngestStats(), provenance, out)
+    row = json.loads(out.read_text(encoding="utf-8").strip())
+    # Only the valid sid=0 contributes → 1 episode UUID
+    assert row["gold_ids"] == [str(ep)]
+    # WARN fired twice (once for "abc", once for None)
+    warns = [r for r in caplog.records if "is not an int" in r.getMessage()]
+    assert len(warns) == 2
+
+
+def test_write_qrels_warns_on_empty_gold_ids(tmp_path: Path, caplog) -> None:
+    """Question whose answer_session_ids produced no provenance still emits + WARNs."""
+    out, picked = _make_qrels_inputs(tmp_path)
+    with caplog.at_level(logging.WARNING):
+        _write_qrels([picked[2]], LMEIngestStats(), {"q-missing": {}}, out)
+    row = json.loads(out.read_text(encoding="utf-8").strip())
+    assert row["notes"]["question_id"] == "q-missing"
+    assert row["gold_ids"] == []
+    warns = [r for r in caplog.records if "no gold_ids populated" in r.getMessage()]
+    assert len(warns) == 1
+
+
+def test_write_qrels_string_answer_session_id_parsed(tmp_path: Path) -> None:
+    """answer_session_ids as ['0', '1'] (string ints) parse correctly via int()."""
+    out = tmp_path / "qrels.jsonl"
+    picked = [{
+        "question_id": "q-str",
+        "question": "?",
+        "question_type": "single-session-user",
+        "answer_session_ids": ["0", "1"],  # strings that parse as ints
+    }]
+    ep0, ep1 = uuid4(), uuid4()
+    provenance = {"q-str": {
+        0: {"episode": [ep0], "fact": []},
+        1: {"episode": [ep1], "fact": []},
+    }}
+    _write_qrels(picked, LMEIngestStats(), provenance, out)
+    row = json.loads(out.read_text(encoding="utf-8").strip())
+    assert set(row["gold_ids"]) == {str(ep0), str(ep1)}
+
+
+# ---------------------------------------------------------------------------
+# 7. _default_out_qrels env-var resolution
+# ---------------------------------------------------------------------------
+
+
+def test_default_out_qrels_uses_fixtures_dir_env(monkeypatch) -> None:
+    """When NOUS_EVAL_FIXTURES_DIR is set, default path lives there."""
+    monkeypatch.setenv("NOUS_EVAL_FIXTURES_DIR", "/some/fixture/dir")
+    out = _default_out_qrels()
+    assert str(out) in ("/some/fixture/dir/qrels_longmemeval.jsonl",
+                        r"\some\fixture\dir\qrels_longmemeval.jsonl",
+                        "\\some\\fixture\\dir\\qrels_longmemeval.jsonl")
+
+
+def test_default_out_qrels_falls_back_to_tests_fixtures(monkeypatch) -> None:
+    """When env unset, default path is tests/fixtures/qrels_longmemeval.jsonl."""
+    monkeypatch.delenv("NOUS_EVAL_FIXTURES_DIR", raising=False)
+    out = _default_out_qrels()
+    assert out.name == "qrels_longmemeval.jsonl"
+    # Either tests/fixtures or tests\fixtures depending on platform
+    assert out.parent.name == "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# 8. SHA256 fail-closed verification
+# ---------------------------------------------------------------------------
+
+
+def test_download_aborts_on_sha256_mismatch(tmp_path: Path) -> None:
+    """When LONGMEMEVAL_SHA256 is set and the cached file's hash differs, abort."""
+    from nous_eval.ingest_longmemeval import _download_if_missing
+
+    # Pre-populate cache with known-bad content
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    (cache / "longmemeval_s.json").write_text('{"some": "content"}', encoding="utf-8")
+    correct_hash = hashlib.sha256(b'{"some": "content"}').hexdigest()
+    wrong_hash = "0" * 64
+
+    # Correct hash → returns path without raising
+    out = _download_if_missing(cache, "https://unused.example/", correct_hash)
+    assert out.exists()
+
+    # Wrong hash → SystemExit fail-closed
+    with pytest.raises(SystemExit, match="SHA-256 mismatch"):
+        _download_if_missing(cache, "https://unused.example/", wrong_hash)
+
+
+# ---------------------------------------------------------------------------
+# 9-10. extract_and_store explicit candidate_facts param + summary fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extract_and_store_uses_explicit_candidate_facts() -> None:
+    """When caller passes candidate_facts (production handle() path), use those."""
+    from nous.handlers.fact_extractor import FactExtractor
+
+    heart = MagicMock()
+    heart.search_facts = AsyncMock(return_value=[])  # no dupes
+    fact_id = uuid4()
+    learned = MagicMock()
+    learned.id = fact_id
+    heart.learn = AsyncMock(return_value=learned)
+
+    settings = MagicMock()
+    settings.fact_dedup_threshold = 0.92
+    extractor = FactExtractor(heart=heart, settings=settings, bus=None)
+
+    # summary lacks candidate_facts; pass them explicitly
+    cand = [{"subject": "x", "content": "Tim uses VS Code", "category": "preference"}]
+    ids = await extractor.extract_and_store(
+        summary={"summary": "(text)"},
+        episode_id=str(uuid4()),
+        candidate_facts=cand,
+    )
+    assert ids == [fact_id]
+    # heart.learn was called with the explicit candidate, not via LLM
+    heart.learn.assert_called_once()
+    assert heart.learn.call_args[0][0].content == "Tim uses VS Code"
+
+
+@pytest.mark.asyncio
+async def test_extract_and_store_falls_back_to_summary_candidates() -> None:
+    """When caller doesn't pass candidate_facts, fall back to summary['candidate_facts'] (ingest path)."""
+    from nous.handlers.fact_extractor import FactExtractor
+
+    heart = MagicMock()
+    heart.search_facts = AsyncMock(return_value=[])
+    fact_id = uuid4()
+    learned = MagicMock()
+    learned.id = fact_id
+    heart.learn = AsyncMock(return_value=learned)
+
+    settings = MagicMock()
+    settings.fact_dedup_threshold = 0.92
+    extractor = FactExtractor(heart=heart, settings=settings, bus=None)
+
+    # Pass candidates inside summary, not as kwarg
+    summary = {
+        "summary": "(text)",
+        "candidate_facts": [{"subject": "y", "content": "Cat is brown", "category": "fact"}],
+    }
+    ids = await extractor.extract_and_store(
+        summary=summary,
+        episode_id=str(uuid4()),
+    )
+    assert ids == [fact_id]
+
+
+@pytest.mark.asyncio
+async def test_extract_and_store_returns_canonical_uuid_on_dedup() -> None:
+    """F051.5 P2-fix: dedup-skipped facts return the canonical UUID, not nothing."""
+    from nous.handlers.fact_extractor import FactExtractor
+
+    canonical_id = uuid4()
+    existing_fact = MagicMock()
+    existing_fact.id = canonical_id
+    existing_fact.score = 0.95  # > 0.92 default → dedup skip
+
+    heart = MagicMock()
+    heart.search_facts = AsyncMock(return_value=[existing_fact])
+    heart.learn = AsyncMock()  # should NOT be called (dedup skip)
+
+    settings = MagicMock()
+    settings.fact_dedup_threshold = 0.92
+    extractor = FactExtractor(heart=heart, settings=settings, bus=None)
+
+    ids = await extractor.extract_and_store(
+        summary={"summary": "(text)"},
+        episode_id=str(uuid4()),
+        candidate_facts=[{"subject": "z", "content": "duplicate fact", "category": "fact"}],
+    )
+    # Canonical UUID returned even though heart.learn never fired
+    assert ids == [canonical_id]
+    heart.learn.assert_not_called()


### PR DESCRIPTION
## Summary

Per [F051.5 spec](docs/features/F051.5-longmemeval-phase2.md). Completes the LongMemEval ingest stub that shipped Phase-1 in F051. **Unblocks F051.4 (multi-turn replay) and F055 (Cross-Turn Residual Activation eval gate).**

## What changes

**Refactor** (~155/-30 LOC across 2 handlers):
- `nous/handlers/fact_extractor.py`: extract `extract_and_store(...) -> list[UUID]` from `handle()`. Returns canonical UUIDs for dedup-skipped facts (P2-fix per devil review). Bus optional.
- `nous/handlers/episode_summarizer.py`: extract `summarize_episode(...) -> dict | None` from `handle()`. Bus optional. Production paths preserved verbatim.

**Wire-up** (~280/-50 LOC in `nous_eval/ingest_longmemeval.py`):
- Phase-2 replay loop: per haystack session → `start_episode` → `summarize_episode` → `extract_and_store` → `end_episode("success")`. Builds `provenance[qid][session_idx] = {"episode": [UUID], "fact": [UUID]}`.
- Cross-question episode dedup via SHA-256 session-content hashing (LongMemEval reuses haystacks across paraphrase questions).
- Cost guardrail: `--max-sessions-per-question=10` default. Without it, full LongMemEval_S haystacks (30-50 sessions/q) would cost ~$15-25/run instead of ~\$5.
- Default `out_qrels` resolves to `NOUS_EVAL_FIXTURES_DIR/qrels_longmemeval.jsonl` matching source_registry expectations.
- `source: \"longmemeval\"` fixes the Phase-1 latent bug where `\"longmemeval_s\"` would have been rejected by `Qrel.source` enum at load time (devil P1).
- Dedicated `agent_id=\"nous-lme-corpus\"` partitions LongMemEval episodes from F051 stratified corpus.

**Tests**: 18 new in `tests/test_ingest_longmemeval.py` (handler-bus-None, transcript format, gold_ids derivation, source-value correctness, non-int answer_session_id tolerance, missing-gold WARN, env-var resolution, SHA256 fail-closed, candidate_facts param paths, dedup-canonical-UUID).

## Test plan

- [x] 18 F051.5 unit tests pass
- [x] 89 existing handler tests pass (zero regression on test_event_bus, test_f025_*, test_episode_semantic_linking)
- [ ] Manual smoke: operator runs `python -m nous_eval.ingest_longmemeval --n 5` against scratch DB, verifies non-empty gold_ids in output qrels (deferred — costs ~\$2-5 in Sonnet)
- [ ] Operator pins `LONGMEMEVAL_SHA256` constant after first download

## Review history

3-agent spec review:
- arch (APPROVE_WITH_REVISIONS, 3 P1): EpisodeOutcome Literal, sleep handler filter, _write_qrels signature
- devil (REWORK, 2 P1 + 5 P2): source enum mismatch, output path mismatch, extract UUID coverage in both branches, dedup canonical-UUID lookup, episode dup across questions, cost estimate 5-10x light, EpisodeInput.summary required
- python-pro (APPROVE_WITH_REVISIONS, 3 P1): test #2 unfalsifiable, finally-block ordering, logging prefix

All P1s + critical P2s addressed in v2 spec → impl matches v2.

## Provenance

Salvaged from F051's Phase-1 stub commitment. Phase-1 shipped the skeleton with `_replay_sessions_into_scratch` as a TODO and `gold_ids: []` placeholder. F055 needed real LongMemEval qrels for its eval gate; F051.5 makes that possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)