### PR TITLE
fix(F051.5): upstream LongMemEval moved to HF + uses string session IDs

### DIFF
--- a/nous_eval/ingest_longmemeval.py
+++ b/nous_eval/ingest_longmemeval.py
@@ -6,7 +6,7 @@ with 20 stratified chat-history-replayed episodes + extracted facts.
 
 Pipeline:
 
-1. Download ``longmemeval_data/longmemeval_s.json`` from the LongMemEval
+1. Download ``longmemeval_data/longmemeval_s_cleaned.json`` from the LongMemEval
    GitHub repo (cached at ``~/.cache/nous-eval/longmemeval/``). Skip if
    already present + hash-checked.
 2. Parse the file (list of ``{question_id, question_type, question,
@@ -41,13 +41,17 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# 2026-04-26 update: upstream moved from GitHub raw to Hugging Face dataset
+# repo. The cleaned variant ("longmemeval_s_cleaned.json") supersedes the
+# original — same schema, sessions cleaned to remove answer-leakage. See
+# repo README: https://github.com/xiaowu0162/LongMemEval (data section).
 LONGMEMEVAL_URL = (
-    "https://raw.githubusercontent.com/xiaowu0162/LongMemEval/main/"
-    "longmemeval_data/longmemeval_s.json"
+    "https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/"
+    "resolve/main/longmemeval_s_cleaned.json"
 )
-# SHA-256 of the upstream file as of 2026-04-20. Updated when upstream changes;
-# mismatch aborts the download (fail-closed).
-LONGMEMEVAL_SHA256 = ""  # populated in Phase 2 once the file is first downloaded
+# SHA-256 of the upstream file. Empty = skip verification (first download).
+# Updated when upstream changes; mismatch aborts the download (fail-closed).
+LONGMEMEVAL_SHA256 = ""
 
 DEFAULT_CACHE_DIR = Path.home() / ".cache" / "nous-eval" / "longmemeval"
 DEFAULT_N = 20
@@ -124,14 +128,14 @@ def _session_to_transcript(session: list | dict) -> str:
 
 
 def _download_if_missing(cache_dir: Path, url: str, expected_sha: str | None) -> Path:
-    """Fetch ``url`` to ``cache_dir/longmemeval_s.json`` once; return path.
+    """Fetch ``url`` to ``cache_dir/longmemeval_s_cleaned.json`` once; return path.
 
     Uses ``httpx`` if available (already a Nous dep), falls back to ``urllib``.
     When ``expected_sha`` is non-empty, abort on hash mismatch — prevents a
     silent upstream change from polluting the qrels set.
     """
     cache_dir.mkdir(parents=True, exist_ok=True)
-    target = cache_dir / "longmemeval_s.json"
+    target = cache_dir / "longmemeval_s_cleaned.json"
     if target.exists():
         logger.info("[eval.ingest_lme] cached %s", target)
     else:
@@ -282,7 +286,19 @@ async def _replay_sessions_into_scratch(
             qid = q.get("question_id", "")
             provenance[qid] = {}
             sessions = (q.get("haystack_sessions") or [])[:max_sessions_per_question]
+            # Cleaned upstream (2026-04-26 onward): haystack_session_ids is a
+            # parallel string-ID array; answer_session_ids references THESE
+            # strings, NOT integer indices. Pre-cleaned upstream had no such
+            # field — fall back to integer-index keying for back-compat.
+            session_ids = q.get("haystack_session_ids") or []
             for session_idx, session in enumerate(sessions):
+                # Per-session key for provenance lookup. Prefer the string ID
+                # when present (cleaned upstream); fall back to int index.
+                session_key = (
+                    session_ids[session_idx]
+                    if session_idx < len(session_ids)
+                    else session_idx
+                )
                 transcript = _session_to_transcript(session)
                 if not transcript:
                     logger.debug("F051.5: qid=%s session=%d empty transcript, skipping", qid, session_idx)
@@ -291,7 +307,7 @@ async def _replay_sessions_into_scratch(
 
                 # Reuse cached UUIDs when the same session appeared in a prior question.
                 if session_hash in seen_session_episode:
-                    provenance[qid][session_idx] = {
+                    provenance[qid][session_key] = {
                         "episode": [seen_session_episode[session_hash]],
                         "fact": list(seen_session_facts[session_hash]),
                     }
@@ -331,7 +347,7 @@ async def _replay_sessions_into_scratch(
                 # 5. Cache + provenance.
                 seen_session_episode[session_hash] = ep.id
                 seen_session_facts[session_hash] = list(fact_ids)
-                provenance[qid][session_idx] = {
+                provenance[qid][session_key] = {
                     "episode": [ep.id],
                     "fact": fact_ids,
                 }
@@ -388,16 +404,28 @@ def _write_qrels(
             qid = q.get("question_id", "")
             answer_sids = q.get("answer_session_ids") or []
             gold_ids: list[str] = []
+            qid_provenance = provenance.get(qid, {})
             for sid in answer_sids:
-                try:
-                    idx = int(sid)
-                except (TypeError, ValueError):
+                # Cleaned upstream uses string session IDs (e.g. "answer_280352e9");
+                # pre-cleaned upstream used 0-based integer indices. Try both.
+                ids_for_session = None
+                if sid in qid_provenance:
+                    ids_for_session = qid_provenance[sid]
+                else:
+                    try:
+                        idx = int(sid)
+                        if idx in qid_provenance:
+                            ids_for_session = qid_provenance[idx]
+                    except (TypeError, ValueError):
+                        pass
+                if ids_for_session is None:
                     logger.warning(
-                        "F051.5: qid=%s answer_session_id %r is not an int — skipping",
+                        "F051.5: qid=%s answer_session_id %r not found in "
+                        "provenance map (was the session capped by "
+                        "--max-sessions-per-question?) — skipping",
                         qid, sid,
                     )
                     continue
-                ids_for_session = provenance.get(qid, {}).get(idx, {})
                 gold_ids.extend(str(u) for u in ids_for_session.get("episode", []))
                 gold_ids.extend(str(u) for u in ids_for_session.get("fact", []))
             if not gold_ids:
@@ -492,7 +520,7 @@ async def run(config: IngestLMEConfig) -> LMEIngestStats:
             config.cache_dir, LONGMEMEVAL_URL, LONGMEMEVAL_SHA256 or None
         )
     else:
-        src = config.cache_dir / "longmemeval_s.json"
+        src = config.cache_dir / "longmemeval_s_cleaned.json"
 
     data = json.loads(src.read_text(encoding="utf-8"))
     if not isinstance(data, list):

--- a/tests/test_ingest_longmemeval.py
+++ b/tests/test_ingest_longmemeval.py
@@ -188,25 +188,47 @@ def test_write_qrels_uses_correct_source_value(tmp_path: Path) -> None:
     assert row["source"] == "longmemeval"
 
 
-def test_write_qrels_skips_non_int_answer_session_id(tmp_path: Path, caplog) -> None:
-    """answer_session_id 'abc' (TypeError) and None (TypeError) are skipped with WARN."""
+def test_write_qrels_handles_unmatched_answer_session_ids(tmp_path: Path, caplog) -> None:
+    """Unmatched answer_session_ids are skipped with WARN; matched ones contribute.
+
+    Cleaned upstream uses string IDs; pre-cleaned upstream used int indices.
+    Loader tries both — string lookup first, then int(sid) fallback. IDs that
+    match neither produce a "not found in provenance map" WARN.
+    """
     out = tmp_path / "qrels.jsonl"
     picked = [{
         "question_id": "q-bad",
         "question": "?",
         "question_type": "single-session-user",
-        "answer_session_ids": ["abc", None, 0],  # str-non-int + None + valid
+        "answer_session_ids": ["nonexistent_id", None, 0],  # unmatched + None + matched-as-int
     }]
     ep = uuid4()
     provenance = {"q-bad": {0: {"episode": [ep], "fact": []}}}
     with caplog.at_level(logging.WARNING):
         _write_qrels(picked, LMEIngestStats(), provenance, out)
     row = json.loads(out.read_text(encoding="utf-8").strip())
-    # Only the valid sid=0 contributes → 1 episode UUID
+    # Only sid=0 (matched as int index) contributes
     assert row["gold_ids"] == [str(ep)]
-    # WARN fired twice (once for "abc", once for None)
-    warns = [r for r in caplog.records if "is not an int" in r.getMessage()]
+    # WARN fired twice (once for "nonexistent_id", once for None)
+    warns = [r for r in caplog.records if "not found in provenance map" in r.getMessage()]
     assert len(warns) == 2
+
+
+def test_write_qrels_handles_string_session_ids(tmp_path: Path) -> None:
+    """Cleaned upstream: answer_session_ids are strings matching haystack_session_ids."""
+    out = tmp_path / "qrels.jsonl"
+    picked = [{
+        "question_id": "q-clean",
+        "question": "?",
+        "question_type": "single-session-user",
+        "answer_session_ids": ["answer_280352e9"],
+    }]
+    ep, fact = uuid4(), uuid4()
+    # Provenance keyed by string session ID (cleaned-upstream shape).
+    provenance = {"q-clean": {"answer_280352e9": {"episode": [ep], "fact": [fact]}}}
+    _write_qrels(picked, LMEIngestStats(), provenance, out)
+    row = json.loads(out.read_text(encoding="utf-8").strip())
+    assert set(row["gold_ids"]) == {str(ep), str(fact)}
 
 
 def test_write_qrels_skips_when_no_gold(tmp_path: Path, caplog) -> None:
@@ -349,7 +371,7 @@ def test_download_aborts_on_sha256_mismatch(tmp_path: Path) -> None:
     # Pre-populate cache with known-bad content
     cache = tmp_path / "cache"
     cache.mkdir()
-    (cache / "longmemeval_s.json").write_text('{"some": "content"}', encoding="utf-8")
+    (cache / "longmemeval_s_cleaned.json").write_text('{"some": "content"}', encoding="utf-8")
     correct_hash = hashlib.sha256(b'{"some": "content"}').hexdigest()
     wrong_hash = "0" * 64
 


### PR DESCRIPTION
## Summary

Two upstream changes broke F051.5 ingest. Caught during the first paced ingest run that just kicked off — download 404'd, then schema audit revealed answer_session_ids changed semantics.

## The bugs

**Bug 1 — URL 404:** `github.com/xiaowu0162/LongMemEval/main/longmemeval_data/longmemeval_s.json` → 404. LongMemEval was cleaned in Sept 2025 and data moved to Hugging Face: `huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/resolve/main/longmemeval_s_cleaned.json` (264 MB, 500 questions).

**Bug 2 — Schema mismatch:** Old upstream `answer_session_ids` was `list[int]` (0-based indices into `haystack_sessions`). Cleaned upstream uses `list[str]` (e.g. `["answer_280352e9"]`) that match the parallel `haystack_session_ids` string array. F051.5's `int(sid)` parsing skipped EVERY `answer_session_id` with a WARN, producing **zero gold_ids on every qrel**. The qrels file would have been empty.

## Fixes

- Update `LONGMEMEVAL_URL` to HF cleaned dataset.
- Cache filename: `longmemeval_s.json` → `longmemeval_s_cleaned.json` (forces re-download for operators upgrading).
- Provenance map keying: use `haystack_session_ids[idx]` string when present (cleaned upstream); fall back to int index for back-compat with old cached data.
- `_write_qrels` lookup: try string-key first, fall back to `int(sid)` parse. Unmatched IDs get clearer `"not found in provenance map"` WARN.

## Tests

- Renamed `test_write_qrels_skips_non_int_answer_session_id` → `test_write_qrels_handles_unmatched_answer_session_ids`; assertions updated.
- Added `test_write_qrels_handles_string_session_ids` covering the cleaned-upstream string-key lookup.
- 22/22 F051.5 tests pass.

## Why this slipped earlier reviews

The 3-agent F051.5 review verified the URL constant existed and was syntactically valid, but didn't actually `curl` it. The schema diff between old and cleaned upstream wasn't visible without downloading the new file. A round-trip "download → parse → assert shape" preflight in CI would have caught both. Filing as a follow-up: F051.5.x add upstream-shape preflight to ingest tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)