### PR TITLE
fix(F051.5): httpx follow_redirects=True + 600s timeout for HF download

### DIFF
--- a/nous_eval/ingest_longmemeval.py
+++ b/nous_eval/ingest_longmemeval.py
@@ -143,7 +143,12 @@ def _download_if_missing(cache_dir: Path, url: str, expected_sha: str | None) ->
         try:
             import httpx
 
-            with httpx.Client(timeout=60) as c:
+            # Hugging Face hosts the dataset behind a CAS bridge that 302's to
+            # a presigned S3-compatible URL. Without follow_redirects=True
+            # httpx surfaces the 302 as an HTTPStatusError instead of fetching
+            # the actual file. Increased timeout to 600s because the LongMemEval
+            # corpus is ~265 MB.
+            with httpx.Client(timeout=600, follow_redirects=True) as c:
                 r = c.get(url)
                 r.raise_for_status()
                 target.write_bytes(r.content)


### PR DESCRIPTION
Tiny follow-up to PR #360. HuggingFace's CAS bridge 302-redirects to a presigned S3-compatible URL (xethub.hf.co); httpx default `follow_redirects=False` made the redirect surface as HTTPStatusError. Also bumped timeout 60s → 600s for the 265 MB file. Tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)