### PR TITLE
fix(F051.5): disable admission control in ingest (sibling to issue #354)

### DIFF
--- a/nous_eval/ingest.py
+++ b/nous_eval/ingest.py
@@ -213,6 +213,16 @@ def _settings_for_ingest(scratch_db_url: str) -> Any:
             "correction_extraction_enabled": False,
             "graph_backfill_enabled": False,
             "rubric_outcome_detection_enabled": False,
+            # F023 admission control silently rejected ~999/1000 candidate_facts
+            # during F051.5 LongMemEval ingest because:
+            # (a) admission_shadow_mode defaults to False (production tightens),
+            # (b) admission_threshold=0.6 with no LLM utility scorer wired
+            # during ingest → most facts score below threshold → rejected.
+            # This is the same class of silent-pipeline-mismatch as issue #354
+            # (edge_audit/densifier column drift).
+            # Ingest is a bulk-load of vetted benchmark data; admission control
+            # is for filtering production traffic. Disable here.
+            "admission_control_enabled": False,
         }
     )
 


### PR DESCRIPTION
## Summary

Same class of silent-pipeline-mismatch bug as #354 (edge_audit/densifier column drift): a system component (F023 admission control) tuned for production was silently rejecting bulk-loaded benchmark data during F051.5 ingest.

## Discovery

LongMemEval ingest #4 produced 200 episodes with 5-7 candidate_facts each (verified via SQL: structured_summary->'candidate_facts' has rich content like 'Robert Anton Wilson', 'Phil Farber', etc.), but only **1 fact** in heart.facts. Investigation:

- `admission_control_enabled=True` (production default)
- `admission_shadow_mode=False` (production tightens to non-shadow)
- `admission_threshold=0.6`
- No LLM utility scorer wired during ingest → most facts score below 0.6 → silently `FactRejected` with only a DEBUG log.

User pointed to issue #354 ('audit and densifier read different columns'), suggesting we look for similar drift bugs. The drift here isn't column-name but pipeline-context: the same component (admission control) does opposite things in two contexts (filter prod traffic vs bulk-load benchmark data) with the same default settings.

## Fix

Add `admission_control_enabled=False` to `_settings_for_ingest`'s override list. Ingest is one-shot bulk-load of vetted benchmark data; admission control's job is to filter production extraction noise, which doesn't apply here.

## Expected impact

Re-running F051.5 ingest will now produce ~1000 facts (200 episodes × ~5 candidate_facts each) instead of 1. Both episode-only and episode+fact gold_ids will be measurable in F055 eval.

Tests pass (22/22). The 1-fact-only signal during ingest #4 was the diagnostic hint; the fix lands before the F055 eval gate fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)