### PR TITLE
fix(F051.5): bypass hybrid-search dedup pre-check during ingest

### DIFF
--- a/nous/handlers/fact_extractor.py
+++ b/nous/handlers/fact_extractor.py
@@ -72,11 +72,25 @@ class FactExtractor:
         settings: Settings,
         bus: EventBus | None,  # F051.5: nullable for direct-invocation paths (ingest)
         llm_client: LLMClient | None = None,
+        dedup_via_search: bool = True,
     ):
+        """
+        Args:
+            dedup_via_search: when True (production default), pre-checks
+                ``search_facts(content)`` against ``fact_dedup_threshold``
+                before calling ``Heart.learn``. The pre-check uses HYBRID
+                search (vector + keyword RRF) which catches lexical
+                paraphrases pure cosine misses. F051.5 ingest sets this
+                False because hybrid RRF scores are unreliable on a
+                near-empty corpus (the lone existing fact RRF≈1.0 trips
+                dedup for every subsequent candidate). Heart.learn's
+                native cosine > 0.95 dedup still runs regardless.
+        """
         self._heart = heart
         self._settings = settings
         self._bus = bus
         self._llm = llm_client
+        self._dedup_via_search = dedup_via_search
         if bus is not None:
             bus.on("episode_summarized", self.handle)
 
@@ -140,20 +154,17 @@ class FactExtractor:
                 logger.debug("Skipping low-confidence fact: %s", fact.get("content", "")[:50])
                 continue
 
-            # Dedup: check if similar fact exists
+            # Dedup: check if similar fact exists (production paraphrase guard)
             content = fact.get("content", "")
-            existing = await self._heart.search_facts(content, limit=1)
-            if existing and existing[0].score is not None and existing[0].score > self._settings.fact_dedup_threshold:
-                # F051.5 P2-fix: don't lose the canonical UUID — caller (ingest)
-                # needs it for gold_ids matching when this fact came from a
-                # different session that already stored the canonical row.
-                # handle() callers ignore the return so prod behavior is intact.
-                stored_ids.append(existing[0].id)
-                logger.debug(
-                    "Dedup skip — adding canonical UUID %s for content: %s",
-                    existing[0].id, content[:50],
-                )
-                continue
+            if self._dedup_via_search:
+                existing = await self._heart.search_facts(content, limit=1)
+                if existing and existing[0].score is not None and existing[0].score > self._settings.fact_dedup_threshold:
+                    stored_ids.append(existing[0].id)
+                    logger.debug(
+                        "Dedup skip — adding canonical UUID %s for content: %s",
+                        existing[0].id, content[:50],
+                    )
+                    continue
 
             # Store — P1-8 fix: pass category from LLM response
             fact_input = FactInput(
@@ -228,15 +239,13 @@ class FactExtractor:
             if not content or not str(content).strip():
                 continue
 
-            # Dedup against existing facts
-            existing = await self._heart.search_facts(content, limit=1)
-            if existing and existing[0].score is not None and existing[0].score > self._settings.fact_dedup_threshold:
-                # F051.5 P2-fix: don't lose the canonical UUID — caller (ingest)
-                # needs it for gold_ids matching when this fact came from a
-                # different session that already stored the canonical row.
-                stored_ids.append(existing[0].id)
-                logger.debug("Dedup skip (candidate) — adding canonical UUID %s for: %s", existing[0].id, content[:50])
-                continue
+            # Dedup: check if similar fact exists
+            if self._dedup_via_search:
+                existing = await self._heart.search_facts(content, limit=1)
+                if existing and existing[0].score is not None and existing[0].score > self._settings.fact_dedup_threshold:
+                    stored_ids.append(existing[0].id)
+                    logger.debug("Dedup skip (candidate) — adding canonical UUID %s for: %s", existing[0].id, content[:50])
+                    continue
 
             fact_input = FactInput(
                 content=content,

--- a/nous_eval/ingest_longmemeval.py
+++ b/nous_eval/ingest_longmemeval.py
@@ -300,6 +300,12 @@ async def _replay_sessions_into_scratch(
         extractor = FactExtractor(
             heart=heart, settings=settings,
             bus=None, llm_client=api_client,
+            # F051.5: disable the hybrid-search pre-check — RRF score is
+            # unreliable on a near-empty corpus (lone fact returns ≈1.0
+            # → trips dedup for every subsequent candidate). Heart.learn's
+            # native cosine > 0.95 dedup still runs. Without this flag,
+            # ingest #5 stored only 1 fact across 200 episodes.
+            dedup_via_search=False,
         )
 
         # Cross-question episode dedup: keyed on session-content hash.


### PR DESCRIPTION
## Summary

Third sibling-of-#354 silent-pipeline-mismatch bug. Same shape as PR #363 (admission-control disabled in ingest): a component tuned for production with hundreds of facts silently misbehaves on a fresh corpus.

## The bug

`fact_extractor._store_candidate_facts` (and `_store_extracted_facts`) had a pre-check:
```python
existing = await self._heart.search_facts(content, limit=1)
if existing[0].score > self._settings.fact_dedup_threshold:  # 0.92
    stored_ids.append(existing[0].id); continue
```

`search_facts` returns **RRF-fused hybrid rank**, not cosine. On a near-empty corpus the lone existing fact returns RRF≈1.0 → trips dedup for every subsequent candidate.

Result on F051.5 ingest #5: 200 episodes × 5+ candidate_facts each = ~1000 candidates → only **1 fact stored** (the very first). All subsequent calls appended that same UUID to stored_ids.

## Fix

Add `dedup_via_search: bool = True` param to `FactExtractor.__init__`. Default True preserves production behavior (the pre-check IS valuable in prod for catching lexical paraphrases pure cosine misses). F051.5 ingest passes False — Heart.learn's native cosine > 0.95 + `_confirm` returning canonical UUID still runs.

## Tests

121/121 pass — production dedup contract preserved (4 tests assert pre-check fires on default-True), ingest gets the bypass (without breaking F051.5's existing tests because the test fixtures don't set the flag).

## What's next

Re-run F051.5 ingest #6. With both #363 (admission control off) AND this PR (dedup pre-check bypassed) in place, expect ~1000 facts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)