### PR TITLE
feat(F056 PR #0): regression.py per-harness extensibility

### DIFF
--- a/nous_eval/regression.py
+++ b/nous_eval/regression.py
@@ -93,13 +93,18 @@ def _primary_metric_for(harness: str) -> str:
 
 
 def _validate_primary_metric(value: str, harness: str | None) -> str:
-    """Resolve `--primary-metric` value, errors clearly on unknown metric.
+    """Resolve `--primary-metric` value, returns error string on unknown metric.
+
+    Returns the resolved metric string on success. Raises `ValueError` with
+    a user-facing message on failure — caller is responsible for translating
+    to a clean CLI exit (matches the `retrieval.py:372-377` pattern, where
+    argparse errors are rendered via `print(..., file=sys.stderr); return 2`).
 
     `value="auto"` → return registry default for `harness`.
     `value` in `_ALL_REPORTED_METRICS_BY_HARNESS[harness]` → return as-is.
     `value` valid for SOME harness but not the requested one → still accept
         (multi-harness reports may need to compare across harness types).
-    `value` not in any registry → raise.
+    `value` not in any registry → raise `ValueError`.
 
     `harness=None` (multi-harness run) → accept any value present in at least
     one harness's reported metrics.
@@ -115,9 +120,27 @@ def _validate_primary_metric(value: str, harness: str | None) -> str:
     for tup in _ALL_REPORTED_METRICS_BY_HARNESS.values():
         all_known.update(tup)
     if value not in all_known:
-        raise argparse.ArgumentTypeError(
+        raise ValueError(
             f"--primary-metric={value!r} is not a known metric. "
             f"Known: {sorted(all_known)}"
+        )
+    return value
+
+
+def _validate_harness(value: str | None) -> str | None:
+    """Validate --harness against the registry, raising on typos.
+
+    Without this guard a typo like `--harness adminssion` parses cleanly,
+    matches no rows in `_fetch_rows`, and exits 0 with "No comparable runs
+    found" — silently passing weekly cron forever. Raises `ValueError` on
+    unknown value; caller translates to a clean CLI exit.
+    """
+    if value is None:
+        return None
+    if value not in _PRIMARY_METRIC_BY_HARNESS:
+        raise ValueError(
+            f"--harness={value!r} is not a known harness. "
+            f"Known: {sorted(_PRIMARY_METRIC_BY_HARNESS)}"
         )
     return value
 
@@ -385,8 +408,17 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     )
     args = p.parse_args(argv)
 
-    # F056: post-parse validation since --primary-metric depends on --harness.
-    args.primary_metric = _validate_primary_metric(args.primary_metric, args.harness)
+    # F056: post-parse validation. --primary-metric depends on --harness so
+    # cannot use argparse's `choices=`. Errors render via project-conventional
+    # `print(..., file=sys.stderr); sys.exit(2)` pattern (matches
+    # `nous_eval/retrieval.py:372-377`) — argparse.ArgumentTypeError only
+    # works inside `type=` callables, not post-parse, so we use ValueError
+    # + parser.error() to get clean output.
+    try:
+        args.harness = _validate_harness(args.harness)
+        args.primary_metric = _validate_primary_metric(args.primary_metric, args.harness)
+    except ValueError as exc:
+        p.error(str(exc))  # exits 2 with friendly "prog: error: ..." prefix
     return args
 
 

--- a/nous_eval/regression.py
+++ b/nous_eval/regression.py
@@ -16,13 +16,22 @@ Examples:
     # Per-config / per-harness filtering
     python -m nous_eval.regression --harness multi_turn_eval --configs baseline,f055_on
 
+    # Per-handler eval (F056)
+    python -m nous_eval.regression --harness admission --primary-metric admission_f1
+
     # Read-only (don't exit non-zero)
     python -m nous_eval.regression --report-only
 
 Schema assumption: rows in `nous_system.eval_runs.metrics` map config name
-to a dict containing `metrics.mrr` (and optionally other metrics). Both the
-F051 retrieval harness (`harness=retrieval`) and F051.4 multi-turn harness
-(`harness=multi_turn_eval`) write this shape.
+to a dict containing the harness-specific scalar metrics. The F051 retrieval
+harness writes `mrr/r_at_10/p_at_1/ndcg_at_10`; F051.4 multi-turn writes the
+same set; F056 handlers write handler-specific metrics (e.g. `admission_f1`).
+
+Per-harness metric registries (F056):
+- `_PRIMARY_METRIC_BY_HARNESS` — which scalar gates the run for each harness.
+- `_ALL_REPORTED_METRICS_BY_HARNESS` — which scalars surface in delta tables.
+  Sub-payloads (e.g. `confusion_matrix` dict) live in raw JSONB and are
+  excluded from delta tables by design.
 """
 from __future__ import annotations
 
@@ -30,8 +39,9 @@ import argparse
 import asyncio
 import logging
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 from sqlalchemy import text
 
@@ -43,21 +53,80 @@ from nous_eval.retrieval_runner import _settings_for_eval_db
 logger = logging.getLogger(__name__)
 
 
-# Metrics tracked for regression. Each maps DB-row metric key → human-readable
-# label. Only `mrr` is gating by default; others are reported but not gated.
-_TRACKED_METRICS = {
-    "mrr": "MRR",
-    "r_at_10": "R@10",
-    "p_at_1": "P@1",
-    "ndcg_at_10": "nDCG@10",
+# F056: which scalar gates the run for each harness type. Lookup at fetch time.
+_PRIMARY_METRIC_BY_HARNESS: dict[str, str] = {
+    "retrieval": "mrr",
+    "multi_turn_eval": "mrr",
+    "admission": "admission_f1",
+    "dedup": "dedup_f1",
+    "backfill": "edge_precision",
+    "summary": "summary_quality",
 }
+
+# F056: which scalar metrics surface in delta-table reports per harness.
+# Sub-payloads (dicts/structs like admission's confusion_matrix) live in raw
+# JSONB and are intentionally excluded — delta tables only handle scalars.
+_ALL_REPORTED_METRICS_BY_HARNESS: dict[str, tuple[str, ...]] = {
+    "retrieval":       ("mrr", "r_at_10", "p_at_1", "ndcg_at_10"),
+    "multi_turn_eval": ("mrr", "r_at_10", "p_at_1", "ndcg_at_10"),
+    "admission":       ("admission_f1", "admission_precision", "admission_recall"),
+    "dedup":           ("dedup_f1", "dedup_f1_leg1", "dedup_f1_leg2"),
+    "backfill":        ("edge_precision", "orphan_resolution_rate", "density_delta"),
+    "summary":         ("summary_quality", "mean_key_point_coverage", "mean_summary_faithfulness"),
+}
+
+# Default fallback harness for legacy rows written before PR #368 added the
+# `harness` key to configs payload. Behavior matches pre-F056 regression.py.
+_DEFAULT_HARNESS = "retrieval"
+
+
+def _reported_metrics_for(harness: str) -> tuple[str, ...]:
+    """Look up the scalar metric tuple for a harness; fall back to retrieval set."""
+    return _ALL_REPORTED_METRICS_BY_HARNESS.get(
+        harness, _ALL_REPORTED_METRICS_BY_HARNESS[_DEFAULT_HARNESS]
+    )
+
+
+def _primary_metric_for(harness: str) -> str:
+    """Look up the gating metric for a harness; fall back to retrieval set."""
+    return _PRIMARY_METRIC_BY_HARNESS.get(harness, _PRIMARY_METRIC_BY_HARNESS[_DEFAULT_HARNESS])
+
+
+def _validate_primary_metric(value: str, harness: str | None) -> str:
+    """Resolve `--primary-metric` value, errors clearly on unknown metric.
+
+    `value="auto"` → return registry default for `harness`.
+    `value` in `_ALL_REPORTED_METRICS_BY_HARNESS[harness]` → return as-is.
+    `value` valid for SOME harness but not the requested one → still accept
+        (multi-harness reports may need to compare across harness types).
+    `value` not in any registry → raise.
+
+    `harness=None` (multi-harness run) → accept any value present in at least
+    one harness's reported metrics.
+    """
+    if value == "auto":
+        if harness is None:
+            # Multi-harness: caller must pass --harness or use per-row primary
+            # via `_primary_metric_for(row.harness)` later.
+            return "auto"
+        return _primary_metric_for(harness)
+
+    all_known: set[str] = set()
+    for tup in _ALL_REPORTED_METRICS_BY_HARNESS.values():
+        all_known.update(tup)
+    if value not in all_known:
+        raise argparse.ArgumentTypeError(
+            f"--primary-metric={value!r} is not a known metric. "
+            f"Known: {sorted(all_known)}"
+        )
+    return value
 
 
 @dataclass(frozen=True)
 class _RunRow:
     created_at: datetime
     git_sha: str
-    harness: str  # "retrieval" or "multi_turn_eval"
+    harness: str  # "retrieval", "multi_turn_eval", "admission", "dedup", "backfill", "summary"
     config_name: str
     metrics: dict[str, float]
     report_path: str | None
@@ -72,6 +141,7 @@ class _Comparison:
     deltas: dict[str, float]  # metric → (latest - baseline)
     regressions: list[str]  # metric names that crossed threshold
     is_regression: bool
+    primary_metric: str = "mrr"  # which metric was gated
 
 
 async def _fetch_rows(
@@ -111,14 +181,18 @@ async def _fetch_rows(
             )
             for created_at, git_sha, configs_json, metrics_json, report_path in result.all():
                 # configs is a JSONB list; metrics is a JSONB dict keyed by config name.
-                # Both are returned as Python objects by asyncpg.
                 configs = configs_json or []
                 metrics_by_config = metrics_json or {}
                 for cfg in configs:
                     cfg_name = cfg.get("name") if isinstance(cfg, dict) else None
                     if not cfg_name:
                         continue
-                    harness = (cfg.get("harness") or "retrieval") if isinstance(cfg, dict) else "retrieval"
+                    # F056: harness-aware. Legacy rows lacking the key default
+                    # to "retrieval" — preserves pre-PR-#368 behavior.
+                    harness = (
+                        cfg.get("harness", _DEFAULT_HARNESS)
+                        if isinstance(cfg, dict) else _DEFAULT_HARNESS
+                    )
                     if harness_filter and harness != harness_filter:
                         continue
                     if config_filter and cfg_name not in config_filter:
@@ -127,12 +201,15 @@ async def _fetch_rows(
                         metrics_by_config.get(cfg_name, {}).get("metrics", {})
                         if isinstance(metrics_by_config, dict) else {}
                     )
+                    # F056: only fetch the scalar metrics this harness reports.
+                    # Sub-payloads (dicts) stay in raw JSONB, never enter _RunRow.
+                    reported = _reported_metrics_for(harness)
                     rows.append(_RunRow(
                         created_at=created_at,
                         git_sha=git_sha or "?",
                         harness=harness,
                         config_name=cfg_name,
-                        metrics={k: float(cfg_metrics.get(k, 0.0)) for k in _TRACKED_METRICS},
+                        metrics={k: float(cfg_metrics.get(k, 0.0)) for k in reported},
                         report_path=report_path,
                     ))
     finally:
@@ -159,6 +236,10 @@ def _compare_bucket(
 
     Returns None when there's no baseline to compare to (single row in bucket
     or all rows clustered within the min-age window — fresh table edge case).
+
+    F056: deltas are computed over the harness-specific reported metrics
+    (not the global retrieval set). `primary_metric="auto"` resolves per-row
+    via the harness registry.
     """
     if not bucket:
         return None
@@ -168,16 +249,21 @@ def _compare_bucket(
     candidates = [r for r in bucket_sorted[:-1] if r.created_at <= cutoff]
     baseline = candidates[-1] if candidates else None
 
+    # F056: use the harness's reported metric set, not a global constant.
+    reported = _reported_metrics_for(latest.harness)
+    effective_primary = (
+        _primary_metric_for(latest.harness) if primary_metric == "auto" else primary_metric
+    )
+
     deltas: dict[str, float] = {}
     regressions: list[str] = []
     if baseline is not None:
-        for metric in _TRACKED_METRICS:
+        for metric in reported:
             delta = latest.metrics.get(metric, 0.0) - baseline.metrics.get(metric, 0.0)
             deltas[metric] = delta
-        # Gate on the primary metric only. Other metrics are informational.
-        primary_delta = deltas.get(primary_metric, 0.0)
+        primary_delta = deltas.get(effective_primary, 0.0)
         if primary_delta < -abs(threshold):
-            regressions.append(primary_metric)
+            regressions.append(effective_primary)
 
     return _Comparison(
         config_name=latest.config_name,
@@ -187,6 +273,7 @@ def _compare_bucket(
         deltas=deltas,
         regressions=regressions,
         is_regression=bool(regressions),
+        primary_metric=effective_primary,
     )
 
 
@@ -202,7 +289,7 @@ def _format_report(
     lines.append("")
     lines.append(
         f"_Comparing latest run to most-recent run >={days*24:.0f}h older_  "
-        f"_threshold: {primary_metric} drop > {threshold*100:.1f}% triggers regression_"
+        f"_threshold: primary metric drop > {threshold*100:.1f}% triggers regression_"
     )
     lines.append("")
 
@@ -211,30 +298,44 @@ def _format_report(
         lines.append("Run the harness at least twice (separated by >=1 day) to populate baselines.")
         return "\n".join(lines)
 
-    header = "| harness | config | latest_MRR | baseline_MRR | d_MRR | d_R@10 | d_P@1 | status |"
-    sep    = "|---|---|---:|---:|---:|---:|---:|---|"
-    lines.append(header)
-    lines.append(sep)
-
+    # F056: group by harness so each section gets harness-specific headers.
+    by_harness: dict[str, list[_Comparison]] = {}
     for c in comparisons:
-        lat_mrr = c.latest.metrics.get("mrr", 0.0)
-        if c.baseline is None:
-            lines.append(
-                f"| {c.harness} | {c.config_name} | {lat_mrr:.3f} | _no baseline_ | "
-                f"-- | -- | -- | _new_ |"
-            )
-            continue
-        bas_mrr = c.baseline.metrics.get("mrr", 0.0)
-        d_mrr = c.deltas.get("mrr", 0.0)
-        d_r = c.deltas.get("r_at_10", 0.0)
-        d_p = c.deltas.get("p_at_1", 0.0)
-        status = "REGRESSION" if c.is_regression else "ok"
-        lines.append(
-            f"| {c.harness} | {c.config_name} | {lat_mrr:.3f} | {bas_mrr:.3f} | "
-            f"{d_mrr:+.3f} | {d_r:+.3f} | {d_p:+.3f} | {status} |"
-        )
+        by_harness.setdefault(c.harness, []).append(c)
 
-    lines.append("")
+    for harness in sorted(by_harness):
+        section = by_harness[harness]
+        reported = _reported_metrics_for(harness)
+        primary = _primary_metric_for(harness) if primary_metric == "auto" else primary_metric
+
+        lines.append(f"## {harness}")
+        lines.append("")
+        # Build dynamic headers: config | latest_<primary> | baseline_<primary> | d_<each metric> | status
+        delta_headers = " | ".join(f"d_{m}" for m in reported)
+        lines.append(
+            f"| config | latest_{primary} | baseline_{primary} | {delta_headers} | status |"
+        )
+        sep = "|---|---:|---:|" + "|".join("---:" for _ in reported) + "|---|"
+        lines.append(sep)
+
+        for c in section:
+            lat_primary = c.latest.metrics.get(primary, 0.0)
+            if c.baseline is None:
+                empty_deltas = " | ".join("--" for _ in reported)
+                lines.append(
+                    f"| {c.config_name} | {lat_primary:.3f} | _no baseline_ | "
+                    f"{empty_deltas} | _new_ |"
+                )
+                continue
+            bas_primary = c.baseline.metrics.get(primary, 0.0)
+            delta_cells = " | ".join(f"{c.deltas.get(m, 0.0):+.3f}" for m in reported)
+            status = "REGRESSION" if c.is_regression else "ok"
+            lines.append(
+                f"| {c.config_name} | {lat_primary:.3f} | {bas_primary:.3f} | "
+                f"{delta_cells} | {status} |"
+            )
+        lines.append("")
+
     n_regressions = sum(1 for c in comparisons if c.is_regression)
     if n_regressions:
         lines.append(f"**{n_regressions} regression(s) detected.**")
@@ -252,20 +353,24 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     p.add_argument(
         "--min-baseline-age-hours", type=float, default=12.0,
         help="Baseline must be at least this many hours older than latest "
-             "(default 12 — avoids same-day re-runs masking each other).",
+             "(default 12 - avoids same-day re-runs masking each other).",
     )
     p.add_argument(
         "--threshold", type=float, default=0.03,
-        help="MRR drop threshold for regression (default 0.03 = 3 percentage points).",
+        help="Primary-metric drop threshold for regression (default 0.03 = 3 percentage points).",
     )
     p.add_argument(
-        "--primary-metric", default="mrr",
-        choices=sorted(_TRACKED_METRICS.keys()),
-        help="Metric to gate on (default mrr; others reported but not gated).",
+        # F056: free-form (was choices= over _PRIMARY_METRIC_BY_HARNESS keys).
+        # Validation happens after parse_args via _validate_primary_metric.
+        "--primary-metric", default="auto", type=str,
+        help="Metric to gate on (default 'auto' - resolved from --harness via "
+             "_PRIMARY_METRIC_BY_HARNESS registry; pass an explicit metric to override).",
     )
     p.add_argument(
-        "--harness", default=None, choices=["retrieval", "multi_turn_eval"],
-        help="Filter to one harness type (default: both).",
+        # F056: free-form (was choices=["retrieval", "multi_turn_eval"]).
+        "--harness", default=None, type=str,
+        help="Filter to one harness type (default: all). Known harnesses: "
+             + ", ".join(sorted(_PRIMARY_METRIC_BY_HARNESS)),
     )
     p.add_argument(
         "--configs", default=None,
@@ -278,7 +383,11 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     p.add_argument(
         "--log-level", default="INFO",
     )
-    return p.parse_args(argv)
+    args = p.parse_args(argv)
+
+    # F056: post-parse validation since --primary-metric depends on --harness.
+    args.primary_metric = _validate_primary_metric(args.primary_metric, args.harness)
+    return args
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/eval/test_regression.py
+++ b/tests/eval/test_regression.py
@@ -1,7 +1,6 @@
 """F056 PR #0: tests for nous_eval/regression.py per-harness extensibility."""
 from __future__ import annotations
 
-import argparse
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -13,9 +12,11 @@ from nous_eval.regression import (
     _Comparison,
     _compare_bucket,
     _format_report,
+    _parse_args,
     _primary_metric_for,
     _reported_metrics_for,
     _RunRow,
+    _validate_harness,
     _validate_primary_metric,
 )
 
@@ -78,8 +79,42 @@ class TestValidatePrimaryMetric:
         assert _validate_primary_metric("mrr", "admission") == "mrr"
 
     def test_unknown_metric_raises(self):
-        with pytest.raises(argparse.ArgumentTypeError):
+        # F056 PR #0 fix: ValueError (was ArgumentTypeError, but that only
+        # renders cleanly when raised from a `type=` callable; we raise post-
+        # parse and the parser.error() call translates to a clean CLI exit).
+        with pytest.raises(ValueError, match="not_a_real_metric"):
             _validate_primary_metric("not_a_real_metric", "admission")
+
+
+class TestValidateHarness:
+    """F056 PR #0: --harness must reject typos.
+
+    Without validation, a typo like `--harness adminssion` parses cleanly,
+    matches no rows, exits 0 with "no comparable runs found" — silently
+    passing weekly cron forever. Devil's advocate review of PR #371 caught
+    this.
+    """
+
+    def test_known_harness_accepted(self):
+        for h in _PRIMARY_METRIC_BY_HARNESS:
+            assert _validate_harness(h) == h
+
+    def test_none_returns_none(self):
+        assert _validate_harness(None) is None
+
+    def test_typo_raises_with_helpful_message(self):
+        with pytest.raises(ValueError, match="adminssion"):
+            _validate_harness("adminssion")
+
+    def test_parse_args_translates_typo_to_clean_exit(self, capsys):
+        # parser.error() should give "prog: error: ..." and SystemExit(2),
+        # NOT a Python traceback (was the prior ArgumentTypeError bug).
+        with pytest.raises(SystemExit) as excinfo:
+            _parse_args(["--harness", "adminssion"])
+        assert excinfo.value.code == 2
+        captured = capsys.readouterr()
+        assert "adminssion" in captured.err
+        assert "Known:" in captured.err
 
 
 # ---------------------------------------------------------------------------

--- a/tests/eval/test_regression.py
+++ b/tests/eval/test_regression.py
@@ -1,0 +1,233 @@
+"""F056 PR #0: tests for nous_eval/regression.py per-harness extensibility."""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from nous_eval.regression import (
+    _ALL_REPORTED_METRICS_BY_HARNESS,
+    _PRIMARY_METRIC_BY_HARNESS,
+    _bucketize,
+    _Comparison,
+    _compare_bucket,
+    _format_report,
+    _primary_metric_for,
+    _reported_metrics_for,
+    _RunRow,
+    _validate_primary_metric,
+)
+
+
+# ---------------------------------------------------------------------------
+# Registry lookups (F056)
+# ---------------------------------------------------------------------------
+
+
+class TestPrimaryMetricRegistry:
+    def test_known_harness_returns_registered(self):
+        assert _primary_metric_for("retrieval") == "mrr"
+        assert _primary_metric_for("multi_turn_eval") == "mrr"
+        assert _primary_metric_for("admission") == "admission_f1"
+        assert _primary_metric_for("dedup") == "dedup_f1"
+        assert _primary_metric_for("backfill") == "edge_precision"
+        assert _primary_metric_for("summary") == "summary_quality"
+
+    def test_unknown_harness_falls_back_to_retrieval(self):
+        # Defensive: if a future harness isn't registered, we don't crash.
+        assert _primary_metric_for("totally-new-harness") == "mrr"
+
+
+class TestReportedMetricsRegistry:
+    def test_admission_excludes_confusion_matrix(self):
+        # F056 v4 design: confusion_matrix is a struct sub-payload, NOT a
+        # delta-table scalar. Must not appear in the registry tuple.
+        assert "confusion_matrix" not in _ALL_REPORTED_METRICS_BY_HARNESS["admission"]
+        assert _ALL_REPORTED_METRICS_BY_HARNESS["admission"] == (
+            "admission_f1", "admission_precision", "admission_recall",
+        )
+
+    def test_all_handler_harnesses_registered(self):
+        # Every handler from F056 spec must have a primary AND a reported set.
+        for harness in ("admission", "dedup", "backfill", "summary"):
+            assert harness in _PRIMARY_METRIC_BY_HARNESS
+            assert harness in _ALL_REPORTED_METRICS_BY_HARNESS
+            # Primary metric must be in the reported set.
+            assert _PRIMARY_METRIC_BY_HARNESS[harness] in _ALL_REPORTED_METRICS_BY_HARNESS[harness]
+
+
+# ---------------------------------------------------------------------------
+# _validate_primary_metric (F056)
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePrimaryMetric:
+    def test_auto_resolves_from_harness(self):
+        assert _validate_primary_metric("auto", "admission") == "admission_f1"
+        assert _validate_primary_metric("auto", "retrieval") == "mrr"
+
+    def test_auto_with_no_harness_returns_auto(self):
+        # Multi-harness reports defer per-row resolution.
+        assert _validate_primary_metric("auto", None) == "auto"
+
+    def test_explicit_metric_in_any_registry_accepted(self):
+        # Cross-harness comparison: a user might gate retrieval on the dedup
+        # leg primary out of curiosity. Not blocked.
+        assert _validate_primary_metric("dedup_f1", "retrieval") == "dedup_f1"
+        assert _validate_primary_metric("mrr", "admission") == "mrr"
+
+    def test_unknown_metric_raises(self):
+        with pytest.raises(argparse.ArgumentTypeError):
+            _validate_primary_metric("not_a_real_metric", "admission")
+
+
+# ---------------------------------------------------------------------------
+# _compare_bucket per-harness (F056)
+# ---------------------------------------------------------------------------
+
+
+def _row(harness: str, ts_offset_h: float, metrics: dict[str, float]) -> _RunRow:
+    return _RunRow(
+        created_at=datetime.now(tz=timezone.utc) + timedelta(hours=ts_offset_h),
+        git_sha="abc123",
+        harness=harness,
+        config_name="baseline",
+        metrics=metrics,
+        report_path=None,
+    )
+
+
+class TestCompareBucketPerHarness:
+    def test_admission_uses_admission_f1_as_primary(self):
+        baseline = _row("admission", -48, {"admission_f1": 0.90, "admission_precision": 0.92, "admission_recall": 0.88})
+        latest   = _row("admission", 0,   {"admission_f1": 0.80, "admission_precision": 0.85, "admission_recall": 0.75})
+        comp = _compare_bucket(
+            [baseline, latest],
+            threshold=0.05, primary_metric="auto", min_baseline_age_hours=12,
+        )
+        assert comp is not None
+        assert comp.primary_metric == "admission_f1"
+        assert comp.is_regression  # 0.80 - 0.90 = -0.10, exceeds 0.05 threshold
+        assert "admission_f1" in comp.regressions
+
+    def test_retrieval_uses_mrr_as_primary(self):
+        baseline = _row("retrieval", -48, {"mrr": 0.90, "r_at_10": 0.50, "p_at_1": 0.85, "ndcg_at_10": 0.60})
+        latest   = _row("retrieval", 0,   {"mrr": 0.85, "r_at_10": 0.50, "p_at_1": 0.85, "ndcg_at_10": 0.60})
+        comp = _compare_bucket(
+            [baseline, latest],
+            threshold=0.03, primary_metric="auto", min_baseline_age_hours=12,
+        )
+        assert comp is not None
+        assert comp.primary_metric == "mrr"
+        assert comp.is_regression  # -0.05 < -0.03
+
+    def test_no_regression_when_primary_within_threshold(self):
+        baseline = _row("admission", -48, {"admission_f1": 0.90, "admission_precision": 0.92, "admission_recall": 0.88})
+        latest   = _row("admission", 0,   {"admission_f1": 0.88, "admission_precision": 0.90, "admission_recall": 0.86})
+        comp = _compare_bucket(
+            [baseline, latest],
+            threshold=0.05, primary_metric="auto", min_baseline_age_hours=12,
+        )
+        assert comp is not None
+        assert not comp.is_regression  # 0.88 - 0.90 = -0.02, within 0.05
+
+    def test_deltas_cover_all_reported_metrics(self):
+        baseline = _row("dedup", -48, {"dedup_f1": 0.85, "dedup_f1_leg1": 0.88, "dedup_f1_leg2": 0.82})
+        latest   = _row("dedup", 0,   {"dedup_f1": 0.83, "dedup_f1_leg1": 0.86, "dedup_f1_leg2": 0.80})
+        comp = _compare_bucket(
+            [baseline, latest],
+            threshold=0.05, primary_metric="auto", min_baseline_age_hours=12,
+        )
+        assert comp is not None
+        # All 3 dedup metrics surface in deltas (not just primary).
+        assert set(comp.deltas) == {"dedup_f1", "dedup_f1_leg1", "dedup_f1_leg2"}
+
+    def test_no_baseline_returns_comparison_with_None_baseline(self):
+        latest = _row("admission", 0, {"admission_f1": 0.90, "admission_precision": 0.92, "admission_recall": 0.88})
+        comp = _compare_bucket(
+            [latest],
+            threshold=0.05, primary_metric="auto", min_baseline_age_hours=12,
+        )
+        assert comp is not None
+        assert comp.baseline is None
+        assert not comp.is_regression
+
+
+# ---------------------------------------------------------------------------
+# Per-harness report formatting (F056)
+# ---------------------------------------------------------------------------
+
+
+class TestFormatReportPerHarness:
+    def test_admission_report_has_admission_headers(self):
+        baseline = _row("admission", -48, {"admission_f1": 0.90, "admission_precision": 0.92, "admission_recall": 0.88})
+        latest   = _row("admission", 0,   {"admission_f1": 0.80, "admission_precision": 0.85, "admission_recall": 0.75})
+        comp = _compare_bucket(
+            [baseline, latest],
+            threshold=0.05, primary_metric="auto", min_baseline_age_hours=12,
+        )
+        report = _format_report([comp], threshold=0.05, primary_metric="auto", days=7)
+        # Headers must be admission-specific, NOT MRR/R@10.
+        assert "latest_admission_f1" in report
+        assert "d_admission_precision" in report
+        assert "## admission" in report
+        assert "REGRESSION" in report
+
+    def test_multi_harness_report_has_separate_sections(self):
+        retrieval_b = _row("retrieval", -48, {"mrr": 0.90, "r_at_10": 0.50, "p_at_1": 0.85, "ndcg_at_10": 0.60})
+        retrieval_l = _row("retrieval", 0,   {"mrr": 0.90, "r_at_10": 0.50, "p_at_1": 0.85, "ndcg_at_10": 0.60})
+        admission_b = _row("admission", -48, {"admission_f1": 0.90, "admission_precision": 0.92, "admission_recall": 0.88})
+        admission_l = _row("admission", 0,   {"admission_f1": 0.92, "admission_precision": 0.93, "admission_recall": 0.90})
+
+        c1 = _compare_bucket(
+            [retrieval_b, retrieval_l],
+            threshold=0.03, primary_metric="auto", min_baseline_age_hours=12,
+        )
+        c2 = _compare_bucket(
+            [admission_b, admission_l],
+            threshold=0.05, primary_metric="auto", min_baseline_age_hours=12,
+        )
+        report = _format_report([c1, c2], threshold=0.05, primary_metric="auto", days=7)
+
+        assert "## admission" in report
+        assert "## retrieval" in report
+        # Each section should have its own headers.
+        assert "latest_admission_f1" in report
+        assert "latest_mrr" in report
+
+    def test_no_baseline_renders_new_marker(self):
+        latest = _row("backfill", 0, {"edge_precision": 0.85, "orphan_resolution_rate": 0.6, "density_delta": 42})
+        comp = _compare_bucket(
+            [latest],
+            threshold=0.10, primary_metric="auto", min_baseline_age_hours=12,
+        )
+        report = _format_report([comp], threshold=0.10, primary_metric="auto", days=7)
+        assert "_new_" in report
+        assert "_no baseline_" in report
+
+
+# ---------------------------------------------------------------------------
+# Legacy-row backwards compat (F056 PR #0)
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyRowFallback:
+    def test_reported_metrics_for_unknown_harness_falls_back_to_retrieval(self):
+        # Pre-PR-#368 rows lacked `harness` key; _fetch_rows defaults to
+        # "retrieval" — verified separately in integration tests. Here we
+        # confirm the unknown-harness lookup path is safe.
+        assert _reported_metrics_for("totally-new") == _ALL_REPORTED_METRICS_BY_HARNESS["retrieval"]
+
+    def test_compare_bucket_with_unknown_harness_uses_retrieval_metrics(self):
+        # If a row's harness isn't in the registry, we fall back to retrieval
+        # set rather than crashing or returning empty deltas.
+        baseline = _row("legacy-retrieval", -48, {"mrr": 0.90, "r_at_10": 0.50, "p_at_1": 0.85, "ndcg_at_10": 0.60})
+        latest   = _row("legacy-retrieval", 0,   {"mrr": 0.80, "r_at_10": 0.40, "p_at_1": 0.75, "ndcg_at_10": 0.55})
+        comp = _compare_bucket(
+            [baseline, latest],
+            threshold=0.03, primary_metric="auto", min_baseline_age_hours=12,
+        )
+        assert comp is not None
+        assert comp.is_regression
+        assert "mrr" in comp.deltas


### PR DESCRIPTION
## Summary

Implements F056 spec §"Phase 1 infra extensions" — the prerequisite PR that unblocks the 4 handler eval PRs (admission, dedup, backfill, summary). Spec at \`docs/features/F056-eval-framework-phase2.md\` (merged via PR #370).

## What

Replaces \`regression.py\`'s hard-coded retrieval-only metric set with two per-harness registries:
- \`_PRIMARY_METRIC_BY_HARNESS\` — which scalar gates the run
- \`_ALL_REPORTED_METRICS_BY_HARNESS\` — which scalars surface in delta tables

Sub-payloads (e.g. admission's \`confusion_matrix\` dict) intentionally excluded — delta tables only handle scalars; struct sub-payloads stay in raw JSONB.

## Five call sites updated

1. \`_fetch_rows\` — uses \`_reported_metrics_for(harness)\` per-row (was \`_TRACKED_METRICS\` global)
2. \`_compare_bucket\` — iterates harness-specific reported metrics, resolves primary via \`_primary_metric_for(harness)\` when \`--primary-metric=auto\`
3. \`_format_report\` — groups by harness, emits per-harness sections with harness-specific headers
4. \`--harness choices=\` → free-form \`str\` (was closed enum)
5. \`--primary-metric choices=\` → free-form \`str\` + \`_validate_primary_metric\` helper (was closed enum that rejected handler metric values at argparse time before the registry was ever consulted)

## Backwards-compat

- Legacy rows (pre-PR-#368) lacking the \`harness\` configs key default to \`"retrieval"\` — preserves pre-F056 behavior
- Unknown harness in registry falls back to retrieval set (defensive)

## Test plan

- [x] 18 new unit tests in \`tests/eval/test_regression.py\` covering registry lookups, per-harness comparison, multi-harness report formatting, legacy-row fallback
- [x] All 93 existing F051 tests pass (\`uv run pytest tests/eval/ tests/test_multi_turn_eval.py\`)
- [x] Smoke test: \`python -m nous_eval.regression --report-only\` renders harness-aware report correctly for the existing retrieval row in \`nous_eval_scratch\`
- [ ] 3-agent review (architecture / devil / python-pro) — to be run against this PR
- [ ] Merge after review approval

Refs: #367 (F056 Phase 2 meta-issue), F056 spec PR #370 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)