### PR TITLE
fix(F056): smoke-test fixes — 4 runtime bugs + 4 first-baseline rows

### DIFF
--- a/nous_eval/handlers/backfill.py
+++ b/nous_eval/handlers/backfill.py
@@ -57,6 +57,17 @@ _HANDLER_NAME = "backfill"
 _DEFAULT_FIXTURE = Path("tests/fixtures/handlers/backfill_corpus.jsonl")
 _LLM_JUDGE_SAMPLE_N = 20
 _LLM_JUDGE_SEED = 42  # Deterministic per F056 spec §"Determinism"
+# Match summary handler — Haiku is plenty for "yes|no|borderline" verdicts
+# and ~5x faster + cheaper than the Sonnet default in main_settings.
+_DEFAULT_JUDGE_MODEL = "claude-haiku-4-5-20251001"
+
+
+def _add_judge_model_arg(parser) -> None:
+    """Extra CLI flag: --judge-model overrides the LLM-judge model."""
+    parser.add_argument(
+        "--judge-model", default=_DEFAULT_JUDGE_MODEL,
+        help=f"Anthropic model for LLM-judge calls (default {_DEFAULT_JUDGE_MODEL}).",
+    )
 
 
 def _settings_with_backfill_overrides(base: Settings) -> Settings:
@@ -99,9 +110,11 @@ async def _seed_facts(
         if ent.entity_type != "fact":
             skipped_types[ent.entity_type] = skipped_types.get(ent.entity_type, 0) + 1
             continue
+        # Heart.learn doesn't expose check_contradictions (FactManager-
+        # level only); subject=None on FactInput makes the contradiction
+        # check at facts.py:407 a no-op without needing the kwarg.
         result = await heart.learn(
             FactInput(content=ent.content, source="backfill_eval"),
-            check_contradictions=False,
         )
         if isinstance(result, FactRejected):
             logger.warning(
@@ -193,6 +206,7 @@ async def _judge_edge(
         "model": model,
         "max_tokens": 16,
         "temperature": 0,
+        "system": "",  # SdkAnthropicClient requires this key (anthropic_client.py:1014)
         "messages": [{"role": "user", "content": prompt}],
     }
     try:
@@ -375,8 +389,9 @@ async def _run_backfill_eval(
                 if src is None or tgt is None:
                     judgments.append("borderline")
                     continue
+                judge_model = getattr(args, "judge_model", _DEFAULT_JUDGE_MODEL)
                 verdict = await _judge_edge(
-                    llm_client, main_settings.background_model,
+                    llm_client, judge_model,
                     src, tgt, edge["relation"],
                 )
                 judgments.append(verdict)
@@ -436,7 +451,7 @@ async def _run_backfill_eval(
         fixture_size=len(entities),
         handler_specific_notes=(
             f"sample_n={_LLM_JUDGE_SAMPLE_N}, sample_seed={_LLM_JUDGE_SEED}, "
-            f"judge_model={main_settings.background_model}"
+            f"judge_model={getattr(args, 'judge_model', _DEFAULT_JUDGE_MODEL)}"
         ),
     )
 
@@ -446,6 +461,7 @@ def main(argv: list[str] | None = None) -> int:
         _HANDLER_NAME,
         _run_backfill_eval,
         default_threshold=0.10,  # 10pp per F056 spec §C
+        extra_args_fn=_add_judge_model_arg,
         argv=argv,
     )
 

--- a/nous_eval/handlers/dedup.py
+++ b/nous_eval/handlers/dedup.py
@@ -228,9 +228,11 @@ async def _seed_background_facts(heart: "Heart") -> list[UUID]:
     """
     bg_uuids: list[UUID] = []
     for content in _BACKGROUND_FACTS:
+        # Note: Heart.learn does NOT expose check_contradictions (FactManager-
+        # level only). Contradiction detection at facts.py:407 only fires when
+        # input.subject is set; we leave subject=None so the check is a no-op.
         result = await heart.learn(
             FactInput(content=content, source="dedup_eval_background"),
-            check_contradictions=False,
         )
         if isinstance(result, FactRejected):
             logger.warning(
@@ -293,11 +295,12 @@ async def _run_one_leg(
     cm = {"tp": 0, "fp": 0, "tn": 0, "fn": 0}
 
     for pair in pairs:
-        # Insert anchor (check_contradictions=False — costs Haiku $ + adds
-        # non-determinism; not measured here)
+        # Insert anchor. Heart.learn doesn't expose check_contradictions
+        # (FactManager-only); contradiction detection at facts.py:407 only
+        # fires when subject is set, so leaving subject=None makes the check
+        # a no-op without needing the kwarg.
         anchor_result = await heart.learn(
             FactInput(content=pair.anchor, source="dedup_eval"),
-            check_contradictions=False,
         )
         if isinstance(anchor_result, FactRejected):
             logger.warning(
@@ -322,8 +325,13 @@ async def _run_one_leg(
 
         # Submit paraphrase via FactExtractor (short-circuits LLM extraction
         # when candidate_facts is non-empty — see fact_extractor.py:127-130).
+        # NOTE: extract_and_store at fact_extractor.py:121-122 short-circuits
+        # `if not summary: return []` BEFORE the candidate_facts branch — so
+        # an empty dict ({} is falsy) skips processing entirely. Pass any
+        # truthy dict to bypass that gate; the contents are unused when
+        # candidate_facts is provided.
         returned_uuids = await extractor.extract_and_store(
-            summary={},
+            summary={"_eval_marker": "dedup-eval"},
             episode_id=f"dedup-eval-{pair.row_id}",
             candidate_facts=[{
                 "content": pair.paraphrase,

--- a/nous_eval/handlers/summary.py
+++ b/nous_eval/handlers/summary.py
@@ -59,6 +59,21 @@ logger = logging.getLogger(__name__)
 _AGENT_ID = "nous-eval-handler-summary"
 _HANDLER_NAME = "summary"
 _DEFAULT_FIXTURE = Path("tests/fixtures/handlers/summary_transcripts.jsonl")
+# F056 spec §D estimates ~$0.36/run with Haiku. Using Sonnet (the default
+# main_settings.background_model) is ~5x slower per call for 240 calls
+# total — empirically observed to push the run past 60 min vs ~15 min
+# with Haiku, with minimal accuracy gain on simple "yes/no/borderline"
+# verdict tasks. Haiku 4.5 is sufficient.
+_DEFAULT_JUDGE_MODEL = "claude-haiku-4-5-20251001"
+
+
+def _add_judge_model_arg(parser) -> None:
+    """Extra CLI flag: --judge-model overrides the LLM-judge model."""
+    parser.add_argument(
+        "--judge-model", default=_DEFAULT_JUDGE_MODEL,
+        help=f"Anthropic model for LLM-judge calls (default {_DEFAULT_JUDGE_MODEL}). "
+             f"Override to claude-sonnet-4-6 for higher-fidelity judging at ~5x cost+latency.",
+    )
 
 
 def _settings_with_summary_overrides(base: Settings) -> Settings:
@@ -138,6 +153,9 @@ async def _judge_key_point_coverage(
         "model": model,
         "max_tokens": 8,
         "temperature": 0,
+        # SdkAnthropicClient at anthropic_client.py:1014 does `payload["system"]`
+        # (not .get) — KeyError if absent. Empty string satisfies both clients.
+        "system": "",
         "messages": [{"role": "user", "content": prompt}],
     }
     try:
@@ -183,6 +201,7 @@ async def _judge_summary_faithfulness(
         "model": model,
         "max_tokens": 16,
         "temperature": 0,
+        "system": "",  # SdkAnthropicClient requires this key (anthropic_client.py:1014)
         "messages": [{"role": "user", "content": prompt}],
     }
     try:
@@ -329,12 +348,13 @@ async def _run_summary_eval(
                 # Step 3: judge twice
                 produced_kp = produced.get("key_points", []) or []
                 produced_summary_text = produced.get("summary", "") or ""
+                judge_model = getattr(args, "judge_model", _DEFAULT_JUDGE_MODEL)
                 kpc = await _judge_key_point_coverage(
-                    llm_client, main_settings.background_model,
+                    llm_client, judge_model,
                     row.gold_key_points, produced_kp,
                 )
                 sf = await _judge_summary_faithfulness(
-                    llm_client, main_settings.background_model,
+                    llm_client, judge_model,
                     row.transcript, produced_summary_text,
                 )
                 coverages.append(kpc)
@@ -405,7 +425,7 @@ async def _run_summary_eval(
         primary_metric="summary_quality",
         fixture_size=len(rows),
         handler_specific_notes=(
-            f"judge_model={main_settings.background_model}, "
+            f"judge_model={getattr(args, 'judge_model', _DEFAULT_JUDGE_MODEL)}, "
             f"include_unreviewed={args.include_unreviewed}, "
             f"null_return_rate={null_returns / len(rows):.3f}"
         ),
@@ -417,6 +437,7 @@ def main(argv: list[str] | None = None) -> int:
         _HANDLER_NAME,
         _run_summary_eval,
         default_threshold=0.05,  # 5pp per F056 spec §D
+        extra_args_fn=_add_judge_model_arg,
         argv=argv,
     )
 


### PR DESCRIPTION
## Summary

End-to-end smoke run of the 4 F056 handlers against real Postgres + Anthropic surfaced **4 bugs** that 80 unit tests missed. All multi-handler. Plus generated first real baseline rows in \`nous_system.eval_runs\` for all 4 handlers — regression CLI now works.

## Bugs caught

1. **\`Heart.learn(check_contradictions=...)\` kwarg doesn't exist** — that's FactManager-level only. 3 handlers had it → \`TypeError\` on first call. Fix: drop the kwarg (contradiction detection is gated on \`input.subject\` which is None in eval paths anyway).

2. **\`extract_and_store(summary={})\` early-returns** at \`fact_extractor.py:121\` (\`if not summary: return []\`) BEFORE the \`candidate_facts\` branch. Dedup F1=0.0 (false floor) on first run. Fix: pass truthy dict.

3. **\`payload["system"]\` KeyError in \`SdkAnthropicClient\`** — \`anthropic_client.py:1014\` uses direct key access. backfill + summary judges crashed on every call → 0/0. Fix: include \`"system": ""\` in payload.

4. **Summary handler defaulted to \`claude-sonnet-4-6\`** — 240 sequential calls took >57 min. Fix: new \`--judge-model\` flag with \`claude-haiku-4-5-20251001\` default. Backfill gets the same treatment for consistency. Both via \`extra_args_fn\` pattern in \`_cli_base\`.

## Baselines now in eval_runs

| Handler | Metric | Value | Finding |
|---|---|---|---|
| admission | F1 | **0.862** | over-admits vague content → #376 |
| dedup | F1 | **0.400** | legs miscalibrated opposite directions → #377 |
| backfill | edge_precision | 0/0 | cross-domain fixture correct (no edges); needs intra-domain F056.2 |
| summary | quality | **0.303** | huge per-type variance — single-session-preference 0.78 vs single-session-assistant 0.05 |

\`python -m nous_eval.regression --report-only\` reads all 4 with per-handler sections and harness-specific column headers. All 4 marked \`_new_\` (first runs). No regressions detected.

## Test plan

- [x] All 80 F056 handler unit tests pass
- [x] All 4 handlers smoke green end-to-end
- [x] regression CLI reads all 4 with correct headers
- [x] 2 production findings filed as #376 + #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)