### PR TITLE
fix(migrator): hotfix migration 039 + harden splitter against ; in string literals

### DIFF
--- a/nous/storage/migrator.py
+++ b/nous/storage/migrator.py
@@ -30,19 +30,59 @@ CREATE TABLE IF NOT EXISTS nous_system.schema_migrations (
 def _split_sql_statements(sql: str) -> list[str]:
     """Split a migration file into individual SQL statements.
 
-    Strips `-- ...` line comments BEFORE splitting on `;` so a semicolon
-    inside a comment does not break the splitter (see bug: migration 034
-    had "-- legacy rows; backfill..." that was mis-split into "backfill..."
-    and executed as SQL).
+    Strips `-- ...` line comments BEFORE walking the body, then splits on
+    top-level `;` while tracking single-quoted string literals so a `;`
+    inside a string (e.g. a COMMENT body) does not chop the statement.
 
-    Block comments `/* ... */` are NOT handled — our migrations don't use
-    them. Dollar-quoted strings `$$...$$` would also need care; current
-    migrations don't use those either.
+    Bugs prevented:
+    - Migration 034 had "-- legacy rows; backfill..." that was mis-split
+      into "backfill..." and executed as SQL (fixed in 38531ba).
+    - Migration 039 had "COMMENT ... 'foo; bar'" which the naive splitter
+      cut mid-string, raising PostgresSyntaxError on prod boot.
+
+    Single-quote escapes are handled the SQL way: doubled `''` inside a
+    string. Block comments `/* ... */` and dollar-quoted strings `$$...$$`
+    are NOT supported — current migrations don't use them.
     """
     stripped = "\n".join(
         ln for ln in sql.splitlines() if not ln.lstrip().startswith("--")
     )
-    return [stmt.strip() for stmt in stripped.split(";") if stmt.strip()]
+    stmts: list[str] = []
+    buf: list[str] = []
+    in_string = False
+    i = 0
+    n = len(stripped)
+    while i < n:
+        ch = stripped[i]
+        if in_string:
+            buf.append(ch)
+            if ch == "'":
+                # SQL escapes single-quote by doubling: '' inside a string.
+                if i + 1 < n and stripped[i + 1] == "'":
+                    buf.append("'")
+                    i += 2
+                    continue
+                in_string = False
+            i += 1
+            continue
+        if ch == "'":
+            in_string = True
+            buf.append(ch)
+            i += 1
+            continue
+        if ch == ";":
+            stmt = "".join(buf).strip()
+            if stmt:
+                stmts.append(stmt)
+            buf = []
+            i += 1
+            continue
+        buf.append(ch)
+        i += 1
+    tail = "".join(buf).strip()
+    if tail:
+        stmts.append(tail)
+    return stmts
 
 
 async def run_migrations(engine: AsyncEngine) -> list[str]:

--- a/sql/migrations/039_decision_confidence_raw.sql
+++ b/sql/migrations/039_decision_confidence_raw.sql
@@ -1,21 +1,20 @@
 -- F058: Add confidence_raw column to brain.decisions for calibration scaling.
 --
--- Stored `confidence` will hold the calibrated value (post temperature
--- scaling) so all downstream consumers — guardrails, quality scoring,
--- supersession threshold, deliberation gates — automatically operate on
--- calibrated input. The original agent-recorded confidence is preserved
--- in `confidence_raw` so calibration evaluation (scripts/eval/eval_calibration.py)
--- can keep measuring drift over time.
+-- Stored confidence holds the calibrated value (post temperature scaling)
+-- so all downstream consumers (guardrails, quality, supersession threshold,
+-- deliberation gates) automatically operate on calibrated input. The
+-- original agent-recorded confidence is preserved in confidence_raw so
+-- calibration evaluation can keep measuring drift over time.
 --
--- Existing rows have `confidence_raw IS NULL`; the calibration eval falls
--- back to `confidence` for those, treating historical decisions as
--- pre-calibration. Going forward every new decision gets both columns
--- populated by Brain._record().
+-- Existing rows have confidence_raw IS NULL. The eval falls back to
+-- confidence for those, treating historical decisions as pre-calibration.
+-- Going forward every new decision gets both columns populated by
+-- Brain._record and Brain._update.
 
-ALTER TABLE brain.decisions ADD COLUMN confidence_raw double precision;
+ALTER TABLE brain.decisions ADD COLUMN IF NOT EXISTS confidence_raw double precision;
 
-CREATE INDEX idx_decisions_confidence_raw ON brain.decisions(confidence_raw)
+CREATE INDEX IF NOT EXISTS idx_decisions_confidence_raw ON brain.decisions(confidence_raw)
     WHERE confidence_raw IS NOT NULL;
 
 COMMENT ON COLUMN brain.decisions.confidence_raw IS
-    'Agent-recorded confidence before temperature scaling; brain.decisions.confidence holds the calibrated value (F058).';
+    'F058: agent-recorded confidence before temperature scaling. brain.decisions.confidence holds the calibrated value.';

--- a/tests/test_migrator_split.py
+++ b/tests/test_migrator_split.py
@@ -83,6 +83,34 @@ def test_split_drops_empty_chunks():
     assert _split_sql_statements("\n\n-- just a comment\n\n") == []
 
 
+def test_split_handles_semicolon_inside_string_literal():
+    """Regression for migration 039: a `;` inside a single-quoted COMMENT
+    string must not split the statement."""
+    sql = (
+        "ALTER TABLE brain.decisions ADD COLUMN IF NOT EXISTS confidence_raw "
+        "double precision;\n"
+        "COMMENT ON COLUMN brain.decisions.confidence_raw IS\n"
+        "    'F058: agent-recorded confidence; brain.decisions.confidence is "
+        "the calibrated value.';\n"
+    )
+    stmts = _split_sql_statements(sql)
+    assert len(stmts) == 2
+    assert stmts[0].startswith("ALTER TABLE")
+    assert stmts[1].startswith("COMMENT ON COLUMN")
+    # The full string survived intact, including the inline semicolon.
+    assert "agent-recorded confidence; brain.decisions" in stmts[1]
+
+
+def test_split_handles_doubled_singlequote_escape():
+    """Inside a string, '' is a literal single quote per SQL spec — the
+    splitter must not exit string mode there."""
+    sql = "INSERT INTO t VALUES ('it''s; fine');\nSELECT 1;"
+    stmts = _split_sql_statements(sql)
+    assert len(stmts) == 2
+    assert "it''s; fine" in stmts[0]
+    assert stmts[1] == "SELECT 1"
+
+
 def test_split_full_migration_034():
     """End-to-end: feed the exact content of migration 034 and assert
     that the three expected statements come out (ALTER TABLE, CREATE


### PR DESCRIPTION
## Summary

Hotfix for prod boot failure on PR #386's migration 039:

\`\`\`
PostgresSyntaxError: unterminated quoted string at or near
"'Agent-recorded confidence before temperature scaling"
\`\`\`

The COMMENT ON COLUMN body contained an inline \`;\`, and \`_split_sql_statements\` splits on \`;\` without tracking quoted strings — the string got chopped mid-literal.

## Two fixes

### 1. Migration 039 made safe + idempotent
- Removed the inline \`;\` from the COMMENT body (now uses periods)
- Added \`IF NOT EXISTS\` to ALTER and CREATE INDEX so partially-applied state (e.g. eval DBs) doesn't block re-run

### 2. Migrator hardened (\`nous/storage/migrator.py\`)
Replaced naive \`sql.split(';')\` with a small state machine that:
- Tracks single-quoted string literals (so \`;\` inside \`'...'\` doesn't split)
- Handles SQL \`''\` escape (doubled quote = literal single-quote inside a string)
- Only splits on top-level \`;\` outside strings
- Still skips \`-- ...\` line comments before walking (existing behavior)

Block comments \`/* ... */\` and dollar-quoted \`$$...$$\` remain unsupported — no current migration uses them.

## Tests

\`tests/test_migrator_split.py\` gets two new regressions:
- \`test_split_handles_semicolon_inside_string_literal\` — this exact bug
- \`test_split_handles_doubled_singlequote_escape\` — SQL \`''\` rule

All 9 tests pass (7 pre-existing + 2 new).

## Prod state

Prod transaction rolled back fully inside \`engine.begin()\` — no schema_migrations row, no partial column. Eval DB had the column+index from a prior manual psql run; the \`IF NOT EXISTS\` clauses make the migration idempotent on top of that.

## Test plan

- [ ] CI passes
- [ ] After merge, \`docker compose up -d\` on prod runs migration 039 cleanly
- [ ] \`brain.decisions.confidence_raw\` column exists post-deploy
- [ ] Pairs with the existing rule from commit 38531ba ("never put \`;\` inside \`-- ...\` comments"); same class of bug, now also covers string literals

🤖 Generated with [Claude Code](https://claude.com/claude-code)