### PR TITLE
fix(F022): fact_extractor must populate FactInput.source_episode_id

### DIFF
--- a/nous/handlers/fact_extractor.py
+++ b/nous/handlers/fact_extractor.py
@@ -12,6 +12,23 @@ import logging
 from typing import Any
 from uuid import UUID
 
+
+def _parse_episode_uuid(episode_id: str | None) -> UUID | None:
+    """Convert a fact_extractor episode_id to UUID, returning None on garbage.
+
+    The handle() event path falls back to ``"?"`` when the upstream event
+    data is missing ``episode_id``; previous bug (orphan-rate audit
+    2026-04-30) was that FactInput.source_episode_id was never set, so
+    every extracted fact had a NULL FK and ``link_episode_deterministic``
+    produced zero edges.
+    """
+    if not episode_id or episode_id == "?":
+        return None
+    try:
+        return UUID(episode_id)
+    except (ValueError, TypeError):
+        return None
+
 from nous.config import Settings
 from nous.events import Event, EventBus
 from nous.handlers import LLMClient, call_background_llm, parse_llm_json
@@ -166,7 +183,10 @@ class FactExtractor:
                     )
                     continue
 
-            # Store — P1-8 fix: pass category from LLM response
+            # Store — P1-8 fix: pass category from LLM response.
+            # F022 orphan-rate audit fix: tag the fact with its source
+            # episode so link_episode_deterministic can create the
+            # extracted_from edge in the next sleep/summary cycle.
             fact_input = FactInput(
                 subject=fact.get("subject", "unknown"),
                 content=content,
@@ -174,6 +194,7 @@ class FactExtractor:
                 confidence=confidence,
                 category=fact.get("category"),
                 source_text=transcript,  # F025 P2-E
+                source_episode_id=_parse_episode_uuid(episode_id),
             )
             result = await self._heart.learn(fact_input)
             if isinstance(result, FactRejected):
@@ -247,6 +268,8 @@ class FactExtractor:
                     logger.debug("Dedup skip (candidate) — adding canonical UUID %s for: %s", existing[0].id, content[:50])
                     continue
 
+            # F022 orphan-rate audit fix: tag candidate facts with their
+            # source episode (same change as the LLM-fallback path above).
             fact_input = FactInput(
                 content=content,
                 subject=subject or "unknown",
@@ -254,6 +277,7 @@ class FactExtractor:
                 source="episode_summarizer",
                 confidence=0.8,  # Default confidence for LLM-extracted candidates
                 source_text=transcript,  # F025 P2-E
+                source_episode_id=_parse_episode_uuid(episode_id),
             )
             result = await self._heart.learn(fact_input)
             if isinstance(result, FactRejected):

--- a/tests/test_fact_extractor_episode_id.py
+++ b/tests/test_fact_extractor_episode_id.py
@@ -1,0 +1,161 @@
+"""Regression test for F022 orphan-rate audit (2026-04-30):
+fact_extractor must populate FactInput.source_episode_id so
+link_episode_deterministic can create extracted_from edges.
+
+Pre-fix: every extracted fact landed with source_episode_id=NULL,
+breaking the link_episode_deterministic SQL query and contributing
+to the 60.4% episode orphan rate measured in production.
+"""
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+
+from nous.handlers.fact_extractor import _parse_episode_uuid
+
+
+class TestParseEpisodeUuid:
+    def test_valid_uuid_returns_uuid(self):
+        u = uuid4()
+        assert _parse_episode_uuid(str(u)) == u
+
+    def test_missing_returns_none(self):
+        assert _parse_episode_uuid(None) is None
+        assert _parse_episode_uuid("") is None
+
+    def test_question_mark_sentinel_returns_none(self):
+        """The handle() path falls back to '?' when event data is missing
+        an episode_id. Must convert to None, not raise."""
+        assert _parse_episode_uuid("?") is None
+
+    def test_garbage_returns_none(self):
+        """Defensive — never raise on malformed input."""
+        assert _parse_episode_uuid("not-a-uuid") is None
+        assert _parse_episode_uuid("12345") is None
+
+
+class TestFactExtractorPopulatesSourceEpisodeId:
+    """Verify both fact-creation paths in fact_extractor pass episode_id
+    through to FactInput.source_episode_id.
+
+    Uses light monkey-patching to capture FactInput calls without
+    requiring a real DB or LLM.
+    """
+
+    @pytest.mark.asyncio
+    async def test_candidate_facts_path_sets_episode_id(self, monkeypatch):
+        from nous.handlers import fact_extractor as fe_mod
+        from nous.heart.schemas import FactInput
+
+        captured: list[FactInput] = []
+
+        class _StubResult:
+            id = uuid4()
+
+        class _StubHeart:
+            async def search_facts(self, *a, **kw):
+                return []
+
+            async def learn(self, fact_input: FactInput):
+                captured.append(fact_input)
+                return _StubResult()
+
+        class _StubSettings:
+            fact_dedup_threshold = 0.92
+
+        ep_id = str(uuid4())
+        ext = fe_mod.FactExtractor.__new__(fe_mod.FactExtractor)
+        ext._heart = _StubHeart()
+        ext._settings = _StubSettings()
+        ext._dedup_via_search = False
+        ext._llm = None
+
+        await ext._store_candidate_facts(
+            candidates=[{"content": "Tim likes coffee", "subject": "Tim",
+                         "category": "preference"}],
+            episode_id=ep_id,
+            transcript=None,
+        )
+
+        assert len(captured) == 1
+        assert captured[0].source_episode_id == UUID(ep_id), (
+            "candidate-facts path must populate source_episode_id"
+        )
+
+    @pytest.mark.asyncio
+    async def test_extracted_facts_path_sets_episode_id(self, monkeypatch):
+        from nous.handlers import fact_extractor as fe_mod
+        from nous.heart.schemas import FactInput
+
+        captured: list[FactInput] = []
+
+        class _StubResult:
+            id = uuid4()
+
+        class _StubHeart:
+            async def search_facts(self, *a, **kw):
+                return []
+
+            async def learn(self, fact_input: FactInput):
+                captured.append(fact_input)
+                return _StubResult()
+
+        class _StubSettings:
+            fact_dedup_threshold = 0.92
+
+        ep_id = str(uuid4())
+        ext = fe_mod.FactExtractor.__new__(fe_mod.FactExtractor)
+        ext._heart = _StubHeart()
+        ext._settings = _StubSettings()
+        ext._dedup_via_search = False
+        ext._llm = None
+
+        await ext._store_extracted_facts(
+            candidates=[{"content": "Use Postgres", "subject": "stack",
+                         "category": "tool", "confidence": 0.9}],
+            episode_id=ep_id,
+            transcript=None,
+        )
+
+        assert len(captured) == 1
+        assert captured[0].source_episode_id == UUID(ep_id), (
+            "LLM-extracted path must populate source_episode_id"
+        )
+
+    @pytest.mark.asyncio
+    async def test_question_mark_episode_id_yields_none(self, monkeypatch):
+        """Defensive: when handle() can't find episode_id and falls back to
+        '?', FactInput.source_episode_id is None (not a parse error)."""
+        from nous.handlers import fact_extractor as fe_mod
+        from nous.heart.schemas import FactInput
+
+        captured: list[FactInput] = []
+
+        class _StubResult:
+            id = uuid4()
+
+        class _StubHeart:
+            async def search_facts(self, *a, **kw):
+                return []
+
+            async def learn(self, fact_input: FactInput):
+                captured.append(fact_input)
+                return _StubResult()
+
+        class _StubSettings:
+            fact_dedup_threshold = 0.92
+
+        ext = fe_mod.FactExtractor.__new__(fe_mod.FactExtractor)
+        ext._heart = _StubHeart()
+        ext._settings = _StubSettings()
+        ext._dedup_via_search = False
+        ext._llm = None
+
+        await ext._store_candidate_facts(
+            candidates=[{"content": "x" * 30, "subject": "test",
+                         "category": "concept"}],
+            episode_id="?",  # sentinel from handle() fallback
+            transcript=None,
+        )
+        assert captured[0].source_episode_id is None


### PR DESCRIPTION
## Summary

Production audit (2026-04-30) measured **60.4% episode orphan rate** — 297 of 492 episodes had zero graph edges. Investigation traced this to two compounding bugs. This PR ships the bigger one (Bug B); Bug A is a follow-up requiring schema migration.

## The bug (Bug B)

Both fact-creation paths in \`nous/handlers/fact_extractor.py\` had \`episode_id\` in scope as a function parameter but built \`FactInput\` without passing it through:

- \`_store_extracted_facts\` — line 170-177 (LLM-extraction path)
- \`_store_candidate_facts\` — line 250-257 (pre-extracted candidates path)

\`FactInput.source_episode_id: UUID | None\` (schema line 89) silently landed as NULL on every fact. Downstream, \`episode_summarizer.py:189\` queried:

\`\`\`sql
SELECT id FROM heart.facts WHERE source_episode_id = :ep_id
\`\`\`

…which always returned 0 rows, so \`link_episode_deterministic\` got an empty \`fact_ids\` list and created zero \`extracted_from\` edges. Episode → orphan.

## Fix

\`source_episode_id=_parse_episode_uuid(episode_id)\` added to both \`FactInput\` constructions. Helper handles the documented \`"?"\` sentinel that \`handle()\` falls back to when upstream event data is missing episode_id (returns None instead of raising).

## Tests

7 unit tests in \`tests/test_fact_extractor_episode_id.py\`:
- \`_parse_episode_uuid\` — 4 cases (valid UUID, None, empty, "?" sentinel, garbage)
- Both fact-creation paths set source_episode_id from the episode_id parameter
- "?" sentinel yields None on FactInput, never raises

All 7 pass locally.

## Expected impact

For every NEW episode after deploy:
- Facts extracted via \`episode_summarized\` event get tagged with the source episode UUID
- The follow-up \`link_episode_deterministic\` call (~30 lines below in the same handler) finds those facts via the FK query and creates \`extracted_from\` edges automatically
- **Orphan rate for new episodes drops to near-zero**

The 297 existing orphans are not retroactively fixed — they need either F040 sleep-cycle backfill (slow, ~30/cycle) or a one-shot backfill script (separate work).

## Out of scope

| Item | Why deferred |
|---|---|
| **Bug A** (\`_active_episodes\` map wiped on container restart, documented \`layer.py:207\`) | Requires schema migration: add session_id to heart.episodes + DB fallback in \`get_active_episode_id\`. ~1-2 days work. |
| **Backfill of existing orphans** | Optional — F040 sleep cycle eventually catches them, or a one-shot SQL script can match by created_at + session. |

## Test plan

- [ ] CI green
- [ ] After deploy: \`SELECT COUNT(*) FROM heart.facts WHERE source_episode_id IS NOT NULL AND created_at > '2026-04-30';\` should grow with each new episode
- [ ] After 1 week: re-run orphan audit. Expect new episodes to have edges; old orphans persist until backfilled

🤖 Generated with [Claude Code](https://claude.com/claude-code)