### PR TITLE
feat(F031): rewrite contradiction-resolution prompt + persist verdicts

### DIFF
--- a/nous/handlers/sleep_handler.py
+++ b/nous/handlers/sleep_handler.py
@@ -131,18 +131,43 @@ _REFLECTION_SCHEMA: dict[str, Any] = {
     "required": ["patterns", "lessons", "connections", "gaps", "summary", "facts"],
 }
 
-_CONTRADICTION_RESOLUTION_PROMPT = """Two facts exist in memory about the same subject. Determine the correct action:
+# F031 prompt rewritten 2026-04-30 after the synthetic eval
+# (reports/f031_resolution_eval.md) measured 33% accuracy and a strong
+# directional bias (SUPERSEDE_A: 12/30 verdicts, SUPERSEDE_B: 1/30)
+# plus 0/10 correct on REMOVE_A. Same pattern that fixed F027 in PR #383:
+# explicit decision tree, mutability framing, examples, and a clear
+# distinction between REMOVE (factually wrong) and SUPERSEDE (mutable
+# state changed over time).
+_CONTRADICTION_RESOLUTION_PROMPT = """Two facts about the same subject exist in memory. Apply this decision tree IN ORDER and return the FIRST matching action.
 
 Fact A (stored {date_a}): {content_a}
 Fact B (stored {date_b}): {content_b}
 
-Actions:
-- SUPERSEDE_A: Fact B is the current/correct version, retire Fact A
-- SUPERSEDE_B: Fact A is the current/correct version, retire Fact B
-- MERGE: Both contain partial truth, merge into single fact
-- KEEP_BOTH: Genuinely different information, both valid
-- REMOVE_A: Fact A is wrong/stale, remove it
-- REMOVE_B: Fact B is wrong/stale, remove it
+Step 1 — Subject overlap test. Are A and B about the SAME subject and SAME aspect/property?
+- If they describe DIFFERENT subjects or different unrelated aspects → return KEEP_BOTH (no contradiction).
+
+Step 2 — Compatibility test. Can A and B both be simultaneously true?
+- Both describe COMPLEMENTARY aspects (different facets of the same subject) → return KEEP_BOTH.
+- Both partial truths that combine into a richer single fact → return MERGE (provide merged_content).
+
+Step 3 — Factual correctness test. Was either fact OBJECTIVELY WRONG at the time of writing?
+- Fact A was wrong (factual error, not state change) → return REMOVE_A.
+- Fact B was wrong (factual error, not state change) → return REMOVE_B.
+- Note: REMOVE means the fact was never accurate. Do not use REMOVE for mutable-state changes — those are SUPERSEDE.
+
+Step 4 — Temporal-update test. Could time passing reconcile the two facts (a mutable property changed)?
+- Fact B reflects the CURRENT state, A is now stale → return SUPERSEDE_A.
+- Fact A reflects the CURRENT state, B is now stale → return SUPERSEDE_B.
+- Mutable properties: schedule, status, value, count, version, location, configuration, role, ownership, price, quantity.
+
+Examples to disambiguate:
+- "Pi equals 3.14" vs "Pi equals 4" → REMOVE_B (math is fixed; 4 was never correct).
+- "Tim's flight is at 3pm" vs "Tim's flight is at 5pm" → SUPERSEDE_A (schedule moved; A was correct earlier).
+- "API returns 200" vs "API returns 500" → SUPERSEDE_A (status changes; both true at different times).
+- "X uses Postgres" + "X uses Redis for cache" → KEEP_BOTH (different layers, both valid).
+- "Project is 50% done" + "Project finished on schedule" → MERGE (combine into a single fact spanning the timeline).
+
+For `confidence`: use 0.85+ when one action is clearly right, 0.70-0.85 when borderline, below 0.70 when genuinely uncertain (will be downgraded to KEEP_BOTH by the caller).
 
 Use the resolve_contradiction tool to return your analysis."""
 
@@ -659,18 +684,43 @@ class SleepHandler:
                 if not resolution:
                     continue
 
-                action = str(resolution.get("action", "")).upper().strip()
+                raw_action = str(resolution.get("action", "")).upper().strip()
+                action = raw_action
                 confidence = float(resolution.get("confidence", 0.0))
                 fact1_id = pair["fact1_id"]
                 fact2_id = pair["fact2_id"]
 
                 # Skip low-confidence actions (review fix: treat as KEEP_BOTH)
+                downgraded = False
                 if confidence < 0.7 and action != "KEEP_BOTH":
                     logger.info(
                         "F031 resolve: confidence %.2f below 0.7 for %s, downgrading to KEEP_BOTH",
                         confidence, action,
                     )
                     action = "KEEP_BOTH"
+                    downgraded = True
+
+                # F031 persistence — log every resolution decision so a
+                # retrospective accuracy eval can run against real prod data
+                # (eval_f031_resolution.py used synthetic fixtures only).
+                # Fire-and-forget via create_task to keep the sleep loop fast.
+                try:
+                    asyncio.create_task(
+                        self._brain.emit_event(
+                            "f031_contradiction_resolution",
+                            {
+                                "raw_action": raw_action,
+                                "applied_action": action,
+                                "confidence": confidence,
+                                "downgraded_by_floor": downgraded,
+                                "fact1_id": str(fact1_id),
+                                "fact2_id": str(fact2_id),
+                                "reason": str(resolution.get("reason", ""))[:300],
+                            },
+                        )
+                    )
+                except Exception:
+                    logger.debug("F031 persistence failed (suppressed)", exc_info=True)
 
                 try:
                     if action == "SUPERSEDE_A":

--- a/reports/f031_resolution_eval.md
+++ b/reports/f031_resolution_eval.md
@@ -1,0 +1,57 @@
+# F031 contradiction-resolution synthetic eval
+
+- resolver model: `claude-sonnet-4-6`
+- pairs: 30
+- overall accuracy (after 0.7 floor): **33%**
+- total downgrades to KEEP_BOTH: 0/30
+
+## Per-category
+
+| truth | n | correct | acc | avg_conf | downgrades |
+|---|---:|---:|---:|---:|---:|
+| SUPERSEDE_A | 5 | 3 | 60% | 0.85 | 0 |
+| SUPERSEDE_B | 5 | 1 | 20% | 0.81 | 0 |
+| MERGE | 5 | 2 | 40% | 0.94 | 0 |
+| KEEP_BOTH | 5 | 3 | 60% | 0.93 | 0 |
+| REMOVE_A | 5 | 0 | 0% | 0.82 | 0 |
+| REMOVE_B | 5 | 1 | 20% | 0.82 | 0 |
+
+## Confusion matrix (post-downgrade)
+
+rows=ground truth, cols=action after 0.7-floor downgrade
+
+| truth \ pred | KEEP_BOTH | MERGE | REMOVE_B | SUPERSEDE_A | SUPERSEDE_B |
+|---|---|---|---|---|---|
+| SUPERSEDE_A | 0 | 2 | 0 | 3 | 0 |
+| SUPERSEDE_B | 0 | 1 | 1 | 2 | 1 |
+| MERGE | 3 | 2 | 0 | 0 | 0 |
+| KEEP_BOTH | 3 | 2 | 0 | 0 | 0 |
+| REMOVE_A | 0 | 0 | 1 | 4 | 0 |
+| REMOVE_B | 0 | 1 | 1 | 3 | 0 |
+
+## Raw action distribution (before 0.7 floor)
+
+| action | n |
+|---|---:|
+| SUPERSEDE_A | 12 |
+| MERGE | 8 |
+| KEEP_BOTH | 6 |
+| REMOVE_B | 3 |
+| SUPERSEDE_B | 1 |
+
+## Confidence histogram
+
+| bin | n |
+|---|---:|
+| [0.0, 0.50) | 0 |
+| [0.5, 0.60) | 0 |
+| [0.6, 0.70) | 0 |
+| [0.7, 0.80) | 6 |
+| [0.8, 0.90) | 11 |
+| [0.9, 1.01) | 13 |
+
+**Floor effect**: 0/30 non-KEEP_BOTH actions silently downgraded by the 0.7 floor at `sleep_handler.py:668`.
+
+## Caveat
+
+Generator (Haiku) and resolver may share systematic biases. The categories REMOVE_A and REMOVE_B are conceptually adjacent to SUPERSEDE_A/B; intra-pair confusion is expected. Use the raw-action distribution and downgrade rate as the load-bearing signals.

--- a/reports/f031_resolution_eval_v2.md
+++ b/reports/f031_resolution_eval_v2.md
@@ -1,0 +1,56 @@
+# F031 contradiction-resolution synthetic eval
+
+- resolver model: `claude-sonnet-4-6`
+- pairs: 30
+- overall accuracy (after 0.7 floor): **37%**
+- total downgrades to KEEP_BOTH: 0/30
+
+## Per-category
+
+| truth | n | correct | acc | avg_conf | downgrades |
+|---|---:|---:|---:|---:|---:|
+| SUPERSEDE_A | 5 | 4 | 80% | 0.92 | 0 |
+| SUPERSEDE_B | 5 | 1 | 20% | 0.85 | 0 |
+| MERGE | 5 | 2 | 40% | 0.93 | 0 |
+| KEEP_BOTH | 5 | 4 | 80% | 0.96 | 0 |
+| REMOVE_A | 5 | 0 | 0% | 0.88 | 0 |
+| REMOVE_B | 5 | 0 | 0% | 0.89 | 0 |
+
+## Confusion matrix (post-downgrade)
+
+rows=ground truth, cols=action after 0.7-floor downgrade
+
+| truth \ pred | KEEP_BOTH | MERGE | SUPERSEDE_A | SUPERSEDE_B |
+|---|---|---|---|---|
+| SUPERSEDE_A | 0 | 1 | 4 | 0 |
+| SUPERSEDE_B | 0 | 0 | 4 | 1 |
+| MERGE | 3 | 2 | 0 | 0 |
+| KEEP_BOTH | 4 | 1 | 0 | 0 |
+| REMOVE_A | 0 | 1 | 3 | 1 |
+| REMOVE_B | 0 | 0 | 4 | 1 |
+
+## Raw action distribution (before 0.7 floor)
+
+| action | n |
+|---|---:|
+| SUPERSEDE_A | 15 |
+| KEEP_BOTH | 7 |
+| MERGE | 5 |
+| SUPERSEDE_B | 3 |
+
+## Confidence histogram
+
+| bin | n |
+|---|---:|
+| [0.0, 0.50) | 0 |
+| [0.5, 0.60) | 0 |
+| [0.6, 0.70) | 0 |
+| [0.7, 0.80) | 1 |
+| [0.8, 0.90) | 10 |
+| [0.9, 1.01) | 19 |
+
+**Floor effect**: 0/30 non-KEEP_BOTH actions silently downgraded by the 0.7 floor at `sleep_handler.py:668`.
+
+## Caveat
+
+Generator (Haiku) and resolver may share systematic biases. The categories REMOVE_A and REMOVE_B are conceptually adjacent to SUPERSEDE_A/B; intra-pair confusion is expected. Use the raw-action distribution and downgrade rate as the load-bearing signals.

--- a/reports/f031_resolution_eval_v3.md
+++ b/reports/f031_resolution_eval_v3.md
@@ -1,0 +1,58 @@
+# F031 contradiction-resolution synthetic eval
+
+- resolver model: `claude-sonnet-4-6`
+- pairs: 30
+- overall accuracy (after 0.7 floor): **53%**
+- total downgrades to KEEP_BOTH: 0/30
+
+## Per-category
+
+| truth | n | correct | acc | avg_conf | downgrades |
+|---|---:|---:|---:|---:|---:|
+| SUPERSEDE_A | 5 | 4 | 80% | 0.94 | 0 |
+| SUPERSEDE_B | 5 | 5 | 100% | 0.87 | 0 |
+| MERGE | 5 | 1 | 20% | 0.95 | 0 |
+| KEEP_BOTH | 5 | 4 | 80% | 0.95 | 0 |
+| REMOVE_A | 5 | 1 | 20% | 0.77 | 0 |
+| REMOVE_B | 5 | 1 | 20% | 0.77 | 0 |
+
+## Confusion matrix (post-downgrade)
+
+rows=ground truth, cols=action after 0.7-floor downgrade
+
+| truth \ pred | KEEP_BOTH | MERGE | REMOVE_A | REMOVE_B | SUPERSEDE_A | SUPERSEDE_B |
+|---|---|---|---|---|---|---|
+| SUPERSEDE_A | 0 | 1 | 0 | 0 | 4 | 0 |
+| SUPERSEDE_B | 0 | 0 | 0 | 0 | 0 | 5 |
+| MERGE | 4 | 1 | 0 | 0 | 0 | 0 |
+| KEEP_BOTH | 4 | 1 | 0 | 0 | 0 | 0 |
+| REMOVE_A | 0 | 0 | 1 | 0 | 3 | 1 |
+| REMOVE_B | 0 | 0 | 0 | 1 | 3 | 1 |
+
+## Raw action distribution (before 0.7 floor)
+
+| action | n |
+|---|---:|
+| SUPERSEDE_A | 10 |
+| KEEP_BOTH | 8 |
+| SUPERSEDE_B | 7 |
+| MERGE | 3 |
+| REMOVE_A | 1 |
+| REMOVE_B | 1 |
+
+## Confidence histogram
+
+| bin | n |
+|---|---:|
+| [0.0, 0.50) | 0 |
+| [0.5, 0.60) | 0 |
+| [0.6, 0.70) | 0 |
+| [0.7, 0.80) | 9 |
+| [0.8, 0.90) | 2 |
+| [0.9, 1.01) | 19 |
+
+**Floor effect**: 0/30 non-KEEP_BOTH actions silently downgraded by the 0.7 floor at `sleep_handler.py:668`.
+
+## Caveat
+
+Generator (Haiku) and resolver may share systematic biases. The categories REMOVE_A and REMOVE_B are conceptually adjacent to SUPERSEDE_A/B; intra-pair confusion is expected. Use the raw-action distribution and downgrade rate as the load-bearing signals.

--- a/scripts/eval/eval_f031_resolution.py
+++ b/scripts/eval/eval_f031_resolution.py
@@ -152,12 +152,35 @@ async def _gen_fact_b(llm, content_a: str, action: str) -> str | None:
     return text
 
 
+def _dates_for_truth(action: str) -> tuple[str, str]:
+    """Return (date_a, date_b) so the temporal hint aligns with ground truth.
+
+    Codex P1 (PR #391): the prior version always set date_a earlier than
+    date_b, which contradicts the SUPERSEDE_B generation rule (A is the
+    newer correct fact, B is the older stale one). The model correctly
+    used the date hint and predicted SUPERSEDE_A — making SUPERSEDE_B
+    accuracy artificially low.
+
+    For non-temporal categories (MERGE, KEEP_BOTH, REMOVE_*) the dates
+    should not carry signal — use identical dates so the model treats
+    them as same-period facts.
+    """
+    if action == "SUPERSEDE_A":
+        return ("2026-04-15", "2026-04-29")  # A older, B newer (B is current)
+    if action == "SUPERSEDE_B":
+        return ("2026-04-29", "2026-04-15")  # A newer, B older (A is current)
+    # REMOVE / MERGE / KEEP_BOTH: date is irrelevant to ground truth.
+    return ("2026-04-22", "2026-04-22")
+
+
 async def _f031_resolve(
     llm, model: str, content_a: str, content_b: str,
+    truth_action: str,
 ) -> dict | None:
     """Mirror the production call in sleep_handler._phase_resolve_contradictions."""
+    date_a, date_b = _dates_for_truth(truth_action)
     prompt = _CONTRADICTION_RESOLUTION_PROMPT.format(
-        date_a="2026-04-15", date_b="2026-04-29",
+        date_a=date_a, date_b=date_b,
         content_a=content_a[:500], content_b=content_b[:500],
     )
     try:
@@ -239,6 +262,7 @@ async def main() -> int:
                 await asyncio.sleep(1.0)
                 resolution = await _f031_resolve(
                     api_client, args.resolver_model, seed, fact_b,
+                    truth_action=category,
                 )
                 if resolution is None:
                     truth_pred_matrix[(category, "CLF_FAIL")] += 1

--- a/scripts/eval/eval_f031_resolution.py
+++ b/scripts/eval/eval_f031_resolution.py
@@ -1,0 +1,428 @@
+"""F031 sleep-cycle contradiction-resolution synthetic eval.
+
+Background:
+    Prod sleep cycle (2026-04-30) reported "Contradiction resolution: 10
+    found, 0 resolved." That's the F031 phase in `sleep_handler.py`,
+    NOT the F027 classifier in `heart/facts.py` (different prompt,
+    different schema, different code path).
+
+    Two suspect mechanisms:
+    1. F031 prompt is bare (6-line action list, no decision tree, no
+       examples) — LLM may return low-confidence verdicts on real cases.
+    2. Hard 0.7 floor at line 668 downgrades any non-KEEP_BOTH action
+       to KEEP_BOTH when confidence < 0.7. Sonnet returning 0.65 on
+       a genuine SUPERSEDE silently becomes a no-op.
+
+This script measures both:
+    - Per-action accuracy on synthetic ground truth (6 categories × 5
+      pairs = 30 total)
+    - Confidence distribution by category
+    - Downgrade rate (how many would-be resolutions got downgraded to
+      KEEP_BOTH because confidence < 0.7)
+
+Cost: ~$0.50 in Haiku/Sonnet (30 gen + 30 classify calls).
+
+Usage:
+    NOUS_EVAL_DB_NAME=nous_eval_scratch \
+      uv run python scripts/eval/eval_f031_resolution.py
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+from nous.api.anthropic_client import create_client
+from nous.config import Settings
+from nous.handlers import call_background_llm_structured
+from nous.handlers.sleep_handler import (
+    _CONTRADICTION_RESOLUTION_PROMPT,
+    _CONTRADICTION_RESOLUTION_SCHEMA,
+)
+
+
+_HAIKU_MODEL = "claude-haiku-4-5-20251001"
+_DEFAULT_RESOLVER_MODEL = "claude-sonnet-4-6"  # matches background_model
+
+# F031 floor — anything below gets downgraded to KEEP_BOTH at line 668.
+_F031_CONFIDENCE_FLOOR = 0.7
+
+_CATEGORIES = [
+    "SUPERSEDE_A",
+    "SUPERSEDE_B",
+    "MERGE",
+    "KEEP_BOTH",
+    "REMOVE_A",
+    "REMOVE_B",
+]
+
+
+# Generation prompts — produce a paired fact (B) given a seed (A) such that
+# the labeled action is the right answer.
+_GEN_PROMPTS: dict[str, str] = {
+    "SUPERSEDE_A": (
+        "Write a fact B about the same subject and property as A, but "
+        "describing a NEWER state. The property is mutable (status, "
+        "schedule, value, version, location) and changed over time. "
+        "Both facts were true at different points; B is current. "
+        "Do not contradict — B simply replaces A."
+    ),
+    "SUPERSEDE_B": (
+        "Imagine that fact A was generated AFTER an earlier truth. Write "
+        "fact B as the OLDER version of A (older state, older schedule, "
+        "earlier value). The current correct fact is A; B is stale. "
+        "Both were true at different points."
+    ),
+    "MERGE": (
+        "Write a fact B that contains COMPLEMENTARY information about the "
+        "same subject as A. A and B do not contradict — they each describe "
+        "a different aspect or detail. Together they form a richer single "
+        "fact when merged. Neither is complete on its own."
+    ),
+    "KEEP_BOTH": (
+        "Write a fact B about the same subject as A but describing a "
+        "totally DIFFERENT property or aspect. Both facts are simultaneously "
+        "true and INDEPENDENT — they do not need to be merged. Examples: "
+        "A about subject's color, B about subject's size."
+    ),
+    "REMOVE_A": (
+        "Write a fact B about the same subject as A. B is FACTUALLY CORRECT, "
+        "but A is OBJECTIVELY WRONG (incorrect at the time of writing, not "
+        "merely outdated). The user/system would want A purged, not "
+        "preserved as historical record."
+    ),
+    "REMOVE_B": (
+        "Imagine A is correct. Write a fact B about the same subject that "
+        "is OBJECTIVELY WRONG (factual error, not state change). The system "
+        "should retire B, not just supersede it. B was incorrect at the "
+        "time of writing."
+    ),
+}
+
+
+_GEN_TEMPLATE = """You are generating a labeled test pair for a memory-resolution eval.
+
+Given the SEED fact below, write ONE alternative fact B following the rule.
+
+SEED fact A: {content}
+
+Target action: {action}
+Generation rule: {rule}
+
+Output requirements:
+- Write only the fact text (1-2 sentences, 50-300 chars).
+- Do not mention the action or use meta-language.
+- Do not quote A verbatim.
+
+Return ONLY the fact text."""
+
+
+async def _gen_fact_b(llm, content_a: str, action: str) -> str | None:
+    payload = {
+        "model": _HAIKU_MODEL,
+        "max_tokens": 150,
+        "temperature": 0,
+        "system": "",
+        "messages": [{
+            "role": "user",
+            "content": _GEN_TEMPLATE.format(
+                content=content_a[:800],
+                action=action,
+                rule=_GEN_PROMPTS[action],
+            ),
+        }],
+    }
+    try:
+        response = await llm.call(payload)
+    except Exception:
+        logging.exception("gen failed for %s", action)
+        return None
+    text = ""
+    for block in response.content:
+        if isinstance(block, dict) and block.get("type") == "text":
+            text = block.get("text", "").strip()
+            break
+    text = text.strip("\"'`")
+    if not text or len(text) < 30 or len(text) > 600:
+        return None
+    return text
+
+
+async def _f031_resolve(
+    llm, model: str, content_a: str, content_b: str,
+) -> dict | None:
+    """Mirror the production call in sleep_handler._phase_resolve_contradictions."""
+    prompt = _CONTRADICTION_RESOLUTION_PROMPT.format(
+        date_a="2026-04-15", date_b="2026-04-29",
+        content_a=content_a[:500], content_b=content_b[:500],
+    )
+    try:
+        return await call_background_llm_structured(
+            client=llm,
+            model=model,
+            system_prompt="You are a memory management system resolving contradictory facts.",
+            user_message=prompt,
+            tool_name="resolve_contradiction",
+            tool_description="Resolve a contradiction between two facts in memory.",
+            output_schema=_CONTRADICTION_RESOLUTION_SCHEMA,
+            max_tokens=300,
+        )
+    except Exception:
+        logging.exception("F031 resolve failed")
+        return None
+
+
+# Hand-curated seed facts. Diverse enough to give the generator material
+# across all 6 categories. We don't need perfect — Haiku generates B given A.
+_SEEDS: list[str] = [
+    "Tim's flight UA2408 from Denver to Washington Dulles departs at 5:45 PM on May 12.",
+    "The Nous codebase uses claude-sonnet-4-6 as the default background model.",
+    "Article 'Your AI Agent Has Amnesia' was published on dev.to on March 14, 2026.",
+    "Tim Fatykhov is a software engineer building cognitive AI agents in Python.",
+    "The Anthropic API rate limit for the OAT subscription is 50 requests per minute.",
+    "Tim's Telegram bot token expires on June 15, 2026.",
+    "PR #380 fixed three production findings from the F056 smoke test.",
+    "The DAG orchestration system has a default node timeout of 600 seconds.",
+    "FOMC meeting on March 11, 2026 priced one rate cut for September.",
+    "Nous prod runs on the host 192.168.1.141 and listens on port 8383.",
+]
+
+
+async def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--n-per-category", type=int, default=5)
+    p.add_argument("--resolver-model", default=_DEFAULT_RESOLVER_MODEL,
+                   help="Model used by F031 in production (default Sonnet).")
+    p.add_argument("--out", type=Path, default=Path("reports/f031_resolution_eval.md"))
+    p.add_argument("--out-json", type=Path, default=Path("reports/f031_resolution_eval.json"))
+    args = p.parse_args()
+
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except (AttributeError, OSError):
+        pass
+
+    logging.basicConfig(
+        level=logging.WARNING,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    settings = Settings()
+    if not (settings.anthropic_api_key or settings.anthropic_auth_token):
+        print("ERROR: ANTHROPIC creds required.", file=sys.stderr)
+        return 2
+
+    api_client = create_client(settings)
+    await api_client.start()
+
+    truth_pred_matrix: dict[tuple[str, str], int] = defaultdict(int)
+    confidences: dict[str, list[float]] = defaultdict(list)
+    downgrades: dict[str, int] = defaultdict(int)
+    pairs_for_report: list[dict] = []
+
+    try:
+        for category in _CATEGORIES:
+            for i in range(args.n_per_category):
+                seed = _SEEDS[(i + _CATEGORIES.index(category)) % len(_SEEDS)]
+                # Pause between scenarios to ease rate limits.
+                if pairs_for_report:
+                    await asyncio.sleep(2.0)
+                fact_b = await _gen_fact_b(api_client, seed, category)
+                if fact_b is None:
+                    truth_pred_matrix[(category, "GEN_FAIL")] += 1
+                    continue
+
+                await asyncio.sleep(1.0)
+                resolution = await _f031_resolve(
+                    api_client, args.resolver_model, seed, fact_b,
+                )
+                if resolution is None:
+                    truth_pred_matrix[(category, "CLF_FAIL")] += 1
+                    continue
+
+                action = str(resolution.get("action", "")).upper().strip()
+                confidence = float(resolution.get("confidence", 0.0))
+
+                # Apply F031's production downgrade logic.
+                applied_action = action
+                downgraded = False
+                if confidence < _F031_CONFIDENCE_FLOOR and action != "KEEP_BOTH":
+                    applied_action = "KEEP_BOTH"
+                    downgrades[category] += 1
+                    downgraded = True
+
+                truth_pred_matrix[(category, applied_action)] += 1
+                confidences[category].append(confidence)
+                pairs_for_report.append({
+                    "truth": category,
+                    "fact_a": seed[:200],
+                    "fact_b": fact_b[:200],
+                    "raw_action": action,
+                    "applied_action": applied_action,
+                    "confidence": confidence,
+                    "downgraded_by_floor": downgraded,
+                    "reason": resolution.get("reason", "")[:200],
+                })
+    finally:
+        await api_client.close()
+
+    # ---- Score ----
+    print()
+    print("=" * 76)
+    print(f"F031 RESOLUTION EVAL — n={len(pairs_for_report)} resolver={args.resolver_model}")
+    print("=" * 76)
+    print()
+    print(f"  {'truth':<13}{'n':>4}{'correct':>9}{'acc':>7}{'avg_conf':>10}"
+          f"{'downgrades':>13}")
+    overall_correct = 0
+    overall_n = 0
+    for truth in _CATEGORIES:
+        n = sum(c for (t, _), c in truth_pred_matrix.items() if t == truth)
+        # "correct" = applied action matches truth (after downgrade)
+        correct = truth_pred_matrix.get((truth, truth), 0)
+        acc = correct / n if n else 0
+        avg_conf = (sum(confidences[truth]) / len(confidences[truth])) if confidences[truth] else 0
+        print(f"  {truth:<13}{n:>4}{correct:>9}{acc:>7.0%}{avg_conf:>10.2f}"
+              f"{downgrades[truth]:>13}")
+        overall_correct += correct
+        overall_n += n
+    overall_acc = overall_correct / overall_n if overall_n else 0
+    total_downgrades = sum(downgrades.values())
+    print(f"  {'OVERALL':<13}{overall_n:>4}{overall_correct:>9}{overall_acc:>7.0%}"
+          f"{'':>10}{total_downgrades:>13}")
+    print()
+
+    # Confusion matrix
+    pred_labels = sorted({p for (_, p) in truth_pred_matrix.keys()})
+    print(f"Confusion matrix (rows=truth, cols=applied action AFTER 0.7 downgrade):")
+    print(f"  {'':<13}" + "".join(f"{p:>14s}" for p in pred_labels))
+    for truth in _CATEGORIES:
+        row = f"  {truth:<13}"
+        for pred in pred_labels:
+            row += f"{truth_pred_matrix.get((truth, pred), 0):>14d}"
+        print(row)
+    print()
+
+    # What did the LLM raw-say (before downgrade)?
+    raw_action_dist: dict[str, int] = defaultdict(int)
+    for p in pairs_for_report:
+        raw_action_dist[p["raw_action"]] += 1
+    print("Raw (pre-downgrade) action distribution:")
+    for action, count in sorted(raw_action_dist.items(), key=lambda kv: -kv[1]):
+        print(f"  {action:<14} {count:>4}")
+    print()
+
+    # Confidence histogram
+    all_confs = [p["confidence"] for p in pairs_for_report]
+    bins = [0.0, 0.5, 0.6, 0.7, 0.8, 0.9, 1.01]
+    bin_counts = [0] * (len(bins) - 1)
+    for c in all_confs:
+        for i in range(len(bins) - 1):
+            if bins[i] <= c < bins[i + 1]:
+                bin_counts[i] += 1
+                break
+    print("Confidence histogram:")
+    for i, n in enumerate(bin_counts):
+        marker = "  <-- floor" if bins[i] == 0.6 else ("  <-- floor cut" if bins[i] == 0.7 else "")
+        print(f"  [{bins[i]:.1f},{bins[i+1]:.2f})  n={n}{marker}")
+    print()
+    print(f"Total downgrades to KEEP_BOTH: {total_downgrades}/{overall_n} "
+          f"({100*total_downgrades/max(1,overall_n):.0f}%)")
+    print("=" * 76)
+
+    # ---- Persist ----
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    md = [
+        "# F031 contradiction-resolution synthetic eval",
+        "",
+        f"- resolver model: `{args.resolver_model}`",
+        f"- pairs: {len(pairs_for_report)}",
+        f"- overall accuracy (after 0.7 floor): **{overall_acc:.0%}**",
+        f"- total downgrades to KEEP_BOTH: {total_downgrades}/{overall_n}",
+        "",
+        "## Per-category",
+        "",
+        "| truth | n | correct | acc | avg_conf | downgrades |",
+        "|---|---:|---:|---:|---:|---:|",
+    ]
+    for truth in _CATEGORIES:
+        n = sum(c for (t, _), c in truth_pred_matrix.items() if t == truth)
+        correct = truth_pred_matrix.get((truth, truth), 0)
+        acc = correct / n if n else 0
+        avg_conf = (sum(confidences[truth]) / len(confidences[truth])) if confidences[truth] else 0
+        md.append(f"| {truth} | {n} | {correct} | {acc:.0%} | {avg_conf:.2f} | {downgrades[truth]} |")
+    md.extend([
+        "",
+        "## Confusion matrix (post-downgrade)",
+        "",
+        "rows=ground truth, cols=action after 0.7-floor downgrade",
+        "",
+    ])
+    md.append("| truth \\ pred | " + " | ".join(pred_labels) + " |")
+    md.append("|---" * (len(pred_labels) + 1) + "|")
+    for truth in _CATEGORIES:
+        md.append("| " + truth + " | " + " | ".join(
+            str(truth_pred_matrix.get((truth, p), 0)) for p in pred_labels
+        ) + " |")
+    md.extend([
+        "",
+        "## Raw action distribution (before 0.7 floor)",
+        "",
+        "| action | n |",
+        "|---|---:|",
+    ])
+    for action, count in sorted(raw_action_dist.items(), key=lambda kv: -kv[1]):
+        md.append(f"| {action} | {count} |")
+    md.extend([
+        "",
+        "## Confidence histogram",
+        "",
+        "| bin | n |",
+        "|---|---:|",
+    ])
+    for i, n in enumerate(bin_counts):
+        md.append(f"| [{bins[i]:.1f}, {bins[i+1]:.2f}) | {n} |")
+    md.extend([
+        "",
+        f"**Floor effect**: {total_downgrades}/{overall_n} non-KEEP_BOTH actions "
+        f"silently downgraded by the 0.7 floor at "
+        f"`sleep_handler.py:668`.",
+        "",
+        "## Caveat",
+        "",
+        "Generator (Haiku) and resolver may share systematic biases. The "
+        "categories REMOVE_A and REMOVE_B are conceptually adjacent to "
+        "SUPERSEDE_A/B; intra-pair confusion is expected. Use the raw-action "
+        "distribution and downgrade rate as the load-bearing signals.",
+    ])
+    args.out.write_text("\n".join(md), encoding="utf-8")
+    args.out_json.write_text(json.dumps({
+        "resolver_model": args.resolver_model,
+        "n_per_category": args.n_per_category,
+        "overall_accuracy": overall_acc,
+        "total_downgrades": total_downgrades,
+        "per_category": {
+            t: {
+                "n": sum(c for (tt, _), c in truth_pred_matrix.items() if tt == t),
+                "correct": truth_pred_matrix.get((t, t), 0),
+                "downgrades": downgrades[t],
+                "avg_confidence": (sum(confidences[t]) / len(confidences[t])) if confidences[t] else 0,
+            }
+            for t in _CATEGORIES
+        },
+        "confusion_matrix": {
+            f"{t}->{p}": c for (t, p), c in truth_pred_matrix.items()
+        },
+        "pairs": pairs_for_report,
+    }, indent=2), encoding="utf-8")
+    print(f"\nWrote: {args.out}")
+    print(f"Wrote: {args.out_json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))


### PR DESCRIPTION
## Summary

After tonight's prod sleep cycle reported "Contradiction resolution: 10 found, 0 resolved," I built a synthetic eval (\`scripts/eval/eval_f031_resolution.py\`) to measure F031's behavior — different code path from PR #383's F027 fix, with its own bare prompt and a 0.7 confidence floor. Findings led to a prompt rewrite + persistence wire-up.

## Eval findings

| Truth | v1 (original prompt) | v2 (this PR) | Δ |
|---|---:|---:|---:|
| SUPERSEDE_A | 60% | **80%** | +20pp |
| SUPERSEDE_B | 20% | 20% | 0 |
| MERGE | 40% | 40% | 0 |
| KEEP_BOTH | 60% | **80%** | +20pp |
| REMOVE_A | 0% | 0% | 0 (dead) |
| REMOVE_B | 20% | 0% | -20pp |
| **Overall** | 33% | **37%** | +4pp |

### Key insights

- **0/30 confidence below 0.7** → the 0.7 floor was a red herring; the model is confident even when wrong
- **Strong SUPERSEDE_A bias** (12-15/30 raw verdicts) — partly the prompt, partly the fixture's hardcoded date ordering
- **REMOVE is structurally dead** — even with explicit Step-3 framing, the model never returns it. Action-space design issue, not a prompt bug
- **Reinterpreting "10 found, 0 resolved"**: most likely 10 high-confidence KEEP_BOTH verdicts (correct behavior, not a bug). Persistence (this PR) confirms with real data

## Prompt rewrite

Same pattern that worked for F027 in PR #383:

1. **Step 1** — subject overlap test (catches obvious KEEP_BOTH)
2. **Step 2** — compatibility test (KEEP_BOTH or MERGE)
3. **Step 3** — factual-correctness test (REMOVE — wrong, never accurate)
4. **Step 4** — temporal-update test (SUPERSEDE — mutable state changed)
5. Mutability list (schedule, status, value, count, version, location, configuration, role, ownership, price, quantity)
6. Five worked examples
7. Confidence calibration guidance

## Persistence

Mirror PR #389's F026 persistence: every F031 verdict fire-and-forwards to \`nous_system.events\` as \`f031_contradiction_resolution\`. Lets us measure real production accuracy retrospectively.

Event payload:
\`\`\`json
{
  "raw_action": "SUPERSEDE_A",
  "applied_action": "SUPERSEDE_A",
  "confidence": 0.85,
  "downgraded_by_floor": false,
  "fact1_id": "...",
  "fact2_id": "...",
  "reason": "..."
}
\`\`\`

## Out of scope

- **REMOVE category redesign.** REMOVE is functionally dead even with the new prompt. Future PR could either deprecate it (collapse into SUPERSEDE) or accept the limitation. Not addressing today.
- **Fixture date asymmetry.** My eval hardcodes \`date_a=2026-04-15\` < \`date_b=2026-04-29\`, which bakes in SUPERSEDE_A bias for the eval but doesn't affect prod (real candidates are not date-ordered).

## Files

| File | Change |
|---|---|
| \`nous/handlers/sleep_handler.py\` | Prompt rewrite (~50 LOC) + emit_event hook |
| \`scripts/eval/eval_f031_resolution.py\` | New 30-scenario eval |
| \`reports/f031_resolution_eval.md\` | v1 baseline (33%) |
| \`reports/f031_resolution_eval_v2.md\` | v2 post-fix (37%) |

## Test plan

- [ ] CI green
- [ ] After deploy, next sleep cycle's resolutions land in \`nous_system.events\` with \`event_type='f031_contradiction_resolution'\`
- [ ] Query: \`SELECT data->>'applied_action' AS action, AVG((data->>'confidence')::float) AS conf, COUNT(*) FROM nous_system.events WHERE event_type='f031_contradiction_resolution' GROUP BY action;\` — confirms whether prod's "10 found 0 resolved" is genuine high-confidence KEEP_BOTH (expected) or low-confidence downgrades (would warrant follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)