### PR TITLE
fix(F031): MERGE without merged_content silently no-op'd in prod

### DIFF
--- a/nous/handlers/sleep_handler.py
+++ b/nous/handlers/sleep_handler.py
@@ -169,6 +169,8 @@ Examples to disambiguate:
 
 For `confidence`: use 0.85+ when one action is clearly right, 0.70-0.85 when borderline, below 0.70 when genuinely uncertain (will be downgraded to KEEP_BOTH by the caller).
 
+CRITICAL: When you choose MERGE, you MUST also produce a non-empty `merged_content` field with the combined single-fact text. If you cannot produce a meaningful merge (the two facts genuinely require both being kept), return KEEP_BOTH instead — never return MERGE with empty merged_content.
+
 Use the resolve_contradiction tool to return your analysis."""
 
 # Tool-use structured output schema for contradiction resolution (Issue #233)
@@ -687,6 +689,7 @@ class SleepHandler:
                 raw_action = str(resolution.get("action", "")).upper().strip()
                 action = raw_action
                 confidence = float(resolution.get("confidence", 0.0))
+                merged_content = str(resolution.get("merged_content", "") or "").strip()
                 fact1_id = pair["fact1_id"]
                 fact2_id = pair["fact2_id"]
 
@@ -700,10 +703,26 @@ class SleepHandler:
                     action = "KEEP_BOTH"
                     downgraded = True
 
+                # 2026-05-01 audit: production sleep cycle reported "10 found,
+                # 0 resolved" — investigation showed 8 of 10 verdicts were
+                # MERGE but `merged_content` was missing (schema makes it
+                # optional). The MERGE branch silently fell through. Treat
+                # missing merged_content on MERGE as KEEP_BOTH and log it
+                # explicitly so the issue is observable.
+                if action == "MERGE" and not merged_content:
+                    logger.warning(
+                        "F031 resolve: MERGE returned without merged_content for %s/%s — downgrading to KEEP_BOTH",
+                        fact1_id, fact2_id,
+                    )
+                    action = "KEEP_BOTH"
+                    downgraded = True
+
                 # F031 persistence — log every resolution decision so a
                 # retrospective accuracy eval can run against real prod data
                 # (eval_f031_resolution.py used synthetic fixtures only).
                 # Fire-and-forget via create_task to keep the sleep loop fast.
+                # 2026-05-01: include `merged_content_present` so the
+                # MERGE-without-content failure mode is observable in prod.
                 try:
                     asyncio.create_task(
                         self._brain.emit_event(
@@ -713,6 +732,7 @@ class SleepHandler:
                                 "applied_action": action,
                                 "confidence": confidence,
                                 "downgraded_by_floor": downgraded,
+                                "merged_content_present": bool(merged_content),
                                 "fact1_id": str(fact1_id),
                                 "fact2_id": str(fact2_id),
                                 "reason": str(resolution.get("reason", ""))[:300],
@@ -739,12 +759,14 @@ class SleepHandler:
                             action, fact2_id, fact1_id, confidence,
                         )
                     elif action == "MERGE":
-                        merged = resolution.get("merged_content", "")
-                        if merged:
+                        # merged_content is guaranteed non-empty here (the
+                        # downgrade-to-KEEP_BOTH guard above catches the empty
+                        # case); but keep a defensive check just in case.
+                        if merged_content:
                             try:
                                 await self._heart.learn(FactInput(
                                     subject=pair.get("subject", None),
-                                    content=merged,
+                                    content=merged_content,
                                     source="contradiction_resolution",
                                     confidence=0.8,
                                     category=pair.get("category", None),

--- a/tests/test_sleep_handler.py
+++ b/tests/test_sleep_handler.py
@@ -839,3 +839,43 @@ class TestStructuredContradictionResolution:
 
         assert result is True
         assert sleep_stats.get("contradictions_resolved", 0) == 0
+
+    @pytest.mark.asyncio
+    async def test_merge_without_content_downgrades_to_keep_both(self):
+        """2026-05-01 audit: prod sleep returned MERGE without merged_content
+        and silently no-op'd. New behavior: log warning and treat as
+        KEEP_BOTH so the resolution is observable and counted accurately."""
+        handler, brain, heart, bus, llm_client = _make_sleep_handler()
+
+        heart.find_contradiction_candidates = AsyncMock(return_value=[
+            {
+                "fact1_id": "f1", "fact2_id": "f2",
+                "content1": "Python is fast", "content2": "Python is slow",
+                "date1": "2026-01-01", "date2": "2026-02-01",
+                "subject": "python", "category": "technical",
+            }
+        ])
+        heart.deactivate_fact = AsyncMock()
+        heart.learn = AsyncMock()
+
+        # Simulate the prod failure mode: action=MERGE, no merged_content
+        resolution = {
+            "action": "MERGE", "confidence": 0.85, "reason": "Both true at different times",
+            # merged_content omitted — this is the bug we're guarding against
+        }
+        response = MagicMock()
+        response.content = [
+            {"type": "tool_use", "id": "toolu_x", "name": "resolve_contradiction",
+             "input": resolution}
+        ]
+        llm_client.call = AsyncMock(return_value=response)
+
+        sleep_stats = {"facts_created": 0, "procedures_created": 0, "censors_retired": 0}
+        result = await handler._phase_resolve_contradictions(sleep_stats)
+
+        assert result is True
+        # MERGE→KEEP_BOTH downgrade means no facts deactivated, no merged fact created
+        heart.deactivate_fact.assert_not_called()
+        heart.learn.assert_not_called()
+        # Counter does NOT increment for KEEP_BOTH (correct prod behavior)
+        assert sleep_stats.get("contradictions_resolved", 0) == 0


### PR DESCRIPTION
## Investigation finding

Prod sleep cycle on 2026-04-30 reported \"10 found, 0 resolved.\" With the new persistence shipped in #391, we could finally inspect what happened:

| applied_action | n | avg_conf |
|---|---:|---:|
| MERGE | 8 | 0.89 |
| KEEP_BOTH | 2 | 0.97 |

But: all 10 fact pairs are still active in prod, and zero new facts were created with \`source=contradiction_resolution\`. So the 8 MERGEs **silently fell through**.

## Root cause

\`_CONTRADICTION_RESOLUTION_SCHEMA\` lists \`merged_content\` in \`properties\` but not in \`required\`. Sonnet returned \`action=MERGE\` without \`merged_content\`. In \`sleep_handler.py:693\`:

\`\`\`python
elif action == \"MERGE\":
    merged = resolution.get(\"merged_content\", \"\")
    if merged:  # <- false, branch silently skipped
        ...
\`\`\`

No exception. No log. No counter increment. No way to diagnose without persisting the event payload.

## Fix (3 surgical changes)

### 1. Prompt strengthened (\`nous/handlers/sleep_handler.py:CONTRADICTION_RESOLUTION_PROMPT\`)
Added: \"When you choose MERGE, you MUST also produce a non-empty merged_content field. If you cannot produce a meaningful merge, return KEEP_BOTH instead.\"

### 2. Code guard
\`\`\`python
if action == \"MERGE\" and not merged_content:
    logger.warning(\"F031 resolve: MERGE returned without merged_content for %s/%s — downgrading to KEEP_BOTH\", ...)
    action = \"KEEP_BOTH\"
    downgraded = True
\`\`\`
Converts the silent no-op into a logged, observable event.

### 3. Persistence enriched
\`f031_contradiction_resolution\` events now include \`merged_content_present: bool\` so future audits see the failure mode directly without cross-referencing fact tables.

## Test

\`test_merge_without_content_downgrades_to_keep_both\` — mocks LLM returning \`action=MERGE\` with no \`merged_content\`. Verifies:
- No facts deactivated (would corrupt memory)
- No \`learn()\` called
- Counter doesn't increment (KEEP_BOTH semantics)
- Phase result is True

3/3 \`TestStructuredContradictionResolution\` pass.

## Expected effect after deploy

If the prompt strengthening works: future sleep cycles produce MERGE verdicts WITH \`merged_content\`, MERGE branch fires, contradictions actually resolve, and \`merged_content_present\` is true in the event payload.

If the prompt doesn't fully fix it: WARNING logs surface the failure mode every time, and the persistence event makes it visible without inspecting prod facts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)