### PR TITLE
fix: Codex follow-up findings on #393 #394 #395

### DIFF
--- a/nous/api/compaction.py
+++ b/nous/api/compaction.py
@@ -766,9 +766,16 @@ class ConversationCompactor:
                 if not isinstance(payload, dict):
                     return None
                 rendered = _format_structured_checkpoint(payload)
-                # Sanity check — the validator below requires the section
-                # markers; rendered output always includes them.
-                if len(rendered) < 100:
+                # Codex P1 follow-up to #395: align with the downstream
+                # `_validate_summary` 200-char minimum. Returning at >=100
+                # but failing validation at 200 wastes a fallback API call.
+                # Returning None here triggers the fallback ONCE.
+                if len(rendered) < 200:
+                    logger.info(
+                        "Compaction structured output rendered to %d chars (<200); "
+                        "falling back to free-form prompt.",
+                        len(rendered),
+                    )
                     return None
                 return rendered
         return None

--- a/nous/cognitive/layer.py
+++ b/nous/cognitive/layer.py
@@ -241,12 +241,17 @@ class CognitiveLayer:
             from sqlalchemy import select
             from nous.storage.models import Episode
             async with self._brain.db.session() as db_session:
+                # Codex P1 follow-up to #394: trivial sessions are closed
+                # via `deactivate_episode` which only flips `active=false`
+                # and leaves `ended_at` NULL. Filter on `active=true` so
+                # those deactivated rows don't get resurrected by warm.
                 result = await db_session.execute(
                     select(Episode.id)
                     .where(
                         Episode.agent_id == self._brain.agent_id,
                         Episode.session_id == session_id,
                         Episode.ended_at.is_(None),
+                        Episode.active.is_(True),
                     )
                     .order_by(Episode.started_at.desc())
                     .limit(1)

--- a/nous/handlers/sleep_handler.py
+++ b/nous/handlers/sleep_handler.py
@@ -693,29 +693,34 @@ class SleepHandler:
                 fact1_id = pair["fact1_id"]
                 fact2_id = pair["fact2_id"]
 
-                # Skip low-confidence actions (review fix: treat as KEEP_BOTH)
-                downgraded = False
+                # Skip low-confidence actions (review fix: treat as KEEP_BOTH).
+                # `downgraded_by_floor` tracks ONLY the confidence-floor downgrade
+                # so eval queries can distinguish floor-driven downgrades from
+                # other causes (Codex P2 follow-up to PR #393).
+                downgraded_by_floor = False
                 if confidence < 0.7 and action != "KEEP_BOTH":
                     logger.info(
                         "F031 resolve: confidence %.2f below 0.7 for %s, downgrading to KEEP_BOTH",
                         confidence, action,
                     )
                     action = "KEEP_BOTH"
-                    downgraded = True
+                    downgraded_by_floor = True
 
                 # 2026-05-01 audit: production sleep cycle reported "10 found,
                 # 0 resolved" — investigation showed 8 of 10 verdicts were
                 # MERGE but `merged_content` was missing (schema makes it
                 # optional). The MERGE branch silently fell through. Treat
                 # missing merged_content on MERGE as KEEP_BOTH and log it
-                # explicitly so the issue is observable.
+                # explicitly so the issue is observable. Tracked via a
+                # separate `downgraded_due_to_missing_content` flag.
+                downgraded_due_to_missing_content = False
                 if action == "MERGE" and not merged_content:
                     logger.warning(
                         "F031 resolve: MERGE returned without merged_content for %s/%s — downgrading to KEEP_BOTH",
                         fact1_id, fact2_id,
                     )
                     action = "KEEP_BOTH"
-                    downgraded = True
+                    downgraded_due_to_missing_content = True
 
                 # F031 persistence — log every resolution decision so a
                 # retrospective accuracy eval can run against real prod data
@@ -731,7 +736,8 @@ class SleepHandler:
                                 "raw_action": raw_action,
                                 "applied_action": action,
                                 "confidence": confidence,
-                                "downgraded_by_floor": downgraded,
+                                "downgraded_by_floor": downgraded_by_floor,
+                                "downgraded_due_to_missing_content": downgraded_due_to_missing_content,
                                 "merged_content_present": bool(merged_content),
                                 "fact1_id": str(fact1_id),
                                 "fact2_id": str(fact2_id),

--- a/tests/test_compaction_structured.py
+++ b/tests/test_compaction_structured.py
@@ -158,6 +158,37 @@ async def test_summarize_structured_swallows_exceptions():
 
 
 @pytest.mark.asyncio
+async def test_summarize_structured_below_validator_minimum_returns_none():
+    """Codex P1 follow-up to #395: structured output rendering to <200
+    chars must return None so the legacy fallback runs. Previously the
+    threshold was 100, mismatched with the validator's 200, causing a
+    wasted API call."""
+    compactor = ConversationCompactor(_settings(True))
+
+    # Minimal payload renders to ~120 chars — below the validator's 200.
+    tool_payload = {
+        "goal": "G",
+        "constraints": [],
+        "progress_done": [],
+        "progress_in_progress": [],
+        "key_decisions": [],
+        "conversation_dynamics": [],
+        "next_steps": [],
+        "critical_context": [],
+    }
+    mock_response = MagicMock()
+    mock_response.content = [
+        {"type": "tool_use", "name": "checkpoint_summary", "input": tool_payload}
+    ]
+    call_api = AsyncMock(return_value=mock_response)
+
+    result = await compactor._summarize_structured(
+        user_content="x", system="y", call_api=call_api,
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
 async def test_summarize_falls_back_to_freeform_when_structured_fails():
     """When the structured path returns None, _summarize tries the legacy path."""
     compactor = ConversationCompactor(_settings(True))

--- a/tests/test_episode_session_id.py
+++ b/tests/test_episode_session_id.py
@@ -108,3 +108,37 @@ async def test_warm_active_episode_swallows_errors():
     # Must not raise
     result = await layer.warm_active_episode("session-err")
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_warm_active_episode_query_filters_active_true():
+    """Codex P1 follow-up to #394: deactivated episodes have ended_at NULL
+    but active=false. The warm query MUST filter on active=true so
+    deactivated rows aren't resurrected. Verify by inspecting the SQL
+    fragment passed to execute()."""
+    from nous.cognitive.layer import CognitiveLayer
+
+    layer = CognitiveLayer.__new__(CognitiveLayer)
+    layer._active_episodes = {}
+    layer._brain = MagicMock()
+    layer._brain.agent_id = "test-agent"
+
+    captured_stmt = []
+
+    async def fake_execute(stmt):
+        captured_stmt.append(stmt)
+        return MagicMock(scalar_one_or_none=MagicMock(return_value=None))
+
+    mock_session = MagicMock()
+    mock_session.execute = fake_execute
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=mock_session)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    layer._brain.db.session = MagicMock(return_value=cm)
+
+    await layer.warm_active_episode("any-session")
+    assert captured_stmt, "execute was not called"
+    # The compiled SELECT must reference both ended_at and active.
+    sql = str(captured_stmt[0])
+    assert "ended_at" in sql.lower()
+    assert "active" in sql.lower()

--- a/tests/test_sleep_handler.py
+++ b/tests/test_sleep_handler.py
@@ -841,6 +841,64 @@ class TestStructuredContradictionResolution:
         assert sleep_stats.get("contradictions_resolved", 0) == 0
 
     @pytest.mark.asyncio
+    async def test_persistence_flags_distinguish_downgrade_reasons(self):
+        """Codex P2 follow-up to #393: `downgraded_by_floor` must reflect
+        confidence-floor downgrades only; missing-merged_content gets its
+        own `downgraded_due_to_missing_content` flag in the persistence
+        event so eval queries can disambiguate the two."""
+        handler, brain, heart, bus, llm_client = _make_sleep_handler()
+
+        captured_events: list[tuple[str, dict]] = []
+
+        async def capture_emit(event_type, data, **kwargs):
+            captured_events.append((event_type, data))
+
+        brain.emit_event = capture_emit
+
+        heart.find_contradiction_candidates = AsyncMock(return_value=[
+            {
+                "fact1_id": "fA", "fact2_id": "fB",
+                "content1": "Pi=3.14", "content2": "Pi=4",
+                "date1": "2026-01-01", "date2": "2026-02-01",
+                "subject": "math", "category": "concept",
+            }
+        ])
+        heart.deactivate_fact = AsyncMock()
+        heart.learn = AsyncMock()
+
+        # MERGE without merged_content; confidence is HIGH (above 0.7) so
+        # the floor doesn't fire. Only the missing-content flag should set.
+        resolution = {
+            "action": "MERGE", "confidence": 0.92,
+            "reason": "Both partial truths",
+            # merged_content omitted
+        }
+        response = MagicMock()
+        response.content = [
+            {"type": "tool_use", "id": "x", "name": "resolve_contradiction",
+             "input": resolution}
+        ]
+        llm_client.call = AsyncMock(return_value=response)
+
+        sleep_stats = {"facts_created": 0, "procedures_created": 0,
+                       "censors_retired": 0}
+        await handler._phase_resolve_contradictions(sleep_stats)
+        # Drain pending fire-and-forget tasks
+        import asyncio as _aio
+        await _aio.sleep(0)
+
+        assert captured_events, "no F031 event emitted"
+        _, data = captured_events[0]
+        assert data["downgraded_by_floor"] is False, (
+            "confidence was 0.92 — floor didn't fire"
+        )
+        assert data["downgraded_due_to_missing_content"] is True, (
+            "MERGE without merged_content should set the missing-content flag"
+        )
+        assert data["applied_action"] == "KEEP_BOTH"
+        assert data["raw_action"] == "MERGE"
+
+    @pytest.mark.asyncio
     async def test_merge_without_content_downgrades_to_keep_both(self):
         """2026-05-01 audit: prod sleep returned MERGE without merged_content
         and silently no-op'd. New behavior: log warning and treat as


### PR DESCRIPTION
## Summary

Three bugs surfaced by Codex bot review of today's PRs. All three are real and fixed in this bundle.

| PR | Codex Severity | Issue | Fix |
|---|---|---|---|
| #393 | P2 | \`downgraded_by_floor\` conflated confidence-floor and missing-content downgrades | Split into two flags |
| #394 | **P1** | \`warm_active_episode\` could resurrect deactivated episodes (trivial sessions are deactivated, not ended) | Add \`active=true\` filter |
| #395 | **P1** | Structured-output gate at 100 chars vs validator's 200 — caused wasted fallback API call | Align to 200 chars |

## Details

### #393 — flag separation
The persistence event's \`downgraded_by_floor\` was being set true for BOTH confidence-floor and missing-merged_content downgrades. Eval queries couldn't tell them apart. New \`downgraded_due_to_missing_content\` flag added; \`downgraded_by_floor\` now reflects only the 0.7 floor. Backwards compatible.

### #394 — warm filter
\`Heart.deactivate_episode\` flips \`active=false\` but leaves \`ended_at=NULL\`. My warm query was matching those rows. Without this fix, a post-restart session could attach new facts to an episode the system had explicitly retired.

\`\`\`sql
WHERE agent_id = :aid
  AND session_id = :sid
  AND ended_at IS NULL
  AND active = true   -- new
\`\`\`

### #395 — structured gate threshold
\`_summarize_structured\` returned at >=100 chars, but \`_validate_summary\` rejects <200. Mismatch caused: structured path "succeeds" → validate fails → fallback runs → second API call. Wasted on every minimal-content compaction.

Raising the gate to 200 means: under-length payloads return None immediately, fallback runs ONCE.

## Tests

3 new regression tests, total 22/22 pass:
- \`test_persistence_flags_distinguish_downgrade_reasons\` — high-conf MERGE-without-content sets only the missing-content flag
- \`test_warm_active_episode_query_filters_active_true\` — SQL captured + asserted to include \`active\`
- \`test_summarize_structured_below_validator_minimum_returns_none\` — 120-char payload returns None

## Test plan

- [x] CI green
- [x] All previous tests still pass
- [ ] After deploy, prod F031 events should surface both flags in different scenarios; warm shouldn't pick up deactivated episodes; compaction shouldn't double-call the API on short summaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)