### PR TITLE
fix(F031): evaluate downgrade conditions against raw_action (Codex P2 from #396)

### DIFF
--- a/nous/handlers/sleep_handler.py
+++ b/nous/handlers/sleep_handler.py
@@ -693,34 +693,31 @@ class SleepHandler:
                 fact1_id = pair["fact1_id"]
                 fact2_id = pair["fact2_id"]
 
-                # Skip low-confidence actions (review fix: treat as KEEP_BOTH).
-                # `downgraded_by_floor` tracks ONLY the confidence-floor downgrade
-                # so eval queries can distinguish floor-driven downgrades from
-                # other causes (Codex P2 follow-up to PR #393).
-                downgraded_by_floor = False
-                if confidence < 0.7 and action != "KEEP_BOTH":
+                # Codex P2 follow-up to #396: evaluate BOTH downgrade
+                # conditions against `raw_action` so a low-confidence
+                # MERGE-without-content correctly sets both flags. The
+                # earlier version checked the missing-content condition
+                # AFTER the floor mutation had already reset action to
+                # KEEP_BOTH, so missing-content downgrades on
+                # low-confidence verdicts were silently undercounted.
+                downgraded_by_floor = (
+                    confidence < 0.7 and raw_action != "KEEP_BOTH"
+                )
+                downgraded_due_to_missing_content = (
+                    raw_action == "MERGE" and not merged_content
+                )
+                if downgraded_by_floor:
                     logger.info(
                         "F031 resolve: confidence %.2f below 0.7 for %s, downgrading to KEEP_BOTH",
-                        confidence, action,
+                        confidence, raw_action,
                     )
-                    action = "KEEP_BOTH"
-                    downgraded_by_floor = True
-
-                # 2026-05-01 audit: production sleep cycle reported "10 found,
-                # 0 resolved" — investigation showed 8 of 10 verdicts were
-                # MERGE but `merged_content` was missing (schema makes it
-                # optional). The MERGE branch silently fell through. Treat
-                # missing merged_content on MERGE as KEEP_BOTH and log it
-                # explicitly so the issue is observable. Tracked via a
-                # separate `downgraded_due_to_missing_content` flag.
-                downgraded_due_to_missing_content = False
-                if action == "MERGE" and not merged_content:
+                if downgraded_due_to_missing_content:
                     logger.warning(
                         "F031 resolve: MERGE returned without merged_content for %s/%s — downgrading to KEEP_BOTH",
                         fact1_id, fact2_id,
                     )
+                if downgraded_by_floor or downgraded_due_to_missing_content:
                     action = "KEEP_BOTH"
-                    downgraded_due_to_missing_content = True
 
                 # F031 persistence — log every resolution decision so a
                 # retrospective accuracy eval can run against real prod data

--- a/tests/test_sleep_handler.py
+++ b/tests/test_sleep_handler.py
@@ -841,6 +841,65 @@ class TestStructuredContradictionResolution:
         assert sleep_stats.get("contradictions_resolved", 0) == 0
 
     @pytest.mark.asyncio
+    async def test_low_conf_merge_without_content_sets_both_flags(self):
+        """Codex P2 follow-up to #396: a verdict that hits BOTH the
+        confidence floor (<0.7) AND missing merged_content must set
+        BOTH flags. The pre-fix logic mutated `action` to KEEP_BOTH on
+        the floor check first, then the missing-content check failed
+        because action was no longer MERGE.
+        """
+        handler, brain, heart, bus, llm_client = _make_sleep_handler()
+
+        captured_events: list[tuple[str, dict]] = []
+
+        async def capture_emit(event_type, data, **kwargs):
+            captured_events.append((event_type, data))
+
+        brain.emit_event = capture_emit
+
+        heart.find_contradiction_candidates = AsyncMock(return_value=[
+            {
+                "fact1_id": "f1", "fact2_id": "f2",
+                "content1": "X", "content2": "Y",
+                "date1": "2026-01-01", "date2": "2026-02-01",
+                "subject": "s", "category": "c",
+            }
+        ])
+        heart.deactivate_fact = AsyncMock()
+        heart.learn = AsyncMock()
+
+        # Both: low confidence (0.5 < 0.7) AND missing merged_content.
+        resolution = {
+            "action": "MERGE", "confidence": 0.5,
+            "reason": "Both apply but unsure",
+            # merged_content omitted
+        }
+        response = MagicMock()
+        response.content = [
+            {"type": "tool_use", "id": "x", "name": "resolve_contradiction",
+             "input": resolution}
+        ]
+        llm_client.call = AsyncMock(return_value=response)
+
+        sleep_stats = {"facts_created": 0, "procedures_created": 0,
+                       "censors_retired": 0}
+        await handler._phase_resolve_contradictions(sleep_stats)
+        import asyncio as _aio
+        await _aio.sleep(0)
+
+        assert captured_events
+        _, data = captured_events[0]
+        assert data["downgraded_by_floor"] is True, (
+            "0.5 < 0.7 floor — must be flagged"
+        )
+        assert data["downgraded_due_to_missing_content"] is True, (
+            "MERGE without merged_content — must be flagged regardless of "
+            "the floor downgrade order"
+        )
+        assert data["raw_action"] == "MERGE"
+        assert data["applied_action"] == "KEEP_BOTH"
+
+    @pytest.mark.asyncio
     async def test_persistence_flags_distinguish_downgrade_reasons(self):
         """Codex P2 follow-up to #393: `downgraded_by_floor` must reflect
         confidence-floor downgrades only; missing-merged_content gets its


### PR DESCRIPTION
## Summary

Codex bot caught a real bug introduced by yesterday's flag-separation work in #396. P2, but worth fixing — it actively undercounts the very failure mode the flag was created to surface.

## The bug

After #396, the code looked like:

\`\`\`python
downgraded_by_floor = False
if confidence < 0.7 and action != \"KEEP_BOTH\":
    action = \"KEEP_BOTH\"  # mutates action
    downgraded_by_floor = True

downgraded_due_to_missing_content = False
if action == \"MERGE\" and not merged_content:  # action already KEEP_BOTH!
    action = \"KEEP_BOTH\"
    downgraded_due_to_missing_content = True
\`\`\`

When a verdict hit BOTH conditions (low confidence AND missing merged_content), the floor check mutated \`action\` to \`KEEP_BOTH\` first; then the missing-content check saw \`action != \"MERGE\"\` and skipped. Result: telemetry recorded \`downgraded_by_floor=True\` but missed \`downgraded_due_to_missing_content=True\`.

That defeats the goal of separating the two reasons — eval queries would systematically undercount missing-content failures on low-confidence verdicts.

## Fix

Compute BOTH conditions against \`raw_action\` (the model's actual verdict, never mutated):

\`\`\`python
downgraded_by_floor = confidence < 0.7 and raw_action != \"KEEP_BOTH\"
downgraded_due_to_missing_content = (
    raw_action == \"MERGE\" and not merged_content
)
if downgraded_by_floor or downgraded_due_to_missing_content:
    action = \"KEEP_BOTH\"
\`\`\`

## Test

\`test_low_conf_merge_without_content_sets_both_flags\` — feeds confidence=0.5 + no merged_content, asserts BOTH flags appear in the persistence event. Pre-fix this would have shown only \`downgraded_by_floor=True\`.

5/5 F031 tests pass.

## Test plan

- [x] CI green
- [ ] After deploy, prod F031 events with both conditions trip both flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)