### PR TITLE
feat(eval): pre-flight assert eval DB matches ORM schema

### DIFF
--- a/nous_eval/ingest_longmemeval.py
+++ b/nous_eval/ingest_longmemeval.py
@@ -275,6 +275,12 @@ async def _replay_sessions_into_scratch(
     api_client = None
     try:
         await db.connect()
+        # Surface schema drift before we start ingesting — without this,
+        # a stale-schema container would let inserts silently poison the
+        # asyncpg session and the operator sees an empty corpus instead
+        # of a clear schema error.
+        from nous_eval.schema_preflight import assert_eval_db_schema_matches_orm
+        await assert_eval_db_schema_matches_orm(db)
         embedder = EmbeddingProvider(
             api_key=settings.openai_api_key,
             model=settings.embedding_model,

--- a/nous_eval/retrieval_runner.py
+++ b/nous_eval/retrieval_runner.py
@@ -400,6 +400,12 @@ def _build_brain_for_eval(
 
     Brain and Heart share the embedding provider (pattern from main.py:69)
     so we don't double up httpx pools.
+
+    Schema preflight: Brain's ORM models (Decision) are validated by the
+    Heart preflight at ``_build_heart_for_eval`` because both factories
+    are called in the same harness invocation against the same eval DB.
+    If you ever construct a Brain in a path that does NOT also build a
+    Heart, call ``assert_eval_db_schema_matches_orm(db)`` at that site.
     """
     return Brain(
         database=db,

--- a/nous_eval/retrieval_runner.py
+++ b/nous_eval/retrieval_runner.py
@@ -310,7 +310,16 @@ async def _build_heart_for_eval(
     closed, even on test failure. Background tasks (EventBus, sleep handler,
     heartbeat) are not started — those belong to :mod:`nous.main`, not to
     the eval harness.
+
+    Pre-flight: asserts the eval DB has every column the ORM expects.
+    Without this, missing migrations cascade into asyncpg
+    InFailedSQLTransactionError mid-query and the eval reports something
+    like "0% sufficient" with no surface signal that the schema is the
+    problem (see PR #398 for the cascade fix).
     """
+    from nous_eval.schema_preflight import assert_eval_db_schema_matches_orm
+    await assert_eval_db_schema_matches_orm(db)
+
     embedding_provider: EmbeddingProvider | None = None
     if settings.openai_api_key:
         embedding_provider = EmbeddingProvider(

--- a/nous_eval/schema_preflight.py
+++ b/nous_eval/schema_preflight.py
@@ -1,0 +1,126 @@
+"""Pre-flight schema check: assert eval DB matches what the ORM expects.
+
+When the eval DB is missing a recent migration (e.g., a new column added
+to ``heart.episodes``), the SQLAlchemy ORM will issue a SELECT that
+includes the new column, asyncpg will raise ``UndefinedColumnError``,
+and that error poisons the connection's transaction (asyncpg marks it
+ABORTED). All subsequent queries in the same session fail with
+``InFailedSQLTransactionError``.
+
+PR #398 fixed the cascade behavior in ``Heart._recall``, but the *root
+cause* is still silent: the eval reports something like "0% sufficient"
+without ever telling you that retrieval crashed at the schema level.
+
+This pre-flight introspects the ORM model columns the harness depends
+on, queries ``information_schema.columns`` against the eval DB, and
+raises ``EvalDBSchemaDriftError`` early — with a one-step remediation
+hint — if any ORM-required column is missing. Would have surfaced
+today's missing-migration-040 gap in seconds rather than hours of
+investigation.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import text
+
+from nous.storage.models import (
+    Censor,
+    Decision,
+    Episode,
+    Fact,
+    Procedure,
+)
+
+if TYPE_CHECKING:
+    from nous.storage.database import Database
+
+
+class EvalDBSchemaDriftError(RuntimeError):
+    """Raised when the eval DB is missing ORM-required columns.
+
+    The message includes which tables/columns are missing and a one-line
+    command to apply pending migrations.
+    """
+
+
+# Tables the retrieval pipeline actually reads from. Adding more models
+# here is cheap and makes the check stricter; removing them weakens it.
+_REQUIRED_MODELS: tuple[type, ...] = (
+    Episode,
+    Fact,
+    Procedure,
+    Censor,
+    Decision,
+)
+
+
+def _orm_column_names(model: type) -> set[str]:
+    """Return the column names the ORM will SELECT for this model."""
+    return {col.name for col in model.__table__.columns}
+
+
+def _qualified_table(model: type) -> tuple[str, str]:
+    """Return ``(schema, table)`` for an ORM model."""
+    table = model.__table__
+    schema = table.schema or "public"
+    return schema, table.name
+
+
+async def assert_eval_db_schema_matches_orm(db: "Database") -> None:
+    """Raise ``EvalDBSchemaDriftError`` if the eval DB lacks ORM columns.
+
+    Runs one ``information_schema.columns`` query per model (cheap;
+    typically 5 round-trips at startup). On success returns silently.
+
+    Call once at eval startup, before any ``heart.recall`` invocation.
+    """
+    missing: list[tuple[str, list[str]]] = []
+
+    async with db.session() as session:
+        for model in _REQUIRED_MODELS:
+            schema, table = _qualified_table(model)
+            orm_cols = _orm_column_names(model)
+
+            result = await session.execute(
+                text(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_schema = :schema AND table_name = :table"
+                ),
+                {"schema": schema, "table": table},
+            )
+            db_cols = {row[0] for row in result}
+
+            # ``search_tsv`` is DB-generated and excluded from inserts in
+            # the snapshot script, but the ORM doesn't model it either —
+            # so we don't need a special case here.
+            missing_cols = sorted(orm_cols - db_cols)
+            if missing_cols:
+                missing.append((f"{schema}.{table}", missing_cols))
+
+    if missing:
+        raise EvalDBSchemaDriftError(_format_drift_message(missing))
+
+
+def _format_drift_message(missing: list[tuple[str, list[str]]]) -> str:
+    lines = [
+        "Eval DB schema drift detected — ORM-required columns missing:",
+        "",
+    ]
+    for table, cols in missing:
+        lines.append(f"  {table}: {', '.join(cols)}")
+    lines += [
+        "",
+        "This usually means the eval DB image was built before one or",
+        "more recent migrations. To apply pending migrations to the",
+        "running eval-scratch container:",
+        "",
+        "  for f in sql/migrations/*.sql; do",
+        "    docker exec -i nous-eval-scratch psql -U nous \\",
+        "      -d nous_eval_scratch < \"$f\";",
+        "  done",
+        "",
+        "Or rebuild the baked image (Dockerfile.eval-db) so initdb",
+        "applies all migrations from scratch.",
+    ]
+    return "\n".join(lines)

--- a/nous_eval/schema_preflight.py
+++ b/nous_eval/schema_preflight.py
@@ -112,15 +112,9 @@ def _format_drift_message(missing: list[tuple[str, list[str]]]) -> str:
     lines += [
         "",
         "This usually means the eval DB image was built before one or",
-        "more recent migrations. To apply pending migrations to the",
-        "running eval-scratch container:",
+        "more recent migrations. The canonical fix is to rebuild the",
+        "eval DB volume so initdb re-applies every migration:",
         "",
-        "  for f in sql/migrations/*.sql; do",
-        "    docker exec -i nous-eval-scratch psql -U nous \\",
-        "      -d nous_eval_scratch < \"$f\";",
-        "  done",
-        "",
-        "Or rebuild the baked image (Dockerfile.eval-db) so initdb",
-        "applies all migrations from scratch.",
+        "  uv run python -m nous_eval.rebuild",
     ]
     return "\n".join(lines)

--- a/tests/test_schema_preflight.py
+++ b/tests/test_schema_preflight.py
@@ -1,0 +1,144 @@
+"""Tests for nous_eval.schema_preflight.
+
+The pre-flight asserts the eval DB has every column the ORM expects
+before the harness fires its first heart.recall — surfacing schema
+drift early instead of letting it cascade into asyncpg
+InFailedSQLTransactionError mid-query.
+
+Tests use mocks rather than a live DB so they run deterministically on
+any environment.
+"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nous_eval.schema_preflight import (
+    EvalDBSchemaDriftError,
+    _orm_column_names,
+    assert_eval_db_schema_matches_orm,
+)
+
+
+def _make_db_with_columns(by_table: dict[tuple[str, str], set[str]]) -> MagicMock:
+    """Build a Database mock whose session returns column names per table.
+
+    by_table maps ``(schema, table) -> set of column names`` that
+    information_schema.columns will appear to return for that table.
+    Tables not in the dict appear empty (i.e., as if the table doesn't
+    exist).
+    """
+    db = MagicMock()
+    session_mock = MagicMock()
+
+    async def _execute(_stmt, params):
+        key = (params["schema"], params["table"])
+        cols = by_table.get(key, set())
+        # information_schema.columns returns one row per column; each row
+        # is a tuple-like with column_name at position 0.
+        rows = [(c,) for c in cols]
+        result = MagicMock()
+        result.__iter__ = lambda self: iter(rows)
+        return result
+
+    session_mock.execute = AsyncMock(side_effect=_execute)
+
+    @asynccontextmanager
+    async def _session():
+        yield session_mock
+
+    db.session = _session
+    return db
+
+
+async def test_preflight_passes_when_all_orm_columns_present():
+    """No raise when every ORM column exists in the eval DB."""
+    from nous.storage.models import Censor, Decision, Episode, Fact, Procedure
+
+    by_table = {
+        ("heart", "episodes"): _orm_column_names(Episode),
+        ("heart", "facts"): _orm_column_names(Fact),
+        ("heart", "procedures"): _orm_column_names(Procedure),
+        ("heart", "censors"): _orm_column_names(Censor),
+        ("brain", "decisions"): _orm_column_names(Decision),
+    }
+    db = _make_db_with_columns(by_table)
+    await assert_eval_db_schema_matches_orm(db)  # must not raise
+
+
+async def test_preflight_raises_when_one_column_missing():
+    """Missing the column today's bug hit (heart.episodes.session_id)
+    must raise with that table + column name in the message."""
+    from nous.storage.models import Censor, Decision, Episode, Fact, Procedure
+
+    # Drop session_id from the eval DB columns to simulate the
+    # migration-040-missing scenario that bit us today.
+    episode_cols = _orm_column_names(Episode) - {"session_id"}
+    by_table = {
+        ("heart", "episodes"): episode_cols,
+        ("heart", "facts"): _orm_column_names(Fact),
+        ("heart", "procedures"): _orm_column_names(Procedure),
+        ("heart", "censors"): _orm_column_names(Censor),
+        ("brain", "decisions"): _orm_column_names(Decision),
+    }
+    db = _make_db_with_columns(by_table)
+
+    with pytest.raises(EvalDBSchemaDriftError) as excinfo:
+        await assert_eval_db_schema_matches_orm(db)
+
+    msg = str(excinfo.value)
+    assert "heart.episodes" in msg
+    assert "session_id" in msg
+    # Remediation hint should be present so the operator knows what to do.
+    assert "migrations" in msg.lower()
+
+
+async def test_preflight_reports_all_drift_in_one_error():
+    """When multiple tables drift, the error lists all of them at once
+    instead of failing on the first and hiding the rest."""
+    from nous.storage.models import Censor, Decision, Episode, Fact, Procedure
+
+    by_table = {
+        ("heart", "episodes"): _orm_column_names(Episode) - {"session_id"},
+        ("heart", "facts"): _orm_column_names(Fact) - {"actionable"},
+        ("heart", "procedures"): _orm_column_names(Procedure),
+        ("heart", "censors"): _orm_column_names(Censor),
+        ("brain", "decisions"): _orm_column_names(Decision) - {"confidence_raw"},
+    }
+    db = _make_db_with_columns(by_table)
+
+    with pytest.raises(EvalDBSchemaDriftError) as excinfo:
+        await assert_eval_db_schema_matches_orm(db)
+
+    msg = str(excinfo.value)
+    # All three drifted columns must appear so the operator sees the
+    # full picture and can apply all pending migrations in one pass.
+    assert "session_id" in msg
+    assert "actionable" in msg
+    assert "confidence_raw" in msg
+
+
+async def test_preflight_raises_when_table_missing_entirely():
+    """If a required table doesn't exist at all (empty column list),
+    every ORM column for it shows as drifted."""
+    from nous.storage.models import Censor, Decision, Fact, Procedure
+
+    # Episodes table has zero columns → every ORM-required column drifts.
+    by_table = {
+        ("heart", "episodes"): set(),
+        ("heart", "facts"): _orm_column_names(Fact),
+        ("heart", "procedures"): _orm_column_names(Procedure),
+        ("heart", "censors"): _orm_column_names(Censor),
+        ("brain", "decisions"): _orm_column_names(Decision),
+    }
+    db = _make_db_with_columns(by_table)
+
+    with pytest.raises(EvalDBSchemaDriftError) as excinfo:
+        await assert_eval_db_schema_matches_orm(db)
+
+    msg = str(excinfo.value)
+    assert "heart.episodes" in msg
+    # A representative column the ORM definitely models on Episode.
+    assert "summary" in msg


### PR DESCRIPTION
## Summary
- Adds `nous_eval/schema_preflight.py` — introspects ORM models the harness uses and asserts every required column exists in the eval DB.
- Wires it into `_build_heart_for_eval` so it runs once per harness invocation, before any `heart.recall` fires.
- Raises `EvalDBSchemaDriftError` with all drift in one pass plus a one-line remediation command.

## Why
Today's investigation: the eval-scratch DB was missing migration 040 (`heart.episodes.session_id`). The ORM SELECT crashed with `UndefinedColumnError`, asyncpg marked the connection's transaction `ABORTED`, and every subsequent fact/procedure sub-search in the same session failed silently with `InFailedSQLTransactionError`. `heart.recall` returned 0 results for every query and the packing eval reported **0% sufficient** — looked like a retrieval-quality crisis; was actually schema drift hidden by cascade silence.

PR #398 fixed the cascade behavior. This PR fixes the *root cause* signal: schema drift now fails loud at startup with a clear message, instead of cascading silently into "0% sufficient."

## What it catches
Live demo against the running `nous-eval-scratch` container (after artificially dropping `session_id`):
```
EvalDBSchemaDriftError: Eval DB schema drift detected — ORM-required columns missing:

  heart.episodes: session_id

This usually means the eval DB image was built before one or
more recent migrations. To apply pending migrations to the
running eval-scratch container:

  for f in sql/migrations/*.sql; do
    docker exec -i nous-eval-scratch psql -U nous       -d nous_eval_scratch < "$f";
  done
```

## Test plan
- [x] 4 mock-based unit tests in `tests/test_schema_preflight.py`:
  - pass case (all columns present)
  - single-column drift (the migration-040 scenario)
  - multi-table drift reported in one error
  - missing-table-entirely degrades gracefully
- [x] Live-tested against `nous-eval-scratch` — passes after migrations applied; fails loud when columns dropped
- [x] Existing `test_retrieval_pipeline.py` unaffected (8/8 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)