### PR TITLE
feat(eval): architectural-query retrieval regression probe

### DIFF
--- a/nous_eval/probes/__init__.py
+++ b/nous_eval/probes/__init__.py
@@ -1,0 +1,13 @@
+"""Diagnostic probes for retrieval-quality investigation.
+
+Each probe targets a specific *behavioural* dimension of recall (rather
+than the aggregate MRR/P@K metrics that ``nous_eval.retrieval`` already
+covers). Probes are designed to:
+
+- Catch regressions on classes of query that the F051 corpus underweights
+  (e.g., architectural / "tell me about X" questions).
+- Produce human-readable per-scenario verdicts so a regression points
+  directly at the failing case.
+
+Run a probe via ``python -m nous_eval.probes.<name>``.
+"""

--- a/nous_eval/probes/arch_query.py
+++ b/nous_eval/probes/arch_query.py
@@ -59,9 +59,15 @@ class ArchProbe:
 
 # Hand-curated probes against agent_id=nous-prod-snapshot. If the
 # corpus snapshot is regenerated and a fragment no longer matches,
-# the probe will SKIP that scenario (won't fail loud) — but the
-# headline TOP-3 / TOP-10 totals will drop, which is the load-bearing
-# regression signal.
+# the probe SKIPs that scenario; --strict additionally fails when too
+# many scenarios skip so corpus drift cannot silently erase coverage
+# (see _MIN_EVALUATED_FRACTION below).
+#
+# Contract for ``gold_fragments``: every fragment in a single probe's
+# tuple must be a *paraphrase of the same answer fact*, not a disjoint
+# fact. ``_gold_ids`` UNIONs across fragments — if you list two
+# fragments that name different facts, the probe will accept either as
+# gold and over-count.
 PROBES: tuple[ArchProbe, ...] = (
     ArchProbe(
         query="Tell me about the heartbeat system.",
@@ -119,6 +125,12 @@ PROBES: tuple[ArchProbe, ...] = (
 # scenario flake doesn't break CI.
 _TOP3_FLOOR = 4   # was 5/6 baseline
 _TOP10_FLOOR = 5  # was 6/6 baseline
+
+# Minimum fraction of probes that must produce a gold match. Without
+# this floor, corpus drift (a fragment going stale after a re-snapshot)
+# would silently lower n_evaluated and the TOP-3/TOP-10 floors would
+# pass trivially. 0.66 = 4 of 6 probes must still find their gold.
+_MIN_EVALUATED_FRACTION = 2 / 3
 
 
 async def _gold_ids(
@@ -255,13 +267,24 @@ async def _async_main(argv: list[str] | None = None) -> int:
           f"(floor for --strict: {_TOP10_FLOOR})")
     print("=" * 80)
 
-    if args.strict and (n3 < _TOP3_FLOOR or n10 < _TOP10_FLOOR):
-        print(
-            f"\nREGRESSION: TOP-3={n3}/{n} (need >={_TOP3_FLOOR}) "
-            f"or TOP-10={n10}/{n} (need >={_TOP10_FLOOR})",
-            file=sys.stderr,
-        )
-        return 1
+    if args.strict:
+        min_evaluated = int(len(PROBES) * _MIN_EVALUATED_FRACTION + 0.999)
+        if n < min_evaluated:
+            print(
+                f"\nCOVERAGE REGRESSION: only {n} of {len(PROBES)} probes "
+                f"found gold in the corpus (need >={min_evaluated}). "
+                f"Likely a corpus refresh has stale gold_fragments — "
+                f"update the probes to match new content.",
+                file=sys.stderr,
+            )
+            return 1
+        if n3 < _TOP3_FLOOR or n10 < _TOP10_FLOOR:
+            print(
+                f"\nRANKING REGRESSION: TOP-3={n3}/{n} (need >={_TOP3_FLOOR}) "
+                f"or TOP-10={n10}/{n} (need >={_TOP10_FLOOR})",
+                file=sys.stderr,
+            )
+            return 1
     return 0
 
 

--- a/nous_eval/probes/arch_query.py
+++ b/nous_eval/probes/arch_query.py
@@ -1,0 +1,273 @@
+"""Architectural-query retrieval regression probe.
+
+Origin (2026-05-02): the F051 aggregate metrics (MRR / P@1 / R@10) on
+the prod-snapshot qrels look healthy (0.828 / 0.778 / 0.922). But
+during a separate context-packing investigation it appeared that
+"tell me about X system" queries surfaced operational chatter instead
+of foundational facts. A v1 ad-hoc probe seemed to confirm the issue
+(rank 64-115 for foundational facts).
+
+After hand-curating the gold IDs properly, the apparent regression
+turned out to be a probe artifact — actual retrieval is healthy on
+these queries: 4/6 TOP-1, 5/6 TOP-3, 6/6 TOP-10. The CE rerank
+window (default 30) is sufficient.
+
+This regression probe locks that finding in. If a future change
+silently degrades architectural-query retrieval, this probe catches
+it. The 6 probes were chosen because they exercise:
+  - Feature-prefix queries ("F034", "F040", "F012", "F011")
+  - Concept queries ("rubric evolver", "cognitive loop")
+  - System-summary queries ("heartbeat system", "cognitive loop")
+
+Run:
+    NOUS_EVAL_DB_NAME=nous_eval_scratch \
+    NOUS_EVAL_AGENT_ID=nous-prod-snapshot \
+      uv run python -m nous_eval.probes.arch_query
+
+Exit code:
+    0 — TOP-3 hit rate >= 0.66 (4 of 6) AND TOP-10 hit rate == 1.0
+    1 — regression detected
+    2 — env / setup error
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from dataclasses import dataclass
+from uuid import UUID
+
+import asyncpg
+
+from nous.brain.brain import Brain
+from nous.brain.embeddings import EmbeddingProvider
+from nous.config import Settings
+from nous.heart.heart import Heart
+from nous.storage.database import Database
+from nous_eval.config import EvalSettings
+from nous_eval.retrieval_runner import _settings_for_eval_db
+
+
+@dataclass(frozen=True)
+class ArchProbe:
+    """One probe: a query + content fragments that ANY foundational fact
+    answering it should contain."""
+
+    query: str
+    gold_fragments: tuple[str, ...]
+
+
+# Hand-curated probes against agent_id=nous-prod-snapshot. If the
+# corpus snapshot is regenerated and a fragment no longer matches,
+# the probe will SKIP that scenario (won't fail loud) — but the
+# headline TOP-3 / TOP-10 totals will drop, which is the load-bearing
+# regression signal.
+PROBES: tuple[ArchProbe, ...] = (
+    ArchProbe(
+        query="Tell me about the heartbeat system.",
+        gold_fragments=(
+            "F034 Heartbeat system",
+            "F034 Heartbeat — Full Implementation",
+            "F034 proactive monitoring",
+        ),
+    ),
+    ArchProbe(
+        query="How does graph densification work?",
+        gold_fragments=(
+            "F040 Graph Densification spec",
+            "graph densification — orphan backfill",
+            "Graph densification: orphan backfill",
+        ),
+    ),
+    ArchProbe(
+        query="What does the rubric evolver do?",
+        gold_fragments=(
+            "Self-Modifying Evaluation Rubrics",
+            "RubricEvolver",
+            "F024-3b",
+        ),
+    ),
+    ArchProbe(
+        query="How are procedures created automatically?",
+        gold_fragments=(
+            "F012 K-Line Learning is shipped",
+            "F012 K-line procedure learning",
+            "auto-creates procedures from",
+        ),
+    ),
+    ArchProbe(
+        query="How do skills get registered in Nous?",
+        gold_fragments=(
+            "Skills in Nous are learned/registered at runtime",
+            "learn_skill tool for registering skills",
+            "skills system uses SKILL.md format",
+        ),
+    ),
+    ArchProbe(
+        query="Tell me about the cognitive loop.",
+        gold_fragments=(
+            "Sense\u2192Frame\u2192Recall\u2192Deliberate\u2192Act\u2192Monitor\u2192Learn",
+            "Sense, Frame, Recall, Deliberate",
+            "cognitive loop (Sense",
+        ),
+    ),
+)
+
+
+# Regression thresholds (informed by 2026-05-02 baseline of 4/6 TOP-1,
+# 5/6 TOP-3, 6/6 TOP-10). Set with one-scenario headroom so a single
+# scenario flake doesn't break CI.
+_TOP3_FLOOR = 4   # was 5/6 baseline
+_TOP10_FLOOR = 5  # was 6/6 baseline
+
+
+async def _gold_ids(
+    raw_conn: asyncpg.Connection, agent_id: str, fragments: tuple[str, ...],
+) -> set[UUID]:
+    """Return all fact IDs whose content matches ANY fragment."""
+    ids: set[UUID] = set()
+    for frag in fragments:
+        rows = await raw_conn.fetch(
+            "SELECT id FROM heart.facts "
+            "WHERE agent_id = $1 AND active = true AND content ILIKE $2",
+            agent_id, f"%{frag}%",
+        )
+        ids.update(r["id"] for r in rows)
+    return ids
+
+
+async def run(
+    eval_settings: EvalSettings,
+    main_settings: Settings,
+    *,
+    print_per_scenario: bool = True,
+) -> tuple[int, int, int, int]:
+    """Run all probes; return (n_evaluated, n_top1, n_top3, n_top10)."""
+    settings = _settings_for_eval_db(eval_settings, main_settings).model_copy(
+        update={"agent_id": eval_settings.agent_id}
+    )
+
+    db = Database(settings)
+    await db.connect()
+    embedder = EmbeddingProvider(
+        api_key=settings.openai_api_key,
+        model=settings.embedding_model,
+        dimensions=settings.embedding_dimensions,
+    )
+    heart = Heart(database=db, settings=settings,
+                  embedding_provider=embedder, owns_embeddings=False)
+    brain = Brain(database=db, settings=settings, embedding_provider=embedder)
+
+    raw_conn = await asyncpg.connect(
+        host=eval_settings.db_host, port=eval_settings.db_port,
+        user=eval_settings.db_user, password=eval_settings.db_password,
+        database=eval_settings.db_name,
+    )
+
+    n_evaluated = n_top1 = n_top3 = n_top10 = 0
+
+    try:
+        async with heart, brain:
+            for probe in PROBES:
+                gold = await _gold_ids(raw_conn, eval_settings.agent_id,
+                                       probe.gold_fragments)
+                if not gold:
+                    if print_per_scenario:
+                        print(f"  [SKIP] {probe.query!r} — no gold in corpus")
+                    continue
+                n_evaluated += 1
+
+                results = await heart.recall(
+                    probe.query, limit=10, types=["fact"],
+                )
+                results = list(results or [])
+
+                first_rank: int | None = None
+                for i, r in enumerate(results, 1):
+                    if r.id in gold:
+                        first_rank = i
+                        break
+
+                if first_rank is None:
+                    marker = "FAIL"
+                elif first_rank == 1:
+                    n_top1 += 1
+                    n_top3 += 1
+                    n_top10 += 1
+                    marker = "TOP-1"
+                elif first_rank <= 3:
+                    n_top3 += 1
+                    n_top10 += 1
+                    marker = f"TOP-3 (#{first_rank})"
+                elif first_rank <= 10:
+                    n_top10 += 1
+                    marker = f"TOP-10 (#{first_rank})"
+                else:
+                    marker = f"OUTSIDE-10 (#{first_rank})"
+
+                if print_per_scenario:
+                    print(f"  [{marker}] {probe.query!r}")
+    finally:
+        await raw_conn.close()
+        await db.disconnect()
+
+    return n_evaluated, n_top1, n_top3, n_top10
+
+
+async def _async_main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description=("Architectural-query retrieval regression probe. "
+                     "Catches degradation on 'tell me about X' style queries "
+                     "that the F051 aggregate qrels underweight."),
+    )
+    p.add_argument(
+        "--strict", action="store_true",
+        help="Exit non-zero if TOP-3 < 4 or TOP-10 < 5 (regression floor).",
+    )
+    args = p.parse_args(argv)
+
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except (AttributeError, OSError):
+        pass
+
+    eval_settings = EvalSettings()
+    main_settings = Settings()
+
+    if not main_settings.openai_api_key:
+        print("ERROR: OPENAI_API_KEY required for embeddings.", file=sys.stderr)
+        return 2
+
+    print()
+    print("=" * 80)
+    print(f"ARCH-QUERY REGRESSION PROBE — agent_id={eval_settings.agent_id}")
+    print("=" * 80)
+
+    n, n1, n3, n10 = await run(eval_settings, main_settings)
+
+    print()
+    print("=" * 80)
+    print(f"SUMMARY (n={n})")
+    print(f"  TOP-1:  {n1}/{n} ({100*n1/max(n,1):.0f}%)")
+    print(f"  TOP-3:  {n3}/{n} ({100*n3/max(n,1):.0f}%)  "
+          f"(floor for --strict: {_TOP3_FLOOR})")
+    print(f"  TOP-10: {n10}/{n} ({100*n10/max(n,1):.0f}%)  "
+          f"(floor for --strict: {_TOP10_FLOOR})")
+    print("=" * 80)
+
+    if args.strict and (n3 < _TOP3_FLOOR or n10 < _TOP10_FLOOR):
+        print(
+            f"\nREGRESSION: TOP-3={n3}/{n} (need >={_TOP3_FLOOR}) "
+            f"or TOP-10={n10}/{n} (need >={_TOP10_FLOOR})",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    return asyncio.run(_async_main(argv))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_arch_query_probe.py
+++ b/tests/test_arch_query_probe.py
@@ -14,6 +14,7 @@ import pytest
 
 from nous_eval.probes.arch_query import (
     PROBES,
+    _MIN_EVALUATED_FRACTION,
     _TOP3_FLOOR,
     _TOP10_FLOOR,
     ArchProbe,
@@ -95,6 +96,24 @@ async def test_gold_ids_unions_across_fragments():
 
     ids = await _gold_ids(raw_conn, "test-agent", ("foo", "bar"))
     assert ids == {fact_id_a, fact_id_b, fact_id_c}
+
+
+def test_min_evaluated_fraction_blocks_corpus_drift_attack():
+    """The coverage floor must require at least 2/3 of probes to match
+    real gold. Without it, a corpus refresh could silently turn 6
+    probes into 1 evaluated probe and the TOP-3 / TOP-10 floors would
+    pass trivially (since 1/1 = 100%)."""
+    n_probes = len(PROBES)
+    min_required = int(n_probes * _MIN_EVALUATED_FRACTION + 0.999)
+    # Sanity: at least 4 of 6 must still match — leaves headroom for
+    # one or two scenarios going stale before failing loud.
+    assert min_required >= 4, (
+        f"Coverage floor is too low ({min_required}/{n_probes}) — "
+        f"a single stale fragment could mask all regressions."
+    )
+    assert min_required <= n_probes, (
+        f"Coverage floor is unreachable ({min_required} > {n_probes})."
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_arch_query_probe.py
+++ b/tests/test_arch_query_probe.py
@@ -1,0 +1,105 @@
+"""Tests for nous_eval.probes.arch_query.
+
+The probe itself needs a live eval DB to produce real numbers; these
+tests cover the probe-construction logic and gold-matching contract
+without booting a database. Mock-based for determinism.
+"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from nous_eval.probes.arch_query import (
+    PROBES,
+    _TOP3_FLOOR,
+    _TOP10_FLOOR,
+    ArchProbe,
+    _gold_ids,
+)
+
+
+def test_probes_are_well_formed():
+    """Every probe must have a non-empty query and at least one gold fragment."""
+    assert len(PROBES) >= 6
+    for probe in PROBES:
+        assert isinstance(probe, ArchProbe)
+        assert probe.query.strip()
+        assert len(probe.gold_fragments) >= 1
+        for frag in probe.gold_fragments:
+            assert isinstance(frag, str)
+            assert len(frag) >= 5  # not a trivial substring
+
+
+def test_probes_cover_distinct_query_classes():
+    """The 6 probes must exercise different query patterns — feature-prefix,
+    concept, system-summary — so the probe catches regressions across
+    classes, not just one."""
+    queries = [p.query.lower() for p in PROBES]
+    # System-summary "tell me about X"
+    assert any("tell me about" in q for q in queries), (
+        "missing system-summary probe ('tell me about X')"
+    )
+    # Capability "how does X work" / "how do X"
+    assert any(q.startswith("how ") for q in queries), (
+        "missing how-does-X-work probe"
+    )
+    # Concept query
+    assert any("what does" in q for q in queries), (
+        "missing what-does-X-do probe"
+    )
+
+
+def test_regression_floors_have_headroom():
+    """Floors should leave one-scenario headroom over baseline so a
+    single flake doesn't break CI. 2026-05-02 baseline: TOP-3 5/6,
+    TOP-10 6/6, so floors must be <= 4 and <= 5 respectively."""
+    n_probes = len(PROBES)
+    assert _TOP3_FLOOR <= n_probes - 1, (
+        f"TOP3 floor {_TOP3_FLOOR} leaves no headroom for {n_probes}-probe set"
+    )
+    assert _TOP10_FLOOR <= n_probes - 1, (
+        f"TOP10 floor {_TOP10_FLOOR} leaves no headroom for {n_probes}-probe set"
+    )
+
+
+@pytest.mark.asyncio
+async def test_gold_ids_unions_across_fragments():
+    """_gold_ids must return the UNION of fact IDs matching ANY fragment,
+    not the intersection. A foundational fact may match only one of
+    several phrasings of the gold answer."""
+    fact_id_a = uuid4()
+    fact_id_b = uuid4()
+    fact_id_c = uuid4()
+
+    # Mock: fragment "foo" matches A,B; fragment "bar" matches B,C.
+    # Union must include {A, B, C}.
+    rows_by_fragment = {
+        "%foo%": [
+            MagicMock(__getitem__=lambda self, k: fact_id_a),
+            MagicMock(__getitem__=lambda self, k: fact_id_b),
+        ],
+        "%bar%": [
+            MagicMock(__getitem__=lambda self, k: fact_id_b),
+            MagicMock(__getitem__=lambda self, k: fact_id_c),
+        ],
+    }
+
+    raw_conn = MagicMock()
+
+    async def _fetch(_sql, _agent_id, fragment):
+        return rows_by_fragment.get(fragment, [])
+    raw_conn.fetch = AsyncMock(side_effect=_fetch)
+
+    ids = await _gold_ids(raw_conn, "test-agent", ("foo", "bar"))
+    assert ids == {fact_id_a, fact_id_b, fact_id_c}
+
+
+@pytest.mark.asyncio
+async def test_gold_ids_empty_when_no_fragment_matches():
+    raw_conn = MagicMock()
+    raw_conn.fetch = AsyncMock(return_value=[])
+    ids = await _gold_ids(raw_conn, "test-agent", ("nonexistent-fragment",))
+    assert ids == set()


### PR DESCRIPTION
## Summary
- Adds `nous_eval.probes.arch_query` — a 6-scenario regression probe for "tell me about X" / "how does X work" / "what does X do" queries.
- Catches degradation that would slip past F051's aggregate qrels (which weight specific-fact lookups over architectural questions).
- Run with `--strict` for CI: exit 1 if TOP-3 < 4 or TOP-10 < 5 (one-scenario headroom over today's baseline).

## Origin (a debugging cautionary tale)
A context-packing investigation seemed to show operational chatter outranking foundational facts ("F034 Heartbeat" buried at hybrid rank 64; "Sense→Frame→Recall" cognitive loop summary at rank 115). I tested two candidate fixes:

| Fix | Arch-query lift | F051 regression |
|---|---|---|
| `vector_weight=0.85` (from 0.7) | none — actually slightly worse on cognitive_loop (115 → 135) | none (identical metrics) |
| `ce_max_candidates=100` (from 30) | hand-eyed wins on heartbeat (top-1 became foundational) | none (identical metrics) |

Both produced **identical F051 metrics** (MRR 0.828, P@1 0.778, R@10 0.922). The arch-query "regression" turned out to be a **probe v1 artifact** — the auto-gold-finder (shortest content match) prefers operational counter facts over longer foundational summaries.

After hand-curating gold IDs, **actual architectural retrieval is healthy**:
| metric | result |
|---|---|
| TOP-1 | 4/6 (67%) |
| TOP-3 | 5/6 (83%) |
| TOP-10 | 6/6 (100%) |

This PR locks that finding into a regression test so the next investigation doesn't chase the same phantom.

## What it covers
6 probes spanning distinct query classes (test-asserted):
- Feature-prefix: F011, F012, F034, F040
- Concept: rubric evolver, cognitive loop
- System-summary: heartbeat system, cognitive loop

## Test plan
- [x] 5 mock-based unit tests in `tests/test_arch_query_probe.py` (probe well-formedness, query-class diversity, regression-floor headroom, gold-ID union semantics)
- [x] Live probe runs end-to-end against `nous_eval_scratch` — passes with `--strict`
- [x] No production code touched; eval-only addition

## Related
Sibling of #398 (heart cascade rollback), #399 (eval-DB schema preflight), #400 (packing scenario buckets) — all part of the eval-framework hardening surfaced by today's investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)