### PR TITLE
fix(sleep): unblock 3 silently-broken sleep phases

### DIFF
--- a/nous/config.py
+++ b/nous/config.py
@@ -105,6 +105,30 @@ class Settings(BaseSettings):
     staleness_penalty_enabled: bool = True
     staleness_half_life_days: int = 30
 
+    # Sleep-cycle stale_scan phase: deactivate facts that are old AND
+    # never recalled. Prior filter (active=true AND superseded_by IS NOT NULL
+    # AND confidence < 0.5) was structurally impossible — the supersede flow
+    # already deactivates at the same time, and prod confidence distribution
+    # never goes below 0.7. New filter targets the actual stale-fact pattern.
+    stale_scan_age_days: int = 60
+    # Categories excluded from stale_scan. `rule` represents explicit user
+    # directives that may be infrequently exercised but still in force —
+    # deactivating them on recall stats alone is unsafe.
+    stale_scan_excluded_categories: list[str] = Field(
+        default_factory=lambda: ["rule"]
+    )
+
+    # Sleep-cycle cluster_consolidation phase (F027): merge near-duplicate
+    # facts under the same subject into one. Prior code picked top-5 clusters
+    # by size, but prod has accumulating subjects like `lesson_learned`
+    # (164 facts) and `Tim` (36 facts) at the top — the LLM correctly
+    # refuses to merge those, leaving the 11 actually-mergeable small
+    # clusters (3-5 facts each) untouched.
+    # Cap cluster size so accumulating subjects are skipped and small
+    # mergeable clusters get a chance.
+    cluster_consolidation_min_facts: int = 3
+    cluster_consolidation_max_facts: int = 10
+
     # F025 P2-C: Transcript truncation limit for episode summarization
     transcript_max_chars: int = 16000
 
@@ -437,6 +461,13 @@ class Settings(BaseSettings):
     procedure_max_per_session: int = 1
     procedure_staleness_days: int = 30
     procedure_weakness_threshold: float = 0.30
+    # Recency gate for cluster eligibility — at least one cluster member
+    # must be created within this window. Was hardcoded 7 days; sleep
+    # cycle health monitor (PR #404) caught that 7 days yielded 3 of 200
+    # eligible candidates, so most clusters never satisfied the gate.
+    # 30 days gives ~71 of 200, making the gate meaningful instead of
+    # blocking.
+    procedure_recency_days: int = 30
 
     # F037: Utility-Boosted Procedure Retrieval
     procedure_utility_boost: bool = True

--- a/nous/handlers/procedure_learner.py
+++ b/nous/handlers/procedure_learner.py
@@ -343,8 +343,16 @@ class ProcedureLearner:
         return rate >= self._settings.procedure_success_rate_min
 
     def _check_recency(self, items: list[Any]) -> bool:
-        """Gate: at least 1 item created in the last 7 days."""
-        cutoff = datetime.now(UTC) - timedelta(days=7)
+        """Gate: at least 1 cluster member created within the recency window.
+
+        Configurable via ``procedure_recency_days`` (default 30). Was
+        hardcoded 7 days; sleep-cycle health monitor (PR #404) caught
+        that 7 days produced ~3 of 200 eligible candidates, so the
+        gate effectively blocked all clustering. 30 days gives a
+        meaningful pool.
+        """
+        days = self._settings.procedure_recency_days
+        cutoff = datetime.now(UTC) - timedelta(days=days)
         for item in items:
             created_at = getattr(item, "created_at", None)
             if created_at and created_at >= cutoff:

--- a/nous/handlers/sleep_handler.py
+++ b/nous/handlers/sleep_handler.py
@@ -820,7 +820,7 @@ class SleepHandler:
             return False
 
     async def _phase_stale_scan(self, sleep_stats: dict) -> bool:
-        """Deactivate facts that are old AND never recalled.
+        """Deactivate facts that are old AND have not been recalled recently.
 
         Original filter combined ``active=true`` with
         ``superseded_by IS NOT NULL`` — that intersection is empty by
@@ -829,11 +829,17 @@ class SleepHandler:
         produced 0 deactivations across 14 consecutive prod cycles.
 
         New filter targets the actual stale-fact failure mode: a fact
-        the agent stored, never used (recall_count == 0), and that has
-        aged past ``stale_scan_age_days`` (default 60). The ``rule``
-        category is excluded by default since rules represent explicit
-        user directives that may be infrequently exercised but still
-        in force; deactivating them on recall stats alone is unsafe.
+        that has aged past ``stale_scan_age_days`` (default 60) AND
+        has either NEVER been recalled or wasn't recalled within the
+        same age window. The OR on the recall side is load-bearing:
+        a ``recall_count == 0`` only filter would permanently exempt
+        facts recalled once years ago and never since — the same
+        silent-failure pattern the original code had in reverse.
+
+        The ``rule`` category is excluded by default since rules
+        represent explicit user directives that may be infrequently
+        exercised but still in force; deactivating them on recall
+        stats alone is unsafe.
         """
         try:
             settings = self._heart.settings
@@ -847,9 +853,11 @@ class SleepHandler:
                     .where(
                         Fact.agent_id == self._heart.agent_id,
                         Fact.active == True,  # noqa: E712
-                        Fact.last_recalled_at.is_(None),
-                        Fact.recall_count == 0,
                         Fact.created_at < cutoff,
+                    )
+                    .where(
+                        (Fact.last_recalled_at.is_(None))
+                        | (Fact.last_recalled_at < cutoff)
                     )
                 )
                 if excluded:
@@ -868,7 +876,8 @@ class SleepHandler:
                 sleep_stats["stale_deactivated"] = count
                 logger.info(
                     "Stale scan: deactivated %d facts older than %d days "
-                    "with recall_count=0 (excluded categories: %s)",
+                    "with no recall in the same window "
+                    "(excluded categories: %s)",
                     count, settings.stale_scan_age_days, excluded,
                 )
             return True

--- a/nous/handlers/sleep_handler.py
+++ b/nous/handlers/sleep_handler.py
@@ -820,23 +820,40 @@ class SleepHandler:
             return False
 
     async def _phase_stale_scan(self, sleep_stats: dict) -> bool:
-        """F027: Deactivate superseded facts that are stale and low-confidence."""
+        """Deactivate facts that are old AND never recalled.
+
+        Original filter combined ``active=true`` with
+        ``superseded_by IS NOT NULL`` — that intersection is empty by
+        design because the supersede flow sets both at the same time.
+        Sleep cycle health monitor (PR #404) caught this: the phase
+        produced 0 deactivations across 14 consecutive prod cycles.
+
+        New filter targets the actual stale-fact failure mode: a fact
+        the agent stored, never used (recall_count == 0), and that has
+        aged past ``stale_scan_age_days`` (default 60). The ``rule``
+        category is excluded by default since rules represent explicit
+        user directives that may be infrequently exercised but still
+        in force; deactivating them on recall stats alone is unsafe.
+        """
         try:
+            settings = self._heart.settings
+            cutoff = datetime.now(UTC) - timedelta(
+                days=settings.stale_scan_age_days
+            )
+            excluded = list(settings.stale_scan_excluded_categories or [])
             async with self._heart.db.session() as session:
-                cutoff = datetime.now(UTC) - timedelta(days=30)
                 stmt = (
                     select(Fact)
                     .where(
                         Fact.agent_id == self._heart.agent_id,
                         Fact.active == True,  # noqa: E712
-                        Fact.superseded_by.isnot(None),
-                        Fact.confidence < 0.5,
-                    )
-                    .where(
-                        (Fact.last_recalled_at.is_(None))
-                        | (Fact.last_recalled_at < cutoff)
+                        Fact.last_recalled_at.is_(None),
+                        Fact.recall_count == 0,
+                        Fact.created_at < cutoff,
                     )
                 )
+                if excluded:
+                    stmt = stmt.where(Fact.category.notin_(excluded))
                 result = await session.execute(stmt)
                 stale_facts = result.scalars().all()
 
@@ -849,19 +866,35 @@ class SleepHandler:
                     await session.commit()
 
                 sleep_stats["stale_deactivated"] = count
-                logger.info("F027 stale scan: deactivated %d stale superseded facts", count)
+                logger.info(
+                    "Stale scan: deactivated %d facts older than %d days "
+                    "with recall_count=0 (excluded categories: %s)",
+                    count, settings.stale_scan_age_days, excluded,
+                )
             return True
         except Exception:
-            logger.warning("F027 stale scan phase failed", exc_info=True)
+            logger.warning("stale_scan phase failed", exc_info=True)
             return False
 
     async def _phase_cluster_consolidation(self, sleep_stats: dict) -> bool:
-        """F027: Merge clusters of 3+ active facts about the same subject."""
+        """F027: Merge clusters of MIN-MAX active facts about the same subject.
+
+        Prior code picked top-5 by size, which always landed on
+        accumulating subjects like ``lesson_learned`` (164 facts) and
+        ``Tim`` (36 facts) — the LLM correctly refuses to collapse those
+        into a single fact. Sleep cycle health monitor (PR #404) caught
+        this: 14 consecutive prod cycles merged 0 clusters. Cap the
+        cluster size so accumulating subjects are skipped and the
+        actually-mergeable small clusters (3-10 facts) get a chance.
+        """
         if not self._llm:
             return True
         try:
+            settings = self._heart.settings
+            min_facts = settings.cluster_consolidation_min_facts
+            max_facts = settings.cluster_consolidation_max_facts
             async with self._heart.db.session() as session:
-                # Find subjects with 3+ active facts
+                # Find subjects with min_facts <= count <= max_facts active facts
                 stmt = (
                     select(Fact.subject, func.count().label("cnt"))
                     .where(
@@ -870,7 +903,8 @@ class SleepHandler:
                         Fact.subject.isnot(None),
                     )
                     .group_by(Fact.subject)
-                    .having(func.count() >= 3)
+                    .having(func.count() >= min_facts)
+                    .having(func.count() <= max_facts)
                     .order_by(func.count().desc())
                     .limit(5)
                 )

--- a/tests/test_f027_supersession.py
+++ b/tests/test_f027_supersession.py
@@ -391,6 +391,14 @@ class TestPhaseStaleScam:
         bus = MagicMock()
         bus.on = MagicMock()
         handler = SleepHandler(brain, heart, settings, bus, llm_client=None)
+        # _phase_stale_scan reads settings off heart (not the handler's
+        # injected settings) — supply numeric/list values explicitly
+        # because MagicMock attribute access returns a MagicMock, which
+        # breaks `timedelta(days=...)` and `notin_(...)`.
+        heart.settings.stale_scan_age_days = 60
+        heart.settings.stale_scan_excluded_categories = ["rule"]
+        heart.settings.cluster_consolidation_min_facts = 3
+        heart.settings.cluster_consolidation_max_facts = 10
         return handler, heart
 
     @pytest.mark.asyncio

--- a/tests/test_procedure_learner.py
+++ b/tests/test_procedure_learner.py
@@ -49,6 +49,10 @@ def _make_settings(**overrides) -> MagicMock:
         procedure_max_per_session=1,
         procedure_staleness_days=30,
         procedure_weakness_threshold=0.30,
+        # Added in PR #405 — _check_recency reads this; was hardcoded
+        # 7 days, bumped to configurable default 30. Mock must supply
+        # an int because timedelta(days=MagicMock()) crashes.
+        procedure_recency_days=30,
         background_model="claude-test",
         api_base_url="https://api.anthropic.com",
         anthropic_api_key="sk-ant-test-key",

--- a/tests/test_sleep_phase_fixes.py
+++ b/tests/test_sleep_phase_fixes.py
@@ -121,3 +121,41 @@ def test_recency_gate_handles_missing_created_at():
 def test_recency_gate_returns_false_on_empty_cluster():
     learner = _make_learner(recency_days=30)
     assert learner._check_recency([]) is False
+
+
+# ---------------------------------------------------------------------------
+# stale_scan filter design — verify the OR-on-recall semantics
+# ---------------------------------------------------------------------------
+
+
+def test_stale_scan_filter_uses_or_on_recall():
+    """The new filter must use OR on the recall side
+    (``last_recalled_at IS NULL OR last_recalled_at < cutoff``). A
+    ``recall_count == 0``-only filter would permanently exempt facts
+    recalled once years ago and never since — same silent-failure
+    pattern the original code had in reverse. Reviewer flagged this
+    on PR #405; verify the source contains the OR semantics rather
+    than the exclude-on-recall_count semantics.
+    """
+    import inspect
+
+    from nous.handlers.sleep_handler import SleepHandler
+
+    src = inspect.getsource(SleepHandler._phase_stale_scan)
+
+    # Filter must check both NULL and <cutoff (the OR branches).
+    assert "last_recalled_at.is_(None)" in src, (
+        "stale_scan filter must check last_recalled_at IS NULL"
+    )
+    assert "last_recalled_at < cutoff" in src, (
+        "stale_scan filter must also check last_recalled_at < cutoff "
+        "so facts recalled long-ago-and-never-again get caught"
+    )
+    # The bug-flagged version used recall_count == 0 as a hard gate.
+    # New version must not gate on recall_count in a SQLAlchemy where().
+    # (The string `recall_count` may legitimately appear in docstring
+    # text describing the bug, so check the SQL clause shape instead.)
+    assert "Fact.recall_count == 0" not in src, (
+        "stale_scan filter must NOT gate on recall_count == 0 — "
+        "facts recalled once long ago would be permanently exempted"
+    )

--- a/tests/test_sleep_phase_fixes.py
+++ b/tests/test_sleep_phase_fixes.py
@@ -1,0 +1,123 @@
+"""Tests for the 3 silently-broken sleep phases fixed after PR #404
+discovered them (stale_scan / cluster_consolidation / procedures).
+
+These tests focus on the *specific failure modes* the prod-data
+analysis identified:
+
+  - stale_scan filtered ``active=true AND superseded_by IS NOT NULL``
+    which is empty by design (the supersede flow deactivates).
+  - cluster_consolidation picked top-5 by size, always landing on
+    accumulating subjects (lesson_learned 164, Tim 36) the LLM
+    correctly refused to merge into one fact.
+  - procedure_learner._check_recency hardcoded a 7-day cutoff —
+    only 3 of 200 eligible decisions fell in that window in prod.
+
+All tests mock the DB / LLM layer; the assertions are about the
+filter / threshold logic, not Postgres semantics.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from nous.config import Settings
+from nous.handlers.procedure_learner import ProcedureLearner
+
+
+# ---------------------------------------------------------------------------
+# Settings — verify the new knobs exist with the documented defaults
+# ---------------------------------------------------------------------------
+
+
+def test_stale_scan_settings_have_safe_defaults():
+    s = Settings()
+    assert s.stale_scan_age_days == 60
+    assert "rule" in s.stale_scan_excluded_categories, (
+        "rule category MUST be excluded by default — rules are user "
+        "directives that may be infrequently exercised but still in "
+        "force; deactivating them on recall stats alone is unsafe."
+    )
+
+
+def test_cluster_consolidation_settings_skip_accumulating_subjects():
+    s = Settings()
+    assert s.cluster_consolidation_min_facts == 3
+    assert s.cluster_consolidation_max_facts == 10, (
+        "max_facts MUST cap at a small number — prod has subjects with "
+        "164 / 36 facts that are accumulating logs (lesson_learned, "
+        "Tim) which the LLM correctly refuses to merge into one."
+    )
+
+
+def test_procedure_recency_window_is_meaningful():
+    s = Settings()
+    # 30 days is the minimum that gives a non-trivial candidate pool
+    # given prod's ~8 successful-reviewed-with-bridge decisions per week.
+    assert s.procedure_recency_days >= 14, (
+        f"procedure_recency_days={s.procedure_recency_days} too tight; "
+        f"prod data shows 7-day window yielded 3 of 200 eligible "
+        f"decisions, blocking the recency gate."
+    )
+
+
+# ---------------------------------------------------------------------------
+# ProcedureLearner._check_recency — actual behavior with the new knob
+# ---------------------------------------------------------------------------
+
+
+def _make_learner(recency_days: int) -> ProcedureLearner:
+    """Build a ProcedureLearner with just enough wiring to exercise
+    _check_recency (which only reads self._settings)."""
+    settings = Settings(procedure_recency_days=recency_days)
+    learner = ProcedureLearner.__new__(ProcedureLearner)
+    learner._settings = settings
+    return learner
+
+
+def test_recency_gate_passes_when_member_within_window():
+    learner = _make_learner(recency_days=30)
+    now = datetime.now(UTC)
+    items = [
+        SimpleNamespace(created_at=now - timedelta(days=200)),  # ancient
+        SimpleNamespace(created_at=now - timedelta(days=15)),   # within 30d
+    ]
+    assert learner._check_recency(items) is True
+
+
+def test_recency_gate_rejects_when_all_outside_window():
+    learner = _make_learner(recency_days=30)
+    now = datetime.now(UTC)
+    items = [
+        SimpleNamespace(created_at=now - timedelta(days=60)),
+        SimpleNamespace(created_at=now - timedelta(days=45)),
+    ]
+    assert learner._check_recency(items) is False
+
+
+def test_recency_gate_respects_settings_window():
+    """The hardcoded 7-day window was the bug. Verify the gate now
+    respects the setting — passing 7 days should still reject items
+    that are 15 days old, while 30 days should accept them."""
+    now = datetime.now(UTC)
+    items = [SimpleNamespace(created_at=now - timedelta(days=15))]
+    # 7-day window → reject (the old behavior)
+    assert _make_learner(7)._check_recency(items) is False
+    # 30-day window → accept (the new default)
+    assert _make_learner(30)._check_recency(items) is True
+
+
+def test_recency_gate_handles_missing_created_at():
+    """A cluster member with no timestamp must not crash the gate."""
+    learner = _make_learner(recency_days=30)
+    items = [
+        SimpleNamespace(created_at=None),
+        SimpleNamespace(),  # no attribute at all
+        SimpleNamespace(created_at=datetime.now(UTC) - timedelta(days=2)),
+    ]
+    assert learner._check_recency(items) is True
+
+
+def test_recency_gate_returns_false_on_empty_cluster():
+    learner = _make_learner(recency_days=30)
+    assert learner._check_recency([]) is False


### PR DESCRIPTION
## Summary
Fixes the 3 silently-broken sleep phases discovered by the sleep cycle health monitor (PR #404).

| Phase | Before | After (expected) |
|---|---|---|
| **stale_scan** | 0/14 cycles (filter structurally impossible) | Activates when corpus has >60-day never-recalled facts |
| **cluster_consolidation** | 0/14 cycles (always picks accumulating subjects too big to merge) | Picks small mergeable clusters (3-10 facts); ~1-3 merges per cycle expected |
| **procedures** (F012) | 0/14 cycles (7-day recency gate yields ~3 of 200 candidates) | 30-day window yields ~71 of 200; gate becomes meaningful filter not a block |

## Root causes (from prod-data analysis)

### stale_scan — old filter was empty by design
Filter: `active=true AND superseded_by IS NOT NULL AND confidence < 0.5`
- Supersede flow deactivates AND sets the link in the same transaction, so `active=true AND superseded_by IS NOT NULL` is always 0 rows.
- `confidence < 0.5` matches 0 rows in prod (min observed confidence is 0.70, mean 0.91).

New filter: never-recalled facts older than 60 days, excluding `rule` category (user directives shouldn't be auto-deactivated on recall stats).

### cluster_consolidation — picked the wrong clusters every time
Old: `HAVING count >= 3 ORDER BY count DESC LIMIT 5` always landed on accumulating subjects (`lesson_learned` 164 facts, `Tim` 36 facts). LLM correctly refused to merge those into one fact. The 11 actually-mergeable small clusters never got a chance.

New: `HAVING count BETWEEN 3 AND 10` — caps cluster size so accumulating subjects skip and small mergeable clusters surface.

### procedure_learner._check_recency — 7-day window too tight
Hardcoded `cutoff = now - 7 days`. Of 200 successful-reviewed-with-bridge prod decisions, only 3 fall in the last 7 days. For a cluster to satisfy the gate it had to contain one of those 3 — vanishingly rare.

Made configurable via `procedure_recency_days` (default 30). 30-day window yields ~71 of 200 candidates eligible.

## New settings (all safe defaults)
```
stale_scan_age_days: int = 60
stale_scan_excluded_categories: list[str] = ["rule"]
cluster_consolidation_min_facts: int = 3
cluster_consolidation_max_facts: int = 10
procedure_recency_days: int = 30
```

## Verification
After deploy, re-run `nous_eval.probes.sleep_cycle_health`. Expected:
- cluster_consolidation: 1-3 merges per cycle → GREEN
- procedures: 0-3 procedures per cycle → GREEN
- stale_scan: still 0 short-term (corpus too young; oldest fact 2026-02-24), will activate as it ages → YELLOW until then

## Test plan
- [x] 8 mock-based unit tests in `tests/test_sleep_phase_fixes.py`
- [x] Settings() parses cleanly with new fields
- [x] All test logic verified against prod-data analysis

## Related
Acts on findings from PR #404. Closes the loop on the eval-tooling-hardening series — the eval found the bugs; this PR fixes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)