### PR TITLE
fix: align stale_scan primary query with NULL-aware exclusion (Codex on #408)

### DIFF
--- a/nous_eval/probes/sleep_filter_dryrun.py
+++ b/nous_eval/probes/sleep_filter_dryrun.py
@@ -146,7 +146,15 @@ async def check_stale_scan(
     params: list = [agent_id, age_days]
     if excluded:
         placeholders = ", ".join(f"${i + 3}" for i in range(len(excluded)))
-        excluded_clause = f"AND category NOT IN ({placeholders})"
+        # Mirror the production filter's NULL handling — `NOT IN`
+        # alone evaluates UNKNOWN for NULL-category rows, silently
+        # excluding them. The fallback `truly_stale` counts already
+        # do this; the primary query must too or the probe will
+        # false-RED on corpora where stale facts are uncategorized.
+        # Codex P1 on PR #408.
+        excluded_clause = (
+            f"AND (category IS NULL OR category NOT IN ({placeholders}))"
+        )
         params.extend(excluded)
     sql = f"""
         SELECT id, content, category, created_at

--- a/tests/test_sleep_filter_dryrun_probe.py
+++ b/tests/test_sleep_filter_dryrun_probe.py
@@ -129,6 +129,27 @@ async def test_stale_scan_red_when_stale_facts_exist_but_filter_selects_zero():
     assert "17 stale facts exist" in result.verdict_reason or "12" in result.verdict_reason
 
 
+def test_stale_scan_primary_query_uses_null_aware_exclusion():
+    """Codex P1 on PR #408: the primary candidate query and the
+    fallback truly_stale counts must apply the same NULL-aware
+    category exclusion. Without symmetry, NULL-category stale facts
+    are excluded from the primary count (because `NOT IN (...)`
+    evaluates UNKNOWN on NULL) but included in fallback truly_stale,
+    causing a false RED verdict.
+    """
+    import inspect
+
+    from nous_eval.probes import sleep_filter_dryrun
+
+    src = inspect.getsource(sleep_filter_dryrun.check_stale_scan)
+    # The primary excluded_clause must match the fallback excl_clause:
+    # both should include `IS NULL OR category NOT IN`.
+    assert src.count("category IS NULL OR category NOT IN") >= 2, (
+        "primary candidate query and fallback truly_stale queries "
+        "must both use NULL-aware category exclusion"
+    )
+
+
 @pytest.mark.asyncio
 async def test_stale_scan_green_when_filter_selects_candidates():
     conn = _make_conn(


### PR DESCRIPTION
## Summary
Codex follow-up on the hotfix bundle (#408). I fixed the **fallback** truly_stale counts in `check_stale_scan` to use `category IS NULL OR category NOT IN (...)` matching the production filter PR #405/#408 changed in `sleep_handler`. But I left the **primary** candidate query with the original `category NOT IN (...)` — same SQL UNKNOWN bug just relocated.

## Asymmetry consequence

A corpus where stale facts happen to be uncategorized:
- primary query selects 0 (NULL excluded by SQL UNKNOWN)
- fallback truly_stale > 0 (correctly handles NULL after PR #408)
- verdict = false RED ("filter broken") — even though the production filter (which now handles NULL after #408 deploys) would correctly select and deactivate those rows

The fix is one symmetric predicate. Test pins the symmetry by asserting the source contains the NULL-aware clause at least twice.

## Test plan
- [x] 13 tests pass (was 12 + 1 new for the symmetry assertion)
- [x] Live dry-run still works against snapshot

## Related
Codex review on PR #408. The original PR #408 found 5 issues across PRs #404–#407; that bundle introduced this symmetric asymmetry that Codex caught on the next round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)