### PR TITLE
fix(F031): preserve supersede chain on MERGE (Codex finding on PR #411)

### DIFF
--- a/nous/handlers/sleep_handler.py
+++ b/nous/handlers/sleep_handler.py
@@ -894,21 +894,56 @@ class SleepHandler:
                         # case); but keep a defensive check just in case.
                         if merged_content:
                             try:
-                                await self._heart.learn(FactInput(
-                                    subject=pair.get("subject", None),
-                                    content=merged_content,
-                                    source="contradiction_resolution",
-                                    confidence=0.8,
-                                    category=pair.get("category", None),
-                                ))
-                                await self._heart.deactivate_fact(fact1_id)
-                                await self._heart.deactivate_fact(fact2_id)
-                                sleep_stats["contradictions_resolved"] += 1
-                                sleep_stats["facts_created"] += 1
-                                logger.info(
-                                    "F031 resolve: MERGE — combined %s + %s into new fact (%.2f confidence)",
-                                    fact1_id, fact2_id, confidence,
+                                merged_detail = await self._heart.learn(
+                                    FactInput(
+                                        subject=pair.get("subject", None),
+                                        content=merged_content,
+                                        source="contradiction_resolution",
+                                        confidence=0.8,
+                                        category=pair.get("category", None),
+                                    )
                                 )
+                                # PR #411 follow-up (Codex P1): F031
+                                # MERGE used to discard the learn()
+                                # result and call deactivate_fact() on
+                                # both originals — leaving them
+                                # active=False with NO superseded_by
+                                # link. That orphaned every successful
+                                # MERGE's source facts (chain broken,
+                                # recoverable only via manual SQL).
+                                # Mirror F027's pattern: capture the
+                                # merged ID, set superseded_by AND
+                                # active=False on both originals in a
+                                # single transaction.
+                                if isinstance(merged_detail, FactRejected):
+                                    # contradiction_resolution is in
+                                    # bypass_sources so this should not
+                                    # happen, but defend in depth.
+                                    logger.warning(
+                                        "F031 MERGE: heart.learn rejected "
+                                        "the merged fact unexpectedly: %s",
+                                        merged_detail.explanation,
+                                    )
+                                else:
+                                    async with self._heart.db.session() as session:
+                                        for orig_id in (fact1_id, fact2_id):
+                                            orm_fact = await session.get(
+                                                Fact, orig_id
+                                            )
+                                            if orm_fact:
+                                                orm_fact.superseded_by = (
+                                                    merged_detail.id
+                                                )
+                                                orm_fact.active = False
+                                        await session.commit()
+                                    sleep_stats["contradictions_resolved"] += 1
+                                    sleep_stats["facts_created"] += 1
+                                    logger.info(
+                                        "F031 resolve: MERGE — combined %s + %s "
+                                        "into %s (%.2f confidence)",
+                                        fact1_id, fact2_id,
+                                        merged_detail.id, confidence,
+                                    )
                             except Exception:
                                 logger.warning(
                                     "MERGE partially failed for %s/%s",

--- a/nous/handlers/sleep_handler.py
+++ b/nous/handlers/sleep_handler.py
@@ -927,6 +927,15 @@ class SleepHandler:
                                 else:
                                     async with self._heart.db.session() as session:
                                         for orig_id in (fact1_id, fact2_id):
+                                            # Defensive: never set
+                                            # superseded_by to own id.
+                                            # Heart.learn always returns
+                                            # a fresh UUID today, but the
+                                            # check is one comparison and
+                                            # removes a class of "what if
+                                            # learn ever changes" bugs.
+                                            if orig_id == merged_detail.id:
+                                                continue
                                             orm_fact = await session.get(
                                                 Fact, orig_id
                                             )
@@ -1227,6 +1236,11 @@ class SleepHandler:
                 # Deactivate originals
                 async with self._heart.db.session() as session:
                     for fact in facts:
+                        # Defensive (mirrors F031 fix on PR #412): never
+                        # set superseded_by to own id. Heart.learn always
+                        # returns a fresh UUID today, but cheap to guard.
+                        if fact.id == merged_detail.id:
+                            continue
                         orm_fact = await session.get(Fact, fact.id)
                         if orm_fact:
                             orm_fact.superseded_by = merged_detail.id

--- a/nous/handlers/sleep_handler.py
+++ b/nous/handlers/sleep_handler.py
@@ -939,11 +939,31 @@ class SleepHandler:
                                             orm_fact = await session.get(
                                                 Fact, orig_id
                                             )
-                                            if orm_fact:
-                                                orm_fact.superseded_by = (
-                                                    merged_detail.id
+                                            if orm_fact is None:
+                                                continue
+                                            # Codex P1 on PR #412: do not
+                                            # clobber an already-populated
+                                            # superseded_by. A concurrent
+                                            # path may have superseded
+                                            # this fact between candidate
+                                            # selection and now; blindly
+                                            # overwriting would lose the
+                                            # original chain target. The
+                                            # active flip is paired —
+                                            # already-superseded facts
+                                            # are already inactive.
+                                            if orm_fact.superseded_by is not None:
+                                                logger.debug(
+                                                    "F031 MERGE: skip supersede "
+                                                    "of %s — already linked to %s",
+                                                    orig_id,
+                                                    orm_fact.superseded_by,
                                                 )
-                                                orm_fact.active = False
+                                                continue
+                                            orm_fact.superseded_by = (
+                                                merged_detail.id
+                                            )
+                                            orm_fact.active = False
                                         await session.commit()
                                     sleep_stats["contradictions_resolved"] += 1
                                     sleep_stats["facts_created"] += 1
@@ -1242,9 +1262,22 @@ class SleepHandler:
                         if fact.id == merged_detail.id:
                             continue
                         orm_fact = await session.get(Fact, fact.id)
-                        if orm_fact:
-                            orm_fact.superseded_by = merged_detail.id
-                            orm_fact.active = False
+                        if orm_fact is None:
+                            continue
+                        # Codex P1 on PR #412 (mirror): do not clobber
+                        # an already-populated superseded_by. A
+                        # concurrent path may have superseded this fact
+                        # between candidate selection and now.
+                        if orm_fact.superseded_by is not None:
+                            logger.debug(
+                                "F027 cluster_merge: skip supersede of %s "
+                                "— already linked to %s",
+                                fact.id,
+                                orm_fact.superseded_by,
+                            )
+                            continue
+                        orm_fact.superseded_by = merged_detail.id
+                        orm_fact.active = False
                     await session.commit()
 
                 merged_fact_id = str(merged_detail.id)

--- a/tests/test_f031_consolidation.py
+++ b/tests/test_f031_consolidation.py
@@ -459,8 +459,14 @@ class TestContradictionResolution:
 
         # heart.db.session() returns an async context manager. AsyncMock alone
         # would yield a coroutine, not an __aenter__/__aexit__ object, so build
-        # the CM explicitly.
-        orm_facts = {fact1_id: MagicMock(), fact2_id: MagicMock()}
+        # the CM explicitly. ORM mocks must have superseded_by=None explicitly
+        # set or MagicMock auto-attr would defeat the race-guard's `is None`
+        # check in sleep_handler.py.
+        orm1 = MagicMock()
+        orm1.superseded_by = None
+        orm2 = MagicMock()
+        orm2.superseded_by = None
+        orm_facts = {fact1_id: orm1, fact2_id: orm2}
         mock_session = MagicMock()
         mock_session.get = AsyncMock(side_effect=lambda _model, fid: orm_facts.get(fid))
         mock_session.commit = AsyncMock()
@@ -497,6 +503,76 @@ class TestContradictionResolution:
             assert orm.active is False
         assert sleep_stats["facts_created"] == 1
         assert sleep_stats["contradictions_resolved"] == 1
+
+    @pytest.mark.asyncio
+    async def test_merge_preserves_existing_supersede_link(self):
+        """Codex P1 on PR #412: MERGE must NOT clobber a pre-existing
+        ``superseded_by`` link. If a concurrent path superseded one of the
+        candidate facts between selection and the MERGE write, the original
+        chain target must win.
+        """
+        fact1_id = uuid4()
+        fact2_id = uuid4()
+        merged_id = uuid4()
+        prior_supersede_target = uuid4()
+
+        heart = AsyncMock()
+        heart.find_contradiction_candidates = AsyncMock(return_value=[{
+            "fact1_id": fact1_id,
+            "fact2_id": fact2_id,
+            "content1": "Tim uses EST",
+            "content2": "Tim's hours are 9-5",
+            "date1": "2026-03-01",
+            "date2": "2026-03-15",
+            "similarity": 0.82,
+        }])
+        merged_detail = MagicMock()
+        merged_detail.id = merged_id
+        heart.learn = AsyncMock(return_value=merged_detail)
+        heart.deactivate_fact = AsyncMock()
+        heart.search_facts = AsyncMock(return_value=[])
+
+        # fact1 was concurrently superseded; fact2 is fresh.
+        orm1 = MagicMock()
+        orm1.superseded_by = prior_supersede_target
+        orm1.active = False  # already inactive (paired invariant)
+        orm2 = MagicMock()
+        orm2.superseded_by = None
+        orm2.active = True
+        orm_facts = {fact1_id: orm1, fact2_id: orm2}
+        mock_session = MagicMock()
+        mock_session.get = AsyncMock(side_effect=lambda _model, fid: orm_facts.get(fid))
+        mock_session.commit = AsyncMock()
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=mock_session)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        heart.db = MagicMock()
+        heart.db.session = MagicMock(return_value=cm)
+
+        llm_response = json.dumps({
+            "action": "MERGE",
+            "confidence": 0.85,
+            "reason": "Complementary timezone info",
+            "merged_content": "Tim works in EST timezone, hours 9-5",
+        })
+        handler, _, _, _, _ = _make_sleep_handler(
+            heart=heart, llm_client=_mock_llm_client(llm_response)
+        )
+        sleep_stats = {"facts_created": 0, "procedures_created": 0, "censors_retired": 0}
+        await handler._phase_resolve_contradictions(sleep_stats)
+
+        # fact1: original chain target preserved, NOT overwritten
+        assert orm1.superseded_by == prior_supersede_target, (
+            "Race-guard must not clobber an already-populated superseded_by"
+        )
+        assert orm1.active is False  # unchanged
+
+        # fact2: normal path, gets linked to merged_id
+        assert orm2.superseded_by == merged_id
+        assert orm2.active is False
+
+        # commit still happens once (only fact2 was modified)
+        mock_session.commit.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_keep_both_takes_no_action(self):

--- a/tests/test_f031_consolidation.py
+++ b/tests/test_f031_consolidation.py
@@ -427,10 +427,19 @@ class TestContradictionResolution:
         heart.deactivate_fact.assert_called_once_with(fact2_id)
 
     @pytest.mark.asyncio
-    async def test_merge_creates_new_deactivates_both(self):
-        """MERGE should learn merged fact and deactivate both originals."""
+    async def test_merge_supersedes_both_originals(self):
+        """MERGE should learn merged fact and link both originals via superseded_by.
+
+        Codex P1 on PR #411 caught that the prior implementation called
+        ``deactivate_fact()`` on both originals, leaving them ``active=False``
+        with no ``superseded_by`` link — orphaning the chain. PR #412 rewrote
+        the branch to capture ``merged_detail.id`` and set ``superseded_by`` +
+        ``active=False`` on both originals in a single session. This test
+        verifies that runtime contract.
+        """
         fact1_id = uuid4()
         fact2_id = uuid4()
+        merged_id = uuid4()
 
         heart = AsyncMock()
         heart.find_contradiction_candidates = AsyncMock(return_value=[{
@@ -442,9 +451,24 @@ class TestContradictionResolution:
             "date2": "2026-03-15",
             "similarity": 0.82,
         }])
-        heart.learn = AsyncMock(return_value=MagicMock())
+        merged_detail = MagicMock()
+        merged_detail.id = merged_id
+        heart.learn = AsyncMock(return_value=merged_detail)
         heart.deactivate_fact = AsyncMock()
         heart.search_facts = AsyncMock(return_value=[])
+
+        # heart.db.session() returns an async context manager. AsyncMock alone
+        # would yield a coroutine, not an __aenter__/__aexit__ object, so build
+        # the CM explicitly.
+        orm_facts = {fact1_id: MagicMock(), fact2_id: MagicMock()}
+        mock_session = MagicMock()
+        mock_session.get = AsyncMock(side_effect=lambda _model, fid: orm_facts.get(fid))
+        mock_session.commit = AsyncMock()
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=mock_session)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        heart.db = MagicMock()
+        heart.db.session = MagicMock(return_value=cm)
 
         llm_response = json.dumps({
             "action": "MERGE",
@@ -459,8 +483,20 @@ class TestContradictionResolution:
         await handler._phase_resolve_contradictions(sleep_stats)
 
         heart.learn.assert_called_once()
-        assert heart.deactivate_fact.call_count == 2
+        # New contract: NO deactivate_fact() calls — supersession handled in-session.
+        heart.deactivate_fact.assert_not_called()
+        # Session entered exactly once and committed.
+        heart.db.session.assert_called_once()
+        mock_session.commit.assert_awaited_once()
+        # Both originals fetched and linked to merged fact.
+        assert mock_session.get.await_count == 2
+        for orig_id, orm in orm_facts.items():
+            assert orm.superseded_by == merged_id, (
+                f"orig {orig_id} should be linked to merged_id"
+            )
+            assert orm.active is False
         assert sleep_stats["facts_created"] == 1
+        assert sleep_stats["contradictions_resolved"] == 1
 
     @pytest.mark.asyncio
     async def test_keep_both_takes_no_action(self):

--- a/tests/test_sleep_handler.py
+++ b/tests/test_sleep_handler.py
@@ -957,6 +957,47 @@ class TestStructuredContradictionResolution:
         assert data["applied_action"] == "KEEP_BOTH"
         assert data["raw_action"] == "MERGE"
 
+    def test_f031_merge_preserves_supersede_chain(self):
+        """Codex finding on PR #411: F031 MERGE used to discard the
+        heart.learn() result and call deactivate_fact() on both
+        originals — leaving them active=False with NO superseded_by
+        link. That orphaned every successful MERGE's source facts
+        (chain broken, recoverable only via manual SQL).
+
+        The fix mirrors F027's pattern: capture merged_detail.id and
+        set superseded_by AND active=False atomically in a single
+        session. Pin that contract via source inspection so a future
+        PR can't accidentally re-introduce the bare deactivate_fact
+        pattern.
+        """
+        import inspect
+
+        from nous.handlers.sleep_handler import SleepHandler
+
+        src = inspect.getsource(SleepHandler._phase_resolve_contradictions)
+
+        # Find the MERGE branch (between `elif action == "MERGE":` and
+        # the next elif).
+        merge_start = src.index('elif action == "MERGE":')
+        merge_end = src.index('elif action == "REMOVE_A":', merge_start)
+        merge_branch = src[merge_start:merge_end]
+
+        # Must capture the learn() result.
+        assert "merged_detail" in merge_branch, (
+            "F031 MERGE must capture heart.learn() return value to use "
+            "its ID for the supersede link"
+        )
+        # Must set superseded_by on the originals (not just deactivate).
+        assert "superseded_by" in merge_branch, (
+            "F031 MERGE must set superseded_by on the originals to "
+            "preserve the supersede chain — Codex P1 on PR #411"
+        )
+        # Must NOT use the bare deactivate_fact pattern that orphans.
+        assert "deactivate_fact(fact1_id)" not in merge_branch, (
+            "F031 MERGE must not bare-deactivate originals — that "
+            "drops the superseded_by link and breaks recovery"
+        )
+
     @pytest.mark.asyncio
     async def test_merge_without_content_downgrades_to_keep_both(self):
         """2026-05-01 audit: prod sleep returned MERGE without merged_content


### PR DESCRIPTION
## Summary
Codex review of PR #411 surfaced a **pre-existing data-integrity bug** in F031 MERGE: the merged fact's UUID was never captured and never linked to the originals via `superseded_by`. Every successful F031 MERGE has been silently orphaning the source facts since the code was written.

## The bug

```python
# sleep_handler.py — F031 MERGE branch (BEFORE this fix)
await self._heart.learn(FactInput(...))     # ← merged fact created
                                             #   but result DISCARDED
await self._heart.deactivate_fact(fact1_id)  # ← active=False, no link
await self._heart.deactivate_fact(fact2_id)  # ← active=False, no link
```

Result: originals end up `active=False` with `superseded_by=NULL` — chain broken, recovery only via manual SQL.

## Why this matters now

PR #411 added `contradiction_resolution` to `bypass_sources` with the safety justification *"the supersede chain preserves originals if a merge turns out wrong."* Codex correctly noted: that claim was false — the chain wasn't being set. So the bypass + bug stacked into a real risk.

## Fix

Mirror F027's pattern (which has always done this correctly):
1. Capture `merged_detail = await self._heart.learn(...)`
2. Defensive: skip if `FactRejected` (shouldn't happen with bypass, but guard)
3. Single session: set `superseded_by = merged_detail.id` AND `active = False` on **both** originals atomically
4. Drop the bare `deactivate_fact()` calls

Result: every successful F031 MERGE now leaves originals reachable via `superseded_by` — and PR #411's safety claim becomes literally true.

## Test

`test_f031_merge_preserves_supersede_chain` uses `inspect.getsource()` to pin the contract:
- MERGE branch must capture `merged_detail`
- MERGE branch must reference `superseded_by`
- MERGE branch must NOT use `deactivate_fact(fact1_id)` (the orphaning pattern)

A future PR can't silently re-introduce the bare-deactivate pattern. Mirrors the inspect-based assertions from PRs #408/#409.

## Test plan
- [x] 3 MERGE-related tests pass (1 new + 2 existing)
- [x] Smoke imports clean
- [x] Will verify in prod via next sleep cycle's audit

## Related
Codex review on PR #411 caught this. The eval-find-then-fix loop continuing into a fourth iteration on F027/F031:
- #404 found F027 silent failure
- #405 fixed cap (LLM still refusing)
- #410 fixed prompt (admission rejecting)
- #411 fixed admission bypass (chain not preserved)
- THIS PR fixes the F031 chain (data integrity restored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)