### PR TITLE
feat(F053+F054): orphan-edge sleep cleanup + keyword channel toggle

### DIFF
--- a/nous/config.py
+++ b/nous/config.py
@@ -79,6 +79,30 @@ class Settings(BaseSettings):
     # F025 prep: hybrid search vector weight (keyword_weight = 1 - vector_weight)
     vector_weight: float = 0.7
     rrf_k: int = 60  # RRF smoothing constant (F025)
+    # F053 (2026-05-03): orphan-edge sleep cleanup.
+    # F031 MERGE / F027 cluster_consolidation deactivate facts but the
+    # `brain.graph_edges` rows incident to those facts remain. Spreading
+    # activation walks edges only (no `active` filter) so it wastes hops
+    # on dead nodes. New sleep phase prunes edges where either endpoint is
+    # an inactive node, bounded per cycle to avoid long exclusive locks.
+    dead_edge_pruning_enabled: bool = True
+    dead_edge_pruning_max_per_cycle: int = 1000
+
+    # F054 (2026-05-03): keyword channel toggle.
+    # F051 channel-isolation eval (90 nous_prod + 20 longmemeval qrels) showed
+    # vector_only ties default RRF byte-for-byte on longmemeval and -0.2% on
+    # nous_prod; keyword_only collapses (MRR 0.07/0.35). Operators with
+    # vector-dominant corpora can flip this off to save one FTS query per
+    # recall. Default True preserves current behavior; eval corpora don't
+    # represent jargon-heavy ingestion (codenames, IDs, rare terms).
+    #
+    # Caveat: when False, _rrf_merge sees an empty keyword list, so every
+    # candidate's RRF score = vector_weight/(k + v_rank) + (1-vector_weight)/
+    # (k + penalty_rank). The keyword half of the score is uniformly suppressed
+    # rather than absent, which can shift absolute scores and interact with
+    # downstream relevance_floor / staleness_penalty consumers. Order is
+    # preserved; absolute thresholds may need tuning if you flip this off.
+    hybrid_search_keyword_enabled: bool = True
 
     # F017: Relevance floor
     relevance_floor_enabled: bool = True

--- a/nous/handlers/sleep_handler.py
+++ b/nous/handlers/sleep_handler.py
@@ -469,6 +469,11 @@ class SleepHandler:
                     phases_completed.append("graph_densification")
 
             if not self._interrupted:
+                success = await self._phase_prune_dead_edges(sleep_stats)
+                if success:
+                    phases_completed.append("prune_dead_edges")
+
+            if not self._interrupted:
                 success = await self._phase_generalize(sleep_stats)
                 if success:
                     phases_completed.append("generalize")
@@ -1341,6 +1346,96 @@ class SleepHandler:
             return True
         except Exception:
             logger.warning("F040 graph densification phase failed", exc_info=True)
+            return False
+
+    async def _phase_prune_dead_edges(self, sleep_stats: dict) -> bool:
+        """F053: Delete graph edges incident to inactive nodes.
+
+        Spreading activation walks ``brain.graph_edges`` without an
+        ``active`` filter (see ``brain/spreading_activation.py``), so
+        edges to deactivated facts/episodes/procedures/decisions waste
+        per-hop activation budget on dead nodes. The orphan supersede
+        chain audit (PR #412) found this exposure surface; this phase
+        is the periodic housekeeping pass that recovers wasted hops.
+
+        Bounded by ``dead_edge_pruning_max_per_cycle`` to keep the
+        exclusive DELETE lock short. The bound is intentional: a single
+        sleep cycle should not block other writers for more than ~1s
+        worth of pruning. If more orphans accumulate than the per-cycle
+        bound, subsequent sleep cycles will continue draining.
+
+        SQL strategy: build the inactive-id pool with one UNION ALL,
+        then DELETE edges whose source OR target appears in that pool.
+        Agent-scoped both on the edges side and the inactive-id side
+        defense-in-depth — no chance of cross-agent edge deletion even
+        if a row was misclassified at write time.
+        """
+        try:
+            if not self._settings.dead_edge_pruning_enabled:
+                return True
+            agent_id = self._settings.agent_id
+            # Defensive int() — keeps tests that mock self._settings as a
+            # bare MagicMock from raising TypeError on the `<= 0` comparison.
+            max_per_cycle = int(self._settings.dead_edge_pruning_max_per_cycle)
+            if max_per_cycle <= 0:
+                return True
+            from sqlalchemy import text
+            async with self._heart.db.session() as session:
+                # `brain.decisions` has no `active` column today — decisions
+                # are append-only and reviewed-not-deleted. If/when a soft-
+                # delete is added, append a UNION ALL branch here. Including
+                # it pre-emptively would crash every sleep cycle until the
+                # column lands (review caught this).
+                sql = text("""
+                    WITH inactive_nodes AS (
+                        SELECT id, 'fact'::text AS node_type
+                        FROM heart.facts
+                        WHERE agent_id = :agent_id AND active = false
+                        UNION ALL
+                        SELECT id, 'episode'
+                        FROM heart.episodes
+                        WHERE agent_id = :agent_id AND active = false
+                        UNION ALL
+                        SELECT id, 'procedure'
+                        FROM heart.procedures
+                        WHERE agent_id = :agent_id AND active = false
+                    ),
+                    victim_edges AS (
+                        SELECT e.id
+                        FROM brain.graph_edges e
+                        WHERE e.agent_id = :agent_id
+                          AND (
+                            (e.source_type, e.source_id) IN (
+                              SELECT node_type, id FROM inactive_nodes
+                            )
+                            OR (e.target_type, e.target_id) IN (
+                              SELECT node_type, id FROM inactive_nodes
+                            )
+                          )
+                        LIMIT :max_per_cycle
+                    )
+                    DELETE FROM brain.graph_edges
+                    WHERE id IN (SELECT id FROM victim_edges)
+                    RETURNING id
+                """)
+                result = await session.execute(
+                    sql,
+                    {"agent_id": agent_id, "max_per_cycle": max_per_cycle},
+                )
+                deleted = len(result.all())
+                await session.commit()
+            sleep_stats["dead_edges_pruned"] = deleted
+            logger.info(
+                "F053 dead-edge prune: deleted %d edges (cap=%d)",
+                deleted, max_per_cycle,
+            )
+            return True
+        except Exception as exc:
+            # Surface error type into sleep_stats so observability dashboards
+            # can alert on silent regressions (review P2). The phase still
+            # returns False so it's excluded from phases_completed.
+            sleep_stats["dead_edges_prune_error"] = type(exc).__name__
+            logger.warning("F053 dead-edge prune failed", exc_info=True)
             return False
 
     async def _phase_generalize(self, sleep_stats: dict) -> bool:

--- a/nous/heart/search.py
+++ b/nous/heart/search.py
@@ -55,6 +55,24 @@ def _resolve_rrf_k() -> int:
     return RuntimeConfig.get().get_rrf_k(settings)
 
 
+def _resolve_keyword_enabled() -> bool:
+    """Resolve hybrid_search_keyword_enabled from settings > default True.
+
+    F054: operator opt-out for vector-dominant corpora. Eval (F051) showed
+    vector-only ties default RRF byte-for-byte on personal-Q&A and within
+    -0.2% on codebase docs, so the FTS query is dead weight on those shapes.
+    No RuntimeConfig override path — this is intentionally a static config
+    flip, not a per-request knob.
+    """
+    from nous.config import Settings
+
+    try:
+        settings = Settings()
+    except Exception:
+        return True
+    return bool(getattr(settings, "hybrid_search_keyword_enabled", True))
+
+
 def _rrf_merge(
     vector_ranked: list[tuple[UUID, float]],
     keyword_ranked: list[tuple[UUID, float]],
@@ -178,19 +196,26 @@ async def hybrid_search(
         result = await session.execute(vector_sql, params)
         vector_results = [(row.id, float(row.score)) for row in result.all()]
 
-    # Keyword search
-    keyword_sql = text(f"""
-        SELECT t.id,
-            ts_rank_cd(t.search_tsv, plainto_tsquery('english', :query_text))
-            / (1.0 + ts_rank_cd(t.search_tsv, plainto_tsquery('english', :query_text))) AS score
-        FROM {table} t
-        WHERE t.search_tsv @@ plainto_tsquery('english', :query_text)
-            {filter_clauses}
-        ORDER BY score DESC
-        LIMIT :limit_expanded
-    """)
-    result = await session.execute(keyword_sql, params)
-    keyword_results = [(row.id, float(row.score)) for row in result.all()]
+    # F054: keyword channel toggle. Skip the FTS query when disabled.
+    # _rrf_merge handles an empty keyword list correctly — degenerates to
+    # vector-only ranking weighted by vector_weight (penalty rank applied to
+    # missing channel cancels out when one channel is empty).
+    # Force-on path when embedding is None preserves the keyword-only
+    # fallback: callers that intentionally pass embedding=None still get FTS.
+    keyword_enabled = _resolve_keyword_enabled() or embedding is None
+    if keyword_enabled:
+        keyword_sql = text(f"""
+            SELECT t.id,
+                ts_rank_cd(t.search_tsv, plainto_tsquery('english', :query_text))
+                / (1.0 + ts_rank_cd(t.search_tsv, plainto_tsquery('english', :query_text))) AS score
+            FROM {table} t
+            WHERE t.search_tsv @@ plainto_tsquery('english', :query_text)
+                {filter_clauses}
+            ORDER BY score DESC
+            LIMIT :limit_expanded
+        """)
+        result = await session.execute(keyword_sql, params)
+        keyword_results = [(row.id, float(row.score)) for row in result.all()]
 
     if embedding is None:
         # Keyword-only fallback — return keyword results directly

--- a/tests/test_f053_dead_edge_prune.py
+++ b/tests/test_f053_dead_edge_prune.py
@@ -1,0 +1,346 @@
+"""F053 — Orphan-edge sleep cleanup phase.
+
+F031 MERGE / F027 cluster_consolidation deactivate facts but leave
+the `brain.graph_edges` rows incident to those facts in place.
+Spreading activation walks edges only (no `active` filter), so it
+wastes per-hop activation budget on dead nodes.
+
+The `_phase_prune_dead_edges` phase runs after `graph_densification`
+each sleep cycle, deletes edges whose source or target points at an
+inactive fact / episode / procedure / decision, bounded per cycle.
+
+This module verifies the phase logic without a real Postgres:
+
+  - flag off                                  -> phase is a no-op (returns True).
+  - flag on + DB success                      -> session.execute called once,
+                                                 commit called, deleted-count
+                                                 propagates into sleep_stats.
+  - max_per_cycle <= 0                        -> phase is a no-op (returns True).
+  - DB exception                              -> caught + returns False
+                                                 (phase excluded from
+                                                 phases_completed downstream).
+  - default Settings has flag on at 1000/cycle -> backward sanity.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from nous.config import Settings
+from nous.events import EventBus
+from nous.handlers.sleep_handler import SleepHandler
+
+
+def _make_handler(
+    *,
+    dead_edge_pruning_enabled: bool = True,
+    dead_edge_pruning_max_per_cycle: int = 1000,
+    deleted_ids: list | None = None,
+    raise_on_execute: bool = False,
+):
+    """Construct a SleepHandler with mocked heart.db.session yielding a CM."""
+    brain = AsyncMock()
+    heart = AsyncMock()
+    settings = Settings(_env_file=None)
+    object.__setattr__(
+        settings, "dead_edge_pruning_enabled", dead_edge_pruning_enabled
+    )
+    object.__setattr__(
+        settings,
+        "dead_edge_pruning_max_per_cycle",
+        dead_edge_pruning_max_per_cycle,
+    )
+    bus = MagicMock(spec=EventBus)
+    bus.on = MagicMock()
+    bus.emit = AsyncMock()
+    llm_client = AsyncMock()
+
+    # Build the async-context-manager mock for heart.db.session().
+    mock_session = MagicMock()
+    if raise_on_execute:
+        mock_session.execute = AsyncMock(side_effect=RuntimeError("db boom"))
+    else:
+        result = MagicMock()
+        result.all = MagicMock(
+            return_value=[MagicMock(id=i) for i in (deleted_ids or [])]
+        )
+        mock_session.execute = AsyncMock(return_value=result)
+    mock_session.commit = AsyncMock()
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=mock_session)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    heart.db = MagicMock()
+    heart.db.session = MagicMock(return_value=cm)
+
+    handler = SleepHandler(brain, heart, settings, bus, llm_client)
+    return handler, mock_session
+
+
+class TestF053DeadEdgePrune:
+    @pytest.mark.asyncio
+    async def test_default_settings_have_flag_on_at_1000(self):
+        s = Settings(_env_file=None)
+        assert s.dead_edge_pruning_enabled is True
+        assert s.dead_edge_pruning_max_per_cycle == 1000
+
+    @pytest.mark.asyncio
+    async def test_flag_off_is_noop(self):
+        handler, mock_session = _make_handler(dead_edge_pruning_enabled=False)
+        sleep_stats = {}
+        result = await handler._phase_prune_dead_edges(sleep_stats)
+        assert result is True
+        mock_session.execute.assert_not_called()
+        assert "dead_edges_pruned" not in sleep_stats
+
+    @pytest.mark.asyncio
+    async def test_max_per_cycle_zero_is_noop(self):
+        handler, mock_session = _make_handler(dead_edge_pruning_max_per_cycle=0)
+        sleep_stats = {}
+        result = await handler._phase_prune_dead_edges(sleep_stats)
+        assert result is True
+        mock_session.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_max_per_cycle_negative_is_noop(self):
+        handler, mock_session = _make_handler(
+            dead_edge_pruning_max_per_cycle=-5
+        )
+        sleep_stats = {}
+        result = await handler._phase_prune_dead_edges(sleep_stats)
+        assert result is True
+        mock_session.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_successful_prune_records_count(self):
+        deleted = [uuid4(), uuid4(), uuid4()]
+        handler, mock_session = _make_handler(deleted_ids=deleted)
+        sleep_stats = {}
+        result = await handler._phase_prune_dead_edges(sleep_stats)
+        assert result is True
+        mock_session.execute.assert_awaited_once()
+        mock_session.commit.assert_awaited_once()
+        assert sleep_stats["dead_edges_pruned"] == 3
+
+    @pytest.mark.asyncio
+    async def test_prune_zero_records_zero(self):
+        handler, mock_session = _make_handler(deleted_ids=[])
+        sleep_stats = {}
+        result = await handler._phase_prune_dead_edges(sleep_stats)
+        assert result is True
+        assert sleep_stats["dead_edges_pruned"] == 0
+
+    @pytest.mark.asyncio
+    async def test_db_exception_returns_false(self):
+        handler, mock_session = _make_handler(raise_on_execute=True)
+        sleep_stats = {}
+        result = await handler._phase_prune_dead_edges(sleep_stats)
+        assert result is False
+        # commit MUST NOT happen on error
+        mock_session.commit.assert_not_called()
+        # Phase should not silently report success; sleep_stats untouched.
+        assert "dead_edges_pruned" not in sleep_stats
+
+    @pytest.mark.asyncio
+    async def test_query_uses_agent_id_and_max_per_cycle(self):
+        """Regression: SQL must bind agent_id + max_per_cycle params."""
+        handler, mock_session = _make_handler(
+            dead_edge_pruning_max_per_cycle=42
+        )
+        await handler._phase_prune_dead_edges({})
+        call = mock_session.execute.await_args
+        params = call.args[1]
+        assert params["agent_id"] == handler._settings.agent_id
+        assert params["max_per_cycle"] == 42
+
+    @pytest.mark.asyncio
+    async def test_sql_does_not_reference_decisions_active(self):
+        """Regression: brain.decisions has no `active` column; the SQL
+        must NOT reference it. Caught by code review on first pass."""
+        handler, mock_session = _make_handler()
+        await handler._phase_prune_dead_edges({})
+        call = mock_session.execute.await_args
+        sql_str = str(call.args[0])
+        # Either the SQL doesn't mention decisions at all, or if it does
+        # (in a comment), it must not pair them with `active`.
+        decisions_block = "FROM brain.decisions" in sql_str
+        active_on_decisions = "decisions" in sql_str.lower() and (
+            "decisions" in sql_str.split("active = false")[0].split("FROM ")[-1]
+            if "active = false" in sql_str
+            else False
+        )
+        assert not decisions_block, (
+            "F053 SQL references brain.decisions in a FROM/WHERE clause; "
+            "decisions has no active column today. Remove the branch."
+        )
+
+    @pytest.mark.asyncio
+    async def test_db_exception_records_error_type(self):
+        """P2 review fix: persist exception type into sleep_stats so
+        observability dashboards can detect silent regressions."""
+        handler, mock_session = _make_handler(raise_on_execute=True)
+        sleep_stats = {}
+        result = await handler._phase_prune_dead_edges(sleep_stats)
+        assert result is False
+        assert sleep_stats.get("dead_edges_prune_error") == "RuntimeError"
+
+
+# ===========================================================================
+# Integration test — real Postgres, end-to-end behavior
+# ===========================================================================
+#
+# Validates that the production SQL inside _phase_prune_dead_edges actually
+# deletes the right edges against a real Postgres instance. Mock-based tests
+# above exercise the Python control flow but don't catch SQL drift (e.g. a
+# missing column, a wrong type cast, a CTE that doesn't return what the
+# DELETE expects). This test inserts a known fixture, calls the phase, and
+# asserts the DB state changed correctly.
+#
+# Skip rules:
+#   - @pytest.mark.integration  → only runs with --integration flag
+#   - @pytest.mark.postgres_only → only runs with NOUS_TEST_DB=postgres
+# Both must be present; on a clean dev box this test stays silent.
+#
+# Run via:
+#   NOUS_TEST_DB=postgres uv run pytest tests/test_f053_dead_edge_prune.py \
+#     -m integration --integration -v
+
+
+@pytest.mark.integration
+@pytest.mark.postgres_only
+class TestF053Integration:
+    """End-to-end F053 against real Postgres.
+
+    The session fixture (tests/conftest.py) wraps each test in a
+    transaction that rolls back on exit, so this test never mutates
+    the dev DB beyond the test scope.
+    """
+
+    @pytest.mark.asyncio
+    async def test_phase_deletes_only_inactive_endpoint_edges(
+        self, db, mock_embeddings,
+    ):
+        """Insert known fixture: 2 active facts + 2 inactive facts +
+        4 edges (2 between active-only, 2 incident to inactive). Run
+        the phase. Verify only the 2 dead edges were deleted; the 2
+        active-active edges survive.
+
+        The handler opens its OWN session from the connection pool, so
+        the rollback-fixture pattern (tests/conftest.py::session) is
+        not usable here — the handler's session wouldn't see the
+        fixture-session's uncommitted data. Instead: commit fixture data
+        with a unique agent_id and DELETE everything in a finally block.
+        """
+        from datetime import UTC, datetime
+        from uuid import uuid4
+
+        from sqlalchemy import text as sql_text
+
+        from nous.config import Settings
+        from nous.events import EventBus
+        from nous.handlers.sleep_handler import SleepHandler
+
+        agent_id = f"f053-it-{uuid4().hex[:8]}"
+
+        # Fixture: 2 active + 2 inactive facts; 4 edges.
+        f_active_a = uuid4()
+        f_active_b = uuid4()
+        f_inactive_a = uuid4()
+        f_inactive_b = uuid4()
+        e_alive_1 = uuid4()
+        e_alive_2 = uuid4()
+        e_dead_src = uuid4()
+        e_dead_tgt = uuid4()
+
+        try:
+            # Insert and commit fixture so the handler's own session sees it.
+            async with db.session() as fs:
+                await fs.execute(sql_text(
+                    "INSERT INTO nous_system.agents (id, name) "
+                    "VALUES (:aid, :name) ON CONFLICT (id) DO NOTHING"
+                ), {"aid": agent_id, "name": "F053 IT agent"})
+                for fid, active in [
+                    (f_active_a, True), (f_active_b, True),
+                    (f_inactive_a, False), (f_inactive_b, False),
+                ]:
+                    await fs.execute(sql_text(
+                        "INSERT INTO heart.facts "
+                        "(id, agent_id, content, active, created_at) "
+                        "VALUES (:id, :aid, :c, :a, :t)"
+                    ), {
+                        "id": fid, "aid": agent_id,
+                        "c": f"f053 fixture {fid}", "a": active,
+                        "t": datetime.now(UTC),
+                    })
+                # Edges:
+                # - e_alive_1, e_alive_2: between active facts (SURVIVE)
+                # - e_dead_src: from inactive → active (DELETE)
+                # - e_dead_tgt: from active → inactive (DELETE)
+                edges = [
+                    (e_alive_1, f_active_a, "fact", f_active_b, "fact", "related_to"),
+                    (e_alive_2, f_active_b, "fact", f_active_a, "fact", "informed_by"),
+                    (e_dead_src, f_inactive_a, "fact", f_active_a, "fact", "supports"),
+                    (e_dead_tgt, f_active_a, "fact", f_inactive_b, "fact", "evidence_for"),
+                ]
+                for eid, src, src_t, tgt, tgt_t, rel in edges:
+                    await fs.execute(sql_text(
+                        "INSERT INTO brain.graph_edges "
+                        "(id, source_id, source_type, target_id, target_type, "
+                        " agent_id, relation, weight) "
+                        "VALUES (:id, :s, :st, :t, :tt, :aid, :rel, 1.0)"
+                    ), {
+                        "id": eid, "s": src, "st": src_t,
+                        "t": tgt, "tt": tgt_t, "aid": agent_id, "rel": rel,
+                    })
+                await fs.commit()
+
+            # Build the real SleepHandler.
+            from unittest.mock import AsyncMock, MagicMock
+            from nous.heart import Heart
+
+            settings = Settings()
+            object.__setattr__(settings, "agent_id", agent_id)
+            object.__setattr__(settings, "dead_edge_pruning_enabled", True)
+            object.__setattr__(settings, "dead_edge_pruning_max_per_cycle", 1000)
+
+            heart = Heart(db, settings, embedding_provider=mock_embeddings)
+            brain = AsyncMock()
+            bus = MagicMock(spec=EventBus)
+            bus.on = MagicMock()
+            bus.emit = AsyncMock()
+            llm_client = AsyncMock()
+
+            handler = SleepHandler(brain, heart, settings, bus, llm_client)
+
+            sleep_stats: dict = {}
+            result = await handler._phase_prune_dead_edges(sleep_stats)
+
+            assert result is True
+            assert sleep_stats.get("dead_edges_pruned") == 2
+
+            # Verify exactly the 2 active-active edges survive.
+            async with db.session() as vs:
+                rows = await vs.execute(sql_text(
+                    "SELECT id FROM brain.graph_edges WHERE agent_id = :aid"
+                ), {"aid": agent_id})
+                surviving_ids = {r.id for r in rows}
+            assert surviving_ids == {e_alive_1, e_alive_2}, (
+                f"expected 2 surviving alive edges, got {surviving_ids}"
+            )
+
+            await heart.close()
+        finally:
+            # Always clean up the fixture rows, even on assertion failure.
+            async with db.session() as cs:
+                await cs.execute(sql_text(
+                    "DELETE FROM brain.graph_edges WHERE agent_id = :aid"
+                ), {"aid": agent_id})
+                await cs.execute(sql_text(
+                    "DELETE FROM heart.facts WHERE agent_id = :aid"
+                ), {"aid": agent_id})
+                await cs.execute(sql_text(
+                    "DELETE FROM nous_system.agents WHERE id = :aid"
+                ), {"aid": agent_id})
+                await cs.commit()

--- a/tests/test_f054_keyword_toggle.py
+++ b/tests/test_f054_keyword_toggle.py
@@ -1,0 +1,175 @@
+"""F054 — Keyword channel toggle in hybrid_search.
+
+The F051 channel-isolation eval (90 nous_prod + 20 longmemeval qrels)
+showed `vector_only` ties default RRF byte-for-byte on longmemeval and
+within -0.2% on nous_prod, while `keyword_only` collapses (MRR 0.07/0.35).
+The keyword channel adds compute (one FTS query per recall) for ~zero
+recall benefit on those workloads. F054 adds an opt-out flag.
+
+This module verifies:
+
+  - flag on (default)            -> both vector + keyword SQL execute.
+  - flag off                     -> keyword SQL is NOT executed; vector still runs.
+  - flag off + embedding=None    -> keyword still runs (keyword-only fallback).
+  - flag off + empty keyword     -> RRF degenerates to vector-only correctly.
+  - default Settings has flag on -> backward compat preserved.
+
+Mocks SQLAlchemy session to capture which SQL strings are executed; uses
+the canonical `text()` SQL statement strings to identify the keyword
+query without depending on full SQL equality.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from nous.config import Settings
+from nous.heart.search import hybrid_search
+
+
+def _mock_session(vector_rows=None, keyword_rows=None) -> AsyncMock:
+    """Build a session whose execute() returns vector then keyword rows.
+
+    Routes by SQL string content: a query containing `plainto_tsquery`
+    is the keyword query; anything else is the vector query.
+    """
+    session = AsyncMock()
+
+    async def execute(sql, params):
+        sql_str = str(sql)
+        result = MagicMock()
+        if "plainto_tsquery" in sql_str:
+            result.all = MagicMock(return_value=keyword_rows or [])
+        else:
+            result.all = MagicMock(return_value=vector_rows or [])
+        return result
+
+    session.execute = AsyncMock(side_effect=execute)
+    return session
+
+
+class TestF054KeywordToggle:
+    @pytest.mark.asyncio
+    async def test_default_settings_have_keyword_enabled(self):
+        s = Settings(_env_file=None)
+        assert s.hybrid_search_keyword_enabled is True
+
+    @pytest.mark.asyncio
+    async def test_flag_on_runs_both_channels(self):
+        """Default behavior: vector SQL + keyword SQL both execute."""
+        v_id, k_id = uuid4(), uuid4()
+        session = _mock_session(
+            vector_rows=[MagicMock(id=v_id, score=0.9)],
+            keyword_rows=[MagicMock(id=k_id, score=0.5)],
+        )
+        with patch(
+            "nous.heart.search._resolve_keyword_enabled", return_value=True
+        ):
+            await hybrid_search(
+                session=session,
+                table="heart.facts",
+                embedding=[0.1, 0.2, 0.3],
+                query_text="anything",
+                agent_id="test-agent",
+            )
+        executed_sqls = [str(c.args[0]) for c in session.execute.await_args_list]
+        assert any("plainto_tsquery" in s for s in executed_sqls), (
+            "keyword SQL should execute when flag on"
+        )
+        assert any("<=>" in s for s in executed_sqls), (
+            "vector SQL should always execute when embedding is provided"
+        )
+
+    @pytest.mark.asyncio
+    async def test_flag_off_skips_keyword(self):
+        """Vector still runs; keyword SQL is NOT executed."""
+        v_id = uuid4()
+        session = _mock_session(
+            vector_rows=[MagicMock(id=v_id, score=0.9)],
+            keyword_rows=[],
+        )
+        with patch(
+            "nous.heart.search._resolve_keyword_enabled", return_value=False
+        ):
+            results = await hybrid_search(
+                session=session,
+                table="heart.facts",
+                embedding=[0.1, 0.2, 0.3],
+                query_text="anything",
+                agent_id="test-agent",
+            )
+        executed_sqls = [str(c.args[0]) for c in session.execute.await_args_list]
+        assert not any("plainto_tsquery" in s for s in executed_sqls), (
+            "keyword SQL should NOT execute when flag off"
+        )
+        assert any("<=>" in s for s in executed_sqls), (
+            "vector SQL should still execute"
+        )
+        assert len(results) == 1
+        assert results[0][0] == v_id
+
+    @pytest.mark.asyncio
+    async def test_flag_off_with_no_embedding_still_runs_keyword(self):
+        """Keyword-only fallback path: embedding=None must force keyword on."""
+        k_id = uuid4()
+        session = _mock_session(
+            vector_rows=[],
+            keyword_rows=[MagicMock(id=k_id, score=0.5)],
+        )
+        with patch(
+            "nous.heart.search._resolve_keyword_enabled", return_value=False
+        ):
+            results = await hybrid_search(
+                session=session,
+                table="heart.facts",
+                embedding=None,
+                query_text="anything",
+                agent_id="test-agent",
+            )
+        executed_sqls = [str(c.args[0]) for c in session.execute.await_args_list]
+        assert any("plainto_tsquery" in s for s in executed_sqls), (
+            "keyword SQL must run as fallback when embedding is None"
+        )
+        assert results == [(k_id, 0.5)]
+
+    def test_resolve_keyword_enabled_falls_back_to_true_on_error(self):
+        """Settings construction failure must default the flag to True
+        (preserve current behavior). P3 review fix.
+
+        `_resolve_keyword_enabled` does `from nous.config import Settings`
+        inside the function body, so we patch at the source module.
+        """
+        from nous.heart.search import _resolve_keyword_enabled
+        with patch("nous.config.Settings", side_effect=Exception("boom")):
+            assert _resolve_keyword_enabled() is True
+
+    @pytest.mark.asyncio
+    async def test_flag_off_returns_vector_results_via_rrf_merge(self):
+        """RRF merge with empty keyword list returns vector-only ranking."""
+        v_ids = [uuid4(), uuid4(), uuid4()]
+        session = _mock_session(
+            vector_rows=[
+                MagicMock(id=v_ids[0], score=0.9),
+                MagicMock(id=v_ids[1], score=0.8),
+                MagicMock(id=v_ids[2], score=0.7),
+            ],
+            keyword_rows=[],
+        )
+        with patch(
+            "nous.heart.search._resolve_keyword_enabled", return_value=False
+        ):
+            results = await hybrid_search(
+                session=session,
+                table="heart.facts",
+                embedding=[0.1, 0.2, 0.3],
+                query_text="anything",
+                agent_id="test-agent",
+            )
+        # All 3 vector ids present in result; order preserved by RRF rank.
+        result_ids = [r[0] for r in results]
+        for vid in v_ids:
+            assert vid in result_ids
+        assert result_ids[0] == v_ids[0]  # rank-0 stays rank-0


### PR DESCRIPTION
## Summary

Two independent retrieval/memory hygiene features driven by the F051 retrieval-eval harness on 2026-05-03.

- **F053** — Orphan-edge sleep cleanup phase. Deletes `brain.graph_edges` rows incident to inactive facts/episodes/procedures, bounded at 1000/cycle. Runs after `graph_densification` each sleep cycle.
- **F054** — Keyword channel toggle (`hybrid_search_keyword_enabled`, default True). When False, `hybrid_search` skips the FTS query; RRF merge degenerates to vector-only.

## Why

**F053**: F031 MERGE / F027 cluster_consolidation deactivate facts but leave their graph edges. Spreading activation walks edges without an `active` filter, wasting per-hop activation budget on dead nodes.

**F054**: F051 channel-isolation eval showed `vector_only` ties default RRF byte-for-byte on longmemeval and within -0.2% on nous_prod, while `keyword_only` collapses (MRR 0.07/0.35). Operators with vector-dominant corpora can save one FTS query per recall.

## Validation

**F053:**
- 10 mock-based unit tests
- 1 integration test (real Postgres, `--integration` flag): inserts 4-edge fixture, asserts only the 2 dead edges are deleted
- SQL transaction validation on prod-shaped corpus: 884 of 3137 edges (28%) cleaned in a single cycle within the 1000 cap

**F054:**
- 6 mock-based unit tests
- F051 retrieval matrix on 90 nous_prod + 20 longmemeval qrels: `f054_keyword_off` ties baseline byte-for-byte (predicted: ties → confirmed)

16 mock tests pass under default sqlite sweep; integration test runs against real Postgres with `--integration` flag.

## Risk

**Low** — F054 default-True is identity. F053 is sleep-cycle housekeeping with bounded LIMIT (no long locks) and full try/except (failures surface as `dead_edges_prune_error` in sleep_stats).

## Net diff

| file | lines | feature |
|---|---:|---|
| `nous/config.py` | +24 | settings for both features |
| `nous/handlers/sleep_handler.py` | +95 | F053 phase + runner wiring |
| `nous/heart/search.py` | +51 | F054 resolver + FTS gate |
| `tests/test_f053_dead_edge_prune.py` | +346 | 10 mock + 1 integration |
| `tests/test_f054_keyword_toggle.py` | +175 | 6 mock |

**Total: +678 / -13** across 5 files.

## What's NOT in this PR

- **F052 (conditional CE rerank by episode-share)** — eval-falsified. Episode share never crosses the threshold on either eval corpus (max 2.7% on nous_prod, 0% on longmemeval). Reverted separately on `tune/memory-recall-and-sleep`.
- Eval framework improvements (RRF resolver fix, determinism check, edge-audit regression, REFUSED verdict on sleep_cycle_health) — separate PR.
- The `evaluations/` folder docs — separate PR.

## Test plan

- [x] Default sqlite sweep: 16/16 tests pass; 1 integration auto-skipped
- [x] Postgres + integration: 17/17 (verified locally on eval-scratch DB)
- [ ] Re-run F051 retrieval matrix on CI to confirm `f054_keyword_off` ties baseline
- [ ] Production smoke after deploy: first sleep cycle should produce `dead_edges_pruned > 0` event for any agent with orphan facts

🤖 Generated with [Claude Code](https://claude.com/claude-code)