### PR TITLE
fix(F058): F040 graph densifier — fall back to plain summary for episodes

### DIFF
--- a/nous/brain/_entity_config.py
+++ b/nous/brain/_entity_config.py
@@ -22,8 +22,15 @@ _ENTITY_CONFIG: dict[str, tuple[str, str, str, str]] = {
     "episode": (
         "heart.episodes",
         "episode",
-        "t.structured_summary->>'summary'",
-        "t.active = true AND t.structured_summary IS NOT NULL",
+        # F058 (2026-05-04): fall back to plain `summary` when
+        # `structured_summary` is NULL. Stuck-open sessions never receive
+        # `episode_ended` → episode_summarizer never fires → structured_summary
+        # stays NULL forever. Plain `summary` (set at episode start, often the
+        # first user message) is always populated. F040 was excluding 76/76
+        # eval-scratch orphans because of the IS NOT NULL filter; same pattern
+        # on prod (78 active orphans, all NULL structured_summary).
+        "COALESCE(t.structured_summary->>'summary', t.summary)",
+        "t.active = true",
     ),
     "procedure": ("heart.procedures", "procedure", "t.description", "t.active = true"),
 }

--- a/tests/test_graph_densifier.py
+++ b/tests/test_graph_densifier.py
@@ -33,12 +33,27 @@ class TestEntityConfig:
         assert content_col == "t.content"
         assert "t.active" in extra
 
-    def test_episode_uses_structured_summary(self):
+    def test_episode_uses_structured_summary_with_fallback(self):
+        """F058: F040 was filtering out 100% of stuck-open episodes
+        because structured_summary was NULL (set only by
+        episode_summarizer on episode_ended). The COALESCE fallback
+        unblocks them; the IS NOT NULL filter is dropped so episodes
+        with only the plain `summary` field are now F040-eligible."""
         _, _, content_col, extra = _ENTITY_CONFIG["episode"]
+        # Both structured_summary AND plain summary must appear in the
+        # content extractor (COALESCE fallback)
         assert "structured_summary" in content_col
+        assert "COALESCE" in content_col
+        assert "t.summary" in content_col
         assert "t." in content_col
+        # Active filter still required
         assert "t.active = true" in extra
-        assert "t.structured_summary IS NOT NULL" in extra
+        # The IS NOT NULL filter MUST be gone (that was the bug)
+        assert "structured_summary IS NOT NULL" not in extra, (
+            "F058 dropped the structured_summary filter; if it's back, "
+            "F040 will silently exclude stuck-open episodes again "
+            "(76/76 prod orphans had this problem pre-F058)."
+        )
 
     def test_decision_no_tags_filter(self):
         """Decision config must NOT reference tags column."""
@@ -186,6 +201,88 @@ async def test_find_orphans_excludes_linked(db, settings, mock_embeddings, _fix_
         orphan_ids = [oid for oid, _ in orphans]
         assert fact_a not in orphan_ids
         assert fact_b not in orphan_ids
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_find_orphans_episode_with_only_plain_summary_is_returned(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint,
+):
+    """F058 regression: episodes with NULL structured_summary but a
+    populated `summary` field MUST be returned by find_orphans.
+
+    Pre-F058 the entity-config filter was
+    ``t.active = true AND t.structured_summary IS NOT NULL`` which
+    silently excluded 100% of stuck-open prod episodes (76/76 in the
+    eval-scratch snapshot, identical shape to prod nous-default).
+    The fix dropped the structured_summary filter and added a
+    COALESCE(structured_summary->>'summary', summary) content fallback
+    so F040 can densify these orphans.
+    """
+    from datetime import UTC, datetime
+    agent_id = f"test-f058-{uuid4().hex[:8]}"
+    linker = GraphLinker(db, mock_embeddings, settings, agent_id)
+    densifier = GraphDensifier(db, linker, mock_embeddings, settings, agent_id)
+
+    plain_only_ep = uuid4()
+    structured_ep = uuid4()
+    emb1 = await mock_embeddings.embed("plain summary only")
+    emb2 = await mock_embeddings.embed("with structured summary")
+    emb1_str = "[" + ",".join(str(float(v)) for v in emb1) + "]"
+    emb2_str = "[" + ",".join(str(float(v)) for v in emb2) + "]"
+
+    async with db.session() as session:
+        # Episode with plain summary only — pre-F058 was excluded
+        await session.execute(text("""
+            INSERT INTO heart.episodes
+              (id, agent_id, summary, structured_summary, started_at,
+               active, tags, embedding)
+            VALUES (:id, :aid, :s, NULL, :t, true, '{}',
+                    CAST(:emb AS vector))
+        """), {
+            "id": plain_only_ep, "aid": agent_id,
+            "s": "stuck-open episode with no structured_summary",
+            "t": datetime.now(UTC), "emb": emb1_str,
+        })
+        # Episode with structured_summary populated (pre-F058 also
+        # included; ensure F058 still includes it)
+        await session.execute(text("""
+            INSERT INTO heart.episodes
+              (id, agent_id, summary, structured_summary, started_at,
+               active, tags, embedding)
+            VALUES (:id, :aid, :s, CAST(:ss AS jsonb), :t, true, '{}',
+                    CAST(:emb AS vector))
+        """), {
+            "id": structured_ep, "aid": agent_id,
+            "s": "fallback summary text", "ss": '{"summary": "structured-version"}',
+            "t": datetime.now(UTC), "emb": emb2_str,
+        })
+        await session.commit()
+
+    try:
+        async with db.session() as session:
+            orphans = await densifier.find_orphans("episode", 50, session)
+            ids_to_content = {oid: content for oid, content in orphans}
+
+        # Both episodes must be returned — F058 fix
+        assert plain_only_ep in ids_to_content, (
+            "plain-summary-only episode missing from find_orphans → "
+            "F058 COALESCE/filter regression"
+        )
+        assert structured_ep in ids_to_content
+
+        # Content extractor must return the right text per episode:
+        # - plain_only_ep: COALESCE picks `summary` (structured is NULL)
+        # - structured_ep: COALESCE picks `structured_summary->>'summary'`
+        assert ids_to_content[plain_only_ep] == \
+            "stuck-open episode with no structured_summary"
+        assert ids_to_content[structured_ep] == "structured-version"
+    finally:
+        async with db.session() as cs:
+            await cs.execute(text(
+                "DELETE FROM heart.episodes WHERE agent_id=:aid"
+            ), {"aid": agent_id})
+            await cs.commit()
 
 
 @pytest.mark.postgres_only


### PR DESCRIPTION
## Summary

One-line fix in `nous/brain/_entity_config.py` that unblocks F040 graph densification for ~76 of 78 prod episode orphans.

## Root cause

Investigation 2026-05-04 (after F057 shipped) found 76/78 active episode orphans on prod had `structured_summary=NULL` but a valid plain `summary` field. F040's `_ENTITY_CONFIG` for episodes was filtering on `t.structured_summary IS NOT NULL`, so `find_orphans` returned 0 candidates for those episodes and they were never densified.

`structured_summary` is a JSONB field set **only** by `episode_summarizer` when `episode_ended` fires. Sessions that crash, timeout, or get abandoned never trigger the summarizer — `structured_summary` stays NULL. Plain `summary` is set at episode start (often = first user message) and is always populated.

## The fix

```python
"episode": (
    "heart.episodes",
    "episode",
-   "t.structured_summary->>'summary'",
-   "t.active = true AND t.structured_summary IS NOT NULL",
+   "COALESCE(t.structured_summary->>'summary', t.summary)",
+   "t.active = true",
),
```

Episodes WITH `structured_summary` still use it (better quality, since the summarizer crafts it for retrieval). Episodes WITHOUT fall back to the plain summary.

## Validation

Eval-scratch on `nous-prod-snapshot` (identical shape to prod nous-default):

| state | active orphans | rate |
|---|---:|---:|
| Pre-F057 baseline | 99/102 | 97.1% |
| After F057 (deterministic re-link) | 76/102 | 74.5% |
| **After F057 + F058 + env-var tuning** | **53/102** | **52.0%** |
| Total reduction | **−46 episodes** | **−45.1pp** |

F040 went from creating 0 episode edges to 97 in one cycle.

## Operator-side env-var tuning (separate from this PR)

Pairs naturally with this fix:

```
NOUS_GRAPH_THRESHOLD_EPISODE_EPISODE=0.70  # was 0.75 → catches 7 more
NOUS_GRAPH_BACKFILL_MAX_EPISODES=200       # was 30 → drains backlog faster
```

Without these, the patch alone catches ~13 orphans on first cycle (the high-confidence cosine ≥0.85 set). With both, ~25 catches per cycle.

## Tests

- **`test_episode_uses_structured_summary_with_fallback`** (sqlite/all-modes): pins the COALESCE in `content_col` and the absence of the `IS NOT NULL` filter. If a future change reverts either, this fails loudly.
- **`test_find_orphans_episode_with_only_plain_summary_is_returned`** (`@pytest.mark.postgres_only` + `@pytest.mark.integration`): inserts one episode with NULL structured_summary (the broken case) + one with structured_summary populated. Asserts both are returned by `find_orphans`, and the COALESCE picks the right text per row.

**4 pass on Postgres+integration; 1 + 3-skipped on default sqlite.**

## Risk

**Low.** Default behavior preserved for episodes that already had `structured_summary` (which is most live-ended episodes). Only changes behavior for the orphan population — and that's the bug being fixed.

## Naming

F058 is the next free feature slot. F055 = Cross-Turn Residual Activation, F056 = Eval Framework Phase 2, F057 = episode re-linker (#415, merged earlier today).

## Test plan

- [x] Default sqlite sweep: 1 pass + 3 postgres-only skipped
- [x] Postgres + integration: 4/4 pass
- [x] End-to-end on eval-scratch: 99 (pre-F057) → 76 (post-F057) → 53 (post-F058 + tuning)
- [ ] Production smoke after deploy + env-tune: orphan rate should drop from ~76% (post-F057) to ~52%; F040's `episodes` count in graph_densification should jump from ~0 to ~25-30 first cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)