### PR TITLE
fix: route idle-timeout session closure through runner.end_conversation

### DIFF
--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -13,7 +13,7 @@ import logging
 import time
 from collections import OrderedDict
 from collections.abc import AsyncGenerator
-from typing import Any
+from typing import Any, Callable
 
 from nous.api.anthropic_client import (
     AnthropicClient,
@@ -446,12 +446,28 @@ class AgentRunner:
 
         return response_text, turn_context, usage
 
-    async def end_conversation(self, session_id: str, agent_id: str | None = None) -> None:
+    async def end_conversation(
+        self,
+        session_id: str,
+        agent_id: str | None = None,
+        *,
+        abort_if: Callable[[], bool] | None = None,
+    ) -> bool:
         """End a conversation with reflection.
 
         1. If conversation has >= 3 turns, generate reflection via LLM
-        2. Call cognitive.end_session(agent_id, session_id, reflection=...)
-        3. Remove from self._conversations
+        2. (Optional) Recheck ``abort_if`` — bail if activity resumed
+        3. Call cognitive.end_session(agent_id, session_id, reflection=...)
+        4. Remove from self._conversations
+
+        ``abort_if`` is a no-arg callable that returns True if the close
+        should be aborted (e.g., the user resumed activity while reflection
+        was running). Checked AFTER reflection (read-only, safe to discard)
+        but BEFORE any state mutation. Used by SessionTimeoutMonitor to
+        prevent orphaning an in-flight turn that landed mid-close.
+
+        Returns True if the conversation was closed, False if aborted.
+        Manual /new path passes ``abort_if=None`` and always returns True.
         """
         _agent_id = agent_id or self._settings.agent_id
         conversation = self._conversations.get(session_id)
@@ -479,6 +495,20 @@ class AgentRunner:
             except Exception as e:
                 logger.warning("Failed to generate reflection: %s", e)
 
+        # Pre-mutation recheck: if abort_if fires here (activity resumed
+        # during reflection), bail before touching any state. Reflection
+        # is best-effort and discarding it is harmless.
+        if abort_if is not None:
+            try:
+                if abort_if():
+                    logger.info(
+                        "Aborting end_conversation for %s — activity resumed during close",
+                        session_id,
+                    )
+                    return False
+            except Exception:
+                logger.debug("abort_if check raised (suppressed)", exc_info=True)
+
         await self._cognitive.end_session(_agent_id, session_id, reflection=reflection)
 
         # Remove conversation + persisted state (008.1 Phase 3)
@@ -495,6 +525,7 @@ class AgentRunner:
         if self._cache_break_detector:  # F036
             self._cache_break_detector.reset()
         await self._delete_conversation_state(session_id)
+        return True
 
     # ------------------------------------------------------------------
     # API call

--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -2094,11 +2094,22 @@ Rules:
             return None
 
     async def _delete_conversation_state(self, session_id: str) -> None:
-        """Remove persisted conversation state on session end."""
+        """Remove persisted conversation state on session end.
+
+        Logged at WARNING with stack trace on failure: a silently-leaked
+        conversation_state row will re-hydrate stale messages on the next
+        session use ("user comes back tomorrow and gets ghost messages"),
+        which is hard to diagnose after the fact. The idle-timeout path
+        newly exercises this code, so visibility matters more now.
+        """
         try:
             await self._heart.delete_conversation_state(
                 agent_id=self._settings.agent_id,
                 session_id=session_id,
             )
         except Exception:
-            logger.debug("Failed to delete conversation state for session %s", session_id)
+            logger.warning(
+                "Failed to delete conversation state for session %s",
+                session_id,
+                exc_info=True,
+            )

--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -130,6 +130,12 @@ class AgentRunner:
             CacheBreakDetector() if settings.cache_break_detection_enabled else None
         )
 
+        # SessionTimeoutMonitor back-reference for synchronous activity
+        # refresh at run_turn start. Late-bound in main.py because monitor
+        # is created earlier than runner. None disables the touch (e.g.,
+        # in unit tests that don't wire the monitor).
+        self._session_monitor: Any | None = None
+
     def _log_f026_decision(
         self, event_type: str, data: dict, session_id: str
     ) -> None:
@@ -266,6 +272,20 @@ class AgentRunner:
         10. Return (response_text, turn_context)
         """
         _agent_id = agent_id or self._settings.agent_id
+
+        # Refresh session activity synchronously BEFORE any long-running
+        # work. The event-bus path (turn_completed) only fires after the
+        # entire LLM+tool loop completes — a multi-minute turn for a
+        # session whose _last_activity was already past threshold would
+        # otherwise be closed mid-stream by a monitor tick. The bus is
+        # async-queued so emitting message_received here would leave a
+        # residual race; the synchronous touch eliminates it.
+        if self._session_monitor is not None:
+            try:
+                self._session_monitor.touch(session_id, _agent_id)
+            except Exception:
+                logger.debug("session_monitor.touch failed (suppressed)", exc_info=True)
+
         conversation = await self._get_or_create_conversation(session_id)
 
         # 2. Pre-turn (F4: plumb conversation_messages for dedup)
@@ -748,6 +768,16 @@ class AgentRunner:
             raise RuntimeError("No tool dispatcher set -- call set_dispatcher() first")
 
         _agent_id = agent_id or self._settings.agent_id
+
+        # Sync activity refresh before any long-running work. See run_turn
+        # for rationale — the bus is queued, so message_received emission
+        # would leave a residual race against the monitor tick.
+        if self._session_monitor is not None:
+            try:
+                self._session_monitor.touch(session_id, _agent_id)
+            except Exception:
+                logger.debug("session_monitor.touch failed (suppressed)", exc_info=True)
+
         conversation = await self._get_or_create_conversation(session_id)
 
         # Pre-turn with conversation dedup (F4)

--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -103,6 +103,15 @@ class AgentRunner:
             )
         self._compaction_locks: dict[str, asyncio.Lock] = {}
 
+        # Per-session lock serializing run_turn / stream_chat against
+        # end_conversation. Prevents the race where the idle-close path
+        # mutates session state (cognitive.end_session pops _active_episodes
+        # at layer.py:1519-1520, runner pops _conversations) while a fresh
+        # run_turn coroutine has interleaved during one of cognitive's
+        # internal awaits. abort_if was only a point-in-time check; the
+        # lock makes the mutation block ACTUALLY exclusive.
+        self._session_locks: dict[str, asyncio.Lock] = {}
+
         # F035.4: Context visibility
         self._context_logger: Any | None = None
         self._current_session_id: str = "unknown"
@@ -182,6 +191,16 @@ class AgentRunner:
             model_override=self._settings.action_gating_model,
         )
         return self._extract_text(resp.content)
+
+    def _get_session_lock(self, session_id: str) -> asyncio.Lock:
+        """Per-session lock for serializing run_turn / stream_chat against
+        end_conversation. Created on first use; popped on successful close.
+        """
+        lock = self._session_locks.get(session_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._session_locks[session_id] = lock
+        return lock
 
     def set_dispatcher(self, dispatcher: Any) -> None:
         """Set the tool dispatcher for tool loop execution."""
@@ -286,165 +305,172 @@ class AgentRunner:
             except Exception:
                 logger.debug("session_monitor.touch failed (suppressed)", exc_info=True)
 
-        conversation = await self._get_or_create_conversation(session_id)
+        # Per-session lock: serializes the entire turn body against
+        # end_conversation. Without this, end_conversation could pop
+        # _conversations[sid] during one of cognitive.end_session's
+        # internal awaits while a fresh run_turn coroutine has interleaved
+        # and is mid-turn — the new turn would be orphaned. The lock is
+        # released automatically on every exit path (return, raise).
+        async with self._get_session_lock(session_id):
+            conversation = await self._get_or_create_conversation(session_id)
 
-        # 2. Pre-turn (F4: plumb conversation_messages for dedup)
-        # Filter to user messages first, then take last 8 (D7: window = user turns)
-        recent_messages = [
-            m.content for m in conversation.messages if m.role == "user"
-        ][-8:]
-        turn_context = await self._cognitive.pre_turn(
-            _agent_id,
-            session_id,
-            user_message,
-            conversation_messages=recent_messages or None,
-            user_id=user_id,
-            user_display_name=user_display_name,
-            skip_episode=skip_episode,
-            is_subtask=is_subtask,
-        )
-
-        # 3. Append user message
-        conversation.messages.append(Message(role="user", content=user_message))
-        usage: dict[str, int] = {"input_tokens": 0, "output_tokens": 0}
-
-        # 3b. Censor block check — skip LLM if input was blocked
-        if turn_context.censor_blocked:
-            response_text = turn_context.censor_block_reason or "I can't process that request."
-            conversation.messages.append(Message(role="assistant", content=response_text))
-            turn_result = TurnResult(response_text=response_text)
-            await self._cognitive.post_turn(_agent_id, session_id, turn_result, turn_context)
-            return response_text, turn_context, usage
-
-        # F026: Get/create execution ledger and set turn
-        ledger = self._get_or_create_ledger(session_id)
-        ledger.set_turn((len(conversation.messages) + 1) // 2)
-
-        # F035.4: Store current context for context logger
-        self._current_session_id = session_id
-        self._current_turn_number = (len(conversation.messages) + 1) // 2
-        self._current_frame_id = turn_context.frame.frame_id if turn_context.frame else "unknown"
-        self._current_call_type = "subtask" if is_subtask else "chat"
-
-        # 4-6. Build system prompt and run tool loop
-        response_text = ""
-        tool_results: list[ToolResult] = []
-        error = None
-        try:
-            corrections = self._pending_corrections.pop(session_id, None)
-            system_prompt = self._build_system_prompt(
-                turn_context, platform=platform,
-                ledger=ledger, corrections=corrections,
+            # 2. Pre-turn (F4: plumb conversation_messages for dedup)
+            # Filter to user messages first, then take last 8 (D7: window = user turns)
+            recent_messages = [
+                m.content for m in conversation.messages if m.role == "user"
+            ][-8:]
+            turn_context = await self._cognitive.pre_turn(
+                _agent_id,
+                session_id,
+                user_message,
+                conversation_messages=recent_messages or None,
+                user_id=user_id,
+                user_display_name=user_display_name,
+                skip_episode=skip_episode,
+                is_subtask=is_subtask,
             )
-            # F036: Handle system_prompt_prefix for both str and dict paths
-            if system_prompt_prefix:
-                if isinstance(system_prompt, dict):
-                    # Prefix is stable across session — prepend to static tier
-                    existing = system_prompt.get("static", "")
-                    system_prompt["static"] = (
-                        system_prompt_prefix + "\n\n" + existing if existing
-                        else system_prompt_prefix
-                    )
+
+            # 3. Append user message
+            conversation.messages.append(Message(role="user", content=user_message))
+            usage: dict[str, int] = {"input_tokens": 0, "output_tokens": 0}
+
+            # 3b. Censor block check — skip LLM if input was blocked
+            if turn_context.censor_blocked:
+                response_text = turn_context.censor_block_reason or "I can't process that request."
+                conversation.messages.append(Message(role="assistant", content=response_text))
+                turn_result = TurnResult(response_text=response_text)
+                await self._cognitive.post_turn(_agent_id, session_id, turn_result, turn_context)
+                return response_text, turn_context, usage
+
+            # F026: Get/create execution ledger and set turn
+            ledger = self._get_or_create_ledger(session_id)
+            ledger.set_turn((len(conversation.messages) + 1) // 2)
+
+            # F035.4: Store current context for context logger
+            self._current_session_id = session_id
+            self._current_turn_number = (len(conversation.messages) + 1) // 2
+            self._current_frame_id = turn_context.frame.frame_id if turn_context.frame else "unknown"
+            self._current_call_type = "subtask" if is_subtask else "chat"
+
+            # 4-6. Build system prompt and run tool loop
+            response_text = ""
+            tool_results: list[ToolResult] = []
+            error = None
+            try:
+                corrections = self._pending_corrections.pop(session_id, None)
+                system_prompt = self._build_system_prompt(
+                    turn_context, platform=platform,
+                    ledger=ledger, corrections=corrections,
+                )
+                # F036: Handle system_prompt_prefix for both str and dict paths
+                if system_prompt_prefix:
+                    if isinstance(system_prompt, dict):
+                        # Prefix is stable across session — prepend to static tier
+                        existing = system_prompt.get("static", "")
+                        system_prompt["static"] = (
+                            system_prompt_prefix + "\n\n" + existing if existing
+                            else system_prompt_prefix
+                        )
+                    else:
+                        system_prompt = system_prompt_prefix + "\n\n" + system_prompt
+
+                # Layer 2: History compaction (Spec 008.1)
+                messages = self._format_messages(conversation)
+                # F036: Compactor needs flat string for token estimation
+                _flat_prompt = (
+                    "\n\n".join(v for v in system_prompt.values() if v)
+                    if isinstance(system_prompt, dict) else system_prompt
+                )
+                if self._compactor and self._settings.compaction_enabled:
+                    system_tokens = self._compactor.estimator.estimate(_flat_prompt)
+                    history_tokens = self._compactor.estimator.estimate_messages(messages)
+                    if self._compactor.should_compact(system_tokens, history_tokens):
+                        lock = self._compaction_locks.setdefault(session_id, asyncio.Lock())
+                        async with lock:
+                            messages = self._format_messages(conversation)
+                            history_tokens = self._compactor.estimator.estimate_messages(messages)
+                            if self._compactor.should_compact(system_tokens, history_tokens):
+                                cut_point = self._compactor.find_cut_point(
+                                    messages, self._settings.effective_keep_recent
+                                )
+                                if cut_point > 0:
+                                    snapshot = messages[:cut_point]
+                                    await self._cognitive.pre_compaction(
+                                        agent_id=_agent_id,
+                                        session_id=session_id,
+                                        message_snapshot=snapshot,
+                                    )
+                                    await self._compactor.compact(
+                                        conversation, messages,
+                                        call_api=self._call_api,
+                                        cut_point=cut_point,
+                                    )
+                                    await self._save_conversation(
+                                        _agent_id, session_id, conversation
+                                    )
                 else:
-                    system_prompt = system_prompt_prefix + "\n\n" + system_prompt
+                    system_tokens = len(_flat_prompt) // 4
+                    history_tokens = sum(
+                        len(m.get("content", "")) // 4 for m in messages
+                    )
 
-            # Layer 2: History compaction (Spec 008.1)
-            messages = self._format_messages(conversation)
-            # F036: Compactor needs flat string for token estimation
-            _flat_prompt = (
-                "\n\n".join(v for v in system_prompt.values() if v)
-                if isinstance(system_prompt, dict) else system_prompt
-            )
-            if self._compactor and self._settings.compaction_enabled:
-                system_tokens = self._compactor.estimator.estimate(_flat_prompt)
-                history_tokens = self._compactor.estimator.estimate_messages(messages)
-                if self._compactor.should_compact(system_tokens, history_tokens):
-                    lock = self._compaction_locks.setdefault(session_id, asyncio.Lock())
-                    async with lock:
-                        messages = self._format_messages(conversation)
-                        history_tokens = self._compactor.estimator.estimate_messages(messages)
-                        if self._compactor.should_compact(system_tokens, history_tokens):
-                            cut_point = self._compactor.find_cut_point(
-                                messages, self._settings.effective_keep_recent
-                            )
-                            if cut_point > 0:
-                                snapshot = messages[:cut_point]
-                                await self._cognitive.pre_compaction(
-                                    agent_id=_agent_id,
-                                    session_id=session_id,
-                                    message_snapshot=snapshot,
-                                )
-                                await self._compactor.compact(
-                                    conversation, messages,
-                                    call_api=self._call_api,
-                                    cut_point=cut_point,
-                                )
-                                await self._save_conversation(
-                                    _agent_id, session_id, conversation
-                                )
-            else:
-                system_tokens = len(_flat_prompt) // 4
-                history_tokens = sum(
-                    len(m.get("content", "")) // 4 for m in messages
+                logger.info(
+                    "Context health: messages=%d, system_tokens~=%d, "
+                    "history_tokens~=%d, frame=%s",
+                    len(messages), system_tokens, history_tokens,
+                    turn_context.frame.frame_id if turn_context else "unknown",
                 )
 
-            logger.info(
-                "Context health: messages=%d, system_tokens~=%d, "
-                "history_tokens~=%d, frame=%s",
-                len(messages), system_tokens, history_tokens,
-                turn_context.frame.frame_id if turn_context else "unknown",
+                response_text, tool_results, usage, thinking_blocks = await self._tool_loop(
+                    system_prompt=system_prompt,
+                    conversation=conversation,
+                    frame_id=turn_context.frame.frame_id,
+                    session_id=session_id,
+                    is_subtask=is_subtask,
+                    max_tool_calls=max_tool_calls,
+                    model_override=model_override,
+                    user_message=user_message,
+                    ledger=ledger,
+                    tool_filter=tool_filter,
+                    is_background=is_background,
+                    extra_tools=extra_tools,
+                    force_tool_on_penultimate=force_tool_on_penultimate,
+                )
+                conversation.messages.append(Message(role="assistant", content=response_text))
+            except Exception as e:
+                logger.error("API call error: %s", e)
+                error = str(e)
+                thinking_blocks = []
+                response_text = "I encountered an error processing your request. Please try again."
+                conversation.messages.append(Message(role="assistant", content=response_text))
+                _caught_exc = e
+            else:
+                _caught_exc = None
+
+            # F026: Post-response claim verification + ghost planning detection
+            if _caught_exc is None:
+                self._verify_claims(session_id, response_text, tool_results, ledger)
+
+            # 7. Post-turn (always called, even on error)
+            turn_result = TurnResult(
+                response_text=response_text,
+                tool_results=tool_results,
+                error=error,
+                thinking_blocks=thinking_blocks,
             )
+            await self._cognitive.post_turn(_agent_id, session_id, turn_result, turn_context)
 
-            response_text, tool_results, usage, thinking_blocks = await self._tool_loop(
-                system_prompt=system_prompt,
-                conversation=conversation,
-                frame_id=turn_context.frame.frame_id,
-                session_id=session_id,
-                is_subtask=is_subtask,
-                max_tool_calls=max_tool_calls,
-                model_override=model_override,
-                user_message=user_message,
-                ledger=ledger,
-                tool_filter=tool_filter,
-                is_background=is_background,
-                extra_tools=extra_tools,
-                force_tool_on_penultimate=force_tool_on_penultimate,
-            )
-            conversation.messages.append(Message(role="assistant", content=response_text))
-        except Exception as e:
-            logger.error("API call error: %s", e)
-            error = str(e)
-            thinking_blocks = []
-            response_text = "I encountered an error processing your request. Please try again."
-            conversation.messages.append(Message(role="assistant", content=response_text))
-            _caught_exc = e
-        else:
-            _caught_exc = None
+            # 8. Safety net: warn if decision frame but record_decision not called
+            self._check_safety_net(turn_context, tool_results)
 
-        # F026: Post-response claim verification + ghost planning detection
-        if _caught_exc is None:
-            self._verify_claims(session_id, response_text, tool_results, ledger)
+            # Store context
+            conversation.turn_contexts.append(turn_context)
 
-        # 7. Post-turn (always called, even on error)
-        turn_result = TurnResult(
-            response_text=response_text,
-            tool_results=tool_results,
-            error=error,
-            thinking_blocks=thinking_blocks,
-        )
-        await self._cognitive.post_turn(_agent_id, session_id, turn_result, turn_context)
+            # Re-raise after cleanup so callers (e.g. subtask worker) see the real error
+            if _caught_exc is not None:
+                raise _caught_exc
 
-        # 8. Safety net: warn if decision frame but record_decision not called
-        self._check_safety_net(turn_context, tool_results)
-
-        # Store context
-        conversation.turn_contexts.append(turn_context)
-
-        # Re-raise after cleanup so callers (e.g. subtask worker) see the real error
-        if _caught_exc is not None:
-            raise _caught_exc
-
-        return response_text, turn_context, usage
+            return response_text, turn_context, usage
 
     async def end_conversation(
         self,
@@ -495,36 +521,52 @@ class AgentRunner:
             except Exception as e:
                 logger.warning("Failed to generate reflection: %s", e)
 
-        # Pre-mutation recheck: if abort_if fires here (activity resumed
-        # during reflection), bail before touching any state. Reflection
-        # is best-effort and discarding it is harmless.
-        if abort_if is not None:
-            try:
-                if abort_if():
-                    logger.info(
-                        "Aborting end_conversation for %s — activity resumed during close",
-                        session_id,
-                    )
-                    return False
-            except Exception:
-                logger.debug("abort_if check raised (suppressed)", exc_info=True)
+        # Acquire the per-session lock BEFORE the abort_if recheck and the
+        # state-mutating cognitive.end_session call. Holding the lock here
+        # makes the entire mutation block exclusive with run_turn/stream_chat:
+        # any in-flight turn must release the lock before we can enter, and
+        # any new turn arriving during our cognitive.end_session awaits will
+        # block at the lock rather than racing through and orphaning state.
+        # Reflection above runs WITHOUT the lock because it's read-only
+        # (just generates a summary string) and slow — holding the lock
+        # during a 15-30s LLM call would needlessly block users.
+        async with self._get_session_lock(session_id):
+            # Pre-mutation recheck: if abort_if fires here (activity resumed
+            # during reflection or while we waited for the lock), bail
+            # before touching any state. Reflection is best-effort and
+            # discarding it is harmless.
+            if abort_if is not None:
+                try:
+                    if abort_if():
+                        logger.info(
+                            "Aborting end_conversation for %s — activity resumed during close",
+                            session_id,
+                        )
+                        return False
+                except Exception:
+                    logger.debug("abort_if check raised (suppressed)", exc_info=True)
 
-        await self._cognitive.end_session(_agent_id, session_id, reflection=reflection)
+            await self._cognitive.end_session(_agent_id, session_id, reflection=reflection)
 
-        # Remove conversation + persisted state (008.1 Phase 3)
-        self._conversations.pop(session_id, None)
-        self._compaction_locks.pop(session_id, None)
-        ledger = self._ledgers.pop(session_id, None)  # F026
-        if ledger and ledger.actions:
-            blocked = sum(1 for a in ledger.actions if a.status == "blocked")
-            logger.info(
-                "F026: Session %s ended — %d actions recorded, %d blocked",
-                session_id, len(ledger.actions), blocked,
-            )
-        self._pending_corrections.pop(session_id, None)  # F026
-        if self._cache_break_detector:  # F036
-            self._cache_break_detector.reset()
-        await self._delete_conversation_state(session_id)
+            # Remove conversation + persisted state (008.1 Phase 3)
+            self._conversations.pop(session_id, None)
+            self._compaction_locks.pop(session_id, None)
+            ledger = self._ledgers.pop(session_id, None)  # F026
+            if ledger and ledger.actions:
+                blocked = sum(1 for a in ledger.actions if a.status == "blocked")
+                logger.info(
+                    "F026: Session %s ended — %d actions recorded, %d blocked",
+                    session_id, len(ledger.actions), blocked,
+                )
+            self._pending_corrections.pop(session_id, None)  # F026
+            if self._cache_break_detector:  # F036
+                self._cache_break_detector.reset()
+            await self._delete_conversation_state(session_id)
+
+        # Lock released — safe to pop the lock entry itself. Aborted closes
+        # (early return False above) intentionally retain the lock entry so
+        # the resumed run_turn keeps using the same mutex object.
+        self._session_locks.pop(session_id, None)
         return True
 
     # ------------------------------------------------------------------
@@ -809,434 +851,440 @@ class AgentRunner:
             except Exception:
                 logger.debug("session_monitor.touch failed (suppressed)", exc_info=True)
 
-        conversation = await self._get_or_create_conversation(session_id)
+        # Per-session lock: serializes the entire streaming turn against
+        # end_conversation. Held across all yields so end_conversation cannot
+        # pop _conversations[sid] mid-stream while a tool result is being
+        # awaited. The async generator keeps the lock until exhausted, so
+        # the consumer driving the for-loop also extends the protection.
+        async with self._get_session_lock(session_id):
+            conversation = await self._get_or_create_conversation(session_id)
 
-        # Pre-turn with conversation dedup (F4)
-        recent_messages = [
-            m.content for m in conversation.messages if m.role == "user"
-        ][-8:]
-        turn_context = await self._cognitive.pre_turn(
-            _agent_id,
-            session_id,
-            user_message,
-            conversation_messages=recent_messages or None,
-            user_id=user_id,
-            user_display_name=user_display_name,
-        )
-
-        conversation.messages.append(Message(role="user", content=user_message))
-
-        # Censor block check — yield block message and return
-        if turn_context.censor_blocked:
-            block_msg = turn_context.censor_block_reason or "I can't process that request."
-            conversation.messages.append(Message(role="assistant", content=block_msg))
-            turn_result = TurnResult(response_text=block_msg)
-            await self._cognitive.post_turn(_agent_id, session_id, turn_result, turn_context)
-            yield StreamEvent(type="text", text=block_msg)
-            yield StreamEvent(type="done")
-            return
-
-        # F026: Get/create execution ledger and set turn
-        ledger = self._get_or_create_ledger(session_id)
-        ledger.set_turn((len(conversation.messages) + 1) // 2)
-
-        # F035.4: Store current context for context logger
-        self._current_session_id = session_id
-        self._current_turn_number = (len(conversation.messages) + 1) // 2
-        self._current_frame_id = turn_context.frame.frame_id if turn_context.frame else "unknown"
-        self._current_call_type = "chat"
-
-        corrections = self._pending_corrections.pop(session_id, None)
-        system_prompt = self._build_system_prompt(
-            turn_context, platform=platform,
-            ledger=ledger, corrections=corrections,
-        )
-        # F036: Handle system_prompt_prefix for both str and dict paths
-        if system_prompt_prefix:
-            if isinstance(system_prompt, dict):
-                existing = system_prompt.get("static", "")
-                system_prompt["static"] = (
-                    system_prompt_prefix + "\n\n" + existing if existing
-                    else system_prompt_prefix
-                )
-            else:
-                system_prompt = system_prompt_prefix + "\n\n" + system_prompt
-        tools = self._dispatcher.available_tools(turn_context.frame.frame_id)
-        messages = self._format_messages(conversation)
-
-        # F036: Compactor needs flat string for token estimation
-        _flat_prompt = (
-            "\n\n".join(v for v in system_prompt.values() if v)
-            if isinstance(system_prompt, dict) else system_prompt
-        )
-
-        # Layer 2: History compaction (Spec 008.1)
-        if self._compactor and self._settings.compaction_enabled:
-            system_tokens = self._compactor.estimator.estimate(_flat_prompt)
-            history_tokens = self._compactor.estimator.estimate_messages(messages)
-            if self._compactor.should_compact(system_tokens, history_tokens):
-                lock = self._compaction_locks.setdefault(session_id, asyncio.Lock())
-                async with lock:
-                    # Re-check under lock (double-check pattern)
-                    messages = self._format_messages(conversation)
-                    history_tokens = self._compactor.estimator.estimate_messages(messages)
-                    if self._compactor.should_compact(system_tokens, history_tokens):
-                        cut_point = self._compactor.find_cut_point(
-                            messages, self._settings.effective_keep_recent
-                        )
-                        if cut_point > 0:
-                            # 008.1 Phase 3: Snapshot for event handlers (decoupled from mutation)
-                            snapshot = messages[:cut_point]
-                            await self._cognitive.pre_compaction(
-                                agent_id=_agent_id,
-                                session_id=session_id,
-                                message_snapshot=snapshot,
-                            )
-                            await self._compactor.compact(
-                                conversation, messages,
-                                call_api=self._call_api,
-                                cut_point=cut_point,
-                            )
-                            # 008.1 Phase 3: Persist state after compaction
-                            await self._save_conversation(
-                                _agent_id, session_id, conversation
-                            )
-                            messages = self._format_messages(conversation)
-        else:
-            system_tokens = len(_flat_prompt) // 4
-            history_tokens = sum(
-                len(m.get("content", "")) // 4 for m in messages
+            # Pre-turn with conversation dedup (F4)
+            recent_messages = [
+                m.content for m in conversation.messages if m.role == "user"
+            ][-8:]
+            turn_context = await self._cognitive.pre_turn(
+                _agent_id,
+                session_id,
+                user_message,
+                conversation_messages=recent_messages or None,
+                user_id=user_id,
+                user_display_name=user_display_name,
             )
 
-        logger.info(
-            "Context health: messages=%d, system_tokens~=%d, "
-            "history_tokens~=%d, frame=%s",
-            len(messages), system_tokens, history_tokens,
-            turn_context.frame.frame_id if turn_context else "unknown",
-        )
+            conversation.messages.append(Message(role="user", content=user_message))
 
-        all_tool_results: list[ToolResult] = []
-        all_thinking_blocks: list[str] = []  # Accumulated across all tool loop iterations
-        total_usage: dict[str, int] = {"input_tokens": 0, "output_tokens": 0}
-        response_text = ""
-        error = None
+            # Censor block check — yield block message and return
+            if turn_context.censor_blocked:
+                block_msg = turn_context.censor_block_reason or "I can't process that request."
+                conversation.messages.append(Message(role="assistant", content=block_msg))
+                turn_result = TurnResult(response_text=block_msg)
+                await self._cognitive.post_turn(_agent_id, session_id, turn_result, turn_context)
+                yield StreamEvent(type="text", text=block_msg)
+                yield StreamEvent(type="done")
+                return
 
-        try:
-            for turn in range(self._settings.max_turns):
-                # Unified block accumulator: keyed by block_index, preserves
-                # original order for thinking block preservation (007 Phase D).
-                all_blocks: dict[int, dict[str, Any]] = {}
-                text_parts: list[str] = []
-                tool_calls: list[dict[str, Any]] = []
-                stop_reason = ""
-                _segment_usage: dict[str, Any] = {}  # F036.1: per-segment usage
+            # F026: Get/create execution ledger and set turn
+            ledger = self._get_or_create_ledger(session_id)
+            ledger.set_turn((len(conversation.messages) + 1) // 2)
 
-                # Emit keepalives while waiting for Anthropic's first byte —
-                # large contexts + thinking can cause long waits (008.1)
-                async for event in self._stream_with_keepalive(
-                    system_prompt=system_prompt,
-                    messages=messages,
-                    tools=tools if tools else None,
-                ):
-                    if event.type == "error":
-                        error = event.text
-                        yield event
-                        return
+            # F035.4: Store current context for context logger
+            self._current_session_id = session_id
+            self._current_turn_number = (len(conversation.messages) + 1) // 2
+            self._current_frame_id = turn_context.frame.frame_id if turn_context.frame else "unknown"
+            self._current_call_type = "chat"
 
-                    elif event.type == "message_start":
-                        if event.usage:
-                            total_usage["input_tokens"] += event.usage.get("input_tokens", 0)
-                        # F036.1: Capture per-segment usage for context logger
-                        _segment_usage = dict(event.usage) if event.usage else {}
-
-                    # -- Thinking blocks (yielded to client for thinking indicators) --
-                    elif event.type == "thinking_start":
-                        all_blocks[event.block_index] = {
-                            "type": "thinking",
-                            "thinking_parts": [],
-                            "signature": "",
-                        }
-                        yield event
-
-                    elif event.type == "redacted_thinking":
-                        # Complete block — data arrives in start event
-                        all_blocks[event.block_index] = {
-                            "type": "redacted_thinking",
-                            "data": event.text,
-                        }
-                        yield event
-
-                    elif event.type == "thinking_delta":
-                        block = all_blocks.get(event.block_index)
-                        if block and block["type"] == "thinking":
-                            block["thinking_parts"].append(event.text)
-                        yield event
-
-                    elif event.type == "signature_delta":
-                        block = all_blocks.get(event.block_index)
-                        if block and block["type"] == "thinking":
-                            block["signature"] = event.text
-
-                    # -- Text blocks --
-                    elif event.type == "text_block_start":
-                        all_blocks[event.block_index] = {
-                            "type": "text",
-                            "text_parts": [],
-                        }
-
-                    elif event.type == "text_delta":
-                        text_parts.append(event.text)
-                        # Also track in block for content reconstruction
-                        for idx in sorted(all_blocks, reverse=True):
-                            if all_blocks[idx]["type"] == "text":
-                                all_blocks[idx]["text_parts"].append(event.text)
-                                break
-                        yield event
-
-                    # -- Tool blocks --
-                    elif event.type == "tool_start":
-                        all_blocks[event.block_index] = {
-                            "type": "tool_use",
-                            "id": event.tool_id,
-                            "name": event.tool_name,
-                            "input_parts": [],
-                        }
-                        yield event
-
-                    elif event.type == "tool_input_delta":
-                        block = all_blocks.get(event.block_index)
-                        if block and block["type"] == "tool_use":
-                            block["input_parts"].append(event.text)
-
-                    elif event.type == "block_stop":
-                        block = all_blocks.get(event.block_index)
-                        if block and block["type"] == "tool_use":
-                            input_json = "".join(block["input_parts"])
-                            try:
-                                block["input"] = json.loads(input_json) if input_json else {}
-                            except json.JSONDecodeError:
-                                block["input"] = {}
-                            tool_calls.append(block)
-
-                    elif event.type == "done":
-                        stop_reason = event.stop_reason
-                        if event.usage:
-                            total_usage["input_tokens"] += event.usage.get("input_tokens", 0)
-                            total_usage["output_tokens"] += event.usage.get("output_tokens", 0)
-                            # F036.1: Merge output_tokens into segment usage
-                            _segment_usage["output_tokens"] = event.usage.get("output_tokens", 0)
-
-                # F036.1: Update context log with per-segment usage (not cumulative)
-                if self._context_logger and self._last_context_entry_id:
-                    self._context_logger.update_response(
-                        entry_id=self._last_context_entry_id,
-                        input_tokens=_segment_usage.get("input_tokens"),
-                        output_tokens=_segment_usage.get("output_tokens"),
-                        cache_creation=_segment_usage.get("cache_creation_input_tokens"),
-                        cache_read=_segment_usage.get("cache_read_input_tokens"),
-                        stop_reason=stop_reason or None,
+            corrections = self._pending_corrections.pop(session_id, None)
+            system_prompt = self._build_system_prompt(
+                turn_context, platform=platform,
+                ledger=ledger, corrections=corrections,
+            )
+            # F036: Handle system_prompt_prefix for both str and dict paths
+            if system_prompt_prefix:
+                if isinstance(system_prompt, dict):
+                    existing = system_prompt.get("static", "")
+                    system_prompt["static"] = (
+                        system_prompt_prefix + "\n\n" + existing if existing
+                        else system_prompt_prefix
                     )
-                    self._last_context_entry_id = None  # Consumed
+                else:
+                    system_prompt = system_prompt_prefix + "\n\n" + system_prompt
+            tools = self._dispatcher.available_tools(turn_context.frame.frame_id)
+            messages = self._format_messages(conversation)
 
-                # Stream segment ended -- collect thinking blocks from this iteration
-                for idx in sorted(all_blocks):
-                    block = all_blocks[idx]
-                    if block["type"] == "thinking":
-                        thinking_text = "".join(block["thinking_parts"]).strip()
-                        if thinking_text:
-                            all_thinking_blocks.append(thinking_text)
+            # F036: Compactor needs flat string for token estimation
+            _flat_prompt = (
+                "\n\n".join(v for v in system_prompt.values() if v)
+                if isinstance(system_prompt, dict) else system_prompt
+            )
 
-                if stop_reason == "end_turn" or not tool_calls:
-                    response_text = "".join(text_parts)
-                    break
-
-                # Build assistant message preserving ALL blocks in index order
-                # (critical for thinking block preservation with interleaved thinking)
-                content_blocks: list[dict[str, Any]] = []
-                for idx in sorted(all_blocks):
-                    block = all_blocks[idx]
-                    if block["type"] == "thinking":
-                        content_blocks.append({
-                            "type": "thinking",
-                            "thinking": "".join(block["thinking_parts"]),
-                            "signature": block["signature"],
-                        })
-                    elif block["type"] == "redacted_thinking":
-                        content_blocks.append({
-                            "type": "redacted_thinking",
-                            "data": block["data"],
-                        })
-                    elif block["type"] == "text":
-                        content_blocks.append({
-                            "type": "text",
-                            "text": "".join(block["text_parts"]),
-                        })
-                    elif block["type"] == "tool_use":
-                        content_blocks.append({
-                            "type": "tool_use",
-                            "id": block["id"],
-                            "name": block["name"],
-                            "input": block.get("input", {}),
-                        })
-                messages.append({"role": "assistant", "content": content_blocks})
-
-                # Execute tools (P1-2: all results in single user message)
-                tool_results_for_message: list[dict[str, Any]] = []
-                for tc in tool_calls:
-                    # F022: Auto-inject source_episode_id into learn_fact.
-                    # Use a local variable (not tc["input"]) to avoid mutating the
-                    # shared block dict that content_blocks already references.
-                    dispatch_input = self._maybe_inject_episode_id(tc["name"], tc["input"], session_id)
-
-                    # F026: Action gating (pre-dispatch)
-                    gated = False
-                    if self._action_gate and ledger:
-                        gate_result = await self._action_gate.check(
-                            tc["name"], dispatch_input, ledger, user_message=user_message,
-                        )
-                        self._log_f026_decision(
-                            "f026_action_gate",
-                            {
-                                "tool_name": tc["name"],
-                                "approved": gate_result.approved,
-                                "reason": gate_result.reason,
-                                "mode": self._settings.action_gating_mode,
-                                "turn": ledger.current_turn,
-                            },
-                            session_id=session_id,
-                        )
-                        if gate_result.approved:
-                            logger.info("F026 gate: %s approved (%s)", tc["name"], gate_result.reason)
-                        else:
-                            if self._settings.action_gating_mode == "enforce":
-                                result_text = f"[BLOCKED by ActionGate] {gate_result.reason}"
-                                if gate_result.suggestion:
-                                    result_text += f"\n{gate_result.suggestion}"
-                                is_error = True
-                                gated = True
-                                ledger.record(tc["name"], dispatch_input, result_text, "blocked")
-                                logger.info("F026 gate: %s BLOCKED (%s)", tc["name"], gate_result.reason)
-                            elif self._settings.action_gating_mode == "warn":
-                                logger.warning("F026 gate: %s would block (%s)", tc["name"], gate_result.reason)
-                            else:
-                                logger.debug("F026 gate: %s would block (%s)", tc["name"], gate_result.reason)
-
-                    if not gated:
-                        start_time = time.monotonic()
-                        result_text, is_error = "", False
-                        async for item in self._dispatch_with_keepalive(
-                            tc["name"], dispatch_input, session_id=session_id
-                        ):
-                            if isinstance(item, StreamEvent):
-                                yield item
-                            else:
-                                result_text, is_error = item
-                        duration_ms = int((time.monotonic() - start_time) * 1000)
-
-                        # F026: Record in execution ledger (post-dispatch)
-                        if ledger:
-                            ledger.record(
-                                tc["name"], dispatch_input, result_text,
-                                "error" if is_error else "success",
+            # Layer 2: History compaction (Spec 008.1)
+            if self._compactor and self._settings.compaction_enabled:
+                system_tokens = self._compactor.estimator.estimate(_flat_prompt)
+                history_tokens = self._compactor.estimator.estimate_messages(messages)
+                if self._compactor.should_compact(system_tokens, history_tokens):
+                    lock = self._compaction_locks.setdefault(session_id, asyncio.Lock())
+                    async with lock:
+                        # Re-check under lock (double-check pattern)
+                        messages = self._format_messages(conversation)
+                        history_tokens = self._compactor.estimator.estimate_messages(messages)
+                        if self._compactor.should_compact(system_tokens, history_tokens):
+                            cut_point = self._compactor.find_cut_point(
+                                messages, self._settings.effective_keep_recent
                             )
-                    else:
-                        duration_ms = 0
-
-                    tool_results_for_message.append({
-                        "type": "tool_result",
-                        "tool_use_id": tc["id"],
-                        "content": result_text,
-                        "is_error": is_error,
-                    })
-
-                    all_tool_results.append(ToolResult(
-                        tool_name=tc["name"],
-                        arguments=tc["input"],
-                        result=result_text if not is_error else None,
-                        error=result_text if is_error else None,
-                        duration_ms=duration_ms,
-                    ))
-
-                    yield StreamEvent(type="tool_end", tool_name=tc["name"])
-
-                messages.append({"role": "user", "content": tool_results_for_message})
-
-                # Prune old tool results before next API call (Spec 008.1 Layer 1)
-                if self._compactor:
-                    extracted_facts = self._compactor.prune_tool_results(messages)
-                    if extracted_facts:
-                        for fact_text in extracted_facts:
-                            try:
-                                await self._heart.learn(FactInput(
-                                    content=fact_text,
-                                    category="technical",
-                                    confidence=0.3,
-                                    source="pre_prune_extraction",
-                                ))
-                            except Exception:
-                                logger.debug("Failed to store pre-prune fact: %s", fact_text[:50])
+                            if cut_point > 0:
+                                # 008.1 Phase 3: Snapshot for event handlers (decoupled from mutation)
+                                snapshot = messages[:cut_point]
+                                await self._cognitive.pre_compaction(
+                                    agent_id=_agent_id,
+                                    session_id=session_id,
+                                    message_snapshot=snapshot,
+                                )
+                                await self._compactor.compact(
+                                    conversation, messages,
+                                    call_api=self._call_api,
+                                    cut_point=cut_point,
+                                )
+                                # 008.1 Phase 3: Persist state after compaction
+                                await self._save_conversation(
+                                    _agent_id, session_id, conversation
+                                )
+                                messages = self._format_messages(conversation)
             else:
-                # Max turns reached -- final call without tools
-                logger.warning("Streaming tool loop reached max_turns=%d", self._settings.max_turns)
-                try:
-                    final = await self._call_api(
+                system_tokens = len(_flat_prompt) // 4
+                history_tokens = sum(
+                    len(m.get("content", "")) // 4 for m in messages
+                )
+
+            logger.info(
+                "Context health: messages=%d, system_tokens~=%d, "
+                "history_tokens~=%d, frame=%s",
+                len(messages), system_tokens, history_tokens,
+                turn_context.frame.frame_id if turn_context else "unknown",
+            )
+
+            all_tool_results: list[ToolResult] = []
+            all_thinking_blocks: list[str] = []  # Accumulated across all tool loop iterations
+            total_usage: dict[str, int] = {"input_tokens": 0, "output_tokens": 0}
+            response_text = ""
+            error = None
+
+            try:
+                for turn in range(self._settings.max_turns):
+                    # Unified block accumulator: keyed by block_index, preserves
+                    # original order for thinking block preservation (007 Phase D).
+                    all_blocks: dict[int, dict[str, Any]] = {}
+                    text_parts: list[str] = []
+                    tool_calls: list[dict[str, Any]] = []
+                    stop_reason = ""
+                    _segment_usage: dict[str, Any] = {}  # F036.1: per-segment usage
+
+                    # Emit keepalives while waiting for Anthropic's first byte —
+                    # large contexts + thinking can cause long waits (008.1)
+                    async for event in self._stream_with_keepalive(
                         system_prompt=system_prompt,
                         messages=messages,
-                        tools=None,
-                    )
-                    response_text = self._extract_text(final.content)
-                except Exception:
-                    response_text = "I reached the maximum number of tool iterations."
+                        tools=tools if tools else None,
+                    ):
+                        if event.type == "error":
+                            error = event.text
+                            yield event
+                            return
 
-            # Store assistant response
-            conversation.messages.append(Message(role="assistant", content=response_text))
+                        elif event.type == "message_start":
+                            if event.usage:
+                                total_usage["input_tokens"] += event.usage.get("input_tokens", 0)
+                            # F036.1: Capture per-segment usage for context logger
+                            _segment_usage = dict(event.usage) if event.usage else {}
 
-        except Exception as e:
-            logger.error("Streaming error: %s", e)
-            error = str(e)
-            response_text = "I encountered an error processing your request."
-            conversation.messages.append(Message(role="assistant", content=response_text))
-            _caught_exc = e
-        except asyncio.CancelledError:
-            # Client disconnect — treat as clean exit, still run cleanup
-            logger.info("Stream cancelled (client disconnect) for session %s", session_id)
-            error = "cancelled"
-            _caught_exc = None
-        else:
-            _caught_exc = None
+                        # -- Thinking blocks (yielded to client for thinking indicators) --
+                        elif event.type == "thinking_start":
+                            all_blocks[event.block_index] = {
+                                "type": "thinking",
+                                "thinking_parts": [],
+                                "signature": "",
+                            }
+                            yield event
 
-            # F026: Post-response claim verification (streaming: warn+inject only)
-            self._verify_claims(session_id, response_text, all_tool_results, ledger)
-        finally:
-            # ALWAYS call post_turn (review P1: guaranteed cleanup).
-            # Shield from cancellation to prevent DB connection pool leaks —
-            # CancelledError during post_turn's DB ops leaves sessions checked
-            # out but never returned to the pool.
-            turn_result = TurnResult(
-                response_text=response_text,
-                tool_results=all_tool_results,
-                error=error,
-                thinking_blocks=all_thinking_blocks,
-            )
-            try:
-                await asyncio.shield(
-                    self._cognitive.post_turn(_agent_id, session_id, turn_result, turn_context)
+                        elif event.type == "redacted_thinking":
+                            # Complete block — data arrives in start event
+                            all_blocks[event.block_index] = {
+                                "type": "redacted_thinking",
+                                "data": event.text,
+                            }
+                            yield event
+
+                        elif event.type == "thinking_delta":
+                            block = all_blocks.get(event.block_index)
+                            if block and block["type"] == "thinking":
+                                block["thinking_parts"].append(event.text)
+                            yield event
+
+                        elif event.type == "signature_delta":
+                            block = all_blocks.get(event.block_index)
+                            if block and block["type"] == "thinking":
+                                block["signature"] = event.text
+
+                        # -- Text blocks --
+                        elif event.type == "text_block_start":
+                            all_blocks[event.block_index] = {
+                                "type": "text",
+                                "text_parts": [],
+                            }
+
+                        elif event.type == "text_delta":
+                            text_parts.append(event.text)
+                            # Also track in block for content reconstruction
+                            for idx in sorted(all_blocks, reverse=True):
+                                if all_blocks[idx]["type"] == "text":
+                                    all_blocks[idx]["text_parts"].append(event.text)
+                                    break
+                            yield event
+
+                        # -- Tool blocks --
+                        elif event.type == "tool_start":
+                            all_blocks[event.block_index] = {
+                                "type": "tool_use",
+                                "id": event.tool_id,
+                                "name": event.tool_name,
+                                "input_parts": [],
+                            }
+                            yield event
+
+                        elif event.type == "tool_input_delta":
+                            block = all_blocks.get(event.block_index)
+                            if block and block["type"] == "tool_use":
+                                block["input_parts"].append(event.text)
+
+                        elif event.type == "block_stop":
+                            block = all_blocks.get(event.block_index)
+                            if block and block["type"] == "tool_use":
+                                input_json = "".join(block["input_parts"])
+                                try:
+                                    block["input"] = json.loads(input_json) if input_json else {}
+                                except json.JSONDecodeError:
+                                    block["input"] = {}
+                                tool_calls.append(block)
+
+                        elif event.type == "done":
+                            stop_reason = event.stop_reason
+                            if event.usage:
+                                total_usage["input_tokens"] += event.usage.get("input_tokens", 0)
+                                total_usage["output_tokens"] += event.usage.get("output_tokens", 0)
+                                # F036.1: Merge output_tokens into segment usage
+                                _segment_usage["output_tokens"] = event.usage.get("output_tokens", 0)
+
+                    # F036.1: Update context log with per-segment usage (not cumulative)
+                    if self._context_logger and self._last_context_entry_id:
+                        self._context_logger.update_response(
+                            entry_id=self._last_context_entry_id,
+                            input_tokens=_segment_usage.get("input_tokens"),
+                            output_tokens=_segment_usage.get("output_tokens"),
+                            cache_creation=_segment_usage.get("cache_creation_input_tokens"),
+                            cache_read=_segment_usage.get("cache_read_input_tokens"),
+                            stop_reason=stop_reason or None,
+                        )
+                        self._last_context_entry_id = None  # Consumed
+
+                    # Stream segment ended -- collect thinking blocks from this iteration
+                    for idx in sorted(all_blocks):
+                        block = all_blocks[idx]
+                        if block["type"] == "thinking":
+                            thinking_text = "".join(block["thinking_parts"]).strip()
+                            if thinking_text:
+                                all_thinking_blocks.append(thinking_text)
+
+                    if stop_reason == "end_turn" or not tool_calls:
+                        response_text = "".join(text_parts)
+                        break
+
+                    # Build assistant message preserving ALL blocks in index order
+                    # (critical for thinking block preservation with interleaved thinking)
+                    content_blocks: list[dict[str, Any]] = []
+                    for idx in sorted(all_blocks):
+                        block = all_blocks[idx]
+                        if block["type"] == "thinking":
+                            content_blocks.append({
+                                "type": "thinking",
+                                "thinking": "".join(block["thinking_parts"]),
+                                "signature": block["signature"],
+                            })
+                        elif block["type"] == "redacted_thinking":
+                            content_blocks.append({
+                                "type": "redacted_thinking",
+                                "data": block["data"],
+                            })
+                        elif block["type"] == "text":
+                            content_blocks.append({
+                                "type": "text",
+                                "text": "".join(block["text_parts"]),
+                            })
+                        elif block["type"] == "tool_use":
+                            content_blocks.append({
+                                "type": "tool_use",
+                                "id": block["id"],
+                                "name": block["name"],
+                                "input": block.get("input", {}),
+                            })
+                    messages.append({"role": "assistant", "content": content_blocks})
+
+                    # Execute tools (P1-2: all results in single user message)
+                    tool_results_for_message: list[dict[str, Any]] = []
+                    for tc in tool_calls:
+                        # F022: Auto-inject source_episode_id into learn_fact.
+                        # Use a local variable (not tc["input"]) to avoid mutating the
+                        # shared block dict that content_blocks already references.
+                        dispatch_input = self._maybe_inject_episode_id(tc["name"], tc["input"], session_id)
+
+                        # F026: Action gating (pre-dispatch)
+                        gated = False
+                        if self._action_gate and ledger:
+                            gate_result = await self._action_gate.check(
+                                tc["name"], dispatch_input, ledger, user_message=user_message,
+                            )
+                            self._log_f026_decision(
+                                "f026_action_gate",
+                                {
+                                    "tool_name": tc["name"],
+                                    "approved": gate_result.approved,
+                                    "reason": gate_result.reason,
+                                    "mode": self._settings.action_gating_mode,
+                                    "turn": ledger.current_turn,
+                                },
+                                session_id=session_id,
+                            )
+                            if gate_result.approved:
+                                logger.info("F026 gate: %s approved (%s)", tc["name"], gate_result.reason)
+                            else:
+                                if self._settings.action_gating_mode == "enforce":
+                                    result_text = f"[BLOCKED by ActionGate] {gate_result.reason}"
+                                    if gate_result.suggestion:
+                                        result_text += f"\n{gate_result.suggestion}"
+                                    is_error = True
+                                    gated = True
+                                    ledger.record(tc["name"], dispatch_input, result_text, "blocked")
+                                    logger.info("F026 gate: %s BLOCKED (%s)", tc["name"], gate_result.reason)
+                                elif self._settings.action_gating_mode == "warn":
+                                    logger.warning("F026 gate: %s would block (%s)", tc["name"], gate_result.reason)
+                                else:
+                                    logger.debug("F026 gate: %s would block (%s)", tc["name"], gate_result.reason)
+
+                        if not gated:
+                            start_time = time.monotonic()
+                            result_text, is_error = "", False
+                            async for item in self._dispatch_with_keepalive(
+                                tc["name"], dispatch_input, session_id=session_id
+                            ):
+                                if isinstance(item, StreamEvent):
+                                    yield item
+                                else:
+                                    result_text, is_error = item
+                            duration_ms = int((time.monotonic() - start_time) * 1000)
+
+                            # F026: Record in execution ledger (post-dispatch)
+                            if ledger:
+                                ledger.record(
+                                    tc["name"], dispatch_input, result_text,
+                                    "error" if is_error else "success",
+                                )
+                        else:
+                            duration_ms = 0
+
+                        tool_results_for_message.append({
+                            "type": "tool_result",
+                            "tool_use_id": tc["id"],
+                            "content": result_text,
+                            "is_error": is_error,
+                        })
+
+                        all_tool_results.append(ToolResult(
+                            tool_name=tc["name"],
+                            arguments=tc["input"],
+                            result=result_text if not is_error else None,
+                            error=result_text if is_error else None,
+                            duration_ms=duration_ms,
+                        ))
+
+                        yield StreamEvent(type="tool_end", tool_name=tc["name"])
+
+                    messages.append({"role": "user", "content": tool_results_for_message})
+
+                    # Prune old tool results before next API call (Spec 008.1 Layer 1)
+                    if self._compactor:
+                        extracted_facts = self._compactor.prune_tool_results(messages)
+                        if extracted_facts:
+                            for fact_text in extracted_facts:
+                                try:
+                                    await self._heart.learn(FactInput(
+                                        content=fact_text,
+                                        category="technical",
+                                        confidence=0.3,
+                                        source="pre_prune_extraction",
+                                    ))
+                                except Exception:
+                                    logger.debug("Failed to store pre-prune fact: %s", fact_text[:50])
+                else:
+                    # Max turns reached -- final call without tools
+                    logger.warning("Streaming tool loop reached max_turns=%d", self._settings.max_turns)
+                    try:
+                        final = await self._call_api(
+                            system_prompt=system_prompt,
+                            messages=messages,
+                            tools=None,
+                        )
+                        response_text = self._extract_text(final.content)
+                    except Exception:
+                        response_text = "I reached the maximum number of tool iterations."
+
+                # Store assistant response
+                conversation.messages.append(Message(role="assistant", content=response_text))
+
+            except Exception as e:
+                logger.error("Streaming error: %s", e)
+                error = str(e)
+                response_text = "I encountered an error processing your request."
+                conversation.messages.append(Message(role="assistant", content=response_text))
+                _caught_exc = e
+            except asyncio.CancelledError:
+                # Client disconnect — treat as clean exit, still run cleanup
+                logger.info("Stream cancelled (client disconnect) for session %s", session_id)
+                error = "cancelled"
+                _caught_exc = None
+            else:
+                _caught_exc = None
+
+                # F026: Post-response claim verification (streaming: warn+inject only)
+                self._verify_claims(session_id, response_text, all_tool_results, ledger)
+            finally:
+                # ALWAYS call post_turn (review P1: guaranteed cleanup).
+                # Shield from cancellation to prevent DB connection pool leaks —
+                # CancelledError during post_turn's DB ops leaves sessions checked
+                # out but never returned to the pool.
+                turn_result = TurnResult(
+                    response_text=response_text,
+                    tool_results=all_tool_results,
+                    error=error,
+                    thinking_blocks=all_thinking_blocks,
                 )
-            except (asyncio.CancelledError, Exception):
-                logger.warning("post_turn cleanup interrupted for session %s", session_id)
-            self._check_safety_net(turn_context, all_tool_results)
-            conversation.turn_contexts.append(turn_context)
+                try:
+                    await asyncio.shield(
+                        self._cognitive.post_turn(_agent_id, session_id, turn_result, turn_context)
+                    )
+                except (asyncio.CancelledError, Exception):
+                    logger.warning("post_turn cleanup interrupted for session %s", session_id)
+                self._check_safety_net(turn_context, all_tool_results)
+                conversation.turn_contexts.append(turn_context)
 
-        # Re-raise after cleanup so callers see the real error
-        if _caught_exc is not None:
-            raise _caught_exc
+            # Re-raise after cleanup so callers see the real error
+            if _caught_exc is not None:
+                raise _caught_exc
 
-        # Note: streaming calibration skipped — accumulated total_usage across
-        # multiple tool iterations would bias the per-char ratio. The _tool_loop
-        # path calibrates per-call which is more accurate. Streaming-only turns
-        # (no tools) are typically short Telegram messages where chars/4 is fine.
+            # Note: streaming calibration skipped — accumulated total_usage across
+            # multiple tool iterations would bias the per-char ratio. The _tool_loop
+            # path calibrates per-call which is more accurate. Streaming-only turns
+            # (no tools) are typically short Telegram messages where chars/4 is fine.
 
-        yield StreamEvent(type="done", stop_reason="end_turn", usage=total_usage)
+            yield StreamEvent(type="done", stop_reason="end_turn", usage=total_usage)
 
     # ------------------------------------------------------------------
     # Tool loop

--- a/nous/handlers/session_monitor.py
+++ b/nous/handlers/session_monitor.py
@@ -144,31 +144,67 @@ class SessionTimeoutMonitor:
             except Exception:
                 logger.exception("Session monitor check failed")
 
-    async def _close_expired(self, session_id: str, agent_id: str) -> None:
+    async def _close_expired(
+        self,
+        session_id: str,
+        agent_id: str,
+        snapshot_idle_time: float,
+    ) -> bool:
         """Dispatch a single timed-out session closure on the canonical path.
 
         Used by _check_timeouts to fan out closures concurrently via gather.
         Exceptions propagate; the caller logs them per-future to keep error
         isolation (one stuck reflection cannot stop the others).
+
+        ``snapshot_idle_time`` is the value of ``_last_activity[session_id]``
+        captured when ``_check_timeouts`` decided to close. Passed as an
+        abort_if check into ``runner.end_conversation`` so a touch during the
+        slow reflection phase (15-30s LLM call) pre-empts the close before
+        any state mutation. Without this, a user resuming activity right as
+        the monitor is closing them would have their fresh in-flight turn
+        orphaned when reflection finishes and the close pops _conversations.
+
+        Returns True if the close went through, False if it was aborted by
+        resumed activity. Used by _check_timeouts to decide whether to drop
+        the session from tracking dicts.
         """
+        def _activity_resumed() -> bool:
+            current = self._last_activity.get(session_id)
+            if current is None:
+                return False
+            # Tolerance avoids floating-point equality issues; touch always
+            # bumps by at least a monotonic tick (orders of magnitude > 0.01).
+            return current > snapshot_idle_time + 0.01
+
         if self._runner is not None:
-            await self._runner.end_conversation(session_id, agent_id=agent_id)
-        elif self._cognitive is not None:
+            return await self._runner.end_conversation(
+                session_id, agent_id=agent_id, abort_if=_activity_resumed
+            )
+        if self._cognitive is not None:
+            # Fallback path (test fixtures / early startup) — no abort_if
+            # plumbing into cognitive.end_session, but the window is much
+            # smaller without the slow reflection LLM call.
+            if _activity_resumed():
+                logger.info(
+                    "Aborting fallback close of %s — activity resumed", session_id,
+                )
+                return False
             await self._cognitive.end_session(
                 agent_id=agent_id,
                 session_id=session_id,
                 reflection=None,
             )
-        else:
-            # Both unwired — should be unreachable in prod (main.py wires
-            # cognitive at construction and runner immediately after).
-            # Logged loudly so a future refactor that breaks the wiring
-            # surfaces a signal instead of silently leaking sessions.
-            logger.error(
-                "Session %s expired but no runner/cognitive available — "
-                "no cleanup performed (check main.py wiring)",
-                session_id,
-            )
+            return True
+        # Both unwired — should be unreachable in prod (main.py wires
+        # cognitive at construction and runner immediately after).
+        # Logged loudly so a future refactor that breaks the wiring
+        # surfaces a signal instead of silently leaking sessions.
+        logger.error(
+            "Session %s expired but no runner/cognitive available — "
+            "no cleanup performed (check main.py wiring)",
+            session_id,
+        )
+        return False
 
     async def _check_timeouts(self) -> None:
         """Check all tracked sessions for timeouts."""
@@ -186,7 +222,10 @@ class SessionTimeoutMonitor:
         # sweep + sleep_started detection — by the cumulative reflection
         # time when multiple sessions expire in the same tick. asyncio.gather
         # bounds the wait to the slowest single closure.
-        expired_pairs: list[tuple[str, str]] = []
+        # Each tuple carries the snapshot of _last_activity[sid] at decision
+        # time so the close path can detect a touch that landed mid-reflection
+        # and abort before mutating state.
+        expired: list[tuple[str, str, float]] = []
         for session_id, last in list(self._last_activity.items()):
             idle_seconds = now - last
             if idle_seconds > self._settings.session_idle_timeout:
@@ -198,13 +237,18 @@ class SessionTimeoutMonitor:
                     session_id,
                     int(idle_seconds),
                 )
-                expired_pairs.append((session_id, agent_id))
+                expired.append((session_id, agent_id, last))
 
-        if expired_pairs:
+        # Default: treat every expired session as eligible for tracking
+        # cleanup. Successful close confirms it; explicit abort or raise
+        # downgrades it (don't pop — let the resumed activity keep state).
+        closed: set[str] = {sid for sid, _, _ in expired}
+
+        if expired:
             results = await asyncio.gather(
                 *(
-                    self._close_expired(sid, aid)
-                    for sid, aid in expired_pairs
+                    self._close_expired(sid, aid, snap)
+                    for sid, aid, snap in expired
                 ),
                 return_exceptions=True,
             )
@@ -215,19 +259,22 @@ class SessionTimeoutMonitor:
             for result in results:
                 if isinstance(result, asyncio.CancelledError):
                     raise result
-            for (sid, _), result in zip(expired_pairs, results):
+            for (sid, _, _), result in zip(expired, results):
                 if isinstance(result, BaseException):
-                    # Failed closure: log + move on. Tracking-dict cleanup
-                    # below runs unconditionally — the F060 abandoned-episode
-                    # sleep phase is the backstop that recovers any episode
-                    # state that this raise left dangling.
+                    # Failed closure: log + drop from tracking. The F060
+                    # abandoned-episode sleep phase is the backstop that
+                    # recovers any episode state the raise left dangling.
                     logger.exception(
                         "Failed to end timed-out session %s",
                         sid,
                         exc_info=result,
                     )
+                elif result is False:
+                    # Aborted by resumed activity — session is live again,
+                    # leave tracking entry intact with the fresh touch.
+                    closed.discard(sid)
 
-        for sid, _ in expired_pairs:
+        for sid in closed:
             self._last_activity.pop(sid, None)
             self._last_agent.pop(sid, None)
 

--- a/nous/handlers/session_monitor.py
+++ b/nous/handlers/session_monitor.py
@@ -91,6 +91,23 @@ class SessionTimeoutMonitor:
         self._global_last_activity = now
         self._sleep_emitted = False  # Reset sleep flag on any activity
 
+    def touch(self, session_id: str, agent_id: str) -> None:
+        """Synchronously refresh activity for a session.
+
+        Called by AgentRunner at the START of run_turn so a long in-flight
+        turn cannot be closed mid-stream by a monitor tick. The event-bus
+        path (``on_activity``) is async-queued — by the time the
+        ``turn_completed`` handler runs the turn is already over, leaving a
+        wide race window where the monitor would close a session whose
+        request was received but whose turn hadn't completed. This direct
+        call closes the window.
+        """
+        now = time.monotonic()
+        self._last_activity[session_id] = now
+        self._last_agent[session_id] = agent_id
+        self._global_last_activity = now
+        self._sleep_emitted = False
+
     async def _on_session_ended(self, event: Event) -> None:
         """Clean up tracking when session ends (explicit or timeout). P1-4 fix."""
         if event.session_id:

--- a/nous/handlers/session_monitor.py
+++ b/nous/handlers/session_monitor.py
@@ -1,7 +1,9 @@
 """Session Timeout Monitor — detects idle sessions and triggers lifecycle events.
 
 Tracks last activity per session. Actions:
-- session idle > session_idle_timeout: calls cognitive.end_session() (P0-10 fix)
+- session idle > session_idle_timeout: routes through runner.end_conversation
+  (canonical path, same as manual /new). Falls back to cognitive.end_session
+  if runner is not wired yet (test fixtures, early startup).
 - global idle > sleep_timeout: emits sleep_started
 
 This solves the problem that most sessions never explicitly end —
@@ -20,6 +22,7 @@ from nous.config import Settings
 from nous.events import Event, EventBus
 
 if TYPE_CHECKING:
+    from nous.api.runner import AgentRunner
     from nous.heart.heart import Heart
 
 logger = logging.getLogger(__name__)
@@ -38,6 +41,16 @@ class SessionTimeoutMonitor:
 
     P1-4 fix: Also registers on session_ended to clean tracking dicts when
     sessions end explicitly.
+
+    Idle-closure parity fix: when ``runner`` is wired, the timeout path calls
+    ``runner.end_conversation`` (canonical /new flow) instead of going straight
+    to ``cognitive.end_session``. That single seam decrements
+    ``runner._conversations`` (which feeds /status memory.active_conversations),
+    drops ledgers/compaction locks/pending corrections, resets the cache-break
+    detector, deletes the persisted conversation_state row, and generates the
+    reflection that yields "learned:" facts. Without it the manual /new path
+    and the idle path diverge — the UI stays populated and reflection-derived
+    facts never land.
     """
 
     def __init__(
@@ -47,11 +60,16 @@ class SessionTimeoutMonitor:
         *,
         cognitive: object | None = None,
         heart: Heart | None = None,
+        runner: AgentRunner | None = None,
     ):
         self._bus = bus
         self._settings = settings
         self._cognitive = cognitive  # CognitiveLayer reference for end_session
         self._heart = heart  # F049: required for WM TTL sweep; None disables
+        # AgentRunner reference for canonical end_conversation path.
+        # Late-bound in main.py because runner is created after this monitor
+        # (mirrors cognitive._monitor._procedure_learner wiring).
+        self._runner = runner
         self._last_activity: dict[str, float] = {}  # session_id -> monotonic time
         self._last_agent: dict[str, str] = {}  # session_id -> agent_id
         self._global_last_activity: float = time.monotonic()
@@ -109,39 +127,90 @@ class SessionTimeoutMonitor:
             except Exception:
                 logger.exception("Session monitor check failed")
 
+    async def _close_expired(self, session_id: str, agent_id: str) -> None:
+        """Dispatch a single timed-out session closure on the canonical path.
+
+        Used by _check_timeouts to fan out closures concurrently via gather.
+        Exceptions propagate; the caller logs them per-future to keep error
+        isolation (one stuck reflection cannot stop the others).
+        """
+        if self._runner is not None:
+            await self._runner.end_conversation(session_id, agent_id=agent_id)
+        elif self._cognitive is not None:
+            await self._cognitive.end_session(
+                agent_id=agent_id,
+                session_id=session_id,
+                reflection=None,
+            )
+        else:
+            # Both unwired — should be unreachable in prod (main.py wires
+            # cognitive at construction and runner immediately after).
+            # Logged loudly so a future refactor that breaks the wiring
+            # surfaces a signal instead of silently leaking sessions.
+            logger.error(
+                "Session %s expired but no runner/cognitive available — "
+                "no cleanup performed (check main.py wiring)",
+                session_id,
+            )
+
     async def _check_timeouts(self) -> None:
         """Check all tracked sessions for timeouts."""
         now = time.monotonic()
 
-        # 1. Check individual session timeouts -> cognitive.end_session()
-        expired = []
+        # 1. Collect expired sessions and dispatch closures concurrently.
+        # Prefer runner.end_conversation when wired — this is the canonical
+        # /new path (reflection LLM, cognitive.end_session, _conversations/
+        # _ledgers/cache-break pops, persisted conversation_state delete).
+        # Fall back to cognitive.end_session when runner is unavailable
+        # (test fixtures, very early startup).
+        #
+        # Concurrency: each closure issues a reflection LLM call (~15-30s).
+        # Serializing them would stall the next tick — and starve F049 WM
+        # sweep + sleep_started detection — by the cumulative reflection
+        # time when multiple sessions expire in the same tick. asyncio.gather
+        # bounds the wait to the slowest single closure.
+        expired_pairs: list[tuple[str, str]] = []
         for session_id, last in list(self._last_activity.items()):
             idle_seconds = now - last
             if idle_seconds > self._settings.session_idle_timeout:
-                agent_id = self._last_agent.get(session_id, "unknown")
+                agent_id = self._last_agent.get(
+                    session_id, self._settings.agent_id
+                )
                 logger.info(
                     "Session %s idle for %ds, triggering end_session",
                     session_id,
                     int(idle_seconds),
                 )
+                expired_pairs.append((session_id, agent_id))
 
-                # P0-10 fix: call cognitive.end_session() which has
-                # episode_id, transcript, and does full cleanup
-                if self._cognitive:
-                    try:
-                        await self._cognitive.end_session(
-                            agent_id=agent_id,
-                            session_id=session_id,
-                            reflection=None,
-                        )
-                    except Exception:
-                        logger.exception(
-                            "Failed to end timed-out session %s", session_id
-                        )
+        if expired_pairs:
+            results = await asyncio.gather(
+                *(
+                    self._close_expired(sid, aid)
+                    for sid, aid in expired_pairs
+                ),
+                return_exceptions=True,
+            )
+            # return_exceptions=True captures CancelledError too. If any
+            # child was cancelled (monitor shutdown via stop() -> task.cancel()),
+            # we MUST re-raise so _check_loop sees the cancel and breaks the
+            # loop. Otherwise shutdown hangs until process kill.
+            for result in results:
+                if isinstance(result, asyncio.CancelledError):
+                    raise result
+            for (sid, _), result in zip(expired_pairs, results):
+                if isinstance(result, BaseException):
+                    # Failed closure: log + move on. Tracking-dict cleanup
+                    # below runs unconditionally — the F060 abandoned-episode
+                    # sleep phase is the backstop that recovers any episode
+                    # state that this raise left dangling.
+                    logger.exception(
+                        "Failed to end timed-out session %s",
+                        sid,
+                        exc_info=result,
+                    )
 
-                expired.append(session_id)
-
-        for sid in expired:
+        for sid, _ in expired_pairs:
             self._last_activity.pop(sid, None)
             self._last_agent.pop(sid, None)
 

--- a/nous/main.py
+++ b/nous/main.py
@@ -493,6 +493,13 @@ async def create_components(settings: Settings) -> dict:
     runner.set_api_client(api_client)
     await runner.start()
 
+    # Late-bind runner into SessionTimeoutMonitor so idle-timeout closures
+    # take the canonical runner.end_conversation path (full cleanup + reflection)
+    # rather than only cognitive.end_session. Mirrors the procedure_learner
+    # late-binding above. Safe no-op if monitor is unavailable.
+    if session_monitor is not None:
+        session_monitor._runner = runner
+
     # F035.4: Context Logger
     context_logger = None
     if settings.context_log_enabled:

--- a/nous/main.py
+++ b/nous/main.py
@@ -499,6 +499,12 @@ async def create_components(settings: Settings) -> dict:
     # late-binding above. Safe no-op if monitor is unavailable.
     if session_monitor is not None:
         session_monitor._runner = runner
+        # Back-reference so runner.run_turn / stream_chat can synchronously
+        # touch _last_activity at request-receipt time, closing the race
+        # where a long in-flight turn would otherwise be closed mid-stream
+        # by a monitor tick (the bus path is queued and turn_completed
+        # only fires after the entire turn finishes).
+        runner._session_monitor = session_monitor
 
     # F035.4: Context Logger
     context_logger = None

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -1186,6 +1186,64 @@ class TestSessionTimeoutMonitor:
         assert monitor._last_activity == {}
 
     @pytest.mark.asyncio
+    async def test_touch_refreshes_activity_synchronously(self):
+        """28g-pre. monitor.touch() updates _last_activity without the event bus.
+
+        Codex caught that turn_completed only fires after the full turn,
+        while message_received is never emitted in production. A long
+        in-flight turn for a session whose _last_activity was already past
+        threshold would be closed mid-stream by a monitor tick. The bus is
+        queued, so emitting message_received at request-receipt would not
+        sync-update — a residual race would remain. monitor.touch() is the
+        synchronous escape hatch.
+        """
+        monitor, _bus, _cognitive = self._make_monitor()
+        before = time.monotonic()
+
+        monitor.touch("sess-touch", "agent-touch")
+
+        assert "sess-touch" in monitor._last_activity
+        assert monitor._last_activity["sess-touch"] >= before
+        assert monitor._last_agent["sess-touch"] == "agent-touch"
+        # touch must also count as global activity (resets sleep timer).
+        assert monitor._sleep_emitted is False
+
+    @pytest.mark.asyncio
+    async def test_touch_prevents_mid_turn_closure(self):
+        """28h. touch() called at run_turn start prevents the mid-turn race.
+
+        Pre-condition: session was already stale (idle past threshold).
+        At run_turn start, runner calls monitor.touch(sid, agent_id).
+        Monitor tick fires next. It MUST NOT close the session because the
+        sync touch refreshed _last_activity. Without the touch, the close
+        would pop runner._conversations mid-stream and the in-flight reply
+        would land in a closed/untracked session.
+        """
+        from nous.handlers.session_monitor import SessionTimeoutMonitor
+
+        bus = EventBus()
+        settings = _mock_settings(
+            session_idle_timeout=1, sleep_timeout=9999, sleep_check_interval=1
+        )
+        runner = AsyncMock()
+        monitor = SessionTimeoutMonitor(bus, settings, runner=runner)
+
+        # Seed a stale session as if a previous turn_completed had fired
+        # long ago and the session has been idle since.
+        monitor._last_activity["live"] = time.monotonic() - 100
+        monitor._last_agent["live"] = "agent-1"
+
+        # Runner starts a new turn — touches BEFORE doing any work.
+        monitor.touch("live", "agent-1")
+
+        # Monitor tick races against the in-flight turn.
+        await monitor._check_timeouts()
+
+        # The session must NOT be closed; touch reset the clock.
+        runner.end_conversation.assert_not_called()
+        assert "live" in monitor._last_activity
+
+    @pytest.mark.asyncio
     async def test_cancelled_child_propagates_to_caller(self):
         """28g. CancelledError raised inside a closure must NOT be swallowed.
 

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -1063,8 +1063,13 @@ class TestSessionTimeoutMonitor:
         # Runner.end_conversation is the canonical entry — assert it was
         # used and cognitive.end_session was NOT called directly (runner
         # invokes it internally, but the mocked runner doesn't, which is
-        # what makes this assertion meaningful).
-        runner.end_conversation.assert_called_once_with("sess-1", agent_id="agent-1")
+        # what makes this assertion meaningful). abort_if callback also
+        # passes through (Codex P1 #2 race fix).
+        runner.end_conversation.assert_called_once()
+        call = runner.end_conversation.call_args
+        assert call.args == ("sess-1",)
+        assert call.kwargs["agent_id"] == "agent-1"
+        assert callable(call.kwargs["abort_if"])
         cognitive.end_session.assert_not_called()
 
     @pytest.mark.asyncio
@@ -1092,9 +1097,10 @@ class TestSessionTimeoutMonitor:
 
         await monitor._check_timeouts()
 
-        runner.end_conversation.assert_called_once_with(
-            "sess-late", agent_id="a-late"
-        )
+        runner.end_conversation.assert_called_once()
+        call = runner.end_conversation.call_args
+        assert call.args == ("sess-late",)
+        assert call.kwargs["agent_id"] == "a-late"
 
     @pytest.mark.asyncio
     async def test_idle_timeout_fans_out_concurrently(self):
@@ -1120,12 +1126,13 @@ class TestSessionTimeoutMonitor:
         gate = asyncio.Event()
         finish_order: list[str] = []
 
-        async def gated_close(session_id, agent_id=None):
+        async def gated_close(session_id, agent_id=None, abort_if=None):
             if session_id == "s1":
                 await asyncio.wait_for(gate.wait(), timeout=2.0)
             elif session_id == "s2":
                 gate.set()
             finish_order.append(session_id)
+            return True  # closed successfully
 
         runner = AsyncMock()
         runner.end_conversation.side_effect = gated_close
@@ -1145,6 +1152,10 @@ class TestSessionTimeoutMonitor:
         # s2 must finish before s1 — proves concurrency (s2 set the gate
         # that s1 was waiting on, so s2 returned before s1 unblocked).
         assert finish_order.index("s2") < finish_order.index("s1"), finish_order
+        # All sessions closed (gated_close returns None ≈ truthy from
+        # AsyncMock side_effect-perspective — but explicit confirmation:
+        # tracking should be empty since none of these sessions were touched
+        # during their close.
         assert monitor._last_activity == {}
         assert monitor._last_agent == {}
 
@@ -1164,9 +1175,10 @@ class TestSessionTimeoutMonitor:
         )
         runner = AsyncMock()
 
-        async def maybe_fail(session_id, agent_id=None):
+        async def maybe_fail(session_id, agent_id=None, abort_if=None):
             if session_id == "boom":
                 raise RuntimeError("simulated runner failure")
+            return True
 
         runner.end_conversation.side_effect = maybe_fail
 
@@ -1207,6 +1219,68 @@ class TestSessionTimeoutMonitor:
         assert monitor._last_agent["sess-touch"] == "agent-touch"
         # touch must also count as global activity (resets sleep timer).
         assert monitor._sleep_emitted is False
+
+    @pytest.mark.asyncio
+    async def test_close_aborts_when_touch_lands_during_reflection(self):
+        """28h-pre. Touch during _close_expired's reflection phase aborts the close.
+
+        Codex P1 #2 on PR #424: even with monitor.touch() at run_turn start,
+        a race remains inside runner.end_conversation itself — reflection is
+        a 15-30s LLM call, and a user message arriving during that window
+        sets _last_activity but the already-running close still pops
+        runner._conversations when reflection finishes.
+
+        Fix: _close_expired passes a snapshot of _last_activity at decision
+        time as an abort_if callback. The runner rechecks right before any
+        state mutation (post-reflection, pre-cognitive.end_session). On
+        abort, the close returns False and the monitor leaves tracking
+        entries intact (the fresh touch keeps the session live).
+        """
+        from nous.handlers.session_monitor import SessionTimeoutMonitor
+
+        bus = EventBus()
+        settings = _mock_settings(
+            session_idle_timeout=1, sleep_timeout=9999, sleep_check_interval=1
+        )
+
+        gate = asyncio.Event()
+        touch_complete = asyncio.Event()
+
+        async def slow_end_conversation(session_id, agent_id=None, abort_if=None):
+            # Simulate the reflection LLM call: park here while the test
+            # touches the session, then resume and consult abort_if exactly
+            # like the real runner does post-reflection.
+            await gate.wait()
+            assert abort_if is not None, "monitor must pass abort_if"
+            return not abort_if()
+
+        runner = AsyncMock()
+        runner.end_conversation.side_effect = slow_end_conversation
+
+        monitor = SessionTimeoutMonitor(bus, settings, runner=runner)
+
+        # Stale session that will be selected as expired.
+        stale_time = time.monotonic() - 100
+        monitor._last_activity["live"] = stale_time
+        monitor._last_agent["live"] = "agent-1"
+
+        async def touch_then_release():
+            # Simulate the user resuming activity mid-reflection.
+            await asyncio.sleep(0.01)
+            monitor.touch("live", "agent-1")
+            touch_complete.set()
+            gate.set()  # release the parked close
+
+        async with asyncio.TaskGroup() as tg:
+            tg.create_task(monitor._check_timeouts())
+            tg.create_task(touch_then_release())
+
+        # Touch ran before close completed.
+        assert touch_complete.is_set()
+        # Close was aborted, so tracking still holds the session with the
+        # fresh touch timestamp.
+        assert "live" in monitor._last_activity
+        assert monitor._last_activity["live"] > stale_time
 
     @pytest.mark.asyncio
     async def test_touch_prevents_mid_turn_closure(self):
@@ -1300,9 +1374,10 @@ class TestSessionTimeoutMonitor:
 
         await monitor._check_timeouts()
 
-        runner.end_conversation.assert_called_once_with(
-            "orphan", agent_id="nous-default"
-        )
+        runner.end_conversation.assert_called_once()
+        call = runner.end_conversation.call_args
+        assert call.args == ("orphan",)
+        assert call.kwargs["agent_id"] == "nous-default"
 
     @pytest.mark.asyncio
     async def test_multiple_sessions_tracked_independently(self):

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -1003,7 +1003,13 @@ class TestSessionTimeoutMonitor:
 
     @pytest.mark.asyncio
     async def test_session_ended_after_idle_timeout(self):
-        """28. session_ended triggered after idle timeout (calls cognitive.end_session, NOT raw event)."""
+        """28. Idle timeout falls back to cognitive.end_session when runner unwired.
+
+        With no runner attached (test fixture / early-startup case), the
+        monitor still calls cognitive.end_session directly — this preserves
+        the original P0-10 minimum behavior. The runner-wired path is
+        covered by test_idle_timeout_routes_through_runner below.
+        """
         monitor, bus, cognitive = self._make_monitor(
             settings=_mock_settings(session_idle_timeout=0, sleep_timeout=9999, sleep_check_interval=1)
         )
@@ -1022,6 +1028,223 @@ class TestSessionTimeoutMonitor:
         call_kwargs = cognitive.end_session.call_args[1]
         assert call_kwargs["agent_id"] == "agent-1"
         assert call_kwargs["session_id"] == "sess-1"
+
+    @pytest.mark.asyncio
+    async def test_idle_timeout_routes_through_runner(self):
+        """28b. With runner wired, idle timeout routes through runner.end_conversation.
+
+        This is the canonical /new path — guarantees the idle close runs full
+        cleanup (reflection, _conversations pop, ledger pop, persisted
+        conversation_state delete) instead of only the cognitive.end_session
+        subset. Without this routing, /status memory.active_conversations stays
+        inflated and reflection-derived facts never land.
+        """
+        from nous.handlers.session_monitor import SessionTimeoutMonitor
+
+        bus = EventBus()
+        settings = _mock_settings(
+            session_idle_timeout=0, sleep_timeout=9999, sleep_check_interval=1
+        )
+        cognitive = AsyncMock()
+        runner = AsyncMock()
+
+        monitor = SessionTimeoutMonitor(
+            bus, settings, cognitive=cognitive, runner=runner
+        )
+
+        # Record activity then force it stale
+        await monitor.on_activity(
+            _make_event("turn_completed", session_id="sess-1", agent_id="agent-1")
+        )
+        monitor._last_activity["sess-1"] = time.monotonic() - 10
+
+        await monitor._check_timeouts()
+
+        # Runner.end_conversation is the canonical entry — assert it was
+        # used and cognitive.end_session was NOT called directly (runner
+        # invokes it internally, but the mocked runner doesn't, which is
+        # what makes this assertion meaningful).
+        runner.end_conversation.assert_called_once_with("sess-1", agent_id="agent-1")
+        cognitive.end_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_idle_timeout_late_bound_runner_works(self):
+        """28c. Late-bound runner (mirroring main.py wiring) is honored.
+
+        main.py constructs the monitor before the runner exists, then sets
+        ``session_monitor._runner = runner`` after. This test pins that
+        contract — the timeout path must read ``self._runner`` at call time,
+        not at construction time. A future refactor that captures the
+        kwarg in a closure or reads it once at __init__ would break this.
+        """
+        monitor, _bus, _cognitive = self._make_monitor(
+            settings=_mock_settings(
+                session_idle_timeout=0, sleep_timeout=9999, sleep_check_interval=1
+            )
+        )
+        runner = AsyncMock()
+        monitor._runner = runner  # late-bind exactly as main.py does
+
+        await monitor.on_activity(
+            _make_event("turn_completed", session_id="sess-late", agent_id="a-late")
+        )
+        monitor._last_activity["sess-late"] = time.monotonic() - 10
+
+        await monitor._check_timeouts()
+
+        runner.end_conversation.assert_called_once_with(
+            "sess-late", agent_id="a-late"
+        )
+
+    @pytest.mark.asyncio
+    async def test_idle_timeout_fans_out_concurrently(self):
+        """28d. Multiple sessions expiring in one tick close CONCURRENTLY (not serially).
+
+        Each closure issues a reflection LLM call (~15-30s). Sequential
+        dispatch would stall the next tick, F049 WM sweep, and sleep_started
+        detection by the cumulative reflection time.
+
+        Pinning concurrency: s1's closure blocks on an event that s2's closure
+        sets. If dispatch is serial, s1 awaits forever (deadlock and timeout).
+        If concurrent, s2 runs while s1 is parked, sets the event, and s1
+        unblocks. A regression to a serial ``for sid, aid in pairs: await
+        self._close_expired(...)`` loop would hang this test.
+        """
+        from nous.handlers.session_monitor import SessionTimeoutMonitor
+
+        bus = EventBus()
+        settings = _mock_settings(
+            session_idle_timeout=0, sleep_timeout=9999, sleep_check_interval=1
+        )
+
+        gate = asyncio.Event()
+        finish_order: list[str] = []
+
+        async def gated_close(session_id, agent_id=None):
+            if session_id == "s1":
+                await asyncio.wait_for(gate.wait(), timeout=2.0)
+            elif session_id == "s2":
+                gate.set()
+            finish_order.append(session_id)
+
+        runner = AsyncMock()
+        runner.end_conversation.side_effect = gated_close
+
+        monitor = SessionTimeoutMonitor(bus, settings, runner=runner)
+
+        for sid, aid in [("s1", "a1"), ("s2", "a2"), ("s3", "a3")]:
+            await monitor.on_activity(
+                _make_event("turn_completed", session_id=sid, agent_id=aid)
+            )
+            monitor._last_activity[sid] = time.monotonic() - 10
+
+        # Bounded timeout — serial dispatch would hang on s1.wait() forever.
+        await asyncio.wait_for(monitor._check_timeouts(), timeout=3.0)
+
+        assert runner.end_conversation.call_count == 3
+        # s2 must finish before s1 — proves concurrency (s2 set the gate
+        # that s1 was waiting on, so s2 returned before s1 unblocked).
+        assert finish_order.index("s2") < finish_order.index("s1"), finish_order
+        assert monitor._last_activity == {}
+        assert monitor._last_agent == {}
+
+    @pytest.mark.asyncio
+    async def test_one_failing_closure_does_not_block_others(self):
+        """28e. A single runner.end_conversation failure must not lose other closures.
+
+        Without return_exceptions=True on gather, the first raise would
+        cancel the rest and they would silently stay in tracking dicts —
+        their next-cycle behavior would be undefined.
+        """
+        from nous.handlers.session_monitor import SessionTimeoutMonitor
+
+        bus = EventBus()
+        settings = _mock_settings(
+            session_idle_timeout=0, sleep_timeout=9999, sleep_check_interval=1
+        )
+        runner = AsyncMock()
+
+        async def maybe_fail(session_id, agent_id=None):
+            if session_id == "boom":
+                raise RuntimeError("simulated runner failure")
+
+        runner.end_conversation.side_effect = maybe_fail
+
+        monitor = SessionTimeoutMonitor(bus, settings, runner=runner)
+
+        for sid, aid in [("ok-1", "a"), ("boom", "a"), ("ok-2", "a")]:
+            await monitor.on_activity(
+                _make_event("turn_completed", session_id=sid, agent_id=aid)
+            )
+            monitor._last_activity[sid] = time.monotonic() - 10
+
+        await monitor._check_timeouts()
+
+        assert runner.end_conversation.call_count == 3
+        # All sessions cleared from tracking despite one raising —
+        # otherwise the failed session sticks around and re-fires every tick.
+        assert monitor._last_activity == {}
+
+    @pytest.mark.asyncio
+    async def test_cancelled_child_propagates_to_caller(self):
+        """28g. CancelledError raised inside a closure must NOT be swallowed.
+
+        ``asyncio.gather(..., return_exceptions=True)`` captures CancelledError
+        the same way it captures other exceptions. If the monitor task is
+        cancelled mid-closure (via stop() -> task.cancel()), each child gets
+        a CancelledError. Without explicit re-raise, _check_loop would not
+        see the cancel and shutdown would hang. This test pins the re-raise.
+        """
+        from nous.handlers.session_monitor import SessionTimeoutMonitor
+
+        bus = EventBus()
+        settings = _mock_settings(
+            session_idle_timeout=0, sleep_timeout=9999, sleep_check_interval=1
+        )
+        runner = AsyncMock()
+        runner.end_conversation.side_effect = asyncio.CancelledError()
+
+        monitor = SessionTimeoutMonitor(bus, settings, runner=runner)
+        await monitor.on_activity(
+            _make_event("turn_completed", session_id="s", agent_id="a")
+        )
+        monitor._last_activity["s"] = time.monotonic() - 10
+
+        with pytest.raises(asyncio.CancelledError):
+            await monitor._check_timeouts()
+
+    @pytest.mark.asyncio
+    async def test_missing_last_agent_falls_back_to_settings_agent_id(self):
+        """28f. When _last_agent is missing, the call uses settings.agent_id (not "unknown").
+
+        ``on_activity`` only sets ``_last_agent[sid]`` if ``event.agent_id`` is
+        truthy, but always sets ``_last_activity[sid]``. The lookup must not
+        leak the prior "unknown" sentinel into downstream paths — wrong-tenant
+        risk. settings.agent_id is the right default for a single-agent
+        deployment.
+        """
+        from nous.handlers.session_monitor import SessionTimeoutMonitor
+
+        bus = EventBus()
+        settings = _mock_settings(
+            session_idle_timeout=0,
+            sleep_timeout=9999,
+            sleep_check_interval=1,
+            agent_id="nous-default",
+        )
+        runner = AsyncMock()
+
+        monitor = SessionTimeoutMonitor(bus, settings, runner=runner)
+
+        # Populate _last_activity WITHOUT _last_agent (simulates an event with
+        # falsy agent_id slipping in).
+        monitor._last_activity["orphan"] = time.monotonic() - 10
+
+        await monitor._check_timeouts()
+
+        runner.end_conversation.assert_called_once_with(
+            "orphan", agent_id="nous-default"
+        )
 
     @pytest.mark.asyncio
     async def test_multiple_sessions_tracked_independently(self):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -428,6 +428,50 @@ async def test_run_turn_safety_net_task_frame_debug(mock_cognitive, mock_setting
 # ---------------------------------------------------------------------------
 
 
+async def test_run_turn_touches_session_monitor(runner, mock_cognitive):
+    """run_turn synchronously touches the wired session_monitor at request start.
+
+    Pins the call-site that closes the mid-turn-closure race Codex flagged
+    on PR #424: without this call, a long in-flight turn for a session whose
+    _last_activity was already past threshold can be closed mid-stream by a
+    monitor tick, popping runner._conversations and orphaning the response.
+    """
+    from unittest.mock import MagicMock
+    monitor = MagicMock()
+    runner._session_monitor = monitor
+
+    session_id = f"test-{uuid.uuid4().hex[:8]}"
+    await runner.run_turn(session_id, "Hello!")
+
+    monitor.touch.assert_called_once_with(session_id, runner._settings.agent_id)
+
+
+async def test_run_turn_touch_failure_does_not_break_turn(runner, mock_cognitive):
+    """A monitor.touch() raise is swallowed; the turn still completes.
+
+    Touch is best-effort — a programming bug in the monitor (e.g., a future
+    refactor that lets touch raise) must not break a chat turn for users.
+    """
+    from unittest.mock import MagicMock
+    monitor = MagicMock()
+    monitor.touch.side_effect = RuntimeError("monitor exploded")
+    runner._session_monitor = monitor
+
+    session_id = f"test-{uuid.uuid4().hex[:8]}"
+    response_text, turn_context, _usage = await runner.run_turn(session_id, "Hello!")
+
+    assert response_text == "Hello from Nous!"
+    monitor.touch.assert_called_once()
+
+
+async def test_run_turn_no_monitor_does_not_raise(runner):
+    """Unwired monitor (None) is a benign no-op — preserves backward compat."""
+    assert runner._session_monitor is None
+    session_id = f"test-{uuid.uuid4().hex[:8]}"
+    response_text, _ctx, _usage = await runner.run_turn(session_id, "Hello!")
+    assert response_text == "Hello from Nous!"
+
+
 async def test_end_conversation(runner, mock_cognitive):
     """Removes from dict, calls cognitive.end_session()."""
     session_id = f"test-{uuid.uuid4().hex[:8]}"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -472,6 +472,52 @@ async def test_run_turn_no_monitor_does_not_raise(runner):
     assert response_text == "Hello from Nous!"
 
 
+async def test_end_conversation_abort_if_skips_state_mutation(runner, mock_cognitive):
+    """abort_if=True after reflection prevents cognitive.end_session + _conversations pop.
+
+    Codex P1 #2 on PR #424: monitor passes abort_if so a user message that
+    lands during reflection (the 15-30s slow phase of close) pre-empts the
+    close before any state is mutated. Pins the contract.
+    """
+    session_id = f"test-{uuid.uuid4().hex[:8]}"
+    await runner.run_turn(session_id, "Hello!")
+    assert session_id in runner._conversations
+
+    closed = await runner.end_conversation(
+        session_id, abort_if=lambda: True
+    )
+
+    assert closed is False
+    # State preserved — session lives on, no end_session call.
+    assert session_id in runner._conversations
+    assert len(mock_cognitive.end_session_calls) == 0
+
+
+async def test_end_conversation_abort_if_false_proceeds(runner, mock_cognitive):
+    """abort_if=False (no activity resumed) still closes normally."""
+    session_id = f"test-{uuid.uuid4().hex[:8]}"
+    await runner.run_turn(session_id, "Hello!")
+
+    closed = await runner.end_conversation(
+        session_id, abort_if=lambda: False
+    )
+
+    assert closed is True
+    assert session_id not in runner._conversations
+    assert len(mock_cognitive.end_session_calls) == 1
+
+
+async def test_end_conversation_default_returns_true(runner, mock_cognitive):
+    """Manual /new path (no abort_if) still returns True and closes unconditionally."""
+    session_id = f"test-{uuid.uuid4().hex[:8]}"
+    await runner.run_turn(session_id, "Hello!")
+
+    closed = await runner.end_conversation(session_id)
+
+    assert closed is True
+    assert session_id not in runner._conversations
+
+
 async def test_end_conversation(runner, mock_cognitive):
     """Removes from dict, calls cognitive.end_session()."""
     session_id = f"test-{uuid.uuid4().hex[:8]}"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -472,6 +472,64 @@ async def test_run_turn_no_monitor_does_not_raise(runner):
     assert response_text == "Hello from Nous!"
 
 
+async def test_run_turn_and_end_conversation_serialize(runner, mock_cognitive):
+    """run_turn and end_conversation must NOT interleave for the same session.
+
+    Codex P1 #3 on PR #424: abort_if was a point-in-time check, but
+    cognitive.end_session has internal awaits during which a fresh run_turn
+    could start and modify state that end_conversation then popped. The
+    per-session lock makes the whole mutation block exclusive.
+
+    Test: start a slow run_turn (block on event), kick off end_conversation
+    concurrently, assert end_conversation does NOT touch cognitive.end_session
+    until run_turn has released the lock.
+    """
+    import asyncio
+    from unittest.mock import AsyncMock as _AsyncMock
+
+    session_id = f"test-{uuid.uuid4().hex[:8]}"
+
+    # Make _tool_loop block on a gate so we can race end_conversation against it.
+    gate = asyncio.Event()
+    timeline: list[str] = []
+
+    async def gated_tool_loop(*args, **kwargs):
+        timeline.append("run_turn.tool_loop.enter")
+        await gate.wait()
+        timeline.append("run_turn.tool_loop.exit")
+        return ("ok", [], {"input_tokens": 0, "output_tokens": 0}, [])
+
+    runner._tool_loop = _AsyncMock(side_effect=gated_tool_loop)
+
+    async def trace_end_session(*args, **kwargs):
+        timeline.append("end_conversation.cognitive.end_session")
+
+    mock_cognitive.end_session = trace_end_session
+
+    async def slow_turn():
+        await runner.run_turn(session_id, "hello")
+
+    async def parallel_close():
+        # Give run_turn a head start so it grabs the lock first.
+        await asyncio.sleep(0.05)
+        timeline.append("end_conversation.start")
+        await runner.end_conversation(session_id)
+        timeline.append("end_conversation.return")
+
+    async def release_after_delay():
+        await asyncio.sleep(0.15)
+        gate.set()
+
+    await asyncio.gather(slow_turn(), parallel_close(), release_after_delay())
+
+    # Run_turn must release the lock before end_conversation enters its
+    # critical section. Specifically, cognitive.end_session must execute
+    # AFTER run_turn.tool_loop.exit.
+    exit_idx = timeline.index("run_turn.tool_loop.exit")
+    cognitive_idx = timeline.index("end_conversation.cognitive.end_session")
+    assert cognitive_idx > exit_idx, timeline
+
+
 async def test_end_conversation_abort_if_skips_state_mutation(runner, mock_cognitive):
     """abort_if=True after reflection prevents cognitive.end_session + _conversations pop.
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -608,6 +608,31 @@ class TestStreamChat:
         assert conv.messages[-1].role == "assistant"
 
     @pytest.mark.asyncio
+    async def test_stream_chat_touches_session_monitor(self, runner, mock_cognitive):
+        """stream_chat syncs activity at request start (Codex P1 on PR #424).
+
+        Mirrors test_run_turn_touches_session_monitor — without this call,
+        a long streaming turn for a session whose _last_activity was already
+        past threshold can be closed mid-stream by a monitor tick.
+        """
+        from unittest.mock import MagicMock as _MagicMock
+
+        async def fake_stream(*args, **kwargs):
+            yield StreamEvent(type="text_delta", text="Hi")
+            yield StreamEvent(type="done", stop_reason="end_turn")
+
+        runner._call_api_stream = MagicMock(side_effect=fake_stream)
+
+        monitor = _MagicMock()
+        runner._session_monitor = monitor
+
+        _events = [
+            e async for e in runner.stream_chat("s-stream", "Hello", agent_id="agent-x")
+        ]
+
+        monitor.touch.assert_called_once_with("s-stream", "agent-x")
+
+    @pytest.mark.asyncio
     async def test_agent_id_plumbed(self, runner, mock_cognitive):
         """agent_id passed to pre_turn and post_turn."""
         cognitive, _ = mock_cognitive


### PR DESCRIPTION
## Summary

- Idle-timed-out sessions only ran `cognitive.end_session`, skipping the runner-side cleanup that the manual `/new` path executes — so `/status memory.active_conversations` stayed inflated, reflection-derived "learned:" facts never landed, and ledgers / persisted `conversation_state` rows / `cache_break_detector` state leaked.
- `SessionTimeoutMonitor` now routes through `runner.end_conversation` when late-bound (mirrors the `cognitive._monitor._procedure_learner` wiring already used in `main.py`). Falls back to `cognitive.end_session` for test fixtures / very early startup.
- Closures fan out concurrently via `asyncio.gather(return_exceptions=True)` so the reflection LLM call (~15-30s per session) does not serially stall the next tick / F049 WM sweep / sleep_started detection. `CancelledError` is re-raised so monitor shutdown still propagates.
- Hardening: `_delete_conversation_state` failure promoted from DEBUG to `WARNING(exc_info=True)` to surface ghost-message regressions. `agent_id` default for orphaned `_last_activity` entries changed from `"unknown"` sentinel to `settings.agent_id`.

## Root cause

`/chat DELETE` → `runner.end_conversation` → reflection LLM + `cognitive.end_session` + pops `_conversations`/`_compaction_locks`/`_ledgers`/`_pending_corrections`, resets `_cache_break_detector`, deletes `conversation_state` DB row.

Idle path (`SessionTimeoutMonitor._check_timeouts`) called `cognitive.end_session(reflection=None)` directly — bypassed every runner-side cleanup step. `/status memory.active_conversations: len(runner._conversations)` (`rest.py:293`) never decremented.

## Test plan

- [x] `tests/test_event_bus.py::TestSessionTimeoutMonitor` — 13/13 pass, including 5 new tests:
  - `test_idle_timeout_routes_through_runner` — runner-wired path uses `runner.end_conversation`, NOT `cognitive.end_session` directly.
  - `test_idle_timeout_late_bound_runner_works` — pins the post-construction `monitor._runner = runner` contract used by `main.py`.
  - `test_idle_timeout_fans_out_concurrently` — event-gated; would deadlock under serial dispatch.
  - `test_one_failing_closure_does_not_block_others` — `return_exceptions=True` keeps the other closures running.
  - `test_cancelled_child_propagates_to_caller` — child `CancelledError` is re-raised so shutdown propagates.
  - `test_missing_last_agent_falls_back_to_settings_agent_id` — orphaned `_last_activity` entries no longer leak `"unknown"`.
- [x] `tests/test_runner.py` — 47/47 pass (no regression on `end_conversation` contract or `_delete_conversation_state`).
- [x] `tests/test_event_bus.py` + `tests/test_event_bus_observability.py` + `tests/test_runner.py` — 138/138 pass.
- [x] Two-cycle review: `code-reviewer` + `silent-failure-hunter` + `pr-test-analyzer`, then re-review after fixes. All findings addressed.
- [ ] Manual smoke after deploy: send a chat, wait `session_idle_timeout`, confirm `/status memory.active_conversations` drops to 0 and `nous_system.events` shows `session_ended` with `had_reflection=true`.

## Files

- `nous/handlers/session_monitor.py` — `runner` kwarg + `_close_expired` helper + concurrent gather + CancelledError re-raise.
- `nous/main.py` — late-bind `session_monitor._runner = runner` after `runner.start()`.
- `nous/api/runner.py` — log-level promotion on `_delete_conversation_state`.
- `tests/test_event_bus.py` — 5 new tests + reframed docstring on the fallback test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)