### PR TITLE
F066.1: DAG fix-stage recovery (spec stub)

### DIFF
--- a/docs/features/F066.1-dag-fix-stage.md
+++ b/docs/features/F066.1-dag-fix-stage.md
@@ -1,0 +1,245 @@
+# F066.1 — DAG Fix-Stage Recovery
+
+> **Status:** Draft (spec stub)
+> **Priority:** P2
+> **Depends on:** F038 (Unified DAG Orchestration — shipped), F061 (Subtask Hardening — shipped)
+> **Related:** F024 (Critic Agent), F032/F033 (subtask completion validation)
+> **Parent:** F066 (DAG Creation & Recovery Improvements — umbrella, TBD)
+> **Author:** Nous
+> **Created:** 2026-05-21
+
+---
+
+## Problem
+
+F038 DAG orchestration ships four node types (`subtask`, `check`, `gate`, `callback`) and three edge types (`dependency`, `cancel_cascade`, `context_flow`). When a node fails, the DAG has exactly two implicit responses:
+
+1. F061's bounded 1× retry on **recoverable** failures (timeout, empty-result, validation-failed).
+2. If retry is exhausted or the failure isn't recoverable: the node enters `failed`, downstream `dependency` successors are `blocked`, and `cancel_cascade` edges propagate cancellation. The DAG halts.
+
+There is no first-class concept of **semantic recovery**: diagnose why the node failed, decide whether and how to repair, and either re-fire with an amended prompt or accept the failure with context.
+
+### Motivating failure (F065, 2026-05-21)
+
+`F065-spec-edge-provenance-godnodes` DAG ran four waves:
+
+- `research` (subtask, w0) — completed
+- `write-spec` (subtask, w1) — completed
+- `fact-check` (subtask, w2) — **failed** (completion check exit code 1)
+- `create-pr` (subtask, w3) — blocked (predecessor failed)
+
+The spec exists on disk. The fact-check job exited non-zero. The DAG stopped. Tim had to ask "what is the status?", then "complete the fix and create the PR" — manually re-entering the loop. The DAG had no path to:
+
+- Inspect *why* fact-check exited 1 (the verification step itself errored vs. it found unverifiable claims)
+- Choose between {re-run fact-check with backoff, amend the prompt to scope claims, accept partial fact-check and proceed to PR with a caveat}
+- Either way, unblock `create-pr`
+
+This is not an isolated case. The pre-market subtask silent-failure (April 17), F032 truncation failures, and the recurring "subtask completed with empty result" pattern all share the same shape: a failure is detected but the response is uniform (retry once, then stop).
+
+### Goals
+
+1. **Per-node failure handlers.** Any node may declare a `fix` child that fires only on its `failed` terminal state.
+2. **Wave-level fix.** A single fix node may attach to a wave (set of parallel siblings) and see all failures at once.
+3. **Typed dispatch.** Nodes optionally declare expected failure modes; the fix node dispatches against a typed table rather than free-form LLM diagnosis.
+4. **Bounded.** Default budget: 1 fix attempt per parent (composable with F061's 1× retry — fix fires *after* retry budget is exhausted).
+5. **Authorable in `dag_create`.** New node type and edge type, validated alongside existing schema.
+
+### Non-goals (this spec)
+
+- Multi-step fix chains (fix-of-a-fix). Out of scope; defer to F066.x.
+- Auto-learning fix policies (RL/EvoSkill-style). Out of scope; mention only as future direction.
+- Reactive replanning of the whole DAG (Critic-driven). Belongs to F024 Phase 3; F066.1 is the local primitive Critic can build on.
+
+---
+
+## Design
+
+### 1. New node type: `fix`
+
+```python
+class FixNode(DagNode):
+    type: Literal["fix"]
+    name: str
+    parent_node: str              # the node this fix attaches to
+    instructions: str             # template; receives {parent_output, failure_reason, success_criteria}
+    expected_modes: list[str] = []  # e.g. ["rate_limit", "empty_result", "validation_failed"]
+    actions: list[Literal[
+        "retry_as_is",
+        "retry_with_amended_prompt",
+        "mark_unrecoverable",
+        "skip_and_continue",
+    ]]
+    max_attempts: int = 1
+    model: str | None = None      # default: same tier as parent
+    timeout_seconds: int | None = None
+```
+
+**Trigger condition:** parent node transitions to `failed` *after* F061 retry budget is exhausted. Not triggered on `cancelled`, `timed_out` (which has its own handling), or `completed`.
+
+**Outputs:** a single chosen action plus, for `retry_with_amended_prompt`, the new prompt string. Other actions take no payload.
+
+### 2. New edge type: `on_failure`
+
+Sibling to `dependency`, `cancel_cascade`, `context_flow`. Connects a parent node to its `fix` child. Cycles disallowed (validator extension).
+
+A fix node has exactly one `on_failure` edge inbound and zero or one `dependency` edges outbound (to whatever should run after the fix completes — typically nothing; the fix re-fires the parent in-place).
+
+### 3. Action semantics
+
+| Action | Effect on parent | Effect on downstream |
+|---|---|---|
+| `retry_as_is` | Re-enqueue parent with original prompt | Successors stay `blocked` until parent completes |
+| `retry_with_amended_prompt` | Re-enqueue parent with new prompt from fix output | Successors stay `blocked` until parent completes |
+| `mark_unrecoverable` | Parent stays `failed`; tag with fix diagnosis | Successors cascade per existing rules |
+| `skip_and_continue` | Parent marked `skipped` (new terminal state); fix output piped into `context_flow` for successors | Successors unblock and run |
+
+`skipped` is a new terminal state that is treated like `completed` for `dependency` resolution but distinguished in telemetry. This is the key escape hatch: it lets the DAG proceed past a non-critical failure (e.g., fact-check found two unverifiable nits) without forcing a binary retry/cancel choice.
+
+### 4. Typed dispatch (optional but recommended)
+
+When `expected_modes` is set on the parent node, the fix node's instructions are interpreted as a dispatch table keyed by mode rather than free-form LLM reasoning. Example:
+
+```yaml
+parent:
+  name: fact-check
+  expected_modes: [rate_limit, empty_result, unverifiable_claim]
+fix:
+  name: fact-check-fix
+  dispatch:
+    rate_limit: retry_as_is        # with implicit backoff handled by F061
+    empty_result: retry_with_amended_prompt  # amend = ask for partial coverage
+    unverifiable_claim: skip_and_continue    # log the nit and proceed
+    _default: mark_unrecoverable
+```
+
+The fix node, when it runs, first classifies the failure into one of the declared modes (single LLM call or rule-based on stderr/output) and then applies the mapped action. This is cheaper than a free-form fix LLM and produces audit-friendly traces.
+
+If `expected_modes` is empty, the fix node falls back to free-form LLM diagnosis with the full `actions` list as the allowed output vocabulary.
+
+### 5. Wave-level fix
+
+Special case: `parent_node` may be the name of a *wave* (`wave_2`, `wave_3`, …) rather than a single node. Trigger condition becomes "any node in the wave entered `failed`". The fix node receives a list of failed siblings and may issue per-sibling actions. Useful for parallel fact-check / parallel test waves where a single failure shouldn't block the others.
+
+### 6. Composition with F061
+
+F061's 1× retry runs first (transparent, internal to subtask harness). Only after retry budget is exhausted does the node enter `failed` and the fix path activate. This means:
+
+- Subtask harness retry handles transient/structural failures.
+- Fix node handles semantic / strategy failures.
+
+No double-counting.
+
+---
+
+## Schema changes
+
+### `dag_nodes` table
+
+```sql
+ALTER TABLE dag_nodes ADD COLUMN expected_modes JSONB DEFAULT '[]'::jsonb;
+ALTER TABLE dag_nodes ADD COLUMN parent_node TEXT;  -- for fix nodes
+ALTER TABLE dag_nodes ADD COLUMN fix_actions JSONB DEFAULT '[]'::jsonb;
+ALTER TABLE dag_nodes ADD COLUMN max_fix_attempts INT DEFAULT 1;
+ALTER TABLE dag_nodes ADD COLUMN fix_attempts_used INT DEFAULT 0;
+
+-- new terminal state
+-- existing states: pending, running, awaiting_check, completed, failed, blocked, cancelled
+-- add: skipped
+```
+
+### `dag_edges` table
+
+```sql
+-- existing edge_type enum: dependency, cancel_cascade, context_flow
+-- add: on_failure
+```
+
+### Validator (`schemas.py`)
+
+- `fix` nodes must have exactly one `on_failure` inbound edge
+- `fix` nodes' `parent_node` must reference an existing node or wave label
+- A node may have at most one `fix` child
+- Fix-of-fix forbidden (validator rejects nested fix nodes)
+
+---
+
+## API changes
+
+### `dag_create`
+
+New optional field in node spec:
+
+```json
+{
+  "name": "fact-check-fix",
+  "type": "fix",
+  "parent_node": "fact-check",
+  "instructions": "Diagnose the fact-check failure. Classify into one of {rate_limit, empty_result, unverifiable_claim}. Apply the mapped action.",
+  "expected_modes": ["rate_limit", "empty_result", "unverifiable_claim"],
+  "actions": ["retry_as_is", "retry_with_amended_prompt", "skip_and_continue"]
+}
+```
+
+New edge type:
+
+```json
+{"from_node": "fact-check", "to_node": "fact-check-fix", "edge_type": "on_failure"}
+```
+
+### `dag_manage`
+
+- `status` output annotates fix-eligible nodes with `fix_pending: true` when they're in `failed` and a fix child exists
+- `retry_node` becomes a no-op (with warning) when a fix node is configured — use the fix path instead
+
+---
+
+## Telemetry
+
+Per-fix-firing record in `dag_node_events`:
+
+- `parent_failure_reason` (extracted from parent terminal output)
+- `classified_mode` (which expected_mode it matched, or `unclassified`)
+- `chosen_action`
+- `amended_prompt` (if applicable, redacted hash + first 200 chars)
+- `outcome` (parent succeeded after fix / parent failed again / parent skipped)
+
+This produces the empirical dataset needed to drive future auto-learning of fix policies (out of scope here, but the data shape supports it).
+
+---
+
+## Rollout
+
+1. **Phase 1** — schema migration, validator changes, `fix` node executor with free-form LLM dispatch only (no `expected_modes` typed dispatch yet).
+2. **Phase 2** — typed dispatch, `skipped` terminal state, telemetry table.
+3. **Phase 3** — wave-level fix nodes.
+4. **Phase 4** — Critic integration (F024): the planner that builds a DAG also authors fix nodes for risky steps.
+
+Phase 1 alone resolves the F065-class failure (fact-check exit 1 → fix node diagnoses → amend prompt → retry → create-pr unblocks).
+
+---
+
+## Open questions
+
+1. **Default behavior when no fix node is authored.** Status quo (cascade cancel). Probably correct — fix nodes should be opt-in to avoid masking bugs.
+2. **Fix node failure.** If the fix node itself errors (LLM call fails, dispatch yields invalid action), parent stays `failed` and is marked `fix_errored`. No fix-of-fix.
+3. **`skipped` vs `completed_with_warnings`.** `skipped` is cleaner conceptually but introduces a new state. Alternative: keep `completed` and add a `warnings` JSONB column. Decision deferred to implementation PR.
+4. **Interaction with `cancel_cascade`.** If a parent has both `cancel_cascade` and `on_failure` outbound edges, which fires first? Proposal: fix runs first, and if its action is `mark_unrecoverable`, cascade then propagates. Lock this in Phase 1.
+
+---
+
+## Success criteria
+
+- F065-shaped DAGs (research → write → fact-check → create-pr) survive a fact-check failure without manual intervention when a fix node is authored.
+- Authoring a fix node adds ≤ 10 lines to a `dag_create` call.
+- Fix-node firing produces a complete telemetry record sufficient to learn dispatch policies later.
+- No regression in DAGs that do not use fix nodes (the feature is purely additive).
+
+---
+
+## References
+
+- F038 — Unified DAG Orchestration (shipped, base layer)
+- F061 — Subtask Hardening (shipped, complements via internal retry)
+- F024 — Critic Agent (related; Phase 3 will author fix nodes)
+- F065 — Edge Provenance & God-Node Surfacing (motivating failure case, 2026-05-21)
+- Failure decision archive: pre-market silent fail (Apr 17), F032 truncation (Apr 1), empty-result completion (multiple)

--- a/docs/features/F066.1-dag-fix-stage.md
+++ b/docs/features/F066.1-dag-fix-stage.md
@@ -14,7 +14,7 @@
 
 F038 DAG orchestration ships four node types (`subtask`, `check`, `gate`, `callback`) and three edge types (`dependency`, `cancel_cascade`, `context_flow`). When a node fails, the DAG has exactly two implicit responses:
 
-1. F061's bounded 1× retry on **recoverable** failures (timeout, empty-result, validation-failed).
+1. F061's bounded 1× retry on **recoverable** failures (`incomplete_no_terminal`, `validation_failed`). F061 explicitly does NOT retry `timed_out`, `errored`, or `cancelled` — those terminal outcomes go straight to the failed state without consuming the retry budget (see `docs/features/F061-subtask-hardening.md` §Mechanism 5 and the Goals list).
 2. If retry is exhausted or the failure isn't recoverable: the node enters `failed`, downstream `dependency` successors are `blocked`, and `cancel_cascade` edges propagate cancellation. The DAG halts.
 
 There is no first-class concept of **semantic recovery**: diagnose why the node failed, decide whether and how to repair, and either re-fire with an amended prompt or accept the failure with context.
@@ -62,7 +62,6 @@ class FixNode(DagNode):
     name: str
     parent_node: str              # the node this fix attaches to
     instructions: str             # template; receives {parent_output, failure_reason, success_criteria}
-    expected_modes: list[str] = []  # e.g. ["rate_limit", "empty_result", "validation_failed"]
     actions: list[Literal[
         "retry_as_is",
         "retry_with_amended_prompt",
@@ -74,7 +73,21 @@ class FixNode(DagNode):
     timeout_seconds: int | None = None
 ```
 
-**Trigger condition:** parent node transitions to `failed` *after* F061 retry budget is exhausted. Not triggered on `cancelled`, `timed_out` (which has its own handling), or `completed`.
+**Note on `expected_modes` field placement (review 2026-05-22):** the
+`expected_modes` field lives on the **parent node** (the thing that may
+fail), NOT on the fix node. The migration column at `dag_nodes.expected_modes`
+is on `dag_nodes` generally, but typed-dispatch only consults it when set
+on the PARENT. The fix node consumes the parent's declared modes plus the
+parent's actual failure to choose an action. See § 4 (Typed dispatch) and
+the YAML example below for the canonical placement.
+
+**Trigger condition:** parent node transitions to `failed` *after* F061's bounded retry has run (where applicable). The fix-stage fires for ALL terminal-failure outcomes that produce a `failed` DAG-node state:
+
+- `incomplete_no_terminal` and `validation_failed` (after F061's 1× retry)
+- `timed_out` and `errored` (no F061 retry — these reach `failed` immediately, which is exactly the F065 fact-check exit-1 scenario the spec exists to fix)
+- DAG-level `failed` from a check-node returning false (no F061 retry path)
+
+Not triggered on `cancelled` (user-cancel via API) or `completed`. The previous draft's "not triggered on timed_out" was based on a misreading of F061; corrected (review 2026-05-22).
 
 **Outputs:** a single chosen action plus, for `retry_with_amended_prompt`, the new prompt string. Other actions take no payload.
 


### PR DESCRIPTION
## Summary

Spec stub for F066.1 — adds a first-class **fix-stage** to DAG orchestration so failures can be diagnosed and repaired instead of cascading into a halt.

**Motivating failure:** F065 spec DAG (May 21, 2026) — fact-check wave failed with exit 1, create-pr blocked, DAG halted with no recovery path.

## What it adds

- New node type `fix` and edge type `on_failure`
- Four dispatch actions: `retry_as_is`, `retry_with_amended_prompt`, `mark_unrecoverable`, `skip_and_continue`
- New terminal state `skipped` for non-critical failures
- Optional **typed dispatch** via `expected_modes` on parent nodes (cheaper than free-form LLM diagnosis, audit-friendly)
- **Wave-level fix** variant for parallel-sibling failures
- Telemetry sufficient to learn fix policies later (future direction, not in scope)

## Composition with F061

F061's 1× subtask retry runs first (transparent). Only after retry budget is exhausted does the node enter \`failed\` and the fix path activate. No double-counting.

## Phase 1 alone resolves the F065 failure class

Single fix node attached to \`fact-check\` → classifies failure → amends prompt or skips → \`create-pr\` unblocks.

## Decision record

Architecture decision recorded: \`001e7100-9638-425d-a756-47a804ccdde2\`

## Status

Draft spec stub. No code changes. Open questions and rollout phases enumerated in §"Open questions" and §"Rollout".