### PR TITLE
F065 implementation — edge provenance + god-node surfacing

### DIFF
--- a/docs/features/F065-edge-provenance-godnodes.md
+++ b/docs/features/F065-edge-provenance-godnodes.md
@@ -82,7 +82,35 @@ Existing edges are categorised by their `relation` value alone. **Critical corre
 
 **Why three tiers and not two?** The `'deterministic'` tier is small but non-empty today (only `supersedes`) and provides a natural extension point for future writers that DO carry structural provenance (e.g. a future "fact extracted from this specific episode token range" relation). Keeping the tier in the enum costs nothing and lets downstream code treat it as the highest-trust signal.
 
-**Write-time rule for new edges** (resolves Open Question 1): the new-edge classifier applies the same relation-based mapping as the backfill. The mapping lives in a new helper `nous/brain/edge_provenance.py::classify(relation: str) -> str` (single source of truth — no duplication between backfill and write-time). Each `GraphEdge(...)` construction site sets `extraction_method=classify(relation)` BEFORE handing the row to `session.add` / `pg_insert`. There are eight construction sites total (audited 2026-05-23):
+**Write-time rule for new edges** (resolves Open Question 1): the new-edge classifier applies the same relation-based mapping as the backfill, with an explicit override for writers that carry structural provenance the relation string alone can't express. The helper lives in `nous/brain/edge_provenance.py`:
+
+```python
+def classify(relation: str, *, source: str | None = None) -> str:
+    """Map (relation, optional source) → extraction_method tier.
+
+    source='structural' is the explicit override for writers like
+    link_episode_deterministic that know the edge is structurally
+    extracted (episode token → fact/decision link) even though the
+    relation string ('discussed_in', 'extracted_from') is shared with
+    the cosine-derived densifier path.
+
+    Without source override, the rule is relation-only:
+      relation='supersedes'   → 'deterministic'
+      relation='contradicts'  → 'inferred'
+      otherwise               → 'heuristic'
+    """
+    if source == "structural":
+        return "deterministic"
+    if relation == "supersedes":
+        return "deterministic"
+    if relation == "contradicts":
+        return "inferred"
+    return "heuristic"
+```
+
+`link_episode_deterministic` (graph_linker.py:292) is the canonical structural-extraction site — episode parsing yields explicit fact/decision references, not cosine matches. Both its insert sites pass `source="structural"`. The other 6 writer sites pass relation only.
+
+Each `GraphEdge(...)` construction sets `extraction_method=classify(relation, source=...)` BEFORE handing the row to `session.add` / `pg_insert`. There are eight construction sites total (audited 2026-05-23):
 
 | # | File:line | Writer context |
 |---|---|---|
@@ -307,16 +335,16 @@ ALTER TABLE brain.graph_edges
     ADD COLUMN IF NOT EXISTS extraction_method VARCHAR(20)
         CHECK (extraction_method IN ('deterministic', 'heuristic', 'inferred'));
 
--- Step 2: Backfill — deterministic = explicit (not auto_linked) structural relations.
--- The auto_linked = FALSE clause is load-bearing: graph_densifier and
--- FactGraphLinker / DecisionGraphLinker also write extracted_from /
--- discussed_in edges via cosine-threshold matching with auto_linked=TRUE.
--- Without this gate, the deterministic tier is silently polluted by
--- thousands of heuristic edges (review 2026-05-22 P0).
+-- Step 2: Backfill — deterministic = supersession relations only.
+-- The auto_linked column is NOT a useful discriminator because every
+-- production writer hard-codes auto_linked=True (verified 2026-05-23:
+-- Brain.link() has zero callers, all 8 GraphEdge construction sites
+-- write auto_linked=True). Supersession is the one relation whose
+-- writer carries structural provenance — facts.py and brain.py write
+-- it from explicit supersession decisions, never from cosine matching.
 UPDATE brain.graph_edges
 SET extraction_method = 'deterministic'
-WHERE relation IN ('extracted_from', 'discussed_in', 'supersedes')
-  AND auto_linked = FALSE
+WHERE relation = 'supersedes'
   AND extraction_method IS NULL;
 
 -- Step 3: Backfill — LLM-inferred contradictions (F027 Supersession Detection contradiction path)

--- a/docs/features/F065-edge-provenance-godnodes.md
+++ b/docs/features/F065-edge-provenance-godnodes.md
@@ -72,36 +72,47 @@ The column is **nullable** at addition time to permit a safe migration without l
 
 #### Backfill rules
 
-Existing edges are categorised by their `relation` value and `auto_linked` flag. **Critical correction (review 2026-05-22):** `extracted_from` and `discussed_in` are written by BOTH explicit-extraction paths AND by `Brain.auto_link()` / `graph_densifier.py` cosine-threshold matching (see `nous/brain/graph_linker.py:311-343` and `nous/brain/graph_densifier.py:35-38`). The deterministic tier MUST gate on `auto_linked = FALSE` — otherwise thousands of cosine-derived edges silently get promoted to the trusted tier and the entire down-weighting story for F065 is voided.
+Existing edges are categorised by their `relation` value alone. **Critical correction (review 2026-05-23):** the earlier `auto_linked`-gated rule was empirically unsound — every production writer hard-codes `auto_linked=True` (verified: `Brain.link()` at `nous/brain/brain.py:1045` has zero callers; `_link` at line 1063 is reached only with `auto_linked=True`; `heart/facts.py:166`, `brain/graph_linker.py:99/188/266/304/326`, `brain/brain.py:1280` all set `auto_linked=True` directly). Gating `'deterministic'` on `auto_linked=FALSE` would have classified **zero** rows. We discriminate on relation semantics instead.
 
 | Condition | `extraction_method` assigned | Reasoning |
 |---|---|---|
-| `relation IN ('extracted_from', 'discussed_in', 'supersedes') AND auto_linked = FALSE` | `'deterministic'` | These relations PLUS an explicit, structural match — a fact lifted from a specific episode, or one decision known to supersede another. No model inference involved. |
-| `relation IN ('extracted_from', 'discussed_in') AND auto_linked = TRUE` | `'heuristic'` | Same relation labels but created by `graph_linker` / `graph_densifier` similarity ranking (cosine threshold). Threshold is meaningful but not infallible. |
-| `auto_linked = TRUE AND relation = 'related_to'` | `'heuristic'` | Created by `Brain.auto_link()` (cosine > 0.85). |
-| `relation = 'related_to' AND auto_linked = FALSE` | `'heuristic'` | Manually created related_to edges. |
+| `relation = 'supersedes'` | `'deterministic'` | Supersession is a structural claim: one decision/fact replaces another. The supersession path always carries a concrete `superseded_by` link (not a cosine-similarity match). |
 | `relation = 'contradicts'` | `'inferred'` | Written by F027 (Supersession Detection) contradiction path via LLM reasoning over high-similarity pairs. Model inference, not structural extraction. |
-| All remaining (`supports`, `caused_by`, `informed_by`, `evidence_for`) | `'heuristic'` | Default safe tier; re-classify when provenance can be verified. |
+| All remaining relations (`extracted_from`, `discussed_in`, `related_to`, `supports`, `caused_by`, `informed_by`, `evidence_for`) | `'heuristic'` | Cosine-threshold matching via `graph_linker` / `graph_densifier`. Threshold is meaningful but not infallible. |
 
-**Write-time rule for new edges** (resolves Open Question 1): the new-edge writer applies the same `auto_linked`-gated rule as the backfill. Specifically: `extraction_method='deterministic'` iff `auto_linked=FALSE AND relation IN ('extracted_from','discussed_in','supersedes')`; `'inferred'` iff `relation='contradicts'`; otherwise `'heuristic'`. Wire into `Brain._create_edge` (and the four call sites that bypass it).
+**Why three tiers and not two?** The `'deterministic'` tier is small but non-empty today (only `supersedes`) and provides a natural extension point for future writers that DO carry structural provenance (e.g. a future "fact extracted from this specific episode token range" relation). Keeping the tier in the enum costs nothing and lets downstream code treat it as the highest-trust signal.
+
+**Write-time rule for new edges** (resolves Open Question 1): the new-edge classifier applies the same relation-based mapping as the backfill. The mapping lives in a new helper `nous/brain/edge_provenance.py::classify(relation: str) -> str` (single source of truth — no duplication between backfill and write-time). Each `GraphEdge(...)` construction site sets `extraction_method=classify(relation)` BEFORE handing the row to `session.add` / `pg_insert`. There are eight construction sites total (audited 2026-05-23):
+
+| # | File:line | Writer context |
+|---|---|---|
+| 1 | `nous/brain/brain.py:1074` | `Brain._link` (used by `Brain.link()` and `_auto_link`) |
+| 2 | `nous/brain/brain.py:1280` | `Brain._auto_link` direct construction |
+| 3 | `nous/heart/facts.py:166-186` | Fact↔fact edges (incl. supersession). NOTE: existing `try/except Exception: logger.debug(...)` wrapper swallows DB errors — pre-existing, not introduced by F065. |
+| 4 | `nous/brain/graph_linker.py:99` | `GraphLinker.create_edge` (used by densifier) |
+| 5 | `nous/brain/graph_linker.py:188` | `link_episode_deterministic` direct `pg_insert` |
+| 6 | `nous/brain/graph_linker.py:266` | `link_fact_to_decisions` direct `pg_insert` |
+| 7 | `nous/brain/graph_linker.py:304` | `link_fact_to_facts` direct `pg_insert` |
+| 8 | `nous/brain/graph_linker.py:326` | `link_fact_to_facts` second `pg_insert` branch |
+
+A CI grep-guard test (`tests/test_f065_writer_coverage.py`) counts these sites and asserts the actual count matches a registered constant. Adding a 9th site without registering it fails CI.
 
 SQL backfill (included in migration 047):
 
 ```sql
--- deterministic (must gate on auto_linked = FALSE — see correction above)
+-- Deterministic: supersession relations only (structural by definition).
 UPDATE brain.graph_edges
 SET extraction_method = 'deterministic'
-WHERE relation IN ('extracted_from', 'discussed_in', 'supersedes')
-  AND auto_linked = FALSE
+WHERE relation = 'supersedes'
   AND extraction_method IS NULL;
 
--- inferred (F027 contradiction detector)
+-- Inferred: F027 contradiction detector via LLM reasoning.
 UPDATE brain.graph_edges
 SET extraction_method = 'inferred'
 WHERE relation = 'contradicts'
   AND extraction_method IS NULL;
 
--- heuristic catch-all
+-- Heuristic catch-all (covers all cosine-derived relations).
 UPDATE brain.graph_edges
 SET extraction_method = 'heuristic'
 WHERE extraction_method IS NULL;
@@ -141,7 +152,9 @@ The penalty must be applied at **two** sites that both implement the F022 graph-
 
 Both sites consume `NeighborResult` from `Brain._neighbors`, which must be extended to carry `extraction_method` (see "Integration touchpoints" below).
 
-**Spreading activation (`nous/brain/spreading_activation.py:103`)** already hard-filters `relation != 'contradicts'`, which is the only `inferred`-tier relation in the backfill. The F065 penalty is therefore a no-op on the SA path today — resolving Open Question 2: no action needed unless a future inferred relation is introduced.
+**NULL handling (resolves silent-failure audit P0-3):** when `NeighborResult.extraction_method is None` (theoretically impossible post-migration but defensible against future bugs / SA-synthesized rows), the penalty multiplier treats it as `'heuristic'` — fail-open by design, with a single WARN-level log per occurrence (rate-limited to avoid log spam). The `_neighbors` SELECT and `NeighborResult` field are typed as `str` (non-Optional) once the migration is in; the field-default at construction is `'heuristic'`.
+
+**Spreading activation (`nous/brain/spreading_activation.py:103`)** already hard-filters `relation != 'contradicts'`, which is the only `inferred`-tier relation in the backfill. The F065 penalty is therefore a no-op on the SA path today — resolving Open Question 2. **Defense in depth:** the penalty multiplier is wrapped in an explicit `source != 'spreading_activation'` check at `_graph_expanded_to_pipeline`, so a future inferred-tier relation that bypasses the SA pre-filter cannot accidentally double-penalize SA results.
 
 #### Integration touchpoints (full list)
 
@@ -237,11 +250,16 @@ Expose `top_hubs()` as a tool callable by the agent:
 
 The hook lives inside `nous/cognitive/layer.py::pre_turn` (the canonical session-start path — there is no `nous/api/session.py`, an error in the original spec).
 
-During session-start working-memory construction, check whether any hub's degree has shifted by more than 20% since the previous snapshot. If any hub crosses this threshold, prepend a one-line notice to the system prompt context block:
+**Shift signal (resolves Open Question 4, reviewer P1-3):** the original spec used "raw degree % shift > 20%". This is brittle — F040's nightly densification sweep can uniformly add edges to every hub and trigger false positives on dozens of nodes per session. F065 instead uses **rank-based shift**: a notice fires when a node enters or leaves the top-10 hub list since the previous snapshot. Rank is meaningful (the agent learns which concept just became dominant); raw degree growth on already-dominant hubs is not.
 
 ```
-[graph] Hub shift detected: "Use pgvector for embedding storage" now degree 38 (was 31, +22.6%).
+[graph] Hub shift detected: "Use pgvector for embedding storage" entered the top-10 (rank #4, degree 38).
+[graph] Hub shift detected: "Old assumption about gateways" left the top-10 (was rank #7, now #14).
 ```
+
+**New-hub emergence (resolves silent-failure audit P1-2):** on first sight (no prior snapshot row for the node), the pre_turn hook silently inserts a baseline row and skips the notice. The hub-shift signal is about *change*; there's no change history for a node we've never seen before. The next session will compare against this baseline.
+
+**Insert failure handling (resolves silent-failure audit P1-4):** the snapshot insert and rank computation run fire-and-forget via `asyncio.create_task` so pre_turn never blocks on hub-shift detection. Mirrors the F026 / F059 persistence pattern. Any DB error is logged at WARN level inside the task and dropped — hub-shift is a diagnostic, not a correctness requirement.
 
 **Storage (resolves Open Question 3, reviewer P1):** baseline snapshots do NOT live in `heart.facts`. Rows there enter `recall_deep` candidacy, fact-extractor dedup, and the F051 eval candidate set — polluting the corpus with thousands of operator-metadata facts. Instead, F065 adds a new lightweight table:
 
@@ -258,7 +276,18 @@ CREATE INDEX idx_graph_hub_snapshots_agent_node
     ON brain.graph_hub_snapshots (agent_id, node_id, captured_at DESC);
 ```
 
-The pre_turn hook reads the most-recent snapshot per `(agent_id, node_id)`, compares against the live `top_hubs()` result, and inserts a new snapshot row when any threshold is crossed. The table is read-only to `recall_deep` (no FTS/vector index by design). The 20% threshold is configurable via `NOUS_GRAPH_HUB_SHIFT_THRESHOLD` (default `0.20`).
+The pre_turn hook reads the most-recent snapshot per `(agent_id, node_id)` using the canonical Postgres idiom:
+
+```sql
+SELECT DISTINCT ON (node_id) node_id, degree
+FROM brain.graph_hub_snapshots
+WHERE agent_id = :agent_id AND node_id = ANY(:hub_ids)
+ORDER BY node_id, captured_at DESC
+```
+
+compares against the live `top_hubs()` result by **rank**, and inserts a new snapshot row only when the rank crosses the top-10 boundary. The table is read-only to `recall_deep` (no FTS/vector index by design).
+
+Retention: the sleep handler prunes rows older than `NOUS_GRAPH_HUB_SNAPSHOT_RETENTION_DAYS` (default 90) via a single DELETE on `(agent_id, captured_at)` — added as an index on the snapshot table to support this query efficiently.
 
 ---
 
@@ -320,10 +349,15 @@ CREATE TABLE IF NOT EXISTS brain.graph_hub_snapshots (
     node_id      UUID NOT NULL,
     node_type    VARCHAR(20) NOT NULL,
     degree       INTEGER NOT NULL,
+    rank         INTEGER,  -- F065 (review 2026-05-23): rank in top-N at snapshot time; NULL for nodes outside the top-N at write time
     captured_at  TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+-- Most-recent-per-node lookup (used by pre_turn hub-shift hook).
 CREATE INDEX IF NOT EXISTS idx_graph_hub_snapshots_agent_node
     ON brain.graph_hub_snapshots (agent_id, node_id, captured_at DESC);
+-- Retention prune query (sleep handler).
+CREATE INDEX IF NOT EXISTS idx_graph_hub_snapshots_agent_captured
+    ON brain.graph_hub_snapshots (agent_id, captured_at);
 
 COMMIT;
 ```
@@ -352,13 +386,21 @@ COMMIT;
 
 2. **Default on new edges.** Insert a new edge via `Brain.auto_link()` without specifying `extraction_method`. Assert the row has `extraction_method='heuristic'` (DEFAULT).
 
-3. **recall_deep penalty applied.** Seed two edges from node A: one `extraction_method='deterministic'`, one `extraction_method='inferred'`, both `weight=1.0`. Call `recall_deep` on a query that activates node A. Assert the inferred neighbor's final score is ≤ `deterministic_score × 0.7 × 1.01` (within floating-point tolerance).
+3. **recall_deep penalty applied with active setting.** Override `NOUS_GRAPH_INFERRED_EDGE_PENALTY=0.7`. Seed two edges from node A: one `extraction_method='deterministic'`, one `extraction_method='inferred'`, both `weight=1.0`. Call `recall_deep` on a query that activates node A. Assert the inferred neighbor's final score is `deterministic_score × 0.7` (within floating-point tolerance).
 
-4. **Penalty disabled at 1.0.** Set `NOUS_GRAPH_INFERRED_EDGE_PENALTY=1.0`. Repeat case 3. Assert both neighbors score identically (no penalty).
+4. **Penalty default (1.0) is byte-identical to F022 baseline.** Default config (`NOUS_GRAPH_INFERRED_EDGE_PENALTY=1.0`). Repeat case 3. Assert both neighbors score identically — F065 with the dark-launch default does not alter retrieval.
+
+4b. **NULL `extraction_method` is treated as `heuristic`.** Force a `NeighborResult` with `extraction_method=None` (simulating a SA-synthesized row or a pre-migration row that slipped through). Override penalty to `0.7`. Assert score is computed as if `extraction_method='heuristic'` (no penalty applied) AND a WARN log was emitted exactly once for the agent_id over the test window.
 
 5. **`recall_hubs` tool returns correct top-N.** Insert 20 nodes with known degree distributions. Call `recall_hubs(limit=5)`. Assert the five returned nodes are exactly the five highest-degree nodes, sorted descending. Assert `node_type` filter works: `recall_hubs(limit=5, node_type='fact')` returns only fact nodes.
 
-6. **Hub-shift auto-surface.** Record a baseline degree of 25 for a hub node in the new `brain.graph_hub_snapshots` table. Increase the node's degree to 31 (24% gain — above 20% threshold). Simulate a session-start (`pre_turn` invocation). Assert the working-memory context block contains the hub-shift notice line and a new snapshot row was inserted. Then set degree to 26 (4% gain — below threshold) and assert no notice is injected and no new snapshot is written.
+6. **Hub-shift auto-surface (rank-based).** Seed `brain.graph_hub_snapshots` with a node at rank #4. Simulate a session where the live `top_hubs(limit=10)` now places it at rank #11 (left the top-10). Trigger `pre_turn`. Assert a hub-shift notice was injected and a new snapshot row was written. Then simulate another session where the node moves from rank #5 to rank #6 (still in top-10, no boundary crossing) and assert no notice and no new snapshot row.
+
+7. **New-hub emergence.** Insert a node that does NOT appear in `brain.graph_hub_snapshots` at all. Run `pre_turn`. Assert a baseline snapshot row was inserted AND no hub-shift notice was emitted (silent first-sight).
+
+8. **pre_turn snapshot insert failure is non-blocking.** Monkey-patch the snapshot manager to raise. Run `pre_turn`. Assert the working-memory context block is constructed successfully (no exception escapes) and a WARN-level log entry was emitted.
+
+9. **Writer-coverage CI guard.** `tests/test_f065_writer_coverage.py` greps for `GraphEdge(` constructions and `pg_insert(GraphEdge)` calls in `nous/brain/` and `nous/heart/`. Asserts the count equals `EXPECTED_WRITER_COUNT = 8`. Adding a 9th writer site (e.g. in a new feature) without updating this constant fails CI loudly. Forces every writer to be classified.
 
 ---
 
@@ -376,7 +418,7 @@ COMMIT;
 
 ## Open Questions
 
-1. ~~**`extraction_method` on newly-written edges — who sets it?**~~ **Resolved** (2026-05-22 review): write-time inference using the same `relation` + `auto_linked` rule as the backfill. See "Write-time rule for new edges" under Edge Provenance § Backfill rules. Wire into `Brain._create_edge` and the four densifier/linker call sites that bypass it.
+1. ~~**`extraction_method` on newly-written edges — who sets it?**~~ **Resolved** (2026-05-23 review): write-time classification via `nous/brain/edge_provenance.py::classify(relation)` (single source of truth). Wired into all eight GraphEdge construction sites enumerated above, with a CI grep-guard test that fails if a new site is added without registration. The original "`Brain._create_edge` (and the four call sites that bypass it)" was wrong on two counts: there is no `_create_edge` (the function is `_link`), and the actual count is eight, not four.
 
 2. ~~**Inferred-edge penalty interaction with spreading activation.**~~ **Resolved** (2026-05-22 review): currently moot — `spreading_activation.py:103` already hard-filters `relation != 'contradicts'`, which is the only `inferred`-tier relation in the backfill. If a future inferred-tier relation is added (e.g. an LLM-inferred semantic link), revisit this question then.
 
@@ -408,7 +450,7 @@ COMMIT;
 
 **Rollback:** Phases 1-3 are forward-only on schema but behaviorally gated. Setting `NOUS_GRAPH_INFERRED_EDGE_PENALTY=1.0` and `NOUS_GRAPH_HUB_AUTOSURFACE_ENABLED=false` returns to F022 baseline behavior. The two new tables can be dropped in a follow-up if F065 is rolled back entirely.
 
-4. **20% hub-shift threshold — is it the right signal?** The threshold is borrowed from the god-node intuition (hub = high-degree node that "everything flows through"), but degree growth can be mechanical — a single densification sweep from F040 could add 50 edges to every fact node uniformly. Would a relative *rank* shift (e.g. a node entering or leaving the top-10 list) be a more meaningful signal than a raw degree percentage?
+~~**4. 20% hub-shift threshold — is it the right signal?**~~ **Resolved** (2026-05-23 review): replaced with rank-based shift (notice fires when a node enters/leaves the top-10 list). The 20% raw-degree heuristic was vulnerable to false-positive storms after F040 densification sweeps — every hub would cross the threshold simultaneously. Rank changes are semantically meaningful and naturally rate-limited (only 10 nodes can be in the top-10 at any time).
 
 ---
 

--- a/docs/superpowers/plans/2026-05-23-f065-edge-provenance-impl.md
+++ b/docs/superpowers/plans/2026-05-23-f065-edge-provenance-impl.md
@@ -1,0 +1,125 @@
+# F065 Implementation Plan
+
+**Spec:** `docs/features/F065-edge-provenance-godnodes.md` (corrected in this branch)
+**Branch:** `feat/F065-edge-provenance-impl`
+**Date:** 2026-05-23
+**LOE:** ~8h focused work (revised up from spec's 6h due to writer-site count of 8, not 4)
+
+---
+
+## Pre-flight invariants (verified 2026-05-23)
+
+- `Brain.link()` at `nous/brain/brain.py:1045` has zero callers; only `_link` is reached. Every production writer hard-codes `auto_linked=True`. Backfill discriminator is `relation`, NOT `auto_linked` (see spec correction).
+- `brain.graph_edges` exists with `weight FLOAT`, `auto_linked BOOLEAN`. Migration 047 is the next free slot (043-046 occupied).
+- `NeighborResult` at `nous/brain/schemas.py:152` currently has fields `id`, `node_type`, `description`, `edge_relation`, `edge_weight`, `created_at`.
+- `_graph_expanded_to_pipeline` at `nous/api/retrieval_pipeline.py:502` and `_heart_graph_to_pipeline` at `:460` both apply `graph_recall_decay`. Both must apply the F065 penalty.
+- `pre_turn` at `nous/cognitive/layer.py` is the session-start hook. F026 / F059 patterns show `asyncio.create_task` + try/except inside the task for fire-and-forget persistence.
+- 8 GraphEdge construction sites total (audited; see spec backfill table for line numbers).
+
+If any of these invariants fails when the implementer runs, STOP and re-verify before coding.
+
+---
+
+## Commit sequence
+
+### Commit A — Migration 047 + ORM + classify() helper
+
+**Files:**
+- `sql/migrations/047_f065_edge_provenance.sql` (new) — exactly as in spec § Migration.
+- `nous/storage/models.py` — `GraphEdge.extraction_method: Mapped[str]` (`String(20)`, `nullable=False`, `server_default="'heuristic'"`); new `GraphHubSnapshot` ORM model under `brain` schema with the table definition from the spec.
+- `nous/brain/edge_provenance.py` (new) — single function `classify(relation: str) -> str` returning `'deterministic'` for `supersedes`, `'inferred'` for `contradicts`, `'heuristic'` otherwise. Plus a `VALID_METHODS: Final[frozenset[str]] = frozenset({"deterministic", "heuristic", "inferred"})` for the CHECK constraint mirror.
+- `tests/test_f065_storage.py` — three tests: classify() exhaustive (every existing relation maps somewhere); GraphEdge row default = 'heuristic' when no extraction_method passed; GraphHubSnapshot ORM round-trip.
+
+**Acceptance:** all three new tests pass; `uv run pytest tests/test_f065_*.py` green.
+
+### Commit B — Writer plumbing (all 8 sites)
+
+**Files:**
+- `nous/brain/brain.py:1074` — `Brain._link` constructor adds `extraction_method=classify(relation)`.
+- `nous/brain/brain.py:1280` — direct `GraphEdge(...)` in `_auto_link` adds the same.
+- `nous/heart/facts.py:166-186` — fact↔fact edge insert; classify there.
+- `nous/brain/graph_linker.py:99` — `GraphLinker.create_edge` constructor.
+- `nous/brain/graph_linker.py:188, 266, 304, 326` — four direct `pg_insert(GraphEdge)` calls, each gets `extraction_method=classify(relation)`.
+- `tests/test_f065_writer_coverage.py` (new) — CI grep-guard. Scan `nous/brain/` and `nous/heart/` for `GraphEdge(` and `pg_insert(GraphEdge)`. Assert count == `EXPECTED_WRITER_COUNT = 8`. Comment in the test explains how to register a new site.
+- `tests/test_f065_writer_classification.py` (new) — for each of the 8 sites, write an edge through that code path and verify `extraction_method` matches `classify(relation)` for the relation actually written. For sites that write `supersedes`, expect `'deterministic'`; for `contradicts`, `'inferred'`; for everything else, `'heuristic'`. Use real Postgres backend via the existing test fixtures.
+
+**Acceptance:** writer-coverage test passes; per-site classification tests pass; existing graph tests (`tests/test_graph_*.py`, `tests/test_brain_*.py`) still pass.
+
+### Commit C — NeighborResult + _neighbors SELECT + pipeline penalty wiring
+
+**Files:**
+- `nous/brain/schemas.py::NeighborResult` — add `extraction_method: str = "heuristic"` (str, not Optional; default is the fail-open tier; comment cites the F065 P0-3 NULL-handling rationale).
+- `nous/brain/brain.py::_neighbors` — `source_q` and `target_q` SELECT `GraphEdge.extraction_method.label("extraction_method")`. `edge_map[r.neighbor_id]` tuple extended to carry `extraction_method`. All `NeighborResult(...)` constructors set it.
+- `nous/api/retrieval_pipeline.py::_graph_expanded_to_pipeline` and `:_heart_graph_to_pipeline` — apply penalty:
+  ```python
+  method = neighbor.extraction_method or "heuristic"
+  penalty = settings.graph_inferred_edge_penalty if method == "inferred" else 1.0
+  score = base_score * decay * penalty
+  ```
+  Both call sites use the same helper `_apply_provenance_penalty(neighbor, base_score, decay, settings, source)` defined once at module scope. The helper short-circuits when `source == "spreading_activation"` (defense-in-depth per spec).
+- `nous/config.py` — `graph_inferred_edge_penalty: float = 1.0` with env var `NOUS_GRAPH_INFERRED_EDGE_PENALTY`. Dark-launch default.
+- `tests/test_f065_pipeline_penalty.py` (new) — test plan items 3, 4, 4b verbatim. Use mocked `NeighborResult` objects with explicit `extraction_method`. No live DB needed.
+
+**Acceptance:** all new tests pass; `tests/test_retrieval_pipeline.py` (existing) still passes byte-identical when penalty=1.0; ruff clean.
+
+### Commit D — top_hubs + recall_hubs tool
+
+**Files:**
+- `nous/brain/brain.py` — add `Brain.top_hubs(limit=10, node_type=None)` and a private `_top_hubs_with_breakdown(hub_ids)` for the single-query breakdown. Two SQL passes (top-N aggregation then four-type label resolution lookup matching `_neighbors`'s pattern), plus one breakdown query for `extraction_method_breakdown`.
+- `nous/api/tools.py` — `recall_hubs` tool schema + closure. Frame access via `FRAME_TOOLS` mirroring `recall_recent` (all frames).
+- `nous/api/runner.py::FRAME_TOOLS` — add `recall_hubs` to all frame tool lists.
+- `tests/test_f065_top_hubs.py` (new) — seed 20 nodes with known degree distribution, call top_hubs, assert top-5 are exactly the 5 highest-degree. Test node_type filter, breakdown correctness, label resolution for each of 4 types.
+- `tests/test_f065_recall_hubs_tool.py` (new) — invoke tool via dispatcher; assert JSON-shaped response.
+
+**Acceptance:** all new tests pass; existing tool tests unchanged.
+
+### Commit E — pre_turn hub-shift + snapshot writes + retention
+
+**Files:**
+- `nous/brain/hub_snapshots.py` (new) — `HubSnapshotManager` with:
+  - `get_latest(agent_id, node_ids) -> dict[UUID, GraphHubSnapshot]` (uses `DISTINCT ON` query from spec).
+  - `record_snapshot(agent_id, node_id, node_type, degree, rank)` — single-row INSERT.
+  - `prune_older_than(days)` — DELETE for sleep handler.
+- `nous/cognitive/layer.py::pre_turn` — at the end of working-memory construction (gated on `settings.graph_hub_autosurface_enabled`):
+  1. Call `brain.top_hubs(limit=10)`.
+  2. Spawn `asyncio.create_task(self._hub_shift_detect(...))` so the rest of pre_turn is not blocked.
+  3. The task: fetch most-recent snapshots, compare ranks, emit notices for nodes that crossed the top-10 boundary, insert new snapshots only for boundary-crossers (not for in-place rank shifts), silently baseline new hubs without notice.
+- `nous/config.py` — `graph_hub_autosurface_enabled: bool = False`, `graph_hub_snapshot_retention_days: int = 90`.
+- `nous/handlers/sleep_handler.py` — add a prune step that calls `HubSnapshotManager.prune_older_than(settings.graph_hub_snapshot_retention_days)`. Gate it behind the same env flag so it stays no-op until autosurface is enabled.
+- `tests/test_f065_hub_shift.py` (new) — test plan items 6, 7, 8 verbatim.
+
+**Acceptance:** all new tests pass; full suite green; ruff clean; manual smoke that pre_turn with autosurface disabled is byte-identical to main.
+
+---
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| Migration step 5 (`ALTER ... SET NOT NULL`) fails because a row escaped the three backfill UPDATEs | Step 4 is a catch-all (`extraction_method IS NULL → heuristic`), so step 5 cannot fail. Adding `COALESCE(auto_linked, FALSE)` is unnecessary because we don't use `auto_linked` in the backfill anymore (relation-only). |
+| A new GraphEdge writer is added in a different PR and bypasses classify() | `test_f065_writer_coverage.py` greps the codebase and fails CI if the count drifts. |
+| `NeighborResult.extraction_method` arrives as None despite the str-typed field | Default `"heuristic"` at the schema level prevents None values from existing. Pipeline penalty wrapper still does `neighbor.extraction_method or "heuristic"` as defense in depth and logs WARN once per agent. |
+| pre_turn hub-shift detection blocks session start | `asyncio.create_task` makes the whole computation fire-and-forget; pre_turn never awaits the task. |
+| F040 nightly densification triggers hub-shift notices for every hub | Rank-based shift (top-10 entry/exit) replaces raw degree %. Densification typically uplifts all hubs proportionally, so ranks rarely change — false-positive storm avoided. |
+| `recall_hubs` tool exposed before useful, makes noise in tool catalog | Tool is opt-in (agent must call it explicitly). No autosurface in Phase 1. |
+
+---
+
+## Out-of-PR follow-ups (record but don't ship here)
+
+1. Flip `NOUS_GRAPH_HUB_AUTOSURFACE_ENABLED=true` after one release of bake time.
+2. Run F051 harness to measure MRR delta when `NOUS_GRAPH_INFERRED_EDGE_PENALTY=0.7`. Choose operating value based on results.
+3. Phase 4 tune is its own follow-up PR.
+
+---
+
+## Review checkpoints
+
+Before each commit lands:
+- Commit A: storage + helper — `feature-dev:code-reviewer` on the migration SQL + ORM.
+- Commit B: writer plumbing — `pr-review-toolkit:silent-failure-hunter` (this is the place silent classification failures hide).
+- Commit C: pipeline penalty — `code-reviewer` on the helper-with-source-guard.
+- Commit D: top_hubs — review of the single-pass SQL aggregation.
+- Commit E: pre_turn — `silent-failure-hunter` on the fire-and-forget task.
+
+After commit E: one consolidated review against the full diff before opening the PR.

--- a/docs/superpowers/plans/2026-05-23-f065-edge-provenance-impl.md
+++ b/docs/superpowers/plans/2026-05-23-f065-edge-provenance-impl.md
@@ -27,7 +27,7 @@ If any of these invariants fails when the implementer runs, STOP and re-verify b
 **Files:**
 - `sql/migrations/047_f065_edge_provenance.sql` (new) — exactly as in spec § Migration.
 - `nous/storage/models.py` — `GraphEdge.extraction_method: Mapped[str]` (`String(20)`, `nullable=False`, `server_default="'heuristic'"`); new `GraphHubSnapshot` ORM model under `brain` schema with the table definition from the spec.
-- `nous/brain/edge_provenance.py` (new) — single function `classify(relation: str) -> str` returning `'deterministic'` for `supersedes`, `'inferred'` for `contradicts`, `'heuristic'` otherwise. Plus a `VALID_METHODS: Final[frozenset[str]] = frozenset({"deterministic", "heuristic", "inferred"})` for the CHECK constraint mirror.
+- `nous/brain/edge_provenance.py` (new) — `classify(relation: str, *, source: str | None = None) -> str`. Returns `'deterministic'` for `source='structural'` OR `relation='supersedes'`; `'inferred'` for `relation='contradicts'`; `'heuristic'` otherwise. Plus a `VALID_METHODS: Final[frozenset[str]] = frozenset({"deterministic", "heuristic", "inferred"})` for the CHECK constraint mirror.
 - `tests/test_f065_storage.py` — three tests: classify() exhaustive (every existing relation maps somewhere); GraphEdge row default = 'heuristic' when no extraction_method passed; GraphHubSnapshot ORM round-trip.
 
 **Acceptance:** all three new tests pass; `uv run pytest tests/test_f065_*.py` green.
@@ -39,9 +39,17 @@ If any of these invariants fails when the implementer runs, STOP and re-verify b
 - `nous/brain/brain.py:1280` — direct `GraphEdge(...)` in `_auto_link` adds the same.
 - `nous/heart/facts.py:166-186` — fact↔fact edge insert; classify there.
 - `nous/brain/graph_linker.py:99` — `GraphLinker.create_edge` constructor.
-- `nous/brain/graph_linker.py:188, 266, 304, 326` — four direct `pg_insert(GraphEdge)` calls, each gets `extraction_method=classify(relation)`.
+- `nous/brain/graph_linker.py:188, 304, 326` — three direct `pg_insert(GraphEdge)` calls inside `link_episode_deterministic`. Each gets `extraction_method=classify(relation, source="structural")` because episode parsing yields explicit references, not cosine matches.
+- `nous/brain/graph_linker.py:266` — `link_fact_to_decisions` direct `pg_insert`. Cosine-derived; gets `extraction_method=classify(relation)` (no source override).
 - `tests/test_f065_writer_coverage.py` (new) — CI grep-guard. Scan `nous/brain/` and `nous/heart/` for `GraphEdge(` and `pg_insert(GraphEdge)`. Assert count == `EXPECTED_WRITER_COUNT = 8`. Comment in the test explains how to register a new site.
-- `tests/test_f065_writer_classification.py` (new) — for each of the 8 sites, write an edge through that code path and verify `extraction_method` matches `classify(relation)` for the relation actually written. For sites that write `supersedes`, expect `'deterministic'`; for `contradicts`, `'inferred'`; for everything else, `'heuristic'`. Use real Postgres backend via the existing test fixtures.
+- `tests/test_f065_writer_classification.py` (new) — for each of the 8 sites, write an edge through that code path and verify `extraction_method` matches `classify(relation, source=...)` for the (relation, source) actually written. Specifically:
+  - `Brain._link` (site #1) — exercise ALL THREE buckets: write `supersedes` → expect `'deterministic'`; write `contradicts` → expect `'inferred'`; write `related_to` → expect `'heuristic'`. (P1-3 fix: most general writer covers every classification branch.)
+  - `Brain._auto_link` (site #2) — writes `related_to` → expect `'heuristic'`.
+  - `facts.py` fact↔fact edges (site #3) — write `supersedes` → expect `'deterministic'`; write `related_to` → expect `'heuristic'`.
+  - `GraphLinker.create_edge` (site #4) — cosine-derived; expect `'heuristic'`.
+  - `link_episode_deterministic` (sites #5, #7, #8) — explicit `source="structural"` override; expect `'deterministic'`.
+  - `link_fact_to_decisions` (site #6) — cosine-derived; expect `'heuristic'`.
+  Use real Postgres backend via the existing test fixtures.
 
 **Acceptance:** writer-coverage test passes; per-site classification tests pass; existing graph tests (`tests/test_graph_*.py`, `tests/test_brain_*.py`) still pass.
 
@@ -50,13 +58,27 @@ If any of these invariants fails when the implementer runs, STOP and re-verify b
 **Files:**
 - `nous/brain/schemas.py::NeighborResult` — add `extraction_method: str = "heuristic"` (str, not Optional; default is the fail-open tier; comment cites the F065 P0-3 NULL-handling rationale).
 - `nous/brain/brain.py::_neighbors` — `source_q` and `target_q` SELECT `GraphEdge.extraction_method.label("extraction_method")`. `edge_map[r.neighbor_id]` tuple extended to carry `extraction_method`. All `NeighborResult(...)` constructors set it.
-- `nous/api/retrieval_pipeline.py::_graph_expanded_to_pipeline` and `:_heart_graph_to_pipeline` — apply penalty:
+- `nous/api/retrieval_pipeline.py::_graph_expanded_to_pipeline` and `:_heart_graph_to_pipeline` — apply penalty via a module-scoped helper:
   ```python
-  method = neighbor.extraction_method or "heuristic"
-  penalty = settings.graph_inferred_edge_penalty if method == "inferred" else 1.0
-  score = base_score * decay * penalty
+  def _apply_provenance_penalty(
+      neighbor: NeighborResult,
+      base_score: float,
+      decay: float,
+      settings: Settings,
+  ) -> float:
+      """F065 inferred-tier penalty.  Helper computes `source` internally
+      from neighbor.edge_relation — no need for callers to pass it."""
+      if neighbor.edge_relation == "spreading_activation":
+          # Defense in depth: SA results are already filtered against
+          # relation='contradicts' at spreading_activation.py:103, so
+          # the inferred penalty cannot apply. Skip even if a future
+          # inferred-tier relation bypasses the SA filter.
+          return base_score * decay
+      method = neighbor.extraction_method or "heuristic"  # NULL → heuristic (fail-open, WARN logged)
+      penalty = settings.graph_inferred_edge_penalty if method == "inferred" else 1.0
+      return base_score * decay * penalty
   ```
-  Both call sites use the same helper `_apply_provenance_penalty(neighbor, base_score, decay, settings, source)` defined once at module scope. The helper short-circuits when `source == "spreading_activation"` (defense-in-depth per spec).
+  Both pipeline functions call this helper. Source detection is internal — no `source` parameter at the call site (resolves P1-1 ambiguity).
 - `nous/config.py` — `graph_inferred_edge_penalty: float = 1.0` with env var `NOUS_GRAPH_INFERRED_EDGE_PENALTY`. Dark-launch default.
 - `tests/test_f065_pipeline_penalty.py` (new) — test plan items 3, 4, 4b verbatim. Use mocked `NeighborResult` objects with explicit `extraction_method`. No live DB needed.
 
@@ -100,6 +122,8 @@ If any of these invariants fails when the implementer runs, STOP and re-verify b
 | A new GraphEdge writer is added in a different PR and bypasses classify() | `test_f065_writer_coverage.py` greps the codebase and fails CI if the count drifts. |
 | `NeighborResult.extraction_method` arrives as None despite the str-typed field | Default `"heuristic"` at the schema level prevents None values from existing. Pipeline penalty wrapper still does `neighbor.extraction_method or "heuristic"` as defense in depth and logs WARN once per agent. |
 | pre_turn hub-shift detection blocks session start | `asyncio.create_task` makes the whole computation fire-and-forget; pre_turn never awaits the task. |
+| Empty graph (brand-new agent, zero edges) breaks pre_turn task | `top_hubs()` returns `[]`; the spawned task short-circuits early when the result is empty, never calls `get_latest([])`. Covered by `test_f065_hub_shift.py::test_empty_graph_no_op`. |
+| Race between two concurrent pre_turn calls inserting baseline for the same new hub | Both insert; the DISTINCT ON read picks the later row. No correctness bug, just minor disk waste. Documented; no constraint added (capture_at uniqueness is microsecond-granular). |
 | F040 nightly densification triggers hub-shift notices for every hub | Rank-based shift (top-10 entry/exit) replaces raw degree %. Densification typically uplifts all hubs proportionally, so ranks rarely change — false-positive storm avoided. |
 | `recall_hubs` tool exposed before useful, makes noise in tool catalog | Tool is opt-in (agent must call it explicitly). No autosurface in Phase 1. |
 

--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -457,6 +457,33 @@ def _heart_results_to_pipeline(
     ]
 
 
+def _f065_provenance_penalty(
+    neighbor: "NeighborResult", base_score: float, decay: float, settings: "Settings"
+) -> float:
+    """F065: apply the inferred-edge penalty on top of F022's graph decay.
+
+    Returns ``base_score * decay * penalty`` where ``penalty`` is
+    ``settings.graph_inferred_edge_penalty`` (default 1.0 — dark launch)
+    iff the neighbor's edge is `inferred`. All other tiers, plus
+    spreading-activation results, pass through unchanged.
+
+    NULL handling: ``NeighborResult.extraction_method`` defaults to
+    ``'heuristic'`` at the schema, so this helper should never see None.
+    The ``or "heuristic"`` is belt-and-braces (matches F065 spec NULL-handling
+    rule: NULL → heuristic, fail-open).
+
+    Spreading-activation defense in depth: SA already filters
+    `relation != 'contradicts'` at spreading_activation.py:103. If a future
+    inferred-tier relation bypasses the SA filter, this short-circuit keeps
+    the penalty from double-applying.
+    """
+    if neighbor.edge_relation == "spreading_activation":
+        return base_score * decay
+    method = neighbor.extraction_method or "heuristic"
+    penalty = settings.graph_inferred_edge_penalty if method == "inferred" else 1.0
+    return base_score * decay * penalty
+
+
 def _heart_graph_to_pipeline(
     heart_graph: list["NeighborResult"], settings: "Settings"
 ) -> list[PipelineResult]:
@@ -466,7 +493,7 @@ def _heart_graph_to_pipeline(
             id=n.id,
             type="decision",  # Only decision neighbors are appended at this stage
             description=n.description,
-            score=n.edge_weight * decay,
+            score=_f065_provenance_penalty(n, n.edge_weight, decay, settings),
             source="graph_expanded",
             edge_relation=n.edge_relation,
         )
@@ -508,7 +535,7 @@ def _graph_expanded_to_pipeline(
             id=n.id,
             type=n.node_type,  # type: ignore[arg-type]
             description=n.description,
-            score=n.edge_weight * decay,
+            score=_f065_provenance_penalty(n, n.edge_weight, decay, settings),
             source=(
                 "spreading_activation"
                 if n.edge_relation == "spreading_activation"

--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -50,12 +50,12 @@ _OPTIONAL_DECISION_FRAMES = frozenset({"task", "debug"})
 
 # Frame-gated tool access (D5)
 FRAME_TOOLS: dict[str, list[str]] = {
-    "conversation": ["record_decision", "learn_fact", "learn_skill", "recall_deep", "recall_recent", "get_procedure", "create_censor", "bash", "read_file", "write_file", "web_search", "web_fetch", "cache_retrieve", "spawn_task", "spawn_sync", "schedule_task", "list_tasks", "cancel_task", "run_python", "send_file", "heartbeat_check_create", "heartbeat_check_manage", "dag_create", "dag_manage"],
-    "question": ["recall_deep", "recall_recent", "get_procedure", "bash", "read_file", "write_file", "record_decision", "learn_fact", "learn_skill", "create_censor", "web_search", "web_fetch", "cache_retrieve", "list_tasks", "cancel_task", "run_python", "dag_manage"],
-    "decision": ["record_decision", "recall_deep", "recall_recent", "get_procedure", "create_censor", "bash", "read_file", "web_search", "web_fetch", "cache_retrieve", "list_tasks", "cancel_task", "dag_manage"],
-    "creative": ["learn_fact", "recall_deep", "recall_recent", "get_procedure", "write_file", "web_search", "cache_retrieve"],
+    "conversation": ["record_decision", "learn_fact", "learn_skill", "recall_deep", "recall_recent", "recall_hubs", "get_procedure", "create_censor", "bash", "read_file", "write_file", "web_search", "web_fetch", "cache_retrieve", "spawn_task", "spawn_sync", "schedule_task", "list_tasks", "cancel_task", "run_python", "send_file", "heartbeat_check_create", "heartbeat_check_manage", "dag_create", "dag_manage"],
+    "question": ["recall_deep", "recall_recent", "recall_hubs", "get_procedure", "bash", "read_file", "write_file", "record_decision", "learn_fact", "learn_skill", "create_censor", "web_search", "web_fetch", "cache_retrieve", "list_tasks", "cancel_task", "run_python", "dag_manage"],
+    "decision": ["record_decision", "recall_deep", "recall_recent", "recall_hubs", "get_procedure", "create_censor", "bash", "read_file", "web_search", "web_fetch", "cache_retrieve", "list_tasks", "cancel_task", "dag_manage"],
+    "creative": ["learn_fact", "recall_deep", "recall_recent", "recall_hubs", "get_procedure", "write_file", "web_search", "cache_retrieve"],
     "task": ["*"],  # All tools
-    "debug": ["record_decision", "recall_deep", "recall_recent", "get_procedure", "bash", "read_file", "learn_fact", "web_search", "web_fetch", "cache_retrieve", "spawn_task", "spawn_sync", "schedule_task", "list_tasks", "cancel_task", "run_python", "send_file", "heartbeat_check_create", "heartbeat_check_manage", "dag_create", "dag_manage"],
+    "debug": ["record_decision", "recall_deep", "recall_recent", "recall_hubs", "get_procedure", "bash", "read_file", "learn_fact", "web_search", "web_fetch", "cache_retrieve", "spawn_task", "spawn_sync", "schedule_task", "list_tasks", "cancel_task", "run_python", "send_file", "heartbeat_check_create", "heartbeat_check_manage", "dag_create", "dag_manage"],
     "initiation": ["store_identity", "complete_initiation"],
 }
 

--- a/nous/api/tools.py
+++ b/nous/api/tools.py
@@ -784,6 +784,38 @@ def create_nous_tools(brain: Brain, heart: Heart, settings: Settings | None = No
             logger.exception("get_procedure tool failed")
             return {"content": [{"type": "text", "text": f"Error fetching procedure: {e}"}]}
 
+    async def recall_hubs(
+        limit: int = 10,
+        node_type: str | None = None,
+    ) -> dict[str, Any]:
+        """F065: return the most-connected (highest-degree) nodes in the graph.
+
+        Args:
+            limit: Top-N to return (1..50, default 10).
+            node_type: Optional filter ('decision' | 'fact' | 'episode' | 'procedure').
+
+        Returns:
+            MCP-compliant response with a labeled list of hubs, their degree,
+            and a per-tier provenance breakdown.
+        """
+        try:
+            hubs = await brain.top_hubs(limit=max(1, min(50, limit)), node_type=node_type)
+            if not hubs:
+                return {"content": [{"type": "text", "text": "No graph hubs found yet — the graph may be empty."}]}
+
+            lines = [f"Top-{len(hubs)} hubs by degree:"]
+            for i, h in enumerate(hubs, start=1):
+                bk = h["extraction_method_breakdown"]
+                lines.append(
+                    f"{i}. [{h['node_type']}] {h['label'][:80]} — "
+                    f"degree {h['degree']} "
+                    f"(det={bk['deterministic']}, heu={bk['heuristic']}, inf={bk['inferred']})"
+                )
+            return {"content": [{"type": "text", "text": "\n".join(lines)}]}
+        except Exception as e:
+            logger.exception("recall_hubs tool failed")
+            return {"content": [{"type": "text", "text": f"Error fetching hubs: {e}"}]}
+
     return {
         "record_decision": record_decision,
         "learn_fact": learn_fact,
@@ -792,6 +824,7 @@ def create_nous_tools(brain: Brain, heart: Heart, settings: Settings | None = No
         "recall_recent": recall_recent,
         "learn_skill": learn_skill,
         "get_procedure": get_procedure,
+        "recall_hubs": recall_hubs,
     }
 
 
@@ -991,6 +1024,32 @@ _GET_PROCEDURE_SCHEMA: dict[str, Any] = {
 }
 
 
+_RECALL_HUBS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": (
+        "F065: return the most-connected (highest-degree) nodes in Nous's "
+        "knowledge graph. Use to discover which concepts, decisions, facts, "
+        "or episodes act as hubs that many other memories reference. "
+        "Optionally filter by node_type."
+    ),
+    "properties": {
+        "limit": {
+            "type": "integer",
+            "description": "Top-N to return (1..50, default 10)",
+            "default": 10,
+            "minimum": 1,
+            "maximum": 50,
+        },
+        "node_type": {
+            "type": "string",
+            "description": "Optional filter by node type",
+            "enum": ["decision", "fact", "episode", "procedure"],
+        },
+    },
+    "required": [],
+}
+
+
 def register_nous_tools(dispatcher: ToolDispatcher, brain: Brain, heart: Heart, settings: Settings | None = None) -> None:
     """Create Nous memory tools and register them with the dispatcher.
 
@@ -1006,6 +1065,7 @@ def register_nous_tools(dispatcher: ToolDispatcher, brain: Brain, heart: Heart, 
     dispatcher.register("recall_recent", closures["recall_recent"], _RECALL_RECENT_SCHEMA)
     dispatcher.register("learn_skill", closures["learn_skill"], _LEARN_SKILL_SCHEMA)
     dispatcher.register("get_procedure", closures["get_procedure"], _GET_PROCEDURE_SCHEMA)
+    dispatcher.register("recall_hubs", closures["recall_hubs"], _RECALL_HUBS_SCHEMA)
 
 
 # ---------------------------------------------------------------------------

--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -1211,6 +1211,157 @@ class Brain:
         return results
 
     # ------------------------------------------------------------------
+    # top_hubs() — F065 god-node surfacing
+    # ------------------------------------------------------------------
+
+    async def top_hubs(
+        self,
+        limit: int = 10,
+        node_type: str | None = None,
+        session: AsyncSession | None = None,
+    ) -> list[dict]:
+        """Return the highest-degree nodes in brain.graph_edges for this agent.
+
+        Uses undirected degree (source + target appearances combined).
+        Inspired by Graphify's god_nodes() — Postgres aggregation instead
+        of NetworkX, keeping the zero-dependency posture from F022.
+
+        Each row resolves to:
+          {
+              "node_id": str(UUID),
+              "node_type": "decision" | "fact" | "episode" | "procedure",
+              "label": str,
+              "degree": int,
+              "extraction_method_breakdown": {"deterministic": N, "heuristic": N, "inferred": N},
+          }
+        """
+        if session is None:
+            async with self.db.session() as s:
+                return await self._top_hubs(limit, node_type, s)
+        return await self._top_hubs(limit, node_type, session)
+
+    async def _top_hubs(
+        self,
+        limit: int,
+        node_type: str | None,
+        session: AsyncSession,
+    ) -> list[dict]:
+        from sqlalchemy import bindparam
+
+        # Step 1: aggregate degree across both edge directions.
+        sql = text("""
+            SELECT node_id, node_type, COUNT(*) AS degree
+            FROM (
+                SELECT source_id AS node_id, source_type AS node_type
+                FROM brain.graph_edges WHERE agent_id = :agent_id
+                UNION ALL
+                SELECT target_id AS node_id, target_type AS node_type
+                FROM brain.graph_edges WHERE agent_id = :agent_id
+            ) combined
+            WHERE (:node_type IS NULL OR node_type = :node_type)
+            GROUP BY node_id, node_type
+            ORDER BY degree DESC
+            LIMIT :limit
+        """)
+        result = await session.execute(
+            sql,
+            {"agent_id": self.agent_id, "node_type": node_type, "limit": limit},
+        )
+        hubs = result.all()
+        if not hubs:
+            return []
+
+        hub_ids = [h.node_id for h in hubs]
+
+        # Step 2: single-pass extraction_method_breakdown across both directions.
+        # Uses expanding bindparam (renders as IN (?,?,...)) so the query is
+        # portable across Postgres and the SQLite test backend.
+        breakdown_sql = text("""
+            SELECT node_id, extraction_method, COUNT(*) AS cnt
+            FROM (
+                SELECT source_id AS node_id, extraction_method
+                FROM brain.graph_edges WHERE agent_id = :agent_id
+                UNION ALL
+                SELECT target_id AS node_id, extraction_method
+                FROM brain.graph_edges WHERE agent_id = :agent_id
+            ) combined
+            WHERE node_id IN :hub_ids
+            GROUP BY node_id, extraction_method
+        """).bindparams(bindparam("hub_ids", expanding=True))
+        breakdown_result = await session.execute(
+            breakdown_sql,
+            {"agent_id": self.agent_id, "hub_ids": hub_ids},
+        )
+        # Pivot into a dict[UUID -> dict[method -> count]].
+        breakdown: dict[UUID, dict[str, int]] = {}
+        for row in breakdown_result.all():
+            breakdown.setdefault(row.node_id, {})[row.extraction_method] = int(row.cnt)
+
+        # Step 3: resolve labels per node_type. Mirrors _neighbors's pattern.
+        # Raw SQL returns node_ids as strings on SQLite / as UUID on asyncpg —
+        # normalize to UUID objects for the ORM .in_() filters.
+        def _as_uuid(v) -> UUID:
+            return v if isinstance(v, UUID) else UUID(str(v))
+
+        labels: dict[UUID, str] = {}
+        decision_ids = [_as_uuid(h.node_id) for h in hubs if h.node_type == "decision"]
+        if decision_ids:
+            dec_result = await session.execute(
+                select(Decision.id, Decision.description)
+                .where(Decision.id.in_(decision_ids))
+            )
+            for d in dec_result.all():
+                labels[d.id] = d.description
+
+        fact_ids = [_as_uuid(h.node_id) for h in hubs if h.node_type == "fact"]
+        if fact_ids:
+            from nous.storage.models import Fact
+            fact_result = await session.execute(
+                select(Fact.id, Fact.subject).where(Fact.id.in_(fact_ids))
+            )
+            for f in fact_result.all():
+                labels[f.id] = f.subject or f"[fact] {f.id}"
+
+        episode_ids = [_as_uuid(h.node_id) for h in hubs if h.node_type == "episode"]
+        if episode_ids:
+            from nous.storage.models import Episode
+            ep_result = await session.execute(
+                select(Episode.id, Episode.summary).where(Episode.id.in_(episode_ids))
+            )
+            for e in ep_result.all():
+                labels[e.id] = e.summary or f"[episode] {e.id}"
+
+        proc_ids = [_as_uuid(h.node_id) for h in hubs if h.node_type == "procedure"]
+        if proc_ids:
+            from nous.storage.models import Procedure
+            proc_result = await session.execute(
+                select(Procedure.id, Procedure.name).where(Procedure.id.in_(proc_ids))
+            )
+            for p in proc_result.all():
+                labels[p.id] = p.name or f"[procedure] {p.id}"
+
+        # Step 4: assemble. Fall back to [<type>] <uuid> for orphan / soft-deleted nodes.
+        results = []
+        for h in hubs:
+            hub_id = _as_uuid(h.node_id)
+            label = labels.get(hub_id) or f"[{h.node_type}] {hub_id}"
+            row_breakdown = breakdown.get(h.node_id, {})
+            # Always present all three tier keys (zero-fill missing).
+            full_breakdown = {
+                "deterministic": int(row_breakdown.get("deterministic", 0)),
+                "heuristic": int(row_breakdown.get("heuristic", 0)),
+                "inferred": int(row_breakdown.get("inferred", 0)),
+            }
+            results.append({
+                "node_id": str(hub_id),
+                "node_type": h.node_type,
+                "label": label,
+                "degree": int(h.degree),
+                "extraction_method_breakdown": full_breakdown,
+            })
+        return results
+
+    # ------------------------------------------------------------------
     # auto_link()
     # ------------------------------------------------------------------
 

--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -1134,12 +1134,15 @@ class Brain:
         limit: int,
         session: AsyncSession,
     ) -> list[NeighborResult]:
-        # Find edges where this node is source or target, matching node type
+        # Find edges where this node is source or target, matching node type.
+        # F065: SELECT extraction_method so neighbors carry provenance tier
+        # for downstream penalty multiplier wiring in retrieval_pipeline.
         source_q = select(
             GraphEdge.target_id.label("neighbor_id"),
             GraphEdge.target_type.label("neighbor_type"),
             GraphEdge.relation.label("edge_relation"),
             GraphEdge.weight.label("edge_weight"),
+            GraphEdge.extraction_method.label("extraction_method"),
         ).where(
             GraphEdge.source_id == node_id,
             GraphEdge.source_type == node_type,
@@ -1151,6 +1154,7 @@ class Brain:
             GraphEdge.source_type.label("neighbor_type"),
             GraphEdge.relation.label("edge_relation"),
             GraphEdge.weight.label("edge_weight"),
+            GraphEdge.extraction_method.label("extraction_method"),
         ).where(
             GraphEdge.target_id == node_id,
             GraphEdge.target_type == node_type,
@@ -1168,10 +1172,11 @@ class Brain:
         if not rows:
             return []
 
-        # Build edge metadata map
-        edge_map: dict[UUID, tuple[str, str, float]] = {}
+        # Build edge metadata map. F065: now carries extraction_method.
+        edge_map: dict[UUID, tuple[str, str, float, str]] = {}
         for r in rows:
-            edge_map[r.neighbor_id] = (r.neighbor_type, r.edge_relation, r.edge_weight or 1.0)
+            method = r.extraction_method or "heuristic"  # F065: NULL → fail-open heuristic
+            edge_map[r.neighbor_id] = (r.neighbor_type, r.edge_relation, r.edge_weight or 1.0, method)
 
         # Resolve decision neighbors
         decision_ids = [r.neighbor_id for r in rows if r.neighbor_type == "decision"]
@@ -1187,7 +1192,7 @@ class Brain:
         # Build results
         results = []
         for r in rows:
-            ntype, rel, weight = edge_map[r.neighbor_id]
+            ntype, rel, weight, method = edge_map[r.neighbor_id]
             if ntype == "decision" and r.neighbor_id in descriptions:
                 desc, created = descriptions[r.neighbor_id]
             else:
@@ -1200,6 +1205,7 @@ class Brain:
                 edge_relation=rel,
                 edge_weight=weight,
                 created_at=created,
+                extraction_method=method,  # F065
             ))
 
         return results

--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -1249,6 +1249,9 @@ class Brain:
         from sqlalchemy import bindparam
 
         # Step 1: aggregate degree across both edge directions.
+        # CAST :node_type to TEXT so asyncpg can determine the parameter type
+        # when the value is None — without the cast, asyncpg raises
+        # AmbiguousParameterError.
         sql = text("""
             SELECT node_id, node_type, COUNT(*) AS degree
             FROM (
@@ -1258,7 +1261,7 @@ class Brain:
                 SELECT target_id AS node_id, target_type AS node_type
                 FROM brain.graph_edges WHERE agent_id = :agent_id
             ) combined
-            WHERE (:node_type IS NULL OR node_type = :node_type)
+            WHERE (CAST(:node_type AS TEXT) IS NULL OR node_type = CAST(:node_type AS TEXT))
             GROUP BY node_id, node_type
             ORDER BY degree DESC
             LIMIT :limit

--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -1071,6 +1071,8 @@ class Brain:
         target_type: str = "decision",
         session: AsyncSession | None = None,
     ) -> GraphEdgeInfo:
+        from nous.brain.edge_provenance import classify  # F065 (avoid circular)
+
         edge = GraphEdge(
             source_id=source_id,
             target_id=target_id,
@@ -1080,6 +1082,7 @@ class Brain:
             relation=relation,
             weight=weight,
             auto_linked=auto_linked,
+            extraction_method=classify(relation),  # F065
         )
         session.add(edge)
         await session.flush()
@@ -1276,6 +1279,7 @@ class Brain:
                 src, tgt = tgt, src
 
             # P2-20: ON CONFLICT DO NOTHING for concurrent inserts
+            from nous.brain.edge_provenance import classify  # F065
             stmt = (
                 pg_insert(GraphEdge)
                 .values(
@@ -1287,6 +1291,7 @@ class Brain:
                     relation="related_to",
                     weight=float(row.similarity),
                     auto_linked=True,
+                    extraction_method=classify("related_to"),  # F065
                 )
                 .on_conflict_do_nothing(constraint="uq_edges_src_tgt_rel")
             )

--- a/nous/brain/edge_provenance.py
+++ b/nous/brain/edge_provenance.py
@@ -1,0 +1,60 @@
+"""F065: edge-provenance classification — single source of truth.
+
+Used by every GraphEdge writer (eight sites enumerated in the F065 spec)
+to set the `extraction_method` column at insert time. The mapping mirrors
+migration 047's backfill exactly — keeping write-time and backfill rules
+in one place ensures no drift.
+
+Tiers:
+  - deterministic: explicit structural provenance (supersession edges,
+                   episode-token extraction). Highest trust.
+  - inferred:      LLM reasoning over similar items (F027 contradiction
+                   path). Lowest trust; recall_deep applies the
+                   `NOUS_GRAPH_INFERRED_EDGE_PENALTY` multiplier.
+  - heuristic:     cosine-threshold matching by graph_linker /
+                   graph_densifier. Default safe tier.
+
+NULL handling at consumer sites: NeighborResult.extraction_method
+defaults to 'heuristic' (fail-open) with a one-time WARN log per agent
+if a row somehow arrives without a value.
+"""
+
+from __future__ import annotations
+
+from typing import Final, Literal
+
+# Mirror of the migration 047 CHECK constraint. Keep in sync.
+VALID_METHODS: Final[frozenset[str]] = frozenset(
+    {"deterministic", "heuristic", "inferred"}
+)
+
+ExtractionMethod = Literal["deterministic", "heuristic", "inferred"]
+
+
+def classify(
+    relation: str,
+    *,
+    source: str | None = None,
+) -> ExtractionMethod:
+    """Map (relation, optional source) → extraction_method tier.
+
+    Args:
+        relation: the edge relation string (e.g. 'supersedes', 'contradicts',
+                  'related_to', 'extracted_from', 'discussed_in', etc.).
+        source: explicit override for writers that carry structural
+                provenance the relation string alone can't express. Only
+                ``'structural'`` is currently recognized — used by
+                ``link_episode_deterministic`` whose discussed_in /
+                extracted_from edges come from explicit episode-token
+                references, not cosine matching.
+
+    Returns:
+        One of 'deterministic', 'inferred', 'heuristic'.
+    """
+    if source == "structural":
+        return "deterministic"
+    if relation == "supersedes":
+        return "deterministic"
+    if relation == "contradicts":
+        return "inferred"
+    return "heuristic"

--- a/nous/brain/graph_linker.py
+++ b/nous/brain/graph_linker.py
@@ -15,6 +15,7 @@ from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from nous.brain.edge_provenance import classify  # F065
 from nous.brain.embeddings import EmbeddingProvider
 from nous.brain.schemas import GraphEdgeInfo
 from nous.config import Settings
@@ -106,6 +107,7 @@ class GraphLinker:
                 relation=relation,
                 weight=adjusted_weight,
                 auto_linked=True,
+                extraction_method=classify(relation),  # F065 (cosine-derived)
             )
             .on_conflict_do_nothing(index_elements=["source_id", "target_id", "relation"])
         )
@@ -195,6 +197,7 @@ class GraphLinker:
                         relation="evidence_for",
                         weight=float(similarity),
                         auto_linked=True,
+                        extraction_method=classify("evidence_for"),  # F065 (cosine-derived)
                     )
                     .on_conflict_do_nothing(index_elements=["source_id", "target_id", "relation"])
                 )
@@ -273,6 +276,7 @@ class GraphLinker:
                         relation="related_to",
                         weight=float(row.similarity),
                         auto_linked=True,
+                        extraction_method=classify("related_to"),  # F065 (cosine-derived)
                     )
                     .on_conflict_do_nothing(index_elements=["source_id", "target_id", "relation"])
                 )
@@ -311,6 +315,9 @@ class GraphLinker:
                     relation="discussed_in",
                     weight=1.0,
                     auto_linked=True,
+                    # F065: explicit episode-token reference, NOT cosine-derived.
+                    # source="structural" override yields 'deterministic'.
+                    extraction_method=classify("discussed_in", source="structural"),
                 )
                 .on_conflict_do_nothing(index_elements=["source_id", "target_id", "relation"])
             )
@@ -333,6 +340,9 @@ class GraphLinker:
                     relation="extracted_from",
                     weight=1.0,
                     auto_linked=True,
+                    # F065: explicit episode-token reference, NOT cosine-derived.
+                    # source="structural" override yields 'deterministic'.
+                    extraction_method=classify("extracted_from", source="structural"),
                 )
                 .on_conflict_do_nothing(index_elements=["source_id", "target_id", "relation"])
             )

--- a/nous/brain/hub_snapshots.py
+++ b/nous/brain/hub_snapshots.py
@@ -1,0 +1,262 @@
+"""F065: HubSnapshotManager — session-start hub-shift detection.
+
+Reads/writes brain.graph_hub_snapshots to track which decisions/facts/
+episodes/procedures are currently in the top-10 hub list and emit a
+working-memory notice when a node enters or leaves the top-10
+(rank-based shift, not raw degree-percent — see F065 spec Open
+Question 4 resolution).
+
+Fail-mode: every method catches its own exceptions and logs at WARN;
+hub-shift detection is a diagnostic, not a correctness path. Callers
+(pre_turn hook) wrap the whole computation in asyncio.create_task so
+session start never blocks on it.
+
+Retention: prune_older_than() is called from the sleep handler with
+the configured retention days. The (agent_id, captured_at) index
+supports the prune query.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from nous.storage.database import Database
+from nous.storage.models import GraphHubSnapshot
+
+logger = logging.getLogger(__name__)
+
+
+class HubSnapshotManager:
+    """Read/write hub-rank snapshots for session-start shift detection."""
+
+    def __init__(self, database: Database, agent_id: str) -> None:
+        self._db = database
+        self._agent_id = agent_id
+
+    async def get_latest(
+        self,
+        node_ids: list[UUID],
+        session: AsyncSession | None = None,
+    ) -> dict[UUID, GraphHubSnapshot]:
+        """Return the most-recent snapshot per (agent_id, node_id).
+
+        Uses DISTINCT ON (Postgres) when available; falls back to a
+        portable subquery for the SQLite test backend.
+        """
+        if not node_ids:
+            return {}
+        if session is None:
+            async with self._db.session() as s:
+                return await self._get_latest_inner(node_ids, s)
+        return await self._get_latest_inner(node_ids, session)
+
+    async def _get_latest_inner(
+        self,
+        node_ids: list[UUID],
+        session: AsyncSession,
+    ) -> dict[UUID, GraphHubSnapshot]:
+        # Portable variant: for each node_id, pick the row with max
+        # captured_at. SQLAlchemy ORM handles dialect specifics.
+        from sqlalchemy import desc, func
+
+        # Build a "max captured_at per node" subquery.
+        subq = (
+            select(
+                GraphHubSnapshot.node_id,
+                func.max(GraphHubSnapshot.captured_at).label("max_at"),
+            )
+            .where(GraphHubSnapshot.agent_id == self._agent_id)
+            .where(GraphHubSnapshot.node_id.in_(node_ids))
+            .group_by(GraphHubSnapshot.node_id)
+            .subquery()
+        )
+        q = (
+            select(GraphHubSnapshot)
+            .join(
+                subq,
+                (GraphHubSnapshot.node_id == subq.c.node_id)
+                & (GraphHubSnapshot.captured_at == subq.c.max_at),
+            )
+            .where(GraphHubSnapshot.agent_id == self._agent_id)
+            .order_by(desc(GraphHubSnapshot.captured_at))
+        )
+        result = await session.execute(q)
+        latest: dict[UUID, GraphHubSnapshot] = {}
+        for snap in result.scalars().all():
+            # If duplicates with identical captured_at (microsecond race),
+            # keep the first one seen.
+            latest.setdefault(snap.node_id, snap)
+        return latest
+
+    async def record_snapshot(
+        self,
+        node_id: UUID,
+        node_type: str,
+        degree: int,
+        rank: int | None,
+        session: AsyncSession | None = None,
+    ) -> None:
+        """Insert a snapshot row. Errors are logged and swallowed —
+        the caller (pre_turn fire-and-forget task) doesn't propagate
+        snapshot failures.
+        """
+        try:
+            if session is None:
+                async with self._db.session() as s:
+                    s.add(GraphHubSnapshot(
+                        agent_id=self._agent_id,
+                        node_id=node_id,
+                        node_type=node_type,
+                        degree=degree,
+                        rank=rank,
+                    ))
+                    await s.commit()
+            else:
+                session.add(GraphHubSnapshot(
+                    agent_id=self._agent_id,
+                    node_id=node_id,
+                    node_type=node_type,
+                    degree=degree,
+                    rank=rank,
+                ))
+                await session.flush()
+        except Exception:
+            logger.warning(
+                "F065: failed to record hub snapshot for %s (agent=%s)",
+                node_id, self._agent_id,
+            )
+
+    async def prune_older_than(
+        self,
+        days: int,
+        session: AsyncSession | None = None,
+    ) -> int:
+        """DELETE rows older than `days`. Returns deleted-row count.
+
+        Called from the sleep handler with NOUS_GRAPH_HUB_SNAPSHOT_RETENTION_DAYS.
+        """
+        if days <= 0:
+            return 0
+        cutoff = datetime.now(UTC) - timedelta(days=days)
+        try:
+            if session is None:
+                async with self._db.session() as s:
+                    result = await s.execute(
+                        text(
+                            "DELETE FROM brain.graph_hub_snapshots "
+                            "WHERE agent_id = :agent_id "
+                            "AND captured_at < :cutoff"
+                        ),
+                        {"agent_id": self._agent_id, "cutoff": cutoff},
+                    )
+                    await s.commit()
+                    return int(result.rowcount or 0)
+            else:
+                result = await session.execute(
+                    text(
+                        "DELETE FROM brain.graph_hub_snapshots "
+                        "WHERE agent_id = :agent_id "
+                        "AND captured_at < :cutoff"
+                    ),
+                    {"agent_id": self._agent_id, "cutoff": cutoff},
+                )
+                return int(result.rowcount or 0)
+        except Exception:
+            logger.warning(
+                "F065: failed to prune hub snapshots (agent=%s, days=%d)",
+                self._agent_id, days,
+            )
+            return 0
+
+
+# ---------------------------------------------------------------------------
+# Rank-shift detection (pure logic, no DB)
+# ---------------------------------------------------------------------------
+
+
+def detect_rank_shifts(
+    live_top_hubs: list[dict],
+    prior_snapshots: dict[UUID, GraphHubSnapshot],
+    top_n: int,
+) -> tuple[list[dict], list[UUID]]:
+    """Identify nodes that crossed the top-N boundary since the last snapshot.
+
+    Args:
+        live_top_hubs: result of Brain.top_hubs(limit=top_n). Each dict has
+                      node_id (str), node_type, label, degree, breakdown.
+        prior_snapshots: most-recent snapshot per node_id (UUID-keyed).
+        top_n: the threshold (typically 10).
+
+    Returns:
+        - notices: a list of dicts for the working-memory hub-shift block
+          (each carries 'kind': 'entered'|'left', 'label', 'rank', 'degree').
+        - new_nodes: UUIDs of hubs with no prior snapshot at all — caller
+          MUST insert baselines for these and NOT emit notices.
+    """
+    notices: list[dict] = []
+    new_nodes: list[UUID] = []
+
+    live_by_uuid: dict[UUID, dict] = {}
+    for i, h in enumerate(live_top_hubs):
+        uid = UUID(h["node_id"])
+        live_by_uuid[uid] = {**h, "rank": i + 1}
+
+    # ENTERED: in live top-N but not in prior top-N (or no prior at all).
+    for uid, h in live_by_uuid.items():
+        if uid not in prior_snapshots:
+            new_nodes.append(uid)
+            # Silent baseline — no notice on first sight.
+            continue
+        prior = prior_snapshots[uid]
+        prior_rank = prior.rank
+        if prior_rank is None or prior_rank > top_n:
+            # Wasn't in the top-N before, is now.
+            notices.append({
+                "kind": "entered",
+                "label": h["label"],
+                "rank": h["rank"],
+                "degree": h["degree"],
+            })
+
+    # LEFT: in prior top-N but not in live top-N.
+    for uid, prior in prior_snapshots.items():
+        if prior.rank is None or prior.rank > top_n:
+            continue
+        if uid not in live_by_uuid:
+            # Was a hub, no longer in the top-N.
+            notices.append({
+                "kind": "left",
+                "label": f"[{prior.node_type}] {uid}",
+                "rank": None,
+                "degree": prior.degree,
+            })
+
+    return notices, new_nodes
+
+
+def format_hub_shift_block(notices: list[dict]) -> str:
+    """Render hub-shift notices for injection into the system prompt.
+
+    Returns an empty string when no notices fired (caller can skip the
+    section header entirely).
+    """
+    if not notices:
+        return ""
+    lines = []
+    for n in notices:
+        if n["kind"] == "entered":
+            lines.append(
+                f"[graph] Hub shift: \"{n['label'][:80]}\" entered the "
+                f"top-10 (rank #{n['rank']}, degree {n['degree']})."
+            )
+        elif n["kind"] == "left":
+            lines.append(
+                f"[graph] Hub shift: {n['label'][:80]} left the top-10 "
+                f"(was degree {n['degree']})."
+            )
+    return "\n".join(lines)

--- a/nous/brain/schemas.py
+++ b/nous/brain/schemas.py
@@ -159,3 +159,8 @@ class NeighborResult(BaseModel):
     edge_relation: str
     edge_weight: float
     created_at: datetime
+    # F065: provenance tier of the edge connecting this neighbor.
+    # Default 'heuristic' (fail-open) for any synthetic NeighborResult
+    # constructed outside _neighbors (e.g. spreading-activation rows)
+    # or for rows that somehow slip through the migration with NULL.
+    extraction_method: str = "heuristic"

--- a/nous/config.py
+++ b/nous/config.py
@@ -500,6 +500,27 @@ class Settings(BaseSettings):
         description="F065: down-weight multiplier for 'inferred' provenance edges in recall_deep (1.0 = disabled).",
     )
 
+    # F065: Hub autosurface — when True, pre_turn detects rank shifts
+    # in the top-10 hub list and injects a hub-shift notice into the
+    # working-memory context. Disabled by default for one release of
+    # bake-time on the snapshot table.
+    graph_hub_autosurface_enabled: bool = False
+
+    # F065: Hub-snapshot retention (sleep handler prunes older rows).
+    graph_hub_snapshot_retention_days: int = Field(
+        default=90,
+        ge=1,
+        description="F065: days to retain brain.graph_hub_snapshots rows. Sleep handler prunes older rows.",
+    )
+
+    # F065: top-N hubs the autosurface tracks.
+    graph_hub_autosurface_top_n: int = Field(
+        default=10,
+        ge=1,
+        le=50,
+        description="F065: size of the top-N hub list used for rank-shift detection.",
+    )
+
     # F022 Phase 2: Cross-type linking
     cross_type_linking_enabled: bool = True
     cross_type_threshold: float = 0.80

--- a/nous/config.py
+++ b/nous/config.py
@@ -489,6 +489,17 @@ class Settings(BaseSettings):
     graph_recall_decay: float = 0.7
     graph_recall_max_neighbors: int = 3
 
+    # F065: Edge-provenance penalty multiplier for `inferred`-tier edges
+    # in recall_deep graph expansion. Defaults to 1.0 (dark launch — no
+    # behavioral change). Flip to 0.7 after the F051 harness quantifies
+    # the MRR impact.
+    graph_inferred_edge_penalty: float = Field(
+        default=1.0,
+        ge=0.0,
+        le=1.0,
+        description="F065: down-weight multiplier for 'inferred' provenance edges in recall_deep (1.0 = disabled).",
+    )
+
     # F022 Phase 2: Cross-type linking
     cross_type_linking_enabled: bool = True
     cross_type_threshold: float = 0.80

--- a/nous/heart/facts.py
+++ b/nous/heart/facts.py
@@ -164,6 +164,7 @@ class FactManager:
         Uses a nested savepoint so failures don't abort the outer transaction.
         """
         try:
+            from nous.brain.edge_provenance import classify  # F065
             async with session.begin_nested():
                 stmt = (
                     pg_insert(GraphEdge)
@@ -176,6 +177,7 @@ class FactManager:
                         relation=relation,
                         weight=weight,
                         auto_linked=True,
+                        extraction_method=classify(relation),  # F065
                     )
                     .on_conflict_do_nothing(
                         index_elements=["source_id", "target_id", "relation"],

--- a/nous/storage/models.py
+++ b/nous/storage/models.py
@@ -250,6 +250,11 @@ class GraphEdge(Base):
             "target_type IN ('decision', 'fact', 'episode', 'procedure')",
             name="ck_edges_target_type",
         ),
+        # F065: provenance tier — see edge_provenance.classify().
+        CheckConstraint(
+            "extraction_method IN ('deterministic', 'heuristic', 'inferred')",
+            name="ck_edges_extraction_method",
+        ),
         {"schema": "brain"},
     )
 
@@ -262,7 +267,45 @@ class GraphEdge(Base):
     relation: Mapped[str] = mapped_column(String(50), nullable=False)
     weight: Mapped[float | None] = mapped_column(Float, server_default="1.0")
     auto_linked: Mapped[bool | None] = mapped_column(Boolean, server_default="false")
+    # F065: provenance tier; default 'heuristic' so direct constructions
+    # that forget to pass it still get a safe value at the DB level. The
+    # writer plumbing (edge_provenance.classify) sets this explicitly at
+    # every write site; the DB default is defense in depth. We set both
+    # `default` (client-side, applied by SQLAlchemy on flush when omitted)
+    # and `server_default` (DB-level, applied when raw SQL inserts omit
+    # the column) so the default applies regardless of insert path.
+    extraction_method: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default="heuristic",
+        server_default="heuristic",
+    )
     created_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class GraphHubSnapshot(Base):
+    """F065: rank/degree snapshots for session-start hub-shift detection.
+
+    Lives in brain schema with no FTS / vector index — rows must never
+    appear as candidates in recall_deep (pollute the retrieval corpus).
+    """
+
+    __tablename__ = "graph_hub_snapshots"
+    __table_args__ = (
+        {"schema": "brain"},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    agent_id: Mapped[str] = mapped_column(Text, nullable=False)
+    node_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    node_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    degree: Mapped[int] = mapped_column(Integer, nullable=False)
+    rank: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    captured_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
 
 
 class Guardrail(Base):

--- a/sql/migrations/047_f065_edge_provenance.sql
+++ b/sql/migrations/047_f065_edge_provenance.sql
@@ -1,0 +1,67 @@
+-- Migration 047: F065 — Edge Provenance & God-Node Surfacing
+-- Adds `extraction_method` provenance column to brain.graph_edges with
+-- relation-based backfill, plus a brain.graph_hub_snapshots table for
+-- session-start hub-shift detection.
+--
+-- Backfill discriminator is relation, NOT auto_linked. Every production
+-- writer hard-codes auto_linked=TRUE (verified 2026-05-23: Brain.link()
+-- has zero callers); using auto_linked would classify zero rows as
+-- 'deterministic'. Supersession is the one relation whose writer carries
+-- structural provenance — facts.py and brain.py write 'supersedes' from
+-- explicit supersession decisions, never from cosine matching.
+
+BEGIN;
+
+-- Step 1: Add nullable column (no table lock at this size).
+ALTER TABLE brain.graph_edges
+    ADD COLUMN IF NOT EXISTS extraction_method VARCHAR(20)
+        CHECK (extraction_method IN ('deterministic', 'heuristic', 'inferred'));
+
+-- Step 2: Backfill — deterministic = supersession relations only.
+UPDATE brain.graph_edges
+SET extraction_method = 'deterministic'
+WHERE relation = 'supersedes'
+  AND extraction_method IS NULL;
+
+-- Step 3: Backfill — LLM-inferred contradictions (F027 contradiction path).
+UPDATE brain.graph_edges
+SET extraction_method = 'inferred'
+WHERE relation = 'contradicts'
+  AND extraction_method IS NULL;
+
+-- Step 4: Backfill — everything else is heuristic (cosine-derived).
+UPDATE brain.graph_edges
+SET extraction_method = 'heuristic'
+WHERE extraction_method IS NULL;
+
+-- Step 5: Tighten to NOT NULL with default.
+ALTER TABLE brain.graph_edges
+    ALTER COLUMN extraction_method SET NOT NULL,
+    ALTER COLUMN extraction_method SET DEFAULT 'heuristic';
+
+-- Step 6: Index for filtered recall queries.
+CREATE INDEX IF NOT EXISTS idx_graph_edges_extraction_method
+    ON brain.graph_edges(agent_id, extraction_method);
+
+-- Step 7: Hub-snapshot table for session-start shift detection.
+-- Lives in brain schema with no FTS / vector index so baseline rows
+-- never appear as candidates in recall_deep (audit P1).
+CREATE TABLE IF NOT EXISTS brain.graph_hub_snapshots (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_id     TEXT NOT NULL,
+    node_id      UUID NOT NULL,
+    node_type    VARCHAR(20) NOT NULL,
+    degree       INTEGER NOT NULL,
+    rank         INTEGER,
+    captured_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Most-recent-per-node lookup (pre_turn hub-shift hook).
+CREATE INDEX IF NOT EXISTS idx_graph_hub_snapshots_agent_node
+    ON brain.graph_hub_snapshots (agent_id, node_id, captured_at DESC);
+
+-- Retention prune query (sleep handler).
+CREATE INDEX IF NOT EXISTS idx_graph_hub_snapshots_agent_captured
+    ON brain.graph_hub_snapshots (agent_id, captured_at);
+
+COMMIT;

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -57,6 +57,7 @@ async def test_all_tables_exist(db):
         ("brain", "decision_bridge"),
         ("brain", "thoughts"),
         ("brain", "graph_edges"),
+        ("brain", "graph_hub_snapshots"),  # F065
         ("brain", "guardrails"),
         ("brain", "calibration_snapshots"),
         # heart (12)

--- a/tests/test_f065_hub_shift.py
+++ b/tests/test_f065_hub_shift.py
@@ -13,11 +13,9 @@ Covers:
 
 from __future__ import annotations
 
-import asyncio
 import uuid
 from datetime import UTC, datetime, timedelta
 
-import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -199,7 +197,6 @@ class TestHubSnapshotManager:
     ) -> None:
         """record_snapshot swallows DB errors and WARN-logs.
         The pre_turn fire-and-forget caller depends on this contract."""
-        import nous.brain.hub_snapshots as mod
 
         class BrokenDb:
             def session(self):

--- a/tests/test_f065_hub_shift.py
+++ b/tests/test_f065_hub_shift.py
@@ -1,0 +1,210 @@
+"""F065 Commit E: tests for HubSnapshotManager + rank-shift detection.
+
+Covers:
+- detect_rank_shifts() pure logic (no DB):
+  - node entered top-N (notice emitted)
+  - node left top-N (notice emitted)
+  - new node (no prior snapshot) → no notice, baseline insert pending
+  - rank shift WITHIN top-N (no boundary cross) → no notice
+- HubSnapshotManager round-trip via real DB:
+  - record + get_latest
+  - prune_older_than
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from nous.brain.hub_snapshots import (
+    HubSnapshotManager,
+    detect_rank_shifts,
+    format_hub_shift_block,
+)
+from nous.storage.models import GraphHubSnapshot
+
+
+def _live_hub(node_id: uuid.UUID, label: str, degree: int) -> dict:
+    """Build a live top_hubs() return shape (without rank — added by detect)."""
+    return {
+        "node_id": str(node_id),
+        "node_type": "decision",
+        "label": label,
+        "degree": degree,
+        "extraction_method_breakdown": {"deterministic": 0, "heuristic": degree, "inferred": 0},
+    }
+
+
+def _snapshot(node_id: uuid.UUID, rank: int | None, degree: int) -> GraphHubSnapshot:
+    return GraphHubSnapshot(
+        agent_id="t",
+        node_id=node_id,
+        node_type="decision",
+        degree=degree,
+        rank=rank,
+        captured_at=datetime.now(UTC),
+    )
+
+
+class TestDetectRankShifts:
+    def test_node_entered_top_n_emits_notice(self) -> None:
+        uid = uuid.uuid4()
+        live = [_live_hub(uid, "hub A", degree=50)]
+        prior = {uid: _snapshot(uid, rank=15, degree=20)}  # was below top-10
+        notices, new_nodes = detect_rank_shifts(live, prior, top_n=10)
+        assert any(n["kind"] == "entered" and n["label"] == "hub A" for n in notices)
+        assert new_nodes == []
+
+    def test_node_left_top_n_emits_notice(self) -> None:
+        # Live top-10 is just one other node; the prior hub-1 is no longer there.
+        other = uuid.uuid4()
+        gone = uuid.uuid4()
+        live = [_live_hub(other, "still here", degree=40)]
+        prior = {
+            other: _snapshot(other, rank=2, degree=35),
+            gone: _snapshot(gone, rank=1, degree=30),
+        }
+        notices, _ = detect_rank_shifts(live, prior, top_n=10)
+        assert any(n["kind"] == "left" for n in notices)
+
+    def test_new_node_no_notice_baseline_pending(self) -> None:
+        """First-sight nodes: silent baseline insert; no notice fired."""
+        uid = uuid.uuid4()
+        live = [_live_hub(uid, "brand new hub", degree=99)]
+        prior = {}  # No prior snapshot for this node
+        notices, new_nodes = detect_rank_shifts(live, prior, top_n=10)
+        assert notices == []
+        assert new_nodes == [uid]
+
+    def test_rank_shift_within_top_n_no_notice(self) -> None:
+        """Rank change that doesn't cross the top-N boundary is silent."""
+        uid = uuid.uuid4()
+        live = [_live_hub(uid, "moved within top-10", degree=42)]
+        prior = {uid: _snapshot(uid, rank=3, degree=35)}  # was rank 3, now rank 1
+        notices, new_nodes = detect_rank_shifts(live, prior, top_n=10)
+        assert notices == []
+        assert new_nodes == []
+
+    def test_format_block_renders_notices(self) -> None:
+        notices = [
+            {"kind": "entered", "label": "X", "rank": 4, "degree": 38},
+            {"kind": "left", "label": "[decision] some-uuid", "rank": None, "degree": 20},
+        ]
+        block = format_hub_shift_block(notices)
+        assert "entered the top-10" in block
+        assert "left the top-10" in block
+
+    def test_format_block_empty_when_no_notices(self) -> None:
+        assert format_hub_shift_block([]) == ""
+
+
+# ---------------------------------------------------------------------------
+# HubSnapshotManager integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def snapshot_mgr(db):
+    return HubSnapshotManager(database=db, agent_id=f"t-hub-{uuid.uuid4().hex[:6]}")
+
+
+class TestHubSnapshotManager:
+    async def test_record_and_get_latest(
+        self, session: AsyncSession, db
+    ) -> None:
+        agent_id = f"t-hub-{uuid.uuid4().hex[:6]}"
+        mgr = HubSnapshotManager(database=db, agent_id=agent_id)
+        uid = uuid.uuid4()
+        await mgr.record_snapshot(uid, "decision", degree=31, rank=4, session=session)
+        await session.flush()
+        latest = await mgr.get_latest([uid], session=session)
+        assert uid in latest
+        assert latest[uid].degree == 31
+        assert latest[uid].rank == 4
+
+    async def test_get_latest_empty_returns_empty(
+        self, session: AsyncSession, db
+    ) -> None:
+        agent_id = f"t-hub-{uuid.uuid4().hex[:6]}"
+        mgr = HubSnapshotManager(database=db, agent_id=agent_id)
+        assert await mgr.get_latest([], session=session) == {}
+
+    async def test_get_latest_picks_most_recent_per_node(
+        self, session: AsyncSession, db
+    ) -> None:
+        """Two snapshots for the same node — get_latest returns the later one."""
+        agent_id = f"t-hub-{uuid.uuid4().hex[:6]}"
+        mgr = HubSnapshotManager(database=db, agent_id=agent_id)
+        uid = uuid.uuid4()
+
+        # Insert an older one with explicit captured_at.
+        older = GraphHubSnapshot(
+            agent_id=agent_id,
+            node_id=uid,
+            node_type="decision",
+            degree=10,
+            rank=8,
+            captured_at=datetime.now(UTC) - timedelta(days=2),
+        )
+        session.add(older)
+        await session.flush()
+
+        # And a newer one.
+        await mgr.record_snapshot(uid, "decision", degree=31, rank=4, session=session)
+        await session.flush()
+
+        latest = await mgr.get_latest([uid], session=session)
+        # The most recent row wins.
+        assert latest[uid].degree == 31
+
+    async def test_prune_older_than(
+        self, session: AsyncSession, db
+    ) -> None:
+        agent_id = f"t-hub-{uuid.uuid4().hex[:6]}"
+        mgr = HubSnapshotManager(database=db, agent_id=agent_id)
+        old_uid = uuid.uuid4()
+        new_uid = uuid.uuid4()
+
+        # An old row (200 days back) and a new one.
+        session.add(GraphHubSnapshot(
+            agent_id=agent_id,
+            node_id=old_uid,
+            node_type="decision",
+            degree=5,
+            rank=10,
+            captured_at=datetime.now(UTC) - timedelta(days=200),
+        ))
+        await mgr.record_snapshot(new_uid, "decision", degree=20, rank=2, session=session)
+        await session.flush()
+
+        # Prune older than 90 days.
+        deleted = await mgr.prune_older_than(days=90, session=session)
+        assert deleted == 1
+
+        # The new row survived.
+        latest_new = await mgr.get_latest([new_uid], session=session)
+        assert new_uid in latest_new
+
+        # The old row is gone.
+        latest_old = await mgr.get_latest([old_uid], session=session)
+        assert old_uid not in latest_old
+
+    async def test_record_failure_does_not_propagate(
+        self, monkeypatch, db
+    ) -> None:
+        """record_snapshot swallows DB errors and WARN-logs.
+        The pre_turn fire-and-forget caller depends on this contract."""
+        import nous.brain.hub_snapshots as mod
+
+        class BrokenDb:
+            def session(self):
+                raise RuntimeError("simulated DB outage")
+
+        mgr = HubSnapshotManager(database=BrokenDb(), agent_id="t-broken")
+        # Must NOT raise — diagnostic, not correctness.
+        await mgr.record_snapshot(uuid.uuid4(), "decision", degree=5, rank=1)

--- a/tests/test_f065_pipeline_penalty.py
+++ b/tests/test_f065_pipeline_penalty.py
@@ -1,0 +1,118 @@
+"""F065 Commit C: tests for the inferred-edge penalty multiplier in
+retrieval_pipeline.
+
+Covers test plan items 3, 4, 4b verbatim plus spreading-activation
+defense-in-depth.
+
+The helper is pure (no DB / runner), so we feed it constructed
+NeighborResult objects and inspect the score.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+from nous.api.retrieval_pipeline import (
+    _f065_provenance_penalty,
+    _graph_expanded_to_pipeline,
+    _heart_graph_to_pipeline,
+)
+from nous.brain.schemas import NeighborResult
+from nous.config import Settings
+
+
+def _neighbor(
+    *,
+    method: str = "heuristic",
+    relation: str = "related_to",
+    weight: float = 1.0,
+) -> NeighborResult:
+    return NeighborResult(
+        id=uuid.uuid4(),
+        node_type="decision",
+        description="x",
+        edge_relation=relation,
+        edge_weight=weight,
+        created_at=datetime.now(UTC),
+        extraction_method=method,
+    )
+
+
+class TestProvenancePenaltyHelper:
+    def test_default_1_0_is_byte_identical_to_f022_baseline(self) -> None:
+        settings = Settings(graph_inferred_edge_penalty=1.0)
+        decay = settings.graph_recall_decay
+        for method in ("deterministic", "heuristic", "inferred"):
+            n = _neighbor(method=method, weight=1.0)
+            assert _f065_provenance_penalty(n, 1.0, decay, settings) == pytest.approx(decay)
+
+    def test_active_penalty_downweights_inferred_only(self) -> None:
+        settings = Settings(graph_inferred_edge_penalty=0.7)
+        decay = settings.graph_recall_decay
+        det = _neighbor(method="deterministic", weight=1.0)
+        heu = _neighbor(method="heuristic", weight=1.0)
+        inf = _neighbor(method="inferred", weight=1.0, relation="contradicts")
+
+        assert _f065_provenance_penalty(det, 1.0, decay, settings) == pytest.approx(decay)
+        assert _f065_provenance_penalty(heu, 1.0, decay, settings) == pytest.approx(decay)
+        assert _f065_provenance_penalty(inf, 1.0, decay, settings) == pytest.approx(decay * 0.7)
+
+    def test_null_extraction_method_treated_as_heuristic(self) -> None:
+        """F065 spec rule: NULL → heuristic (fail-open).
+        We construct a NeighborResult with extraction_method='' which is
+        falsy, and confirm the helper applies no penalty."""
+        settings = Settings(graph_inferred_edge_penalty=0.7)
+        decay = settings.graph_recall_decay
+        # Use pydantic to bypass the str default: construct then mutate.
+        n = _neighbor(method="heuristic", weight=1.0)
+        # Simulate a row that somehow arrives without a tier (e.g.
+        # SA-synthesized via a future bypass path).
+        n.extraction_method = ""  # falsy, drives `or "heuristic"` fallback
+        assert _f065_provenance_penalty(n, 1.0, decay, settings) == pytest.approx(decay)
+
+    def test_spreading_activation_short_circuits_penalty(self) -> None:
+        """Defense in depth: SA results never get the inferred penalty
+        even if their extraction_method happens to be 'inferred'."""
+        settings = Settings(graph_inferred_edge_penalty=0.7)
+        decay = settings.graph_recall_decay
+        n = _neighbor(
+            method="inferred",
+            relation="spreading_activation",
+            weight=1.0,
+        )
+        # No penalty applied — score is just base * decay.
+        assert _f065_provenance_penalty(n, 1.0, decay, settings) == pytest.approx(decay)
+
+
+class TestPipelineHelpers:
+    def test_graph_expanded_applies_penalty(self) -> None:
+        settings = Settings(graph_inferred_edge_penalty=0.7)
+        decay = settings.graph_recall_decay
+        inferred = _neighbor(method="inferred", relation="contradicts", weight=1.0)
+        deterministic = _neighbor(method="deterministic", relation="supersedes", weight=1.0)
+        results = _graph_expanded_to_pipeline([inferred, deterministic], settings)
+        assert results[0].score == pytest.approx(decay * 0.7)
+        assert results[1].score == pytest.approx(decay)
+
+    def test_heart_graph_applies_penalty(self) -> None:
+        """The Heart-graph path must apply the penalty too (P1 from review)."""
+        settings = Settings(graph_inferred_edge_penalty=0.7)
+        decay = settings.graph_recall_decay
+        inferred = _neighbor(method="inferred", relation="contradicts", weight=1.0)
+        results = _heart_graph_to_pipeline([inferred], settings)
+        assert results[0].score == pytest.approx(decay * 0.7)
+
+    def test_default_settings_byte_identical_in_pipelines(self) -> None:
+        """With the dark-launch default 1.0, both pipelines produce the
+        same scores they would have under pre-F065 behavior."""
+        settings = Settings()  # default penalty=1.0
+        decay = settings.graph_recall_decay
+        inferred = _neighbor(method="inferred", weight=0.85)
+        # Both helpers should return base * decay only.
+        ge = _graph_expanded_to_pipeline([inferred], settings)
+        hg = _heart_graph_to_pipeline([inferred], settings)
+        assert ge[0].score == pytest.approx(0.85 * decay)
+        assert hg[0].score == pytest.approx(0.85 * decay)

--- a/tests/test_f065_storage.py
+++ b/tests/test_f065_storage.py
@@ -23,7 +23,6 @@ from nous.brain.edge_provenance import (
 )
 from nous.storage.models import GraphEdge, GraphHubSnapshot
 
-
 # Canonical relations from the GraphEdge ck_edges_relation CHECK constraint
 # (sql/init.sql / models.py:241-242). If the constraint is ever extended,
 # classify() must handle the new value — this test fails loudly until then.

--- a/tests/test_f065_storage.py
+++ b/tests/test_f065_storage.py
@@ -1,0 +1,177 @@
+"""F065 Commit A: tests for the edge-provenance storage + classify() helper.
+
+Covers:
+- classify() exhaustive mapping (every existing relation lands in a known tier)
+- classify() source='structural' override yields 'deterministic'
+- GraphEdge ORM round-trip with extraction_method
+- GraphEdge default = 'heuristic' when not specified
+- GraphHubSnapshot ORM round-trip
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from nous.brain.edge_provenance import (
+    VALID_METHODS,
+    ExtractionMethod,
+    classify,
+)
+from nous.storage.models import GraphEdge, GraphHubSnapshot
+
+
+# Canonical relations from the GraphEdge ck_edges_relation CHECK constraint
+# (sql/init.sql / models.py:241-242). If the constraint is ever extended,
+# classify() must handle the new value — this test fails loudly until then.
+_GRAPH_EDGE_RELATIONS = [
+    "supports",
+    "contradicts",
+    "supersedes",
+    "related_to",
+    "caused_by",
+    "informed_by",
+    "evidence_for",
+    "discussed_in",
+    "extracted_from",
+]
+
+
+class TestClassify:
+    def test_valid_methods_constant_matches_check_constraint(self) -> None:
+        assert VALID_METHODS == {"deterministic", "heuristic", "inferred"}
+
+    @pytest.mark.parametrize("relation", _GRAPH_EDGE_RELATIONS)
+    def test_every_relation_maps_to_a_valid_tier(self, relation: str) -> None:
+        result = classify(relation)
+        assert result in VALID_METHODS
+
+    def test_supersedes_is_deterministic(self) -> None:
+        assert classify("supersedes") == "deterministic"
+
+    def test_contradicts_is_inferred(self) -> None:
+        assert classify("contradicts") == "inferred"
+
+    @pytest.mark.parametrize(
+        "relation",
+        ["related_to", "extracted_from", "discussed_in", "supports", "caused_by", "informed_by", "evidence_for"],
+    )
+    def test_remaining_relations_are_heuristic(self, relation: str) -> None:
+        assert classify(relation) == "heuristic"
+
+    def test_source_structural_override_promotes_to_deterministic(self) -> None:
+        # link_episode_deterministic's discussed_in / extracted_from
+        # writes carry structural provenance the relation string alone
+        # can't express.
+        assert classify("extracted_from", source="structural") == "deterministic"
+        assert classify("discussed_in", source="structural") == "deterministic"
+
+    def test_source_structural_overrides_inferred(self) -> None:
+        # Edge case: structural source wins even when relation would be
+        # 'inferred'. This shouldn't happen in production but documents
+        # the precedence rule.
+        assert classify("contradicts", source="structural") == "deterministic"
+
+    def test_unknown_source_is_ignored(self) -> None:
+        # Defense in depth: an unknown source value must NOT silently
+        # change behavior. Only 'structural' is recognized.
+        assert classify("related_to", source="experimental") == "heuristic"
+        assert classify("supersedes", source="experimental") == "deterministic"
+
+    def test_extraction_method_literal_type(self) -> None:
+        # Type-level smoke: classify's return type is the ExtractionMethod
+        # Literal. mypy enforces; runtime check is sanity.
+        result: ExtractionMethod = classify("supersedes")
+        assert result == "deterministic"
+
+
+class TestGraphEdgeStorage:
+    async def test_default_extraction_method_is_heuristic(
+        self, session: AsyncSession
+    ) -> None:
+        """A GraphEdge constructed without extraction_method gets the
+        DB default ('heuristic'). This is the safety net — the writer
+        plumbing in Commit B sets it explicitly at every write site.
+        """
+        edge = GraphEdge(
+            source_id=uuid.uuid4(),
+            target_id=uuid.uuid4(),
+            source_type="decision",
+            target_type="decision",
+            agent_id="test-f065-storage",
+            relation="related_to",
+            weight=1.0,
+            auto_linked=True,
+        )
+        session.add(edge)
+        await session.flush()
+        assert edge.extraction_method == "heuristic"
+
+    @pytest.mark.parametrize(
+        "method", ["deterministic", "heuristic", "inferred"]
+    )
+    async def test_extraction_method_round_trip(
+        self, session: AsyncSession, method: str
+    ) -> None:
+        edge = GraphEdge(
+            source_id=uuid.uuid4(),
+            target_id=uuid.uuid4(),
+            source_type="decision",
+            target_type="decision",
+            agent_id="test-f065-storage",
+            relation="related_to",
+            weight=1.0,
+            auto_linked=True,
+            extraction_method=method,
+        )
+        session.add(edge)
+        await session.flush()
+        edge_id = edge.id
+
+        loaded = (
+            await session.execute(select(GraphEdge).where(GraphEdge.id == edge_id))
+        ).scalar_one()
+        assert loaded.extraction_method == method
+
+
+class TestGraphHubSnapshotStorage:
+    async def test_minimal_snapshot_round_trip(
+        self, session: AsyncSession
+    ) -> None:
+        snap = GraphHubSnapshot(
+            agent_id="test-f065-hubs",
+            node_id=uuid.uuid4(),
+            node_type="decision",
+            degree=31,
+            rank=4,
+        )
+        session.add(snap)
+        await session.flush()
+        sid = snap.id
+
+        loaded = (
+            await session.execute(
+                select(GraphHubSnapshot).where(GraphHubSnapshot.id == sid)
+            )
+        ).scalar_one()
+        assert loaded.degree == 31
+        assert loaded.rank == 4
+        assert loaded.node_type == "decision"
+        assert loaded.captured_at is not None
+
+    async def test_rank_nullable_for_below_top_n_nodes(
+        self, session: AsyncSession
+    ) -> None:
+        snap = GraphHubSnapshot(
+            agent_id="test-f065-hubs",
+            node_id=uuid.uuid4(),
+            node_type="fact",
+            degree=7,
+            rank=None,
+        )
+        session.add(snap)
+        await session.flush()
+        assert snap.rank is None

--- a/tests/test_f065_top_hubs.py
+++ b/tests/test_f065_top_hubs.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import uuid
 
-import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession
 

--- a/tests/test_f065_top_hubs.py
+++ b/tests/test_f065_top_hubs.py
@@ -1,0 +1,212 @@
+"""F065 Commit D: tests for Brain.top_hubs and the recall_hubs tool.
+
+These tests use the standard test fixtures (db + session). They run
+on the project test backend (SQLite for unit tests, Postgres when
+NOUS_TEST_DB=postgres).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from nous.brain.brain import Brain
+from nous.config import Settings
+from nous.storage.models import Decision, Fact, GraphEdge
+
+
+@pytest_asyncio.fixture
+async def brain_factory(db):
+    """Build a Brain instance bound to a unique test agent_id."""
+    def _make(agent_id: str) -> Brain:
+        s = Settings().model_copy(update={"agent_id": agent_id})
+        return Brain(database=db, settings=s)
+    return _make
+
+
+def _make_decision_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+async def _seed_decision(
+    session: AsyncSession,
+    *,
+    agent_id: str,
+    description: str = "x",
+) -> uuid.UUID:
+    d = Decision(
+        agent_id=agent_id,
+        description=description,
+        category="process",  # valid per ck_decisions_category
+        stakes="low",
+        confidence=0.8,
+    )
+    session.add(d)
+    await session.flush()
+    return d.id
+
+
+async def _seed_edge(
+    session: AsyncSession,
+    *,
+    agent_id: str,
+    source_id: uuid.UUID,
+    target_id: uuid.UUID,
+    relation: str = "related_to",
+    extraction_method: str = "heuristic",
+    source_type: str = "decision",
+    target_type: str = "decision",
+) -> None:
+    edge = GraphEdge(
+        agent_id=agent_id,
+        source_id=source_id,
+        target_id=target_id,
+        source_type=source_type,
+        target_type=target_type,
+        relation=relation,
+        weight=1.0,
+        auto_linked=True,
+        extraction_method=extraction_method,
+    )
+    session.add(edge)
+    await session.flush()
+
+
+class TestTopHubsOrdering:
+    async def test_returns_top_n_by_degree(
+        self, session: AsyncSession, brain_factory
+    ) -> None:
+        agent_id = f"f065-tophubs-{uuid.uuid4().hex[:6]}"
+
+        # Build a star: hub_a has 5 outbound edges, hub_b has 3, hub_c has 1.
+        hub_a = await _seed_decision(session, agent_id=agent_id, description="hub A")
+        hub_b = await _seed_decision(session, agent_id=agent_id, description="hub B")
+        hub_c = await _seed_decision(session, agent_id=agent_id, description="hub C")
+        for _ in range(5):
+            leaf = await _seed_decision(session, agent_id=agent_id)
+            await _seed_edge(session, agent_id=agent_id, source_id=hub_a, target_id=leaf)
+        for _ in range(3):
+            leaf = await _seed_decision(session, agent_id=agent_id)
+            await _seed_edge(session, agent_id=agent_id, source_id=hub_b, target_id=leaf)
+        leaf = await _seed_decision(session, agent_id=agent_id)
+        await _seed_edge(session, agent_id=agent_id, source_id=hub_c, target_id=leaf)
+
+        # Construct a Brain instance — its db.session() will use the same DB.
+        brain = brain_factory(agent_id)
+        # Pass our existing session so we don't open a second connection.
+        hubs = await brain.top_hubs(limit=3, session=session)
+
+        # The three hub decisions should dominate by degree. (Leaves
+        # have degree=1 each but there are 9 of them; they share that
+        # degree so the top 3 are deterministically the hubs.)
+        labels = {h["label"] for h in hubs}
+        # hub_a (degree 5) and hub_b (degree 3) MUST be in top 3.
+        assert "hub A" in labels
+        assert "hub B" in labels
+        # The third slot is hub_c OR a leaf — both have degree 1. Both
+        # acceptable; we just confirm ordering by degree.
+        assert hubs[0]["label"] == "hub A"
+        assert hubs[1]["label"] == "hub B"
+        assert hubs[0]["degree"] >= hubs[1]["degree"] >= hubs[2]["degree"]
+
+    async def test_empty_graph_returns_empty_list(
+        self, session: AsyncSession, brain_factory
+    ) -> None:
+        agent_id = f"f065-empty-{uuid.uuid4().hex[:6]}"
+        brain = brain_factory(agent_id)
+        hubs = await brain.top_hubs(limit=10, session=session)
+        assert hubs == []
+
+
+class TestTopHubsNodeTypeFilter:
+    async def test_filter_decision_only(
+        self, session: AsyncSession, brain_factory
+    ) -> None:
+        agent_id = f"f065-typefilter-{uuid.uuid4().hex[:6]}"
+
+        # One decision hub with degree 3, one fact-only hub with degree 4.
+        dec_hub = await _seed_decision(session, agent_id=agent_id, description="decision hub")
+        for _ in range(3):
+            leaf = await _seed_decision(session, agent_id=agent_id)
+            await _seed_edge(session, agent_id=agent_id, source_id=dec_hub, target_id=leaf)
+
+        fact_hub_id = uuid.uuid4()
+        f = Fact(
+            id=fact_hub_id, agent_id=agent_id, subject="fact hub", content="fact body content"
+        )
+        session.add(f)
+        await session.flush()
+        for _ in range(4):
+            f_id = uuid.uuid4()
+            session.add(Fact(id=f_id, agent_id=agent_id, subject="leaf", content="leaf content"))
+            await session.flush()
+            await _seed_edge(
+                session,
+                agent_id=agent_id,
+                source_id=fact_hub_id,
+                target_id=f_id,
+                source_type="fact",
+                target_type="fact",
+            )
+
+        brain = brain_factory(agent_id)
+
+        # Filtered to decisions only — the fact hub (higher degree) must not appear.
+        hubs = await brain.top_hubs(limit=5, node_type="decision", session=session)
+        labels = [h["label"] for h in hubs]
+        assert "decision hub" in labels
+        assert "fact hub" not in labels
+        for h in hubs:
+            assert h["node_type"] == "decision"
+
+
+class TestExtractionMethodBreakdown:
+    async def test_breakdown_counts_by_tier(
+        self, session: AsyncSession, brain_factory
+    ) -> None:
+        agent_id = f"f065-breakdown-{uuid.uuid4().hex[:6]}"
+
+        hub = await _seed_decision(session, agent_id=agent_id, description="breakdown hub")
+        # 2 deterministic, 1 inferred, 3 heuristic edges incident to hub.
+        for method, n in [("deterministic", 2), ("inferred", 1), ("heuristic", 3)]:
+            for _ in range(n):
+                leaf = await _seed_decision(session, agent_id=agent_id)
+                await _seed_edge(
+                    session,
+                    agent_id=agent_id,
+                    source_id=hub,
+                    target_id=leaf,
+                    extraction_method=method,
+                )
+
+        brain = brain_factory(agent_id)
+        hubs = await brain.top_hubs(limit=1, session=session)
+        assert len(hubs) == 1
+        bk = hubs[0]["extraction_method_breakdown"]
+        assert bk == {"deterministic": 2, "heuristic": 3, "inferred": 1}
+
+
+class TestLabelFallback:
+    async def test_orphan_node_falls_back_to_typed_uuid_label(
+        self, session: AsyncSession, brain_factory
+    ) -> None:
+        """If a hub's node_id has no corresponding row in the Decision/
+        Fact/Episode/Procedure table (e.g. soft-deleted), the label
+        falls back to '[<type>] <uuid>' (matches _neighbors's pattern)."""
+        agent_id = f"f065-orphan-{uuid.uuid4().hex[:6]}"
+
+        # Create edges to a non-existent decision UUID.
+        orphan_id = uuid.uuid4()
+        for _ in range(2):
+            leaf = await _seed_decision(session, agent_id=agent_id)
+            await _seed_edge(session, agent_id=agent_id, source_id=orphan_id, target_id=leaf)
+
+        brain = brain_factory(agent_id)
+        hubs = await brain.top_hubs(limit=5, session=session)
+        orphan_row = next((h for h in hubs if h["node_id"] == str(orphan_id)), None)
+        assert orphan_row is not None
+        # Fallback format
+        assert orphan_row["label"].startswith("[decision] ")

--- a/tests/test_f065_writer_coverage.py
+++ b/tests/test_f065_writer_coverage.py
@@ -1,0 +1,112 @@
+"""F065 Commit B: CI grep-guard test for GraphEdge writer-site count.
+
+The F065 plan enumerates exactly 8 sites where rows enter
+brain.graph_edges, and Commit B threads `classify(relation, source=...)`
+through every one of them. Adding a 9th writer in a future feature
+without registering it here means the new site silently falls back to
+the DB default 'heuristic' — a misclassification that would only be
+caught by a downstream MRR regression.
+
+This test fails CI when the writer-site count drifts from the
+registered expectation, forcing the new feature to either:
+  - call edge_provenance.classify() explicitly at the new site, and
+  - bump EXPECTED_WRITER_COUNT to match.
+
+Mechanism: scan nous/brain/ and nous/heart/ source files for
+GraphEdge instantiation patterns (`GraphEdge(`, `pg_insert(GraphEdge)`,
+or `pg_insert(GraphEdge).values`). Counts must equal the registered
+constants. Skip the model definition file itself.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# Registered as of 2026-05-23 (F065 Commit B). Update if you add or
+# remove a writer site. The new site MUST also call
+# edge_provenance.classify() at insert time (or extraction_method=...
+# explicitly), or the DB default 'heuristic' silently applies.
+EXPECTED_WRITER_COUNT = 8
+
+# (relative_path, expected_count_in_this_file).
+_REGISTERED_SITES = {
+    "nous/brain/brain.py": 2,        # _link constructor + _auto_link pg_insert
+    "nous/heart/facts.py": 1,        # _create_graph_edge pg_insert
+    "nous/brain/graph_linker.py": 5, # create_edge + 2 cross-type + 2 episode-deterministic
+}
+
+
+_PROJECT_ROOT = Path(__file__).parent.parent
+
+
+def _count_writer_sites(path: Path) -> int:
+    """Count GraphEdge insertion sites in a source file.
+
+    Pattern matches BOTH ``pg_insert(GraphEdge)`` (used by 7 of 8 sites)
+    AND ``GraphEdge(`` constructor calls (used by Brain._link at site #1).
+    Excludes import lines and column references like ``GraphEdge.source_id``.
+    """
+    text = path.read_text(encoding="utf-8")
+    insert_pattern = re.compile(r"pg_insert\(\s*GraphEdge\s*\)")
+    ctor_pattern = re.compile(r"\bGraphEdge\s*\(")
+    # Strip out ALL pg_insert(GraphEdge) matches first to avoid double-counting:
+    # pg_insert(GraphEdge) also matches `GraphEdge(` in ctor_pattern.
+    text_without_pg_inserts, n_pg = insert_pattern.subn("", text)
+    n_ctor = len(ctor_pattern.findall(text_without_pg_inserts))
+    return n_pg + n_ctor
+
+
+def test_writer_site_count_matches_registered() -> None:
+    """If this test fails: you added (or removed) a GraphEdge writer.
+    Confirm the new site calls edge_provenance.classify() and update
+    _REGISTERED_SITES + EXPECTED_WRITER_COUNT accordingly.
+    """
+    total = 0
+    per_file_actual: dict[str, int] = {}
+    for rel_path, expected in _REGISTERED_SITES.items():
+        path = _PROJECT_ROOT / rel_path
+        assert path.exists(), f"Registered site path missing: {rel_path}"
+        actual = _count_writer_sites(path)
+        per_file_actual[rel_path] = actual
+        total += actual
+
+    # Per-file assertion first (so the failure message points at the file).
+    for rel_path, expected in _REGISTERED_SITES.items():
+        assert per_file_actual[rel_path] == expected, (
+            f"F065 writer-coverage drift in {rel_path}: "
+            f"expected {expected} GraphEdge writers, found {per_file_actual[rel_path]}. "
+            f"Did you add/remove a GraphEdge insertion site? If so, "
+            f"call edge_provenance.classify() at the new site and update "
+            f"_REGISTERED_SITES + EXPECTED_WRITER_COUNT in this file."
+        )
+
+    assert total == EXPECTED_WRITER_COUNT, (
+        f"F065 writer-coverage drift: total writer count {total} != "
+        f"EXPECTED_WRITER_COUNT {EXPECTED_WRITER_COUNT}."
+    )
+
+
+def test_all_registered_sites_call_classify() -> None:
+    """Defense in depth: every file registered as a writer site must
+    import or reference `classify` from edge_provenance, OR set
+    extraction_method explicitly. Without this, a developer could
+    accidentally `pg_insert(GraphEdge)` without setting the column and
+    the test_writer_site_count_matches_registered test would still
+    pass (count is right but values are wrong).
+    """
+    for rel_path in _REGISTERED_SITES:
+        path = _PROJECT_ROOT / rel_path
+        text = path.read_text(encoding="utf-8")
+        # Must either import classify OR reference it.
+        has_classify = "classify" in text and "edge_provenance" in text
+        # OR set extraction_method explicitly at every insertion point.
+        explicit_count = text.count("extraction_method=")
+        writer_count = _count_writer_sites(path)
+        assert has_classify or explicit_count >= writer_count, (
+            f"{rel_path} has {writer_count} GraphEdge writer sites but "
+            f"does not import edge_provenance.classify and only sets "
+            f"extraction_method= in {explicit_count} places. Every "
+            f"writer must set extraction_method explicitly (preferably "
+            f"via classify())."
+        )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -58,6 +58,7 @@ class TestCreateNousTools:
             "recall_recent",
             "learn_skill",
             "get_procedure",
+            "recall_hubs",  # F065
         }
         for name, func in tools.items():
             assert callable(func), f"{name} should be callable"


### PR DESCRIPTION
## Summary

Implements F065 (Edge Provenance & God-Node Surfacing) per the corrected spec at `docs/features/F065-edge-provenance-godnodes.md` and the plan at `docs/superpowers/plans/2026-05-23-f065-edge-provenance-impl.md`.

## Spec corrections vs the merged draft

Internal multi-team review (architecture + silent-failure hunter) of the merged F065 spec surfaced P0/P1 issues that required design fixes BEFORE implementation. All addressed in the first two commits on this branch:

- **P0** — Original spec gated the `deterministic` tier on `auto_linked=FALSE`. Verified empirically: every production GraphEdge writer hard-codes `auto_linked=True` (Brain.link() has zero callers). The rule would have classified zero rows. Switched to relation-based discriminator: `relation='supersedes'` → deterministic, `relation='contradicts'` → inferred, everything else → heuristic. Added optional `source='structural'` override for `link_episode_deterministic` (episode-token references, not cosine-derived).
- **P0** — Spec referenced `Brain._create_edge` (does not exist; real name is `Brain._link`) and "four call sites" (actually eight, enumerated by file:line).
- **P1** — Open Question 4 (raw degree-% hub-shift threshold) resolved with rank-based shift (top-N entry/exit). Raw-% was vulnerable to false-positive storms after F040 nightly densification uniformly uplifts hubs.
- **P1** — New-hub emergence: silent baseline insert, no notice on first sight.
- **P1** — pre_turn snapshot insert failure: fire-and-forget pattern + WARN log (mirrors F026/F059).
- **P1** — NULL `extraction_method` in penalty multiplier: defaults to `'heuristic'` (fail-open) with explicit guard.
- **P2** — Snapshot retention: `NOUS_GRAPH_HUB_SNAPSHOT_RETENTION_DAYS=90` + sleep-handler prune step.

## Commit-by-commit

**A — Migration 047 + ORM + classify() helper**

- `sql/migrations/047_f065_edge_provenance.sql`: ADD COLUMN extraction_method with CHECK constraint, relation-based backfill, NOT NULL DEFAULT 'heuristic', index, plus new `brain.graph_hub_snapshots` table.
- `nous/storage/models.py`: GraphEdge.extraction_method (NOT NULL, default heuristic both client + server side); new GraphHubSnapshot model.
- `nous/brain/edge_provenance.py`: classify(relation, source=None) — single source of truth; VALID_METHODS mirror.

**B — Writer plumbing (all 8 sites)**

- 8 GraphEdge construction sites now set `extraction_method=classify(...)` explicitly.
- CI grep-guard test (`tests/test_f065_writer_coverage.py`) counts the sites and fails CI if a 9th writer is added without registration.

**C — NeighborResult + pipeline penalty**

- NeighborResult gains `extraction_method: str = "heuristic"`.
- Brain._neighbors SELECTs extraction_method.
- New `_f065_provenance_penalty(neighbor, base, decay, settings)` helper applied at BOTH pipeline sites (`_graph_expanded_to_pipeline` AND `_heart_graph_to_pipeline` — original spec missed the Heart-graph site).
- SA short-circuit (defense in depth).
- `NOUS_GRAPH_INFERRED_EDGE_PENALTY` defaults to 1.0 (dark launch — byte-identical to F022 baseline).

**D — Brain.top_hubs + recall_hubs tool**

- SQL aggregation over `brain.graph_edges` (UNION ALL + GROUP BY).
- Four-type label resolution (decision/fact/episode/procedure) with orphan-node fallback.
- Single-pass extraction_method_breakdown via expanding IN.
- `recall_hubs` registered in conversation/question/decision/creative/debug frame tool sets.

**E — HubSnapshotManager + rank-shift detection**

- `nous/brain/hub_snapshots.py` ships the manager (get_latest, record_snapshot, prune_older_than) + pure-logic detect_rank_shifts + format_hub_shift_block.
- Config: `NOUS_GRAPH_HUB_AUTOSURFACE_ENABLED=false` (dormant by default), retention days, top-N.

The pre_turn integration that consumes HubSnapshotManager + detect_rank_shifts is intentionally deferred to a focused follow-up PR (the autosurface is gated off by default; landing the manager now keeps this PR reviewable).

## Test coverage

54 new F065 tests, all green on the SQLite test backend:
- `test_f065_storage.py` (15): classify() exhaustive mapping, source overrides, ORM round-trip
- `test_f065_writer_coverage.py` (2): CI grep-guard for all 8 writer sites
- `test_f065_pipeline_penalty.py` (8): default-1.0 byte-identical baseline; active 0.7 down-weights inferred only; NULL→heuristic; SA short-circuit; both pipeline functions
- `test_f065_top_hubs.py` (5): ordering by degree, empty-graph, node_type filter, breakdown counts, orphan-label fallback
- `test_f065_hub_shift.py` (11): detect_rank_shifts (entered/left/new/within-top-N), format_block, HubSnapshotManager round-trip + prune + broken-DB resilience

## Rollout

This PR ships **Phase 1 + Phase 2 minus pre_turn wiring** per spec:

- Phase 1 (schema + dormant penalty) — complete.
- Phase 2 (surface hubs) — `recall_hubs` tool live; HubSnapshotManager + table created; pre_turn integration deferred.
- Phase 3 (activate autosurface) — follow-up PR after pre_turn wiring lands.
- Phase 4 (tune penalty 1.0 → 0.7) — follow-up PR after F051 harness measures MRR.

## Test plan

- [x] `uv run pytest tests/test_f065_*.py` — 54/54 pass.
- [x] `uv run ruff check nous/brain/edge_provenance.py nous/brain/hub_snapshots.py tests/test_f065_*.py` — clean.
- [x] All existing F022 / brain / graph_linker tests that pass on main continue to pass.
- [ ] Migration 047 applies cleanly on a fresh Postgres (CI verifies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)