### PR TITLE
F066.1 Phase 1 implementation — fix-stage node type + skipped state

### DIFF
--- a/docs/superpowers/plans/2026-05-23-f066.1-dag-fix-stage-impl.md
+++ b/docs/superpowers/plans/2026-05-23-f066.1-dag-fix-stage-impl.md
@@ -1,0 +1,100 @@
+# F066.1 Implementation Plan — Phase 1 only
+
+**Spec:** `docs/features/F066.1-dag-fix-stage.md`
+**Branch:** `feat/F066.1-dag-fix-stage-impl`
+**Date:** 2026-05-23
+**Scope:** Phase 1 — schema + fix-node executor with free-form LLM dispatch. Typed dispatch (Phase 2), wave-level fix (Phase 3), and Critic integration (Phase 4) are explicitly deferred.
+
+---
+
+## Pre-flight invariants
+
+- `DAGNodeType` (`nous/dag/schemas.py:17`) enum: `subtask`, `check`, `gate`, `callback`. Phase 1 adds `fix`.
+- `DAGNodeStatus` (`schemas.py:37`) enum: `pending`, `ready`, `running`, `awaiting_check`, `completed`, `failed`, `blocked`, `cancelled`. Phase 1 adds `skipped`.
+- `EdgeType` Literal (`schemas.py:54`): `dependency`, `cancel_cascade`, `context_flow`. Phase 1 adds `on_failure`.
+- Orchestrator state-machine hooks: `_advance_dag` → `_propagate_failures` (`orchestrator.py:687`). Phase 1 hooks the fix path BEFORE failures propagate, so a successful fix prevents cascade.
+- Next migration slot: 048 (047 was F065).
+
+---
+
+## Commit sequence
+
+### Commit A — Schema + ORM + Pydantic-level validation
+
+**Files:**
+- `sql/migrations/048_f066_1_dag_fix_stage.sql` (new). Steps:
+  - Update `dag_nodes` CHECK constraint on `node_type` to include `'fix'`.
+  - Update `dag_nodes` CHECK constraint on `status` to include `'skipped'`.
+  - Update `dag_edges` CHECK on `edge_type` to include `'on_failure'`.
+  - Add columns to `dag_nodes`: `parent_node TEXT NULL`, `fix_actions JSONB NULL`, `max_fix_attempts INTEGER NOT NULL DEFAULT 1`, `fix_attempts_used INTEGER NOT NULL DEFAULT 0`, `expected_modes JSONB NOT NULL DEFAULT '[]'::jsonb`.
+  - Index on `(dag_id, parent_node)` for fast fix-child lookup at parent-failure time.
+- `nous/storage/models.py`: extend `DAGNode` with the 5 new columns.
+- `nous/dag/schemas.py`:
+  - `DAGNodeType` enum gains `fix = "fix"`.
+  - `DAGNodeStatus` enum gains `skipped = "skipped"`.
+  - `EdgeType` Literal extended to include `"on_failure"`.
+  - `DAGNodeSpec` gains optional fields: `parent_node: str | None`, `fix_actions: list[str] | None`, `max_fix_attempts: int = 1`, `expected_modes: list[str] = []`.
+  - Pydantic validator: when `type == DAGNodeType.fix`, `parent_node` must be non-empty and `fix_actions` must be a non-empty subset of `{retry_as_is, retry_with_amended_prompt, mark_unrecoverable, skip_and_continue}`.
+- `nous/dag/store.py::DAGStore.create`: thread the 5 new fields from `DAGNodeSpec` to the INSERT.
+- `nous/dag/store.py::_validate_dag`: enforce DAG-level invariants:
+  - A `fix` node MUST have exactly one inbound `on_failure` edge.
+  - Its `parent_node` MUST reference a real node in the DAG.
+  - A `fix` node cannot be the `parent_node` of another fix (no fix-of-fix).
+  - At most one fix child per parent node.
+- Tests: `tests/test_f066_1_schemas.py` — Pydantic-level validation, enum membership, DAGStore.create round-trip for a DAG with one fix node.
+
+### Commit B — Fix-node executor + action processing
+
+**Files:**
+- `nous/dag/fix_executor.py` (new):
+  - `class FixActionResult(NamedTuple)`: `action: str`, `amended_prompt: str | None`, `mode: str | None`.
+  - `async def run_fix_node(fix_node, parent_node, dag, runner, settings) -> FixActionResult`:
+    - Builds a prompt with `{parent_output, failure_reason, success_criteria}` from the parent.
+    - Single LLM call (free-form) constrained to choose one action from `fix_node.fix_actions`.
+    - Returns the action + optional amended prompt.
+    - Free-form dispatch only (Phase 1); typed dispatch via `expected_modes` is Phase 2.
+- `nous/dag/orchestrator.py`:
+  - In `_advance_dag`, after `_sync_subtask_node` completes a node's failure write but BEFORE `_propagate_failures` cascades:
+    ```python
+    await self._try_fix_failed_nodes(dag)
+    ```
+  - New method `_try_fix_failed_nodes(dag)`:
+    - For each node in `failed` with `fix_attempts_used < max_fix_attempts`, find its `on_failure` child.
+    - If a fix child exists: call `run_fix_node`, get action, apply it.
+    - Action handlers:
+      - `retry_as_is`: bump `fix_attempts_used`, set parent back to `pending`, dispatch on next tick.
+      - `retry_with_amended_prompt`: bump counter, update parent `instructions` with amended prompt, set to `pending`.
+      - `mark_unrecoverable`: leave as `failed`, tag with diagnosis (write to `result` field).
+      - `skip_and_continue`: set parent to `skipped` (the new terminal state).
+  - `_propagate_failures` extended: treat `skipped` like `completed` for `dependency` resolution (successors unblock).
+  - `_check_dag_completion`: `skipped` counts as a terminal state alongside `completed` / `failed`.
+- Tests: `tests/test_f066_1_fix_executor.py` + integration test for each action's orchestrator behavior.
+
+### Commit C — Final integration + docs
+
+**Files:**
+- `nous/dag/orchestrator.py`: edge-case handling (fix node itself errors → parent stays failed, `fix_attempts_used` increments anyway to prevent retry loop).
+- `CLAUDE.md`: env vars (none new for Phase 1 — fix is gated structurally, not via env).
+- `docs/features/INDEX.md`: F066.1 status update.
+
+---
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| Migration 048 fails because `dag_nodes` CHECK on `status` rejects existing rows that have `'skipped'` — but no existing rows have it; safe | Verify with a count query before SET NOT NULL (no NOT NULL needed since `skipped` is just a new allowed value, not new column) |
+| Fix-node LLM call fails or returns garbage | Catch in orchestrator; mark parent `fix_errored` (still in `failed`); bump `fix_attempts_used` to prevent infinite retry loop |
+| Cycle: fix node depends on parent which has fix node | `_validate_dag` rejects fix-of-fix at creation time |
+| `skip_and_continue` unblocks successors that depend on parent output | Documented behavior — caller opted in by authoring `skip_and_continue` in `fix_actions`. The fix output is piped into successors via `context_flow` (Phase 2 feature; Phase 1 just transitions state and successors run with whatever they had) |
+| F061 retry budget vs fix attempts | F061 retries internally on `incomplete_no_terminal` / `validation_failed`. Fix fires AFTER F061 exits. `fix_attempts_used` counts fix runs only, not F061 attempts. No double-counting because they're tracked on different columns |
+
+---
+
+## Out of scope (Phase 2+)
+
+- Typed dispatch via `expected_modes` (Phase 2)
+- Wave-level fix (Phase 3)
+- Critic auto-authoring fix nodes (Phase 4)
+- Fix-node telemetry table (Phase 2)
+- `context_flow` propagation of fix output to successors (Phase 2)

--- a/nous/dag/fix_executor.py
+++ b/nous/dag/fix_executor.py
@@ -1,0 +1,103 @@
+"""F066.1 — fix-node action selection.
+
+Phase 1 ships a deterministic rule-based dispatcher. The spec calls for
+free-form LLM dispatch in Phase 1; we deviate intentionally to keep the
+state-machine surface (new node type, new terminal state, action
+processing) testable and reviewable without standing up an LLM-call
+mechanism inside the orchestrator. LLM-based diagnosis lands in a
+Phase 1.5 follow-up that swaps `choose_action` for a single LLM call
+with tool-use constraint on `fix_actions`.
+
+The rule (Phase 1):
+
+  parent.error contains substring         → action (if in fix_actions)
+  --------------------------------------------------------------
+  "incomplete_no_terminal" / "validation_failed"
+                                          → retry_as_is
+  "timed_out"                             → skip_and_continue if available, else mark_unrecoverable
+  any other / "errored"                   → skip_and_continue if available, else mark_unrecoverable
+
+Any action not present in `fix_actions` is replaced by the next allowed
+fallback. If no allowed action matches, `mark_unrecoverable` is the
+final fallback (always implicitly available).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class FixActionResult:
+    """Outcome of a fix-node firing."""
+
+    action: str
+    amended_prompt: str | None = None
+    mode: str | None = None
+    rationale: str | None = None
+
+
+def choose_action(
+    parent_error: str | None,
+    parent_status: str,
+    fix_actions: list[str] | None,
+) -> FixActionResult:
+    """Pick the fix action for a failed parent based on its error string.
+
+    Args:
+        parent_error: the failing parent node's error column (may be None).
+        parent_status: the parent's current status (typically 'failed').
+        fix_actions: the allowed action vocabulary declared on the fix node.
+
+    Returns:
+        FixActionResult with chosen action + rationale.
+    """
+    allowed = set(fix_actions or [])
+    # mark_unrecoverable is always implicitly available as a last resort,
+    # even if not declared.
+    allowed.add("mark_unrecoverable")
+
+    err = (parent_error or "").lower()
+
+    # Recoverable / structural failures → retry.
+    if any(token in err for token in ("incomplete_no_terminal", "validation_failed")):
+        if "retry_as_is" in allowed:
+            return FixActionResult(
+                action="retry_as_is",
+                rationale=f"parent.error matched recoverable pattern; chose retry_as_is",
+            )
+
+    # Timed out → prefer skip over retry (retry of a timeout is wasteful).
+    if "timed_out" in err or "timeout" in err:
+        if "skip_and_continue" in allowed:
+            return FixActionResult(
+                action="skip_and_continue",
+                rationale="parent timed out; chose skip_and_continue",
+            )
+        if "mark_unrecoverable" in allowed:
+            return FixActionResult(
+                action="mark_unrecoverable",
+                rationale="parent timed out; no skip allowed; chose mark_unrecoverable",
+            )
+
+    # Everything else (errored, unknown) → prefer skip if allowed.
+    if "skip_and_continue" in allowed:
+        return FixActionResult(
+            action="skip_and_continue",
+            rationale=f"parent error ({err[:80] or 'unknown'}); chose skip_and_continue",
+        )
+    if "retry_with_amended_prompt" in allowed:
+        # Amended prompt is a noop in Phase 1 (no LLM diagnosis to amend
+        # with); fall through to mark_unrecoverable instead of retry-loop.
+        logger.debug(
+            "F066.1: retry_with_amended_prompt declared but Phase 1 has no "
+            "LLM diagnosis to amend with; falling through"
+        )
+
+    return FixActionResult(
+        action="mark_unrecoverable",
+        rationale="no recoverable action matched; mark_unrecoverable (final fallback)",
+    )

--- a/nous/dag/orchestrator.py
+++ b/nous/dag/orchestrator.py
@@ -1042,10 +1042,25 @@ class DAGOrchestrator:
             )
 
             # Always bump fix_attempts_used so we cap retries even if the
-            # action ends up being a noop.
+            # action ends up being a noop. Also transition the fix node
+            # itself to a terminal status — without this, the DAG never
+            # completes because _check_dag_completion sees the fix node
+            # stuck in 'pending' forever (Codex P1 on b333f78). The fix
+            # node is conceptually a one-shot per firing; if the parent
+            # fails again and budget remains, the next tick re-fires it
+            # via the same code path (the lookup in fix_by_parent is by
+            # parent_node string, not by fix node status).
             fix_node.fix_attempts_used += 1
+            fix_node.status = "completed"
+            fix_node.result = (
+                f"Fix-stage chose '{outcome.action}' for parent '{parent.name}': "
+                f"{outcome.rationale or ''}".strip()
+            )
             await self._store.update_node(
-                fix_node.id, fix_attempts_used=fix_node.fix_attempts_used,
+                fix_node.id,
+                fix_attempts_used=fix_node.fix_attempts_used,
+                status="completed",
+                result=fix_node.result,
             )
 
             if outcome.action == "retry_as_is" or outcome.action == "retry_with_amended_prompt":
@@ -1274,7 +1289,31 @@ class DAGOrchestrator:
                 logger.debug("Could not disable check %s", node.check_name)
 
     async def _check_dag_completion(self, dag: ExecutionDAG) -> None:
-        """Check if all nodes are terminal and set final DAG status."""
+        """Check if all nodes are terminal and set final DAG status.
+
+        F066.1: a fix node that never fires (because its parent reached
+        a non-failed terminal state) would otherwise sit in 'pending'
+        forever, keeping the DAG running. Auto-complete idle fix nodes
+        when their parent terminates without ever failing.
+        """
+        # Sweep pending fix nodes whose parent reached a non-failed terminal.
+        node_by_name = {n.name: n for n in dag.nodes}
+        for n in dag.nodes:
+            if n.node_type != "fix" or n.status != "pending":
+                continue
+            parent = node_by_name.get(n.parent_node or "")
+            if parent is None:
+                continue
+            if parent.status in ("completed", "skipped", "cancelled"):
+                n.status = "completed"
+                n.result = (
+                    f"Fix-stage not fired — parent '{parent.name}' "
+                    f"reached terminal '{parent.status}' without failure."
+                )
+                await self._store.update_node(
+                    n.id, status="completed", result=n.result,
+                )
+
         statuses = {n.status for n in dag.nodes}
 
         # If any nodes are still non-terminal, DAG is not done

--- a/nous/dag/orchestrator.py
+++ b/nous/dag/orchestrator.py
@@ -23,8 +23,17 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Terminal statuses — nodes in these states won't be touched
-_TERMINAL = frozenset({"completed", "failed", "blocked", "cancelled"})
+# Terminal statuses — nodes in these states won't be touched.
+# F066.1: 'skipped' is a terminal state introduced by skip_and_continue
+# fix action; it behaves like 'completed' for dependency resolution but
+# is distinguished in telemetry.
+_TERMINAL = frozenset({"completed", "failed", "blocked", "cancelled", "skipped"})
+
+# F066.1: statuses that "resolve" a node for dependency-resolution
+# purposes — i.e. _find_ready_nodes treats them as satisfied predecessors.
+# `skipped` joins `completed` here because skip_and_continue says
+# "proceed past this failure"; cascade-failed nodes are NOT in this set.
+_RESOLVED = frozenset({"completed", "skipped"})
 
 # Budget warning threshold (80%)
 _BUDGET_WARNING_RATIO = 0.80
@@ -231,6 +240,12 @@ class DAGOrchestrator:
         # 2.5. Recover orphaned wave-0 nodes that are stuck in 'ready' status
         # because start_dag() was bypassed or the dispatch failed silently.
         await self._recover_stale_ready_nodes(dag)
+
+        # 2.7. F066.1: try to apply a fix to any node that just transitioned
+        # to 'failed' BEFORE the cascade fires. A successful fix either
+        # retries the parent (back to 'pending') or skips it (terminal
+        # 'skipped') — in either case the cascade should not propagate.
+        await self._try_fix_failed_nodes(dag)
 
         # 3. Propagate failures
         await self._propagate_failures(dag)
@@ -957,6 +972,106 @@ class DAGOrchestrator:
                 node.name, dag.id, dag_age_seconds,
             )
 
+    async def _try_fix_failed_nodes(self, dag: ExecutionDAG) -> None:
+        """F066.1: apply fix-stage recovery to nodes that just failed.
+
+        For each non-fix node currently in 'failed' status, look up its
+        fix child (a fix node with parent_node == this node's name) and,
+        if found AND fix_attempts_used < max_fix_attempts, run the fix
+        executor and apply the chosen action.
+
+        Action semantics:
+          - retry_as_is: bump attempts, set parent back to 'pending' so
+            _find_ready_nodes picks it up on the next tick (or this one).
+            Clear `error` so cascade doesn't trigger on the stale value.
+          - retry_with_amended_prompt: same as retry_as_is in Phase 1
+            (no LLM diagnosis → no amended prompt to apply); falls back
+            to mark_unrecoverable per fix_executor.choose_action.
+          - mark_unrecoverable: leave parent in 'failed'; record fix
+            diagnosis in result; let _propagate_failures cascade.
+          - skip_and_continue: set parent to 'skipped' (terminal state);
+            successors will unblock via _RESOLVED predicate.
+
+        Fail-safe: if the fix node itself errors, we bump
+        fix_attempts_used to prevent an infinite retry loop and leave
+        the parent in 'failed' so cascade proceeds normally.
+        """
+        from nous.dag.fix_executor import choose_action
+
+        # Index fix nodes by parent_node for O(1) lookup.
+        fix_by_parent: dict[str, DAGNode] = {}
+        for n in dag.nodes:
+            if n.node_type == "fix" and n.parent_node:
+                fix_by_parent[n.parent_node] = n
+
+        if not fix_by_parent:
+            return
+
+        for parent in dag.nodes:
+            if parent.node_type == "fix":
+                continue
+            if parent.status != "failed":
+                continue
+            fix_node = fix_by_parent.get(parent.name)
+            if fix_node is None:
+                continue
+            if fix_node.fix_attempts_used >= fix_node.max_fix_attempts:
+                continue
+
+            try:
+                outcome = choose_action(
+                    parent_error=parent.error,
+                    parent_status=parent.status,
+                    fix_actions=fix_node.fix_actions,
+                )
+            except Exception:
+                logger.exception(
+                    "F066.1: fix_executor raised for parent %s (DAG %s); "
+                    "bumping fix_attempts_used and leaving parent failed",
+                    parent.name, dag.id,
+                )
+                fix_node.fix_attempts_used += 1
+                await self._store.update_node(
+                    fix_node.id, fix_attempts_used=fix_node.fix_attempts_used,
+                )
+                continue
+
+            logger.info(
+                "F066.1: fix '%s' chose '%s' for parent '%s' — %s",
+                fix_node.name, outcome.action, parent.name, outcome.rationale,
+            )
+
+            # Always bump fix_attempts_used so we cap retries even if the
+            # action ends up being a noop.
+            fix_node.fix_attempts_used += 1
+            await self._store.update_node(
+                fix_node.id, fix_attempts_used=fix_node.fix_attempts_used,
+            )
+
+            if outcome.action == "retry_as_is" or outcome.action == "retry_with_amended_prompt":
+                # Re-enqueue parent for dispatch on next tick.
+                parent.status = "pending"
+                parent.error = None
+                await self._store.update_node(
+                    parent.id, status="pending", error=None,
+                )
+            elif outcome.action == "skip_and_continue":
+                parent.status = "skipped"
+                parent.result = (
+                    f"Fix '{fix_node.name}': {outcome.rationale or 'skipped by fix-stage'}"
+                )
+                await self._store.update_node(
+                    parent.id, status="skipped", result=parent.result,
+                )
+            else:
+                # mark_unrecoverable — leave 'failed' but annotate.
+                diag = f"Fix '{fix_node.name}': {outcome.rationale or 'mark_unrecoverable'}"
+                existing = parent.result or ""
+                parent.result = (existing + "\n" + diag).strip()
+                await self._store.update_node(
+                    parent.id, result=parent.result,
+                )
+
     def _find_ready_nodes(self, dag: ExecutionDAG) -> list[DAGNode]:
         """Find pending nodes whose all dependency/context_flow predecessors are completed."""
         # Build set of predecessor node_ids per node (dependency + context_flow)
@@ -966,11 +1081,19 @@ class DAGOrchestrator:
                 dep_map[str(edge.to_node_id)].add(str(edge.from_node_id))
 
         # Completed node IDs
-        completed_ids = {str(n.id) for n in dag.nodes if n.status == "completed"}
+        # F066.1: 'skipped' resolves dependencies just like 'completed'.
+        completed_ids = {str(n.id) for n in dag.nodes if n.status in _RESOLVED}
 
         ready: list[DAGNode] = []
         for node in dag.nodes:
             if node.status != "pending":
+                continue
+            # F066.1: fix nodes are NOT dispatched by the normal ready path.
+            # They are launched by _try_fix_failed_nodes when their parent
+            # transitions to 'failed'. Skipping here prevents the silent
+            # no-op fallthrough in _launch_node where node_type='fix' has
+            # no branch.
+            if node.node_type == "fix":
                 continue
             predecessors = dep_map[str(node.id)]
             if predecessors <= completed_ids:  # All predecessors completed

--- a/nous/dag/schemas.py
+++ b/nous/dag/schemas.py
@@ -21,6 +21,11 @@ class DAGNodeType(str, Enum):
     check = "check"
     gate = "gate"
     callback = "callback"
+    # F066.1 — fix-stage recovery. Fix nodes are dispatched by the
+    # orchestrator's _try_fix_failed_nodes hook (NOT by _find_ready_nodes /
+    # _dispatch_ready_nodes), so they sit in 'pending' until their parent
+    # transitions to 'failed'.
+    fix = "fix"
 
 
 class DAGStatus(str, Enum):
@@ -45,13 +50,29 @@ class DAGNodeStatus(str, Enum):
     failed = "failed"
     blocked = "blocked"
     cancelled = "cancelled"
+    # F066.1 — terminal state set by fix-node action 'skip_and_continue'.
+    # Treated like 'completed' for dependency resolution; distinguished in
+    # telemetry so operators can see which nodes were intentionally bypassed.
+    skipped = "skipped"
 
 
 # ---------------------------------------------------------------------------
 # Edge / Node specs
 # ---------------------------------------------------------------------------
 
-EdgeType = Literal["dependency", "cancel_cascade", "context_flow"]
+EdgeType = Literal["dependency", "cancel_cascade", "context_flow", "on_failure"]
+
+
+# F066.1 — vocabulary for the `fix_actions` field on fix nodes.
+FixAction = Literal[
+    "retry_as_is",
+    "retry_with_amended_prompt",
+    "mark_unrecoverable",
+    "skip_and_continue",
+]
+_VALID_FIX_ACTIONS = frozenset(
+    {"retry_as_is", "retry_with_amended_prompt", "mark_unrecoverable", "skip_and_continue"}
+)
 
 
 class DAGEdgeSpec(BaseModel):
@@ -110,6 +131,43 @@ class DAGNodeSpec(BaseModel):
             "(NOUS_DAG_NODE_DEFAULT_STALL_TIMEOUT). 0 = explicitly disabled for this node. "
             "When > 0, the orchestrator fails the node if no activity ping arrived within "
             "this window. Clamped to NOUS_DAG_NODE_MAX_STALL_TIMEOUT at insert."
+        ),
+    )
+
+    # F066.1 — fix-stage recovery. Set only when type=='fix'.
+    parent_node: str | None = Field(
+        None,
+        description=(
+            "F066.1: for fix nodes only — name of the node this fix attaches "
+            "to. The fix fires when the parent transitions to 'failed' "
+            "(after F061's bounded retry, where applicable)."
+        ),
+    )
+    fix_actions: list[FixAction] | None = Field(
+        None,
+        description=(
+            "F066.1: for fix nodes only — allowed action vocabulary the LLM "
+            "may choose from. Must be a non-empty subset of "
+            "{retry_as_is, retry_with_amended_prompt, mark_unrecoverable, "
+            "skip_and_continue}."
+        ),
+    )
+    max_fix_attempts: int = Field(
+        1,
+        ge=1,
+        le=3,
+        description=(
+            "F066.1: maximum number of fix attempts per parent failure. "
+            "Default 1 (one fix attempt). After exhaustion the parent stays "
+            "in its terminal state."
+        ),
+    )
+    expected_modes: list[str] = Field(
+        default_factory=list,
+        description=(
+            "F066.1: declared failure modes for typed dispatch (Phase 2). "
+            "Phase 1 ignores this field — kept in the schema for forward "
+            "compatibility with the eventual typed-dispatch executor."
         ),
     )
 
@@ -201,6 +259,77 @@ class DAGCreateRequest(BaseModel):
                 raise ValueError(f"Edge references unknown node: '{edge.to_node}'")
             if edge.from_node == edge.to_node:
                 raise ValueError(f"Self-loop detected on node: '{edge.from_node}'")
+
+        # --- F066.1: fix-node structural constraints ---
+        nodes_by_name: dict[str, DAGNodeSpec] = {n.name: n for n in self.nodes}
+        fix_nodes = [n for n in self.nodes if n.type == DAGNodeType.fix]
+        for fn in fix_nodes:
+            # Fix node MUST declare parent_node + fix_actions.
+            if not fn.parent_node:
+                raise ValueError(
+                    f"Fix node '{fn.name}' must declare parent_node"
+                )
+            if not fn.fix_actions:
+                raise ValueError(
+                    f"Fix node '{fn.name}' must declare a non-empty fix_actions list"
+                )
+            invalid = [a for a in fn.fix_actions if a not in _VALID_FIX_ACTIONS]
+            if invalid:
+                raise ValueError(
+                    f"Fix node '{fn.name}' has invalid actions: {invalid}. "
+                    f"Allowed: {sorted(_VALID_FIX_ACTIONS)}"
+                )
+            # parent_node must reference a real node in the DAG.
+            if fn.parent_node not in name_set:
+                raise ValueError(
+                    f"Fix node '{fn.name}' references unknown parent_node '{fn.parent_node}'"
+                )
+            # No fix-of-fix.
+            parent = nodes_by_name[fn.parent_node]
+            if parent.type == DAGNodeType.fix:
+                raise ValueError(
+                    f"Fix node '{fn.name}' has another fix node as parent — fix-of-fix is forbidden"
+                )
+
+        # At most one fix child per parent (count on_failure edges per source).
+        on_failure_count_by_parent: dict[str, int] = {}
+        on_failure_inbound_by_fix: dict[str, int] = {}
+        for edge in self.edges:
+            if edge.edge_type == "on_failure":
+                # The TARGET must be a fix node; the SOURCE is the parent.
+                tgt = nodes_by_name.get(edge.to_node)
+                src = nodes_by_name.get(edge.from_node)
+                if tgt is None or tgt.type != DAGNodeType.fix:
+                    raise ValueError(
+                        f"on_failure edge target '{edge.to_node}' must be a fix node"
+                    )
+                if src is None or src.type == DAGNodeType.fix:
+                    raise ValueError(
+                        f"on_failure edge source '{edge.from_node}' cannot be another fix node"
+                    )
+                on_failure_count_by_parent[edge.from_node] = (
+                    on_failure_count_by_parent.get(edge.from_node, 0) + 1
+                )
+                on_failure_inbound_by_fix[edge.to_node] = (
+                    on_failure_inbound_by_fix.get(edge.to_node, 0) + 1
+                )
+
+        # Every fix node MUST have exactly one on_failure inbound edge,
+        # AND that edge's parent MUST match fn.parent_node.
+        for fn in fix_nodes:
+            inbound = on_failure_inbound_by_fix.get(fn.name, 0)
+            if inbound != 1:
+                raise ValueError(
+                    f"Fix node '{fn.name}' must have exactly one on_failure "
+                    f"inbound edge; found {inbound}"
+                )
+        # At most one fix child per parent.
+        for parent_name, count in on_failure_count_by_parent.items():
+            if count > 1:
+                raise ValueError(
+                    f"Node '{parent_name}' has {count} fix children; at most "
+                    "one is allowed"
+                )
 
         # --- cycle detection + wave computation ---
         waves = self.compute_waves()

--- a/nous/dag/schemas.py
+++ b/nous/dag/schemas.py
@@ -315,13 +315,30 @@ class DAGCreateRequest(BaseModel):
                 )
 
         # Every fix node MUST have exactly one on_failure inbound edge,
-        # AND that edge's parent MUST match fn.parent_node.
+        # AND that edge's source MUST equal fn.parent_node.
+        # Build (fix_name → set of edge sources) so we can compare.
+        on_failure_sources_by_fix: dict[str, list[str]] = {}
+        for edge in self.edges:
+            if edge.edge_type == "on_failure":
+                on_failure_sources_by_fix.setdefault(edge.to_node, []).append(edge.from_node)
+
         for fn in fix_nodes:
             inbound = on_failure_inbound_by_fix.get(fn.name, 0)
             if inbound != 1:
                 raise ValueError(
                     f"Fix node '{fn.name}' must have exactly one on_failure "
                     f"inbound edge; found {inbound}"
+                )
+            # Source of the on_failure edge MUST match parent_node, or
+            # runtime lookup (by parent_node string) won't find this fix
+            # when the cited edge's source fails (Codex round-2 P2).
+            sources = on_failure_sources_by_fix.get(fn.name, [])
+            if sources and sources[0] != fn.parent_node:
+                raise ValueError(
+                    f"Fix node '{fn.name}' parent_node='{fn.parent_node}' "
+                    f"but its on_failure edge source is '{sources[0]}'. "
+                    f"These must match — the runtime fix dispatcher keys "
+                    f"by parent_node string."
                 )
         # At most one fix child per parent.
         for parent_name, count in on_failure_count_by_parent.items():

--- a/nous/dag/store.py
+++ b/nous/dag/store.py
@@ -118,13 +118,25 @@ class DAGStore:
                             "would never fire (silent dead config). Reduce "
                             "stall_timeout_seconds or raise timeout_seconds."
                         )
+                # F066.1: fix nodes stay in 'pending' regardless of wave —
+                # they only activate when their parent transitions to 'failed'
+                # via _try_fix_failed_nodes. Without this guard, a wave-0
+                # fix node would be promoted to 'ready' here and dispatched
+                # by start_dag's wave_zero loop, hitting the silent
+                # fallthrough in _launch_node.
+                if spec.type.value == "fix":
+                    initial_status = "pending"
+                elif wave == 0:
+                    initial_status = "ready"
+                else:
+                    initial_status = "pending"
                 node = DAGNode(
                     dag_id=dag.id,
                     name=spec.name,
                     description=spec.description,
                     node_type=spec.type.value,
                     wave=wave,
-                    status="ready" if wave == 0 else "pending",
+                    status=initial_status,
                     instructions=spec.instructions or None,
                     tools=spec.tools,
                     frame_type=spec.frame_type,
@@ -135,6 +147,11 @@ class DAGStore:
                     completion_check_interval=spec.completion_check_interval,
                     max_check_attempts=spec.max_check_attempts,
                     stall_timeout_seconds=resolved_stall,
+                    # F066.1 — fix-stage columns.
+                    parent_node=spec.parent_node,
+                    fix_actions=spec.fix_actions,
+                    max_fix_attempts=spec.max_fix_attempts,
+                    expected_modes=list(spec.expected_modes),
                 )
                 session.add(node)
                 node_map[spec.name] = node

--- a/nous/storage/models.py
+++ b/nous/storage/models.py
@@ -936,12 +936,13 @@ class DAGNode(Base):
 
     __tablename__ = "dag_nodes"
     __table_args__ = (
+        # F066.1 adds 'skipped' to status; 'fix' to node_type.
         CheckConstraint(
-            "status IN ('pending', 'ready', 'running', 'awaiting_check', 'completed', 'failed', 'blocked', 'cancelled')",
+            "status IN ('pending', 'ready', 'running', 'awaiting_check', 'completed', 'failed', 'blocked', 'cancelled', 'skipped')",
             name="chk_dag_node_status",
         ),
         CheckConstraint(
-            "node_type IN ('subtask', 'check', 'gate', 'callback')",
+            "node_type IN ('subtask', 'check', 'gate', 'callback', 'fix')",
             name="chk_dag_node_type",
         ),
         UniqueConstraint("dag_id", "name", name="uq_dag_node_name"),
@@ -998,6 +999,23 @@ class DAGNode(Base):
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     injected_context: Mapped[str | None] = mapped_column(Text)
+
+    # F066.1 — fix-stage recovery. parent_node names the node a fix attaches
+    # to; fix_actions is the allowed action vocabulary for free-form dispatch;
+    # max_fix_attempts caps fix re-runs per parent; fix_attempts_used tracks
+    # consumed attempts; expected_modes is reserved for Phase 2 typed
+    # dispatch (Phase 1 ignores it).
+    parent_node: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    fix_actions: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    max_fix_attempts: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1, server_default="1"
+    )
+    fix_attempts_used: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    expected_modes: Mapped[list] = mapped_column(
+        JSONB, nullable=False, default=list, server_default="'[]'::jsonb"
+    )
 
     dag: Mapped["ExecutionDAG"] = relationship("ExecutionDAG", back_populates="nodes")
 

--- a/sql/migrations/048_f066_1_dag_fix_stage.sql
+++ b/sql/migrations/048_f066_1_dag_fix_stage.sql
@@ -11,8 +11,11 @@
 BEGIN;
 
 -- Step 1: extend node_type CHECK constraint to include 'fix'.
--- The DROP + ADD pattern takes a brief AccessExclusiveLock. Acceptable
--- here because the dag_nodes table is bounded (small in prod).
+-- Drop BOTH possible names (Postgres-auto from inline CHECK in F038
+-- migration 032 + the ORM-defined name) to be safe; only one will exist
+-- at any given time depending on the deployment history.
+ALTER TABLE nous_system.dag_nodes
+    DROP CONSTRAINT IF EXISTS dag_nodes_node_type_check;
 ALTER TABLE nous_system.dag_nodes
     DROP CONSTRAINT IF EXISTS chk_dag_node_type;
 ALTER TABLE nous_system.dag_nodes
@@ -20,6 +23,10 @@ ALTER TABLE nous_system.dag_nodes
     CHECK (node_type IN ('subtask', 'check', 'gate', 'callback', 'fix'));
 
 -- Step 2: extend status CHECK constraint to include 'skipped'.
+-- Drop both possible names (mirrors the F033 pattern at
+-- 033_dag_completion_check.sql).
+ALTER TABLE nous_system.dag_nodes
+    DROP CONSTRAINT IF EXISTS dag_nodes_status_check;
 ALTER TABLE nous_system.dag_nodes
     DROP CONSTRAINT IF EXISTS chk_dag_node_status;
 ALTER TABLE nous_system.dag_nodes
@@ -28,6 +35,15 @@ ALTER TABLE nous_system.dag_nodes
         'pending', 'ready', 'running', 'awaiting_check',
         'completed', 'failed', 'blocked', 'cancelled', 'skipped'
     ));
+
+-- Step 2b: extend dag_edges edge_type CHECK constraint to include 'on_failure'.
+ALTER TABLE nous_system.dag_edges
+    DROP CONSTRAINT IF EXISTS dag_edges_edge_type_check;
+ALTER TABLE nous_system.dag_edges
+    DROP CONSTRAINT IF EXISTS chk_dag_edge_type;
+ALTER TABLE nous_system.dag_edges
+    ADD CONSTRAINT chk_dag_edge_type
+    CHECK (edge_type IN ('dependency', 'cancel_cascade', 'context_flow', 'on_failure'));
 
 -- Step 3: new fix-stage columns.
 ALTER TABLE nous_system.dag_nodes

--- a/sql/migrations/048_f066_1_dag_fix_stage.sql
+++ b/sql/migrations/048_f066_1_dag_fix_stage.sql
@@ -1,0 +1,45 @@
+-- Migration 048: F066.1 — DAG Fix-Stage Recovery (Phase 1)
+--
+-- Adds the `fix` node type, the `skipped` terminal state, and per-fix
+-- columns (parent_node, fix_actions, max_fix_attempts, fix_attempts_used,
+-- expected_modes) to dag_nodes.
+--
+-- Phase 1 ships free-form LLM dispatch only. Typed-dispatch via
+-- expected_modes lands in Phase 2 (the column is added now for forward
+-- compatibility).
+
+BEGIN;
+
+-- Step 1: extend node_type CHECK constraint to include 'fix'.
+-- The DROP + ADD pattern takes a brief AccessExclusiveLock. Acceptable
+-- here because the dag_nodes table is bounded (small in prod).
+ALTER TABLE nous_system.dag_nodes
+    DROP CONSTRAINT IF EXISTS chk_dag_node_type;
+ALTER TABLE nous_system.dag_nodes
+    ADD CONSTRAINT chk_dag_node_type
+    CHECK (node_type IN ('subtask', 'check', 'gate', 'callback', 'fix'));
+
+-- Step 2: extend status CHECK constraint to include 'skipped'.
+ALTER TABLE nous_system.dag_nodes
+    DROP CONSTRAINT IF EXISTS chk_dag_node_status;
+ALTER TABLE nous_system.dag_nodes
+    ADD CONSTRAINT chk_dag_node_status
+    CHECK (status IN (
+        'pending', 'ready', 'running', 'awaiting_check',
+        'completed', 'failed', 'blocked', 'cancelled', 'skipped'
+    ));
+
+-- Step 3: new fix-stage columns.
+ALTER TABLE nous_system.dag_nodes
+    ADD COLUMN IF NOT EXISTS parent_node        VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS fix_actions        JSONB,
+    ADD COLUMN IF NOT EXISTS max_fix_attempts   INTEGER NOT NULL DEFAULT 1,
+    ADD COLUMN IF NOT EXISTS fix_attempts_used  INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS expected_modes     JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+-- Step 4: index for fast fix-child lookup when a parent fails.
+CREATE INDEX IF NOT EXISTS idx_dag_nodes_parent_node
+    ON nous_system.dag_nodes (dag_id, parent_node)
+    WHERE parent_node IS NOT NULL;
+
+COMMIT;

--- a/tests/test_dag_schemas.py
+++ b/tests/test_dag_schemas.py
@@ -127,6 +127,7 @@ class TestEnums:
             DAGNodeType.check,
             DAGNodeType.gate,
             DAGNodeType.callback,
+            DAGNodeType.fix,  # F066.1
         }
 
     def test_dag_statuses(self):
@@ -149,6 +150,7 @@ class TestEnums:
             DAGNodeStatus.failed,
             DAGNodeStatus.blocked,
             DAGNodeStatus.cancelled,
+            DAGNodeStatus.skipped,  # F066.1
         }
 
 

--- a/tests/test_f066_1_fix_stage.py
+++ b/tests/test_f066_1_fix_stage.py
@@ -227,6 +227,28 @@ class TestFixNodeValidator:
                 edges=[],  # missing on_failure
             )
 
+    def test_on_failure_edge_source_must_match_parent_node(self) -> None:
+        """Codex round-2 P2: prevent inconsistent DAGs where the
+        on_failure edge source differs from the fix node's parent_node.
+        Runtime keys fixes by parent_node, not by edge source."""
+        with pytest.raises(ValueError, match="must match"):
+            DAGCreateRequest(
+                name="bad",
+                nodes=[
+                    DAGNodeSpec(name="A", type=DAGNodeType.subtask),
+                    DAGNodeSpec(name="B", type=DAGNodeType.subtask),
+                    DAGNodeSpec(
+                        name="fix",
+                        type=DAGNodeType.fix,
+                        parent_node="A",  # but the edge below points from B
+                        fix_actions=["retry_as_is"],
+                    ),
+                ],
+                edges=[
+                    DAGEdgeSpec(from_node="B", to_node="fix", edge_type="on_failure"),
+                ],
+            )
+
 
 # ---------------------------------------------------------------------------
 # Enum membership

--- a/tests/test_f066_1_fix_stage.py
+++ b/tests/test_f066_1_fix_stage.py
@@ -1,0 +1,436 @@
+"""F066.1 Phase 1 tests: fix-node state machine + rule-based dispatcher.
+
+Covers:
+- Pydantic validator: fix-node required fields, invalid actions, no-fix-of-fix,
+  on_failure edge constraints, at-most-one-fix-child-per-parent.
+- fix_executor.choose_action rule-based dispatch.
+- Orchestrator end-to-end: parent fails → fix fires → action applied;
+  fix_attempts_used cap; skipped state unblocks successors.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+
+from nous.config import Settings
+from nous.dag.fix_executor import FixActionResult, choose_action
+from nous.dag.orchestrator import DAGOrchestrator, _RESOLVED, _TERMINAL
+from nous.dag.schemas import (
+    DAGCreateRequest,
+    DAGEdgeSpec,
+    DAGNodeSpec,
+    DAGNodeStatus,
+    DAGNodeType,
+)
+from nous.dag.store import DAGStore
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def store(db):
+    """DAGStore with a unique agent_id per test."""
+    agent_id = f"f066-1-{uuid.uuid4().hex[:8]}"
+    return DAGStore(db, agent_id, Settings())
+
+
+@pytest.fixture
+def subtask_mgr():
+    mgr = AsyncMock()
+    mgr.create.return_value = SimpleNamespace(id=uuid.uuid4(), status="pending")
+    return mgr
+
+
+@pytest.fixture
+def dynamic_loader():
+    loader = AsyncMock()
+    loader.create_check = AsyncMock(return_value={"name": "t"})
+    loader._registry = MagicMock()
+    loader._registry.get_check.return_value = None
+    return loader
+
+
+@pytest.fixture
+def orchestrator(store, subtask_mgr, dynamic_loader):
+    return DAGOrchestrator(
+        store=store,
+        subtask_mgr=subtask_mgr,
+        dynamic_loader=dynamic_loader,
+        settings=Settings(),
+    )
+
+
+def _parent_with_fix_request(fix_actions: list[str] | None = None) -> DAGCreateRequest:
+    """A DAG with one subtask parent + one fix child via on_failure edge."""
+    if fix_actions is None:
+        fix_actions = ["retry_as_is", "skip_and_continue"]
+    return DAGCreateRequest(
+        name="parent-with-fix-dag",
+        nodes=[
+            DAGNodeSpec(name="parent", type=DAGNodeType.subtask, instructions="do thing"),
+            DAGNodeSpec(
+                name="fix-parent",
+                type=DAGNodeType.fix,
+                parent_node="parent",
+                fix_actions=fix_actions,
+                instructions="diagnose and recover",
+            ),
+        ],
+        edges=[
+            DAGEdgeSpec(from_node="parent", to_node="fix-parent", edge_type="on_failure"),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validator tests
+# ---------------------------------------------------------------------------
+
+
+class TestFixNodeValidator:
+    def test_valid_fix_node_dag_accepted(self) -> None:
+        req = _parent_with_fix_request()
+        # No exception raised.
+        assert any(n.type == DAGNodeType.fix for n in req.nodes)
+
+    def test_fix_node_without_parent_node_rejected(self) -> None:
+        with pytest.raises(ValueError, match="parent_node"):
+            DAGCreateRequest(
+                name="bad",
+                nodes=[
+                    DAGNodeSpec(name="p", type=DAGNodeType.subtask),
+                    DAGNodeSpec(
+                        name="fix",
+                        type=DAGNodeType.fix,
+                        fix_actions=["retry_as_is"],
+                    ),
+                ],
+                edges=[DAGEdgeSpec(from_node="p", to_node="fix", edge_type="on_failure")],
+            )
+
+    def test_fix_node_without_fix_actions_rejected(self) -> None:
+        with pytest.raises(ValueError, match="fix_actions"):
+            DAGCreateRequest(
+                name="bad",
+                nodes=[
+                    DAGNodeSpec(name="p", type=DAGNodeType.subtask),
+                    DAGNodeSpec(name="fix", type=DAGNodeType.fix, parent_node="p"),
+                ],
+                edges=[DAGEdgeSpec(from_node="p", to_node="fix", edge_type="on_failure")],
+            )
+
+    def test_fix_node_invalid_action_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            DAGCreateRequest(
+                name="bad",
+                nodes=[
+                    DAGNodeSpec(name="p", type=DAGNodeType.subtask),
+                    DAGNodeSpec(
+                        name="fix",
+                        type=DAGNodeType.fix,
+                        parent_node="p",
+                        fix_actions=["nonexistent_action"],
+                    ),
+                ],
+                edges=[DAGEdgeSpec(from_node="p", to_node="fix", edge_type="on_failure")],
+            )
+
+    def test_fix_node_unknown_parent_rejected(self) -> None:
+        with pytest.raises(ValueError, match="unknown parent_node"):
+            DAGCreateRequest(
+                name="bad",
+                nodes=[
+                    DAGNodeSpec(name="p", type=DAGNodeType.subtask),
+                    DAGNodeSpec(
+                        name="fix",
+                        type=DAGNodeType.fix,
+                        parent_node="ghost",
+                        fix_actions=["retry_as_is"],
+                    ),
+                ],
+                # Use an edge that references the fake parent so cycle/edge
+                # validation passes — but the parent_node string is wrong.
+                edges=[],
+            )
+
+    def test_fix_of_fix_rejected(self) -> None:
+        with pytest.raises(ValueError, match="fix-of-fix"):
+            DAGCreateRequest(
+                name="bad",
+                nodes=[
+                    DAGNodeSpec(name="p", type=DAGNodeType.subtask),
+                    DAGNodeSpec(
+                        name="fix1",
+                        type=DAGNodeType.fix,
+                        parent_node="p",
+                        fix_actions=["retry_as_is"],
+                    ),
+                    DAGNodeSpec(
+                        name="fix2",
+                        type=DAGNodeType.fix,
+                        parent_node="fix1",  # FORBIDDEN
+                        fix_actions=["retry_as_is"],
+                    ),
+                ],
+                edges=[
+                    DAGEdgeSpec(from_node="p", to_node="fix1", edge_type="on_failure"),
+                    DAGEdgeSpec(from_node="fix1", to_node="fix2", edge_type="on_failure"),
+                ],
+            )
+
+    def test_two_fix_children_per_parent_rejected(self) -> None:
+        with pytest.raises(ValueError, match="at most"):
+            DAGCreateRequest(
+                name="bad",
+                nodes=[
+                    DAGNodeSpec(name="p", type=DAGNodeType.subtask),
+                    DAGNodeSpec(
+                        name="fix1",
+                        type=DAGNodeType.fix,
+                        parent_node="p",
+                        fix_actions=["retry_as_is"],
+                    ),
+                    DAGNodeSpec(
+                        name="fix2",
+                        type=DAGNodeType.fix,
+                        parent_node="p",
+                        fix_actions=["skip_and_continue"],
+                    ),
+                ],
+                edges=[
+                    DAGEdgeSpec(from_node="p", to_node="fix1", edge_type="on_failure"),
+                    DAGEdgeSpec(from_node="p", to_node="fix2", edge_type="on_failure"),
+                ],
+            )
+
+    def test_fix_node_without_on_failure_edge_rejected(self) -> None:
+        with pytest.raises(ValueError, match="exactly one on_failure"):
+            DAGCreateRequest(
+                name="bad",
+                nodes=[
+                    DAGNodeSpec(name="p", type=DAGNodeType.subtask),
+                    DAGNodeSpec(
+                        name="fix",
+                        type=DAGNodeType.fix,
+                        parent_node="p",
+                        fix_actions=["retry_as_is"],
+                    ),
+                ],
+                edges=[],  # missing on_failure
+            )
+
+
+# ---------------------------------------------------------------------------
+# Enum membership
+# ---------------------------------------------------------------------------
+
+
+class TestEnumExtensions:
+    def test_fix_in_dag_node_type(self) -> None:
+        assert DAGNodeType.fix == "fix"
+
+    def test_skipped_in_dag_node_status(self) -> None:
+        assert DAGNodeStatus.skipped == "skipped"
+
+    def test_skipped_in_terminal_set(self) -> None:
+        assert "skipped" in _TERMINAL
+
+    def test_skipped_in_resolved_set(self) -> None:
+        """Successors of a skipped node must unblock — skipped is resolved."""
+        assert "skipped" in _RESOLVED
+        # Sanity: 'failed' is NOT resolved (otherwise cascade would never fire).
+        assert "failed" not in _RESOLVED
+
+
+# ---------------------------------------------------------------------------
+# Rule-based dispatcher (fix_executor.choose_action)
+# ---------------------------------------------------------------------------
+
+
+class TestChooseAction:
+    def test_incomplete_no_terminal_retries(self) -> None:
+        out = choose_action(
+            parent_error="validation: incomplete_no_terminal — submit_final_report missing",
+            parent_status="failed",
+            fix_actions=["retry_as_is", "skip_and_continue"],
+        )
+        assert out.action == "retry_as_is"
+
+    def test_validation_failed_retries(self) -> None:
+        out = choose_action(
+            parent_error="schema_invalid: validation_failed on payload",
+            parent_status="failed",
+            fix_actions=["retry_as_is", "skip_and_continue"],
+        )
+        assert out.action == "retry_as_is"
+
+    def test_timed_out_prefers_skip(self) -> None:
+        out = choose_action(
+            parent_error="Timeout after 600s — timed_out",
+            parent_status="failed",
+            fix_actions=["retry_as_is", "skip_and_continue"],
+        )
+        assert out.action == "skip_and_continue"
+
+    def test_timed_out_falls_back_to_unrecoverable_if_no_skip(self) -> None:
+        out = choose_action(
+            parent_error="timed_out: deadline",
+            parent_status="failed",
+            fix_actions=["retry_as_is"],
+        )
+        assert out.action == "mark_unrecoverable"
+
+    def test_unknown_error_prefers_skip(self) -> None:
+        out = choose_action(
+            parent_error="random unexpected exception",
+            parent_status="failed",
+            fix_actions=["skip_and_continue", "mark_unrecoverable"],
+        )
+        assert out.action == "skip_and_continue"
+
+    def test_mark_unrecoverable_is_implicit_last_resort(self) -> None:
+        """Even if fix_actions is empty, mark_unrecoverable is always returnable."""
+        out = choose_action(
+            parent_error="anything",
+            parent_status="failed",
+            fix_actions=[],
+        )
+        assert out.action == "mark_unrecoverable"
+
+    def test_none_error_handled(self) -> None:
+        out = choose_action(
+            parent_error=None,
+            parent_status="failed",
+            fix_actions=["skip_and_continue"],
+        )
+        # Empty error → no specific match → prefers skip if available.
+        assert out.action == "skip_and_continue"
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratorFixApplication:
+    """End-to-end: tick processes parent failure → fix fires → action applied."""
+
+    @pytest.mark.asyncio
+    async def test_fix_node_inserted_as_pending_not_ready(
+        self, store, orchestrator
+    ):
+        """A wave-0 fix node MUST NOT be dispatched at start_dag time —
+        it sits 'pending' until parent fails."""
+        dag = await store.create(_parent_with_fix_request())
+        await orchestrator.start_dag(dag.id)
+
+        fetched = await store.get_dag(dag.id)
+        fix_node = next(n for n in fetched.nodes if n.node_type == "fix")
+        assert fix_node.status == "pending"
+
+    @pytest.mark.asyncio
+    async def test_retry_action_resets_parent_to_pending(
+        self, store, orchestrator, subtask_mgr
+    ):
+        dag = await store.create(_parent_with_fix_request(["retry_as_is"]))
+        await orchestrator.start_dag(dag.id)
+
+        # Simulate parent failure with a recoverable error.
+        fetched = await store.get_dag(dag.id)
+        parent = next(n for n in fetched.nodes if n.name == "parent")
+        await store.update_node(
+            parent.id, status="failed", error="validation_failed: payload"
+        )
+
+        await orchestrator.tick()
+
+        fetched = await store.get_dag(dag.id)
+        parent = next(n for n in fetched.nodes if n.name == "parent")
+        fix_node = next(n for n in fetched.nodes if n.node_type == "fix")
+
+        # Parent re-enqueued for dispatch.
+        assert parent.status in ("pending", "ready", "running")
+        # Fix attempts consumed.
+        assert fix_node.fix_attempts_used == 1
+        # Error cleared on retry.
+        assert parent.error is None or parent.error == ""
+
+    @pytest.mark.asyncio
+    async def test_skip_action_marks_parent_skipped(
+        self, store, orchestrator
+    ):
+        dag = await store.create(
+            _parent_with_fix_request(["skip_and_continue"])
+        )
+        await orchestrator.start_dag(dag.id)
+
+        fetched = await store.get_dag(dag.id)
+        parent = next(n for n in fetched.nodes if n.name == "parent")
+        await store.update_node(
+            parent.id, status="failed", error="timed_out: deadline exceeded"
+        )
+
+        await orchestrator.tick()
+
+        fetched = await store.get_dag(dag.id)
+        parent = next(n for n in fetched.nodes if n.name == "parent")
+        assert parent.status == "skipped"
+        # result records the fix rationale
+        assert parent.result and "skip" in parent.result.lower()
+
+    @pytest.mark.asyncio
+    async def test_mark_unrecoverable_keeps_failed(
+        self, store, orchestrator
+    ):
+        # Only mark_unrecoverable is allowed (no retry, no skip).
+        dag = await store.create(
+            _parent_with_fix_request(["mark_unrecoverable"])
+        )
+        await orchestrator.start_dag(dag.id)
+
+        fetched = await store.get_dag(dag.id)
+        parent = next(n for n in fetched.nodes if n.name == "parent")
+        await store.update_node(
+            parent.id, status="failed", error="unknown panic"
+        )
+
+        await orchestrator.tick()
+
+        fetched = await store.get_dag(dag.id)
+        parent = next(n for n in fetched.nodes if n.name == "parent")
+        assert parent.status == "failed"
+        assert parent.result and "unrecoverable" in parent.result.lower()
+
+    @pytest.mark.asyncio
+    async def test_fix_attempts_cap_prevents_infinite_retry(
+        self, store, orchestrator
+    ):
+        dag = await store.create(_parent_with_fix_request(["retry_as_is"]))
+        await orchestrator.start_dag(dag.id)
+
+        # Manually consume the fix budget by setting fix_attempts_used to max.
+        fetched = await store.get_dag(dag.id)
+        fix_node = next(n for n in fetched.nodes if n.node_type == "fix")
+        await store.update_node(
+            fix_node.id, fix_attempts_used=fix_node.max_fix_attempts,
+        )
+
+        parent = next(n for n in fetched.nodes if n.name == "parent")
+        await store.update_node(
+            parent.id, status="failed", error="validation_failed"
+        )
+
+        await orchestrator.tick()
+
+        fetched = await store.get_dag(dag.id)
+        parent = next(n for n in fetched.nodes if n.name == "parent")
+        # Budget exhausted — fix does not re-fire; parent stays failed.
+        assert parent.status == "failed"


### PR DESCRIPTION
## Summary

Phase 1 of F066.1 per the spec at \`docs/features/F066.1-dag-fix-stage.md\` and the plan at \`docs/superpowers/plans/2026-05-23-f066.1-dag-fix-stage-impl.md\`.

## Ships

- New \`fix\` node type, \`skipped\` terminal state, \`on_failure\` edge type
- Migration 048: extends \`dag_nodes\` CHECK constraints + adds 5 fix-stage columns
- \`DAGCreateRequest\` validator: enforces fix-node structural invariants
- Orchestrator hook \`_try_fix_failed_nodes\` (runs BEFORE \`_propagate_failures\`)
- \`fix_executor.choose_action\` rule-based dispatcher
- 24 new tests, all green; 88 pre-existing DAG tests unchanged

## Deviation from spec

Phase 1 ships rule-based dispatch instead of LLM-based free-form dispatch (the spec's Phase 1 target). Rationale: the value is the state-machine surface; LLM dispatch requires standing up an LLM-call mechanism inside the orchestrator, which is a larger change. Rule-based delivers the F065-class repair scenario with ~30 lines and zero new infrastructure. LLM-based dispatch is queued as Phase 1.5 follow-up that swaps \`choose_action\`.

## Plan-review P0 fixes addressed

Internal multi-team review of the plan flagged 3 P0s; all addressed in this PR:

- **P0-1**: fix nodes auto-dispatched on tick 1 → fix nodes are now stored with status='pending' regardless of wave, AND \`_find_ready_nodes\` skips \`node_type == 'fix'\`.
- **P0-2**: \`'skipped'\` was not in \`_TERMINAL\` → added.
- **P0-3**: \`_find_ready_nodes\` used \`completed\` only as the resolved-predecessor set → introduced \`_RESOLVED = {completed, skipped}\` so \`skip_and_continue\` actually unblocks successors.

## Test plan

- [x] \`uv run pytest tests/test_f066_1_fix_stage.py -v\` — 24/24 green
- [x] \`uv run pytest tests/test_dag_orchestrator.py tests/test_dag_store.py tests/test_dag_concurrency_caps.py\` — 88/88 green (no regression)
- [ ] CI: Postgres-backed migration applies cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)