### PR TITLE
F066.1 Phase 1.5 — LLM-based fix-node dispatch (tool-use constraint)

### DIFF
--- a/nous/config.py
+++ b/nous/config.py
@@ -521,6 +521,24 @@ class Settings(BaseSettings):
         description="F065: size of the top-N hub list used for rank-shift detection.",
     )
 
+    # F066.1 Phase 1.5: LLM-based fix-node dispatch. When False (default),
+    # the orchestrator uses fix_executor.choose_action (rule-based, Phase 1
+    # behavior). When True AND an LLM client is wired into DAGOrchestrator,
+    # the orchestrator calls fix_executor.choose_action_llm; any failure
+    # (timeout, parse error, unsupported action) falls back to the
+    # rule-based path.
+    dag_fix_llm_dispatch_enabled: bool = False
+    dag_fix_llm_model: str = Field(
+        default="claude-haiku-4-5-20251001",
+        description="F066.1 Phase 1.5: model for fix-node LLM dispatch. Default Haiku — the action set is small (4 enum values) and the prompt is short.",
+    )
+    dag_fix_llm_timeout_seconds: float = Field(
+        default=10.0,
+        gt=0.0,
+        le=60.0,
+        description="F066.1 Phase 1.5: per-call timeout for the fix-node LLM dispatcher. Bounded so a slow LLM never hangs the orchestrator tick.",
+    )
+
     # F022 Phase 2: Cross-type linking
     cross_type_linking_enabled: bool = True
     cross_type_threshold: float = 0.80

--- a/nous/dag/fix_executor.py
+++ b/nous/dag/fix_executor.py
@@ -1,14 +1,23 @@
 """F066.1 — fix-node action selection.
 
-Phase 1 ships a deterministic rule-based dispatcher. The spec calls for
-free-form LLM dispatch in Phase 1; we deviate intentionally to keep the
-state-machine surface (new node type, new terminal state, action
-processing) testable and reviewable without standing up an LLM-call
-mechanism inside the orchestrator. LLM-based diagnosis lands in a
-Phase 1.5 follow-up that swaps `choose_action` for a single LLM call
-with tool-use constraint on `fix_actions`.
+Phase 1 shipped a deterministic rule-based dispatcher. Phase 1.5 adds an
+LLM-based dispatcher that uses tool-use constraint to pick an action from
+``fix_actions`` and (optionally) generate an amended prompt for the
+``retry_with_amended_prompt`` action.
 
-The rule (Phase 1):
+Selection precedence at runtime:
+
+1. If ``settings.dag_fix_llm_dispatch_enabled`` AND an LLM client is
+   wired into the orchestrator → call ``choose_action_llm``.
+2. If the LLM call fails (timeout, parse error, unsupported action) →
+   fall back to ``choose_action`` (rule-based).
+3. If the flag is off OR no LLM client is wired → ``choose_action``
+   directly.
+
+This keeps the Phase 1 contract intact when the flag is off and ensures
+the system degrades gracefully when the LLM is unavailable.
+
+Rule-based rule (Phase 1, unchanged):
 
   parent.error contains substring         → action (if in fix_actions)
   --------------------------------------------------------------
@@ -16,16 +25,14 @@ The rule (Phase 1):
                                           → retry_as_is
   "timed_out"                             → skip_and_continue if available, else mark_unrecoverable
   any other / "errored"                   → skip_and_continue if available, else mark_unrecoverable
-
-Any action not present in `fix_actions` is replaced by the next allowed
-fallback. If no allowed action matches, `mark_unrecoverable` is the
-final fallback (always implicitly available).
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -100,4 +107,186 @@ def choose_action(
     return FixActionResult(
         action="mark_unrecoverable",
         rationale="no recoverable action matched; mark_unrecoverable (final fallback)",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase 1.5: LLM-based dispatcher
+# ---------------------------------------------------------------------------
+
+
+_CHOOSE_FIX_ACTION_TOOL_NAME = "choose_fix_action"
+
+
+def _build_choose_fix_action_tool(fix_actions: list[str]) -> dict:
+    """Build the tool schema for the LLM. The action enum is constrained
+    to fix_actions verbatim so the model can't return an action the fix
+    node didn't authorize."""
+    return {
+        "name": _CHOOSE_FIX_ACTION_TOOL_NAME,
+        "description": (
+            "Choose ONE action to apply to the parent failure. If you choose "
+            "'retry_with_amended_prompt' you MUST also provide a "
+            "non-empty 'amended_prompt' that addresses the failure cause."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": list(fix_actions),
+                    "description": "The action to apply.",
+                },
+                "amended_prompt": {
+                    "type": "string",
+                    "description": (
+                        "Required when action='retry_with_amended_prompt'. "
+                        "The revised prompt to retry the parent with."
+                    ),
+                },
+                "rationale": {
+                    "type": "string",
+                    "description": "One-sentence reasoning for the chosen action.",
+                },
+            },
+            "required": ["action", "rationale"],
+            "additionalProperties": False,
+        },
+    }
+
+
+def _build_fix_prompt(
+    parent_name: str,
+    parent_instructions: str | None,
+    parent_error: str | None,
+    parent_result: str | None,
+    fix_instructions: str | None,
+    fix_actions: list[str],
+) -> str:
+    """Render the user-message prompt for the LLM dispatcher."""
+    lines = []
+    if fix_instructions:
+        lines.append("# Fix-node instructions")
+        lines.append(fix_instructions)
+        lines.append("")
+    lines.append("# Failing parent node")
+    lines.append(f"name: {parent_name}")
+    if parent_instructions:
+        lines.append(f"instructions: {parent_instructions[:600]}")
+    if parent_error:
+        lines.append(f"error: {parent_error[:800]}")
+    if parent_result:
+        lines.append(f"result: {parent_result[:800]}")
+    lines.append("")
+    lines.append("# Allowed actions (you MUST choose one of these)")
+    for a in fix_actions:
+        lines.append(f"- {a}")
+    lines.append("")
+    lines.append(
+        "Call the choose_fix_action tool ONCE with your chosen action, "
+        "a one-sentence rationale, and (if action='retry_with_amended_prompt') "
+        "an amended_prompt that addresses the failure cause."
+    )
+    return "\n".join(lines)
+
+
+async def choose_action_llm(
+    *,
+    parent_name: str,
+    parent_instructions: str | None,
+    parent_error: str | None,
+    parent_result: str | None,
+    fix_instructions: str | None,
+    fix_actions: list[str],
+    llm_client: Any,
+    model: str,
+    timeout_seconds: float,
+) -> FixActionResult:
+    """LLM-driven free-form fix-action dispatch (Phase 1.5).
+
+    Uses tool-use forced choice so the model returns a structured action
+    from ``fix_actions``. Any failure (timeout, parse error, unsupported
+    action) raises — the caller (orchestrator) catches and falls back to
+    the rule-based ``choose_action``.
+
+    Args:
+        parent_name: parent node name (string label only).
+        parent_instructions: parent's instructions / prompt (truncated).
+        parent_error: parent's error column (truncated).
+        parent_result: parent's result column, if any (truncated).
+        fix_instructions: the fix node's instructions template.
+        fix_actions: the allowed action vocabulary (passed verbatim into
+            the tool's enum constraint).
+        llm_client: Anthropic-compatible client (see nous.api.anthropic_client).
+        model: model identifier.
+        timeout_seconds: hard timeout for the call (passed to
+            asyncio.wait_for so a slow LLM never hangs the orchestrator
+            tick).
+
+    Returns:
+        FixActionResult with the chosen action (always ∈ fix_actions ∪
+        {mark_unrecoverable}). Raises on any failure.
+    """
+    if not fix_actions:
+        # Defensive: caller should have validated this. Surface as an
+        # exception so the rule-based fallback can take over.
+        raise ValueError("fix_actions must be non-empty for LLM dispatch")
+
+    tool = _build_choose_fix_action_tool(fix_actions)
+    prompt = _build_fix_prompt(
+        parent_name=parent_name,
+        parent_instructions=parent_instructions,
+        parent_error=parent_error,
+        parent_result=parent_result,
+        fix_instructions=fix_instructions,
+        fix_actions=fix_actions,
+    )
+    payload = {
+        "model": model,
+        "max_tokens": 512,
+        "tools": [tool],
+        # Force the tool — Anthropic's tool_choice with a specific tool
+        # name guarantees the model returns a tool_use block.
+        "tool_choice": {"type": "tool", "name": _CHOOSE_FIX_ACTION_TOOL_NAME},
+        "messages": [
+            {"role": "user", "content": prompt},
+        ],
+    }
+
+    response = await asyncio.wait_for(
+        llm_client.call(payload),
+        timeout=timeout_seconds,
+    )
+
+    # Extract the tool_use block.
+    tool_input: dict | None = None
+    for block in (response.content or []):
+        if block.get("type") == "tool_use" and block.get("name") == _CHOOSE_FIX_ACTION_TOOL_NAME:
+            tool_input = block.get("input") or {}
+            break
+    if tool_input is None:
+        raise ValueError(
+            f"LLM dispatch: no {_CHOOSE_FIX_ACTION_TOOL_NAME} tool_use block in response"
+        )
+
+    action = tool_input.get("action")
+    if action not in fix_actions:
+        raise ValueError(
+            f"LLM dispatch: model returned action '{action}' not in "
+            f"fix_actions {fix_actions}"
+        )
+
+    amended_prompt = tool_input.get("amended_prompt") or None
+    if action == "retry_with_amended_prompt" and not amended_prompt:
+        # Contract violation — fall back to rule-based.
+        raise ValueError(
+            "LLM dispatch: action='retry_with_amended_prompt' requires "
+            "a non-empty amended_prompt"
+        )
+
+    rationale = tool_input.get("rationale") or "LLM dispatch: no rationale provided"
+    return FixActionResult(
+        action=action,
+        amended_prompt=amended_prompt,
+        rationale=f"LLM dispatch: {rationale}",
     )

--- a/nous/dag/fix_executor.py
+++ b/nous/dag/fix_executor.py
@@ -244,6 +244,12 @@ async def choose_action_llm(
     payload = {
         "model": model,
         "max_tokens": 512,
+        # Codex P1 (2026-05-22): SdkAnthropicClient._payload_to_kwargs
+        # at anthropic_client.py:1014 indexes payload["system"] (not .get),
+        # so an empty string is required to keep the SDK backend from
+        # KeyError-ing before the request ever reaches Anthropic. Mirrors
+        # nous_eval/handlers/summary.py:158.
+        "system": "",
         "tools": [tool],
         # Force the tool — Anthropic's tool_choice with a specific tool
         # name guarantees the model returns a tool_use block.

--- a/nous/dag/orchestrator.py
+++ b/nous/dag/orchestrator.py
@@ -69,12 +69,18 @@ class DAGOrchestrator:
         bus: EventBus | None = None,
         *,
         settings: Settings,
+        llm_client: object | None = None,
     ) -> None:
         self._store = store
         self._subtask_mgr = subtask_mgr
         self._dynamic_loader = dynamic_loader
         self._bus = bus
         self._settings = settings
+        # F066.1 Phase 1.5: optional LLM client for fix-node free-form dispatch.
+        # When None or when settings.dag_fix_llm_dispatch_enabled=False, the
+        # orchestrator falls back to fix_executor.choose_action (rule-based,
+        # Phase 1 behavior).
+        self._llm_client = llm_client
         self._lock = asyncio.Lock()
 
     async def tick(self) -> int:
@@ -996,7 +1002,7 @@ class DAGOrchestrator:
         fix_attempts_used to prevent an infinite retry loop and leave
         the parent in 'failed' so cascade proceeds normally.
         """
-        from nous.dag.fix_executor import choose_action
+        from nous.dag.fix_executor import choose_action, choose_action_llm
 
         # Index fix nodes by parent_node for O(1) lookup.
         fix_by_parent: dict[str, DAGNode] = {}
@@ -1018,23 +1024,61 @@ class DAGOrchestrator:
             if fix_node.fix_attempts_used >= fix_node.max_fix_attempts:
                 continue
 
-            try:
-                outcome = choose_action(
-                    parent_error=parent.error,
-                    parent_status=parent.status,
-                    fix_actions=fix_node.fix_actions,
-                )
-            except Exception:
-                logger.exception(
-                    "F066.1: fix_executor raised for parent %s (DAG %s); "
-                    "bumping fix_attempts_used and leaving parent failed",
-                    parent.name, dag.id,
-                )
-                fix_node.fix_attempts_used += 1
-                await self._store.update_node(
-                    fix_node.id, fix_attempts_used=fix_node.fix_attempts_used,
-                )
-                continue
+            outcome = None
+            llm_enabled = (
+                getattr(self._settings, "dag_fix_llm_dispatch_enabled", False)
+                and self._llm_client is not None
+            )
+            if llm_enabled:
+                # Phase 1.5: try LLM-based dispatch first; fall back to
+                # rule-based on any failure (timeout, parse error, etc.).
+                try:
+                    outcome = await choose_action_llm(
+                        parent_name=parent.name,
+                        parent_instructions=parent.instructions,
+                        parent_error=parent.error,
+                        parent_result=parent.result,
+                        fix_instructions=fix_node.instructions,
+                        fix_actions=fix_node.fix_actions or [],
+                        llm_client=self._llm_client,
+                        model=getattr(
+                            self._settings, "dag_fix_llm_model",
+                            "claude-haiku-4-5-20251001",
+                        ),
+                        timeout_seconds=getattr(
+                            self._settings, "dag_fix_llm_timeout_seconds", 10.0,
+                        ),
+                    )
+                    logger.info(
+                        "F066.1 Phase 1.5: LLM dispatch chose '%s' for parent '%s'",
+                        outcome.action, parent.name,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "F066.1 Phase 1.5: LLM dispatch failed (%s); falling "
+                        "back to rule-based choose_action",
+                        type(exc).__name__,
+                    )
+                    outcome = None
+
+            if outcome is None:
+                try:
+                    outcome = choose_action(
+                        parent_error=parent.error,
+                        parent_status=parent.status,
+                        fix_actions=fix_node.fix_actions,
+                    )
+                except Exception:
+                    logger.exception(
+                        "F066.1: fix_executor raised for parent %s (DAG %s); "
+                        "bumping fix_attempts_used and leaving parent failed",
+                        parent.name, dag.id,
+                    )
+                    fix_node.fix_attempts_used += 1
+                    await self._store.update_node(
+                        fix_node.id, fix_attempts_used=fix_node.fix_attempts_used,
+                    )
+                    continue
 
             logger.info(
                 "F066.1: fix '%s' chose '%s' for parent '%s' — %s",
@@ -1065,11 +1109,21 @@ class DAGOrchestrator:
 
             if outcome.action == "retry_as_is" or outcome.action == "retry_with_amended_prompt":
                 # Re-enqueue parent for dispatch on next tick.
+                update_kwargs: dict[str, Any] = {"status": "pending", "error": None}
+                # F066.1 Phase 1.5: when LLM dispatch returns an amended
+                # prompt, replace the parent's instructions so the next
+                # dispatch sees the revised prompt. Phase 1 (rule-based)
+                # always has amended_prompt=None — this branch is a no-op
+                # for that path.
+                if (
+                    outcome.action == "retry_with_amended_prompt"
+                    and outcome.amended_prompt
+                ):
+                    parent.instructions = outcome.amended_prompt
+                    update_kwargs["instructions"] = outcome.amended_prompt
                 parent.status = "pending"
                 parent.error = None
-                await self._store.update_node(
-                    parent.id, status="pending", error=None,
-                )
+                await self._store.update_node(parent.id, **update_kwargs)
             elif outcome.action == "skip_and_continue":
                 parent.status = "skipped"
                 parent.result = (

--- a/tests/test_f066_1_llm_dispatch.py
+++ b/tests/test_f066_1_llm_dispatch.py
@@ -1,0 +1,390 @@
+"""F066.1 Phase 1.5: LLM-based fix-node dispatch.
+
+Covers:
+- choose_action_llm: happy path, action constraint enforcement,
+  retry_with_amended_prompt requires amended_prompt, timeout falls
+  back, no tool_use block falls back, unknown action falls back.
+- orchestrator integration: flag-on + LLM success applies LLM action;
+  flag-on + LLM failure falls back to rule-based; flag-off uses rule-based.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+
+from nous.config import Settings
+from nous.dag.fix_executor import (
+    FixActionResult,
+    choose_action,
+    choose_action_llm,
+)
+from nous.dag.orchestrator import DAGOrchestrator
+from nous.dag.schemas import (
+    DAGCreateRequest,
+    DAGEdgeSpec,
+    DAGNodeSpec,
+    DAGNodeType,
+)
+from nous.dag.store import DAGStore
+
+
+def _llm_response(action: str, *, amended_prompt: str | None = None, rationale: str = "rationale"):
+    """Construct a mock ApiResponse with a tool_use block."""
+    tool_input: dict = {"action": action, "rationale": rationale}
+    if amended_prompt is not None:
+        tool_input["amended_prompt"] = amended_prompt
+    return SimpleNamespace(
+        content=[
+            {
+                "type": "tool_use",
+                "name": "choose_fix_action",
+                "input": tool_input,
+                "id": "toolu_test",
+            }
+        ],
+        stop_reason="tool_use",
+        usage={"input_tokens": 100, "output_tokens": 50},
+    )
+
+
+def _llm_client_returning(payload_response):
+    client = MagicMock()
+    client.call = AsyncMock(return_value=payload_response)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# choose_action_llm direct tests
+# ---------------------------------------------------------------------------
+
+
+class TestChooseActionLLM:
+    @pytest.mark.asyncio
+    async def test_happy_path_skip_and_continue(self):
+        client = _llm_client_returning(
+            _llm_response("skip_and_continue", rationale="test failed and is non-critical")
+        )
+        result = await choose_action_llm(
+            parent_name="fact-check",
+            parent_instructions="verify the claims",
+            parent_error="unverifiable_claim",
+            parent_result=None,
+            fix_instructions="diagnose and recover",
+            fix_actions=["retry_as_is", "skip_and_continue"],
+            llm_client=client,
+            model="claude-haiku-4-5-20251001",
+            timeout_seconds=5.0,
+        )
+        assert result.action == "skip_and_continue"
+        assert "LLM dispatch" in (result.rationale or "")
+        client.call.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_action_outside_fix_actions_raises(self):
+        client = _llm_client_returning(_llm_response("mark_unrecoverable"))
+        with pytest.raises(ValueError, match="not in fix_actions"):
+            await choose_action_llm(
+                parent_name="p",
+                parent_instructions=None,
+                parent_error=None,
+                parent_result=None,
+                fix_instructions=None,
+                fix_actions=["retry_as_is"],  # mark_unrecoverable NOT allowed
+                llm_client=client,
+                model="x",
+                timeout_seconds=5.0,
+            )
+
+    @pytest.mark.asyncio
+    async def test_retry_with_amended_prompt_requires_amended_prompt(self):
+        client = _llm_client_returning(
+            _llm_response("retry_with_amended_prompt", amended_prompt=None)
+        )
+        with pytest.raises(ValueError, match="amended_prompt"):
+            await choose_action_llm(
+                parent_name="p",
+                parent_instructions=None,
+                parent_error=None,
+                parent_result=None,
+                fix_instructions=None,
+                fix_actions=["retry_with_amended_prompt"],
+                llm_client=client,
+                model="x",
+                timeout_seconds=5.0,
+            )
+
+    @pytest.mark.asyncio
+    async def test_retry_with_amended_prompt_happy_path(self):
+        client = _llm_client_returning(
+            _llm_response(
+                "retry_with_amended_prompt",
+                amended_prompt="Try again but only check claim #1 and #3",
+                rationale="claim #2 was unverifiable",
+            )
+        )
+        result = await choose_action_llm(
+            parent_name="p",
+            parent_instructions="verify all claims",
+            parent_error="unverifiable_claim",
+            parent_result=None,
+            fix_instructions=None,
+            fix_actions=["retry_with_amended_prompt", "skip_and_continue"],
+            llm_client=client,
+            model="x",
+            timeout_seconds=5.0,
+        )
+        assert result.action == "retry_with_amended_prompt"
+        assert result.amended_prompt == "Try again but only check claim #1 and #3"
+
+    @pytest.mark.asyncio
+    async def test_no_tool_use_block_raises(self):
+        empty_resp = SimpleNamespace(content=[], stop_reason="end_turn", usage={})
+        client = _llm_client_returning(empty_resp)
+        with pytest.raises(ValueError, match="no choose_fix_action"):
+            await choose_action_llm(
+                parent_name="p",
+                parent_instructions=None,
+                parent_error=None,
+                parent_result=None,
+                fix_instructions=None,
+                fix_actions=["retry_as_is"],
+                llm_client=client,
+                model="x",
+                timeout_seconds=5.0,
+            )
+
+    @pytest.mark.asyncio
+    async def test_empty_fix_actions_raises(self):
+        client = _llm_client_returning(_llm_response("retry_as_is"))
+        with pytest.raises(ValueError, match="non-empty"):
+            await choose_action_llm(
+                parent_name="p",
+                parent_instructions=None,
+                parent_error=None,
+                parent_result=None,
+                fix_instructions=None,
+                fix_actions=[],
+                llm_client=client,
+                model="x",
+                timeout_seconds=5.0,
+            )
+
+    @pytest.mark.asyncio
+    async def test_timeout_propagates(self):
+        import asyncio
+
+        async def _slow(_payload):
+            await asyncio.sleep(0.5)
+            return _llm_response("retry_as_is")
+
+        client = MagicMock()
+        client.call = _slow
+
+        with pytest.raises(asyncio.TimeoutError):
+            await choose_action_llm(
+                parent_name="p",
+                parent_instructions=None,
+                parent_error=None,
+                parent_result=None,
+                fix_instructions=None,
+                fix_actions=["retry_as_is"],
+                llm_client=client,
+                model="x",
+                timeout_seconds=0.05,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def store(db):
+    agent_id = f"f066-1-llm-{uuid.uuid4().hex[:8]}"
+    return DAGStore(db, agent_id, Settings())
+
+
+@pytest.fixture
+def subtask_mgr():
+    mgr = AsyncMock()
+    mgr.create.return_value = SimpleNamespace(id=uuid.uuid4(), status="pending")
+    return mgr
+
+
+@pytest.fixture
+def dynamic_loader():
+    loader = AsyncMock()
+    loader.create_check = AsyncMock(return_value={"name": "t"})
+    loader._registry = MagicMock()
+    loader._registry.get_check.return_value = None
+    return loader
+
+
+def _parent_with_fix_request(fix_actions: list[str]) -> DAGCreateRequest:
+    return DAGCreateRequest(
+        name="parent-with-fix",
+        nodes=[
+            DAGNodeSpec(name="parent", type=DAGNodeType.subtask, instructions="original prompt"),
+            DAGNodeSpec(
+                name="fix-parent",
+                type=DAGNodeType.fix,
+                parent_node="parent",
+                fix_actions=fix_actions,
+                instructions="recover from failure",
+            ),
+        ],
+        edges=[DAGEdgeSpec(from_node="parent", to_node="fix-parent", edge_type="on_failure")],
+    )
+
+
+class TestOrchestratorLLMDispatch:
+    @pytest.mark.asyncio
+    async def test_llm_dispatch_applied_when_flag_on(
+        self, store, subtask_mgr, dynamic_loader
+    ):
+        """Flag on + working LLM → orchestrator uses LLM-chosen action."""
+        llm_client = _llm_client_returning(
+            _llm_response("skip_and_continue", rationale="LLM said skip")
+        )
+        settings = Settings().model_copy(update={
+            "dag_fix_llm_dispatch_enabled": True,
+            "dag_fix_llm_timeout_seconds": 5.0,
+        })
+        orch = DAGOrchestrator(
+            store=store,
+            subtask_mgr=subtask_mgr,
+            dynamic_loader=dynamic_loader,
+            settings=settings,
+            llm_client=llm_client,
+        )
+
+        dag = await store.create(_parent_with_fix_request(["retry_as_is", "skip_and_continue"]))
+        await orch.start_dag(dag.id)
+
+        # Fail the parent so the fix fires.
+        fetched = await store.get_dag(dag.id)
+        parent = next(n for n in fetched.nodes if n.name == "parent")
+        await store.update_node(parent.id, status="failed", error="validation_failed")
+
+        await orch.tick()
+
+        fetched = await store.get_dag(dag.id)
+        parent = next(n for n in fetched.nodes if n.name == "parent")
+        # LLM said skip — even though rule-based would have said retry_as_is
+        # (because parent.error contains 'validation_failed').
+        assert parent.status == "skipped"
+        llm_client.call.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_llm_failure_falls_back_to_rule_based(
+        self, store, subtask_mgr, dynamic_loader
+    ):
+        """LLM raises → orchestrator falls back to choose_action."""
+        llm_client = MagicMock()
+        llm_client.call = AsyncMock(side_effect=RuntimeError("LLM unavailable"))
+
+        settings = Settings().model_copy(update={
+            "dag_fix_llm_dispatch_enabled": True,
+        })
+        orch = DAGOrchestrator(
+            store=store,
+            subtask_mgr=subtask_mgr,
+            dynamic_loader=dynamic_loader,
+            settings=settings,
+            llm_client=llm_client,
+        )
+
+        dag = await store.create(_parent_with_fix_request(["retry_as_is"]))
+        await orch.start_dag(dag.id)
+
+        fetched = await store.get_dag(dag.id)
+        parent = next(n for n in fetched.nodes if n.name == "parent")
+        await store.update_node(parent.id, status="failed", error="validation_failed")
+
+        await orch.tick()
+
+        fetched = await store.get_dag(dag.id)
+        parent = next(n for n in fetched.nodes if n.name == "parent")
+        # Rule-based: validation_failed → retry_as_is → parent set to pending.
+        assert parent.status in ("pending", "ready", "running")
+        llm_client.call.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_flag_off_uses_rule_based(
+        self, store, subtask_mgr, dynamic_loader
+    ):
+        """Flag off → LLM not called even if client is wired."""
+        llm_client = MagicMock()
+        llm_client.call = AsyncMock(return_value=_llm_response("skip_and_continue"))
+
+        # Default settings: flag is False.
+        orch = DAGOrchestrator(
+            store=store,
+            subtask_mgr=subtask_mgr,
+            dynamic_loader=dynamic_loader,
+            settings=Settings(),
+            llm_client=llm_client,
+        )
+
+        dag = await store.create(_parent_with_fix_request(["retry_as_is", "skip_and_continue"]))
+        await orch.start_dag(dag.id)
+
+        fetched = await store.get_dag(dag.id)
+        parent = next(n for n in fetched.nodes if n.name == "parent")
+        await store.update_node(parent.id, status="failed", error="validation_failed")
+
+        await orch.tick()
+
+        # Rule-based path: chose retry_as_is for validation_failed.
+        fetched = await store.get_dag(dag.id)
+        parent = next(n for n in fetched.nodes if n.name == "parent")
+        assert parent.status in ("pending", "ready", "running")
+        # The LLM client must NOT have been called.
+        llm_client.call.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_amended_prompt_applied_to_parent_instructions(
+        self, store, subtask_mgr, dynamic_loader
+    ):
+        """LLM returns retry_with_amended_prompt + new prompt → parent's
+        instructions is overwritten."""
+        llm_client = _llm_client_returning(
+            _llm_response(
+                "retry_with_amended_prompt",
+                amended_prompt="Revised: only check items A and C",
+                rationale="item B is unverifiable",
+            )
+        )
+        settings = Settings().model_copy(update={
+            "dag_fix_llm_dispatch_enabled": True,
+        })
+        orch = DAGOrchestrator(
+            store=store,
+            subtask_mgr=subtask_mgr,
+            dynamic_loader=dynamic_loader,
+            settings=settings,
+            llm_client=llm_client,
+        )
+
+        dag = await store.create(
+            _parent_with_fix_request(["retry_with_amended_prompt", "mark_unrecoverable"])
+        )
+        await orch.start_dag(dag.id)
+
+        fetched = await store.get_dag(dag.id)
+        parent = next(n for n in fetched.nodes if n.name == "parent")
+        await store.update_node(parent.id, status="failed", error="unverifiable_claim")
+
+        await orch.tick()
+
+        fetched = await store.get_dag(dag.id)
+        parent = next(n for n in fetched.nodes if n.name == "parent")
+        # Parent re-enqueued AND instructions amended.
+        assert parent.status in ("pending", "ready", "running")
+        assert parent.instructions == "Revised: only check items A and C"

--- a/tests/test_f066_1_llm_dispatch.py
+++ b/tests/test_f066_1_llm_dispatch.py
@@ -159,6 +159,36 @@ class TestChooseActionLLM:
             )
 
     @pytest.mark.asyncio
+    async def test_payload_includes_system_key_for_sdk_backend(self):
+        """Codex P1 (2026-05-22): SdkAnthropicClient._payload_to_kwargs indexes
+        payload["system"] unconditionally. Without this key, the SDK backend
+        raises KeyError before reaching Anthropic and every LLM dispatch
+        silently falls back to rule-based. Guard the payload shape so the
+        regression can't reappear.
+        """
+        captured: dict = {}
+
+        async def _capture(payload):
+            captured.update(payload)
+            return _llm_response("retry_as_is")
+
+        client = MagicMock()
+        client.call = _capture
+
+        await choose_action_llm(
+            parent_name="p",
+            parent_instructions=None,
+            parent_error="incomplete_no_terminal",
+            parent_result=None,
+            fix_instructions=None,
+            fix_actions=["retry_as_is"],
+            llm_client=client,
+            model="x",
+            timeout_seconds=5.0,
+        )
+        assert "system" in captured, "payload must include 'system' for SDK backend"
+
+    @pytest.mark.asyncio
     async def test_empty_fix_actions_raises(self):
         client = _llm_client_returning(_llm_response("retry_as_is"))
         with pytest.raises(ValueError, match="non-empty"):


### PR DESCRIPTION
## Summary

Adds the LLM-based fix-node dispatcher promised by the F066.1 spec's "Phase 1 free-form LLM dispatch" item. Phase 1 shipped a rule-based dispatcher as a deliberate scope cut; Phase 1.5 fulfills the spec while keeping the Phase 1 rule-based path as a fallback.

## Selection precedence

\`\`\`
settings.dag_fix_llm_dispatch_enabled AND llm_client wired
    → choose_action_llm (Phase 1.5)
        LLM failure (timeout, parse error, unsupported action)
            → fall back to choose_action (Phase 1)
flag off OR no llm_client
    → choose_action directly (Phase 1)
\`\`\`

## Tool-use constraint

The LLM is forced (via \`tool_choice={"type":"tool","name":"choose_fix_action"}\`) to return a tool_use block. The tool's input schema constrains \`action\` to an enum populated verbatim from \`fix_actions\`, so the model cannot pick an action the fix node didn't authorize. \`amended_prompt\` is required when \`action='retry_with_amended_prompt'\`.

## Files

- \`nous/dag/fix_executor.py\` — new \`choose_action_llm\` function + tool schema + prompt builder
- \`nous/dag/orchestrator.py\` — \`__init__\` accepts \`llm_client=None\`; \`_try_fix_failed_nodes\` tries LLM dispatch first when flag is on, falls back to rule-based on failure; \`retry_with_amended_prompt\` action now overwrites \`parent.instructions\` with \`outcome.amended_prompt\`
- \`nous/config.py\` — 3 new settings: \`dag_fix_llm_dispatch_enabled\` (default False), \`dag_fix_llm_model\` (default Haiku), \`dag_fix_llm_timeout_seconds\` (default 10s)
- \`tests/test_f066_1_llm_dispatch.py\` — 11 new tests

## Test plan

- [x] \`uv run pytest tests/test_f066_1_llm_dispatch.py\` — 11/11 pass
- [x] \`uv run pytest tests/test_f066_1_fix_stage.py\` — 25/25 still pass (Phase 1 contract intact)
- [x] \`uv run pytest tests/test_dag_orchestrator.py tests/test_dag_store.py\` — 69/69 pass

## Rollout

1. **This PR** — lands the integration dormant (flag default false).
2. **Wire \`llm_client\` in main.py** — separate ops PR. The orchestrator currently doesn't receive an LLM client. The constructor accepts \`llm_client=None\` so the integration here doesn't break the call site, but to actually use LLM dispatch in prod, \`main.py\` needs to pass the existing Anthropic client (the one Heart / handlers already use) into \`DAGOrchestrator(...)\`.
3. **Flip flag** — separate ops PR after dogfooding on test DAGs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)