### PR TITLE
eval(F065): F051 configs for penalty A/B + autosurface neutrality

### DIFF
--- a/nous_eval/retrieval.py
+++ b/nous_eval/retrieval.py
@@ -131,6 +131,39 @@ _DEFAULT_CONFIGS: dict[str, RetrievalConfig] = {
         description="F022 graph recall + spreading activation disabled.",
     ),
     # ------------------------------------------------------------------
+    # F065 phase 4 — Edge-provenance penalty A/B.
+    # Baseline (1.0, default) vs candidate (0.7). Pair with `baseline` to
+    # measure the MRR delta of down-weighting `inferred`-tier graph edges
+    # during recall_deep expansion. Flip the default in nous/config.py
+    # only after this A/B clears the gate semantics in
+    # `decide_gate_f050` (per-source regression cap + majority positive).
+    # ------------------------------------------------------------------
+    "f065_penalty_on": RetrievalConfig(
+        name="f065_penalty_on",
+        flags={"graph_inferred_edge_penalty": 0.7},
+        description=(
+            "F065 phase 4: penalize `inferred`-tier provenance edges by "
+            "0.7x during recall_deep expansion. Pair with `baseline` "
+            "(penalty=1.0) for A/B."
+        ),
+    ),
+    # F065 autosurface neutrality probe.
+    # Toggles the pre_turn hub-shift autosurface flag ON. The autosurface
+    # writes into the system prompt only — it does NOT touch recall_deep,
+    # so MRR is expected to be byte-identical to baseline. The config
+    # exists so the F051 harness can produce the receipt that closes
+    # the loop (zero delta confirmed) rather than asserting neutrality
+    # by inspection.
+    "f065_autosurface_on": RetrievalConfig(
+        name="f065_autosurface_on",
+        flags={"graph_hub_autosurface_enabled": True},
+        description=(
+            "F065 follow-up: enable pre_turn hub-shift autosurface. "
+            "Autosurface affects system-prompt context, not recall_deep — "
+            "expected MRR delta vs baseline is exactly 0."
+        ),
+    ),
+    # ------------------------------------------------------------------
     # F053 — density-eval diagnostic configs (used by
     # `python -m nous_eval.density_eval`, not the retrieval matrix).
     # ------------------------------------------------------------------

--- a/tests/eval/test_f065_configs.py
+++ b/tests/eval/test_f065_configs.py
@@ -1,0 +1,63 @@
+"""F065 phase 4 — eval configs registry guard.
+
+These configs land dormant in `nous_eval._DEFAULT_CONFIGS` so the F051
+matrix runner can be invoked as:
+
+    python -m nous_eval.retrieval --configs baseline,f065_penalty_on
+
+without anyone needing to remember which Settings flag to flip. The
+tests pin both the registry entry AND the flag name — typos in the
+flag name would otherwise only fail at run time inside a Docker'd
+eval DB.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.eval
+
+try:
+    from nous.config import Settings
+    from nous_eval.retrieval import _DEFAULT_CONFIGS
+except ImportError:
+    pytest.skip(
+        "nous_eval.retrieval (+deps) not yet available",
+        allow_module_level=True,
+    )
+
+
+class TestF065PenaltyConfig:
+    def test_config_registered(self) -> None:
+        assert "f065_penalty_on" in _DEFAULT_CONFIGS
+
+    def test_config_flips_inferred_edge_penalty_to_0_7(self) -> None:
+        cfg = _DEFAULT_CONFIGS["f065_penalty_on"]
+        assert cfg.flags == {"graph_inferred_edge_penalty": 0.7}
+
+    def test_flag_applies_to_settings(self) -> None:
+        """Flag name MUST match a real Settings field; pydantic's model_copy
+        with update= validates unknown keys."""
+        cfg = _DEFAULT_CONFIGS["f065_penalty_on"]
+        base = Settings()
+        # Confirm baseline default first — if the production default ever
+        # changes to 0.7, this guard wakes us up so we can switch the eval
+        # config to a new candidate value.
+        assert base.graph_inferred_edge_penalty == 1.0
+        overridden = base.model_copy(update=cfg.flags)
+        assert overridden.graph_inferred_edge_penalty == 0.7
+
+
+class TestF065AutosurfaceConfig:
+    def test_config_registered(self) -> None:
+        assert "f065_autosurface_on" in _DEFAULT_CONFIGS
+
+    def test_config_flips_autosurface_flag(self) -> None:
+        cfg = _DEFAULT_CONFIGS["f065_autosurface_on"]
+        assert cfg.flags == {"graph_hub_autosurface_enabled": True}
+
+    def test_flag_applies_to_settings(self) -> None:
+        cfg = _DEFAULT_CONFIGS["f065_autosurface_on"]
+        base = Settings()
+        assert base.graph_hub_autosurface_enabled is False
+        overridden = base.model_copy(update=cfg.flags)
+        assert overridden.graph_hub_autosurface_enabled is True


### PR DESCRIPTION
## Summary
- Adds `f065_penalty_on` (graph_inferred_edge_penalty=0.7) to the F051 default config matrix — pair with `baseline` for the penalty multiplier A/B.
- Adds `f065_autosurface_on` (graph_hub_autosurface_enabled=True) as the autosurface neutrality probe (expected MRR delta = 0; the flag only changes pre_turn injection, not recall_deep).
- Pins both registry entries and Settings field names with `tests/eval/test_f065_configs.py` so typos fail at unit-test time instead of at run time inside the eval DB.

## Why now
- PR #434 ships the autosurface integration gated off; PR #435 ships the LLM dispatch for F066.1 Phase 1.5. Both rely on an F051 evaluation before flipping defaults (penalty 1.0 → 0.7) or claiming neutrality (autosurface).
- The harness already supports `--configs <name>,<name>`. The missing piece was named configs that flip the F065-specific flags; without them every eval run requires re-typing the flag overrides.
- Both candidates are deliberately separate configs so they can be run independently and so the autosurface probe's neutrality claim can be falsified rather than asserted.

## Run procedure
```bash
docker compose --profile eval up -d nous-eval-db

# Penalty A/B — informs the ops PR (flip default to 0.7?)
python -m nous_eval.retrieval --configs baseline,f065_penalty_on --gate-only

# Autosurface neutrality — expected zero delta receipt
python -m nous_eval.retrieval --configs baseline,f065_autosurface_on --gate-only
```

## Test plan
- [x] `pytest tests/eval/test_f065_configs.py` — 6/6 passing locally.
- [ ] Run the matrix against the eval DB once Docker is available (deferred — environment).
- [ ] If penalty A/B shows aggregate MRR delta ≥ +7% with no per-source regression > 3% and majority positive: open ops PR flipping `graph_inferred_edge_penalty` default to 0.7.
- [ ] If autosurface delta is non-zero: investigate — autosurface shouldn't touch retrieval, so non-zero would indicate a bug elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)