### PR TITLE
F051+F065: merge-score pipeline + auto-linker inferred tagging

### DIFF
--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -156,6 +156,7 @@ async def run_recall_pipeline(
     memory_types: list[str] | None = None,
     residual_activations: dict[UUID, float] | None = None,
     apply_mmr: bool | None = None,
+    rerank_by_score: bool = False,
 ) -> tuple[list[PipelineResult], PipelineStats]:
     """Run the full retrieval pipeline.
 
@@ -199,6 +200,25 @@ async def run_recall_pipeline(
     # Attach contradiction links to matching results
     if acc.contradictions:
         _attach_contradictions(results, acc.contradictions)
+
+    # F065 follow-up (2026-05-23): optional score-based merge.
+    #
+    # The default stage-order assembly above places graph-expanded items
+    # AFTER heart_results in the concatenated list — so they always sit
+    # at position 11+ for a top-K=10 reader, no matter how high their
+    # scores are. That makes every graph-touching feature (F022 spreading
+    # activation, F030 MMR-after-graph, F065 inferred-edge penalty)
+    # invisible to a top-K=10 eval.
+    #
+    # When ``rerank_by_score=True``, we stably re-sort by score descending
+    # (Python's sort is stable, so equal scores preserve stage order as
+    # a tiebreaker). Default ``False`` keeps the `recall_deep` tool output
+    # byte-identical to its committed snapshot — only callers that opt in
+    # (the F051 harness today) see the new behavior. When we're confident
+    # the merged ordering is preferable in production too, the default
+    # can be flipped and the snapshot regenerated.
+    if rerank_by_score:
+        results.sort(key=lambda r: r.score or 0.0, reverse=True)
 
     stats = PipelineStats(
         ce_reranked=False,  # CE rerank happens inside heart.recall already

--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -1073,6 +1073,13 @@ class Brain:
     ) -> GraphEdgeInfo:
         from nous.brain.edge_provenance import classify  # F065 (avoid circular)
 
+        # F065 phase 4 follow-up (2026-05-23): auto-linked writes are
+        # cosine-derived "inferred" provenance even when the relation is
+        # neither contradicts nor supersedes. Without this tagging, the
+        # F065 penalty multiplier had nothing to apply to in prod (0
+        # contradicts rows — see nous/heart/facts.py:35 for the F027
+        # classifier's CONTRADICTION bias).
+        writer = "auto_linker" if auto_linked else None
         edge = GraphEdge(
             source_id=source_id,
             target_id=target_id,
@@ -1082,7 +1089,7 @@ class Brain:
             relation=relation,
             weight=weight,
             auto_linked=auto_linked,
-            extraction_method=classify(relation),  # F065
+            extraction_method=classify(relation, source=writer),
         )
         session.add(edge)
         await session.flush()
@@ -1451,7 +1458,7 @@ class Brain:
                     relation="related_to",
                     weight=float(row.similarity),
                     auto_linked=True,
-                    extraction_method=classify("related_to"),  # F065
+                    extraction_method=classify("related_to", source="auto_linker"),
                 )
                 .on_conflict_do_nothing(constraint="uq_edges_src_tgt_rel")
             )

--- a/nous/brain/edge_provenance.py
+++ b/nous/brain/edge_provenance.py
@@ -41,20 +41,36 @@ def classify(
     Args:
         relation: the edge relation string (e.g. 'supersedes', 'contradicts',
                   'related_to', 'extracted_from', 'discussed_in', etc.).
-        source: explicit override for writers that carry structural
-                provenance the relation string alone can't express. Only
-                ``'structural'`` is currently recognized — used by
-                ``link_episode_deterministic`` whose discussed_in /
-                extracted_from edges come from explicit episode-token
-                references, not cosine matching.
+        source: writer-identity tag explicitly passed by the call site.
+                Recognized values:
+                  - ``'structural'``: explicit episode-token / supersession
+                    references, not cosine-derived. → deterministic.
+                  - ``'auto_linker'``: event-bus cosine auto-linker writes
+                    (``nous/brain/graph_linker.py`` related_to / evidence_for
+                    paths). → inferred. Added 2026-05-23 as the F065 phase 4
+                    follow-up: prod has 0 ``contradicts`` rows (F027
+                    classifier is biased toward UPDATE — see
+                    ``nous/heart/facts.py:35``), so the original
+                    relation-only rule left ``inferred`` empty and the
+                    penalty multiplier dormant. Tagging the auto-linker as
+                    its own writer aligns the tier with operational reality.
+                  - ``'ce_backfill'``: F040 sleep-cycle cross-encoder
+                    backfill. Also cosine-derived. → inferred.
 
     Returns:
         One of 'deterministic', 'inferred', 'heuristic'.
     """
-    if source == "structural":
-        return "deterministic"
+    # Precedence: structural-provenance relations win over any source
+    # tag, because supersedes/contradicts encode the writer's intent in
+    # the relation itself. The `source` tag only disambiguates relations
+    # that COULD be either heuristic or inferred (related_to,
+    # evidence_for, informed_by, etc.).
     if relation == "supersedes":
         return "deterministic"
     if relation == "contradicts":
+        return "inferred"
+    if source == "structural":
+        return "deterministic"
+    if source in ("auto_linker", "ce_backfill"):
         return "inferred"
     return "heuristic"

--- a/nous/brain/graph_linker.py
+++ b/nous/brain/graph_linker.py
@@ -107,7 +107,7 @@ class GraphLinker:
                 relation=relation,
                 weight=adjusted_weight,
                 auto_linked=True,
-                extraction_method=classify(relation),  # F065 (cosine-derived)
+                extraction_method=classify(relation, source="auto_linker"),  # F065
             )
             .on_conflict_do_nothing(index_elements=["source_id", "target_id", "relation"])
         )
@@ -197,7 +197,7 @@ class GraphLinker:
                         relation="evidence_for",
                         weight=float(similarity),
                         auto_linked=True,
-                        extraction_method=classify("evidence_for"),  # F065 (cosine-derived)
+                        extraction_method=classify("evidence_for", source="auto_linker"),
                     )
                     .on_conflict_do_nothing(index_elements=["source_id", "target_id", "relation"])
                 )
@@ -276,7 +276,7 @@ class GraphLinker:
                         relation="related_to",
                         weight=float(row.similarity),
                         auto_linked=True,
-                        extraction_method=classify("related_to"),  # F065 (cosine-derived)
+                        extraction_method=classify("related_to", source="auto_linker"),
                     )
                     .on_conflict_do_nothing(index_elements=["source_id", "target_id", "relation"])
                 )

--- a/nous_eval/retrieval_runner.py
+++ b/nous_eval/retrieval_runner.py
@@ -508,6 +508,13 @@ async def _run_one(
             settings=settings,
             limit=top_k,
             memory_types=memory_types,
+            # F065 follow-up (2026-05-23): merge stage outputs by score so
+            # graph-expanded items can compete for the top-K window. The
+            # default stage-order concatenation pins them at position 11+,
+            # making every graph-touching config invisible to top-K=10
+            # scoring. Without this, F065 penalty / F022 spreading /
+            # F030 MMR-after-graph all produce structurally-zero deltas.
+            rerank_by_score=True,
         )
     except Exception as exc:
         # Per plan silent-failure table: captured, not zero-scored.

--- a/nous_eval/synthesize_inferred_edges.py
+++ b/nous_eval/synthesize_inferred_edges.py
@@ -1,0 +1,141 @@
+"""F051 eval-only synthesis: relabel auto-linker edges as `inferred`.
+
+Production today writes almost no `contradicts`-relation edges (the F027
+classifier is deliberately biased toward UPDATE/supersedes — see
+`nous/heart/facts.py:35-70`), so migration 047's backfill rule leaves
+`extraction_method='inferred'` empty. That makes the F065 penalty
+multiplier a no-op in every eval run: zero inferred-tier edges to weigh.
+
+This script mutates the **eval DB only** (never prod) to seed inferred
+labels onto a subset of heuristic edges that resemble the population the
+F065 penalty was conceptually designed to target: cosine-auto-linked
+`related_to` rows from the event-bus auto-linker. The goal is to
+validate the penalty hypothesis empirically before committing to a
+production migration that would do the same thing for real (see
+task #29 / Step 3).
+
+Usage:
+    python -m nous_eval.synthesize_inferred_edges \\
+        --agent-id nous-prod-snapshot \\
+        --relation related_to
+
+The eval DB host/port/db_name come from NOUS_EVAL_DB_* env vars (same
+as the retrieval harness).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+
+from sqlalchemy import text
+
+from nous.config import Settings
+from nous.storage.database import Database
+from nous_eval.config import EvalSettings
+from nous_eval.retrieval_runner import _settings_for_eval_db
+
+logger = logging.getLogger(__name__)
+
+
+async def _relabel(
+    db: Database, agent_id: str, relation: str, dry_run: bool
+) -> tuple[int, int]:
+    """Returns (eligible_count, updated_count)."""
+    async with db.session() as session:
+        count_row = (await session.execute(
+            text("""
+                SELECT COUNT(*)
+                FROM brain.graph_edges
+                WHERE agent_id = :agent_id
+                  AND relation = :relation
+                  AND extraction_method = 'heuristic'
+                  AND auto_linked = true
+            """),
+            {"agent_id": agent_id, "relation": relation},
+        )).scalar_one()
+        eligible = int(count_row or 0)
+
+        if dry_run or eligible == 0:
+            return eligible, 0
+
+        result = await session.execute(
+            text("""
+                UPDATE brain.graph_edges
+                SET extraction_method = 'inferred'
+                WHERE agent_id = :agent_id
+                  AND relation = :relation
+                  AND extraction_method = 'heuristic'
+                  AND auto_linked = true
+            """),
+            {"agent_id": agent_id, "relation": relation},
+        )
+        await session.commit()
+        return eligible, int(result.rowcount or 0)
+
+
+async def _summary(db: Database, agent_id: str) -> dict[str, int]:
+    async with db.session() as session:
+        rows = (await session.execute(
+            text("""
+                SELECT extraction_method, COUNT(*) AS c
+                FROM brain.graph_edges
+                WHERE agent_id = :agent_id
+                GROUP BY extraction_method
+            """),
+            {"agent_id": agent_id},
+        )).all()
+    return {r.extraction_method: int(r.c) for r in rows}
+
+
+async def _run_async(args: argparse.Namespace) -> int:
+    eval_settings = EvalSettings()
+    eval_settings.warn_if_default_password()
+    base_settings = Settings()
+    main_settings = _settings_for_eval_db(eval_settings, base_settings)
+
+    db = Database(settings=main_settings)
+    await db.connect()
+    try:
+        before = await _summary(db, args.agent_id)
+        logger.info("BEFORE: %s", before)
+        eligible, updated = await _relabel(
+            db, args.agent_id, args.relation, args.dry_run
+        )
+        after = await _summary(db, args.agent_id)
+        logger.info("ELIGIBLE matching filter: %d", eligible)
+        if args.dry_run:
+            logger.info("DRY RUN — no rows changed")
+        else:
+            logger.info("UPDATED %d rows", updated)
+        logger.info("AFTER: %s", after)
+    finally:
+        await db.disconnect()
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m nous_eval.synthesize_inferred_edges",
+        description="Relabel auto-linker edges as 'inferred' on the eval DB only.",
+    )
+    parser.add_argument("--agent-id", default="nous-prod-snapshot",
+                        help="Eval DB agent_id whose edges to relabel.")
+    parser.add_argument("--relation", default="related_to",
+                        help="Relation to relabel. Default `related_to`.")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show counts without mutating.")
+    parser.add_argument("--log-level", default="info")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=args.log_level.upper(),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    return asyncio.run(_run_async(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sql/migrations/049_f065_auto_linker_inferred.sql
+++ b/sql/migrations/049_f065_auto_linker_inferred.sql
@@ -15,14 +15,22 @@
 -- written by the same code paths pre-fix.
 --
 -- Discriminator: auto_linked=true AND extraction_method='heuristic' AND
--- relation NOT IN ('supersedes', 'contradicts'). The relation filter
--- protects rows that migration 047 already classified by structural
--- provenance — those keep their tier.
+-- relation NOT IN the structural-provenance set:
+--   - 'supersedes' and 'contradicts' are already classified by
+--     migration 047 (supersedes→deterministic, contradicts→inferred);
+--     re-running over them would be a no-op anyway.
+--   - 'discussed_in' and 'extracted_from' are written by
+--     `link_episode_deterministic` in nous/brain/graph_linker.py:320,345
+--     which calls classify(..., source='structural') for new writes,
+--     yielding 'deterministic'. But rows created before migration 047
+--     were backfilled to 'heuristic' (relation-only rule). Codex P1
+--     (2026-05-23): without excluding those relations here, the
+--     backfill would silently flip legacy structural edges to
+--     'inferred', applying the F065 penalty to deterministic
+--     provenance.
 --
 -- F027 supersedes/contradicts writes also set auto_linked=true (see
--- nous/heart/facts.py:179) but their extraction_method was already set
--- correctly by relation in migration 047, so they're skipped by the
--- relation-filter.
+-- nous/heart/facts.py:179) but the relation filter above protects them.
 
 BEGIN;
 
@@ -30,6 +38,9 @@ UPDATE brain.graph_edges
 SET extraction_method = 'inferred'
 WHERE auto_linked = true
   AND extraction_method = 'heuristic'
-  AND relation NOT IN ('supersedes', 'contradicts');
+  AND relation NOT IN (
+      'supersedes', 'contradicts',         -- already classified by relation
+      'discussed_in', 'extracted_from'      -- structural per graph_linker
+  );
 
 COMMIT;

--- a/sql/migrations/049_f065_auto_linker_inferred.sql
+++ b/sql/migrations/049_f065_auto_linker_inferred.sql
@@ -1,0 +1,35 @@
+-- Migration 049: F065 phase 4 follow-up — reclassify auto-linker rows as inferred.
+--
+-- Migration 047 backfilled extraction_method using ONLY the relation
+-- string (supersedes→deterministic, contradicts→inferred, else→heuristic).
+-- That left `inferred` empty in prod because the F027 classifier at
+-- nous/heart/facts.py:35-70 is deliberately biased away from CONTRADICTION
+-- (UPDATE is listed first to counter the false-positive bias the team
+-- observed pre-F027). As a result the F065 penalty multiplier had
+-- nothing to apply to and shipped dormant.
+--
+-- The fix at the write path (nous/brain/edge_provenance.py::classify +
+-- source="auto_linker" call-site tagging in nous/brain/graph_linker.py)
+-- makes new writes correctly classify cosine-auto-linker edges as
+-- `inferred`. This migration backfills the EXISTING rows that were
+-- written by the same code paths pre-fix.
+--
+-- Discriminator: auto_linked=true AND extraction_method='heuristic' AND
+-- relation NOT IN ('supersedes', 'contradicts'). The relation filter
+-- protects rows that migration 047 already classified by structural
+-- provenance — those keep their tier.
+--
+-- F027 supersedes/contradicts writes also set auto_linked=true (see
+-- nous/heart/facts.py:179) but their extraction_method was already set
+-- correctly by relation in migration 047, so they're skipped by the
+-- relation-filter.
+
+BEGIN;
+
+UPDATE brain.graph_edges
+SET extraction_method = 'inferred'
+WHERE auto_linked = true
+  AND extraction_method = 'heuristic'
+  AND relation NOT IN ('supersedes', 'contradicts');
+
+COMMIT;

--- a/sql/migrations/049_f065_auto_linker_inferred.sql
+++ b/sql/migrations/049_f065_auto_linker_inferred.sql
@@ -14,40 +14,39 @@
 -- `inferred`. This migration backfills the EXISTING rows that were
 -- written by the same code paths pre-fix.
 --
--- Discriminator: auto_linked=true AND extraction_method='heuristic'
--- AND weight < 1.0 AND relation NOT IN ('supersedes', 'contradicts').
+-- Discriminator (relation-conditional, NOT a blanket weight gate):
 --
--- The weight predicate splits the two writers that produce
--- discussed_in / extracted_from rows:
+--   - For `discussed_in` / `extracted_from`: weight=1.0 is the literal
+--     signature of `link_episode_deterministic`
+--     (nous/brain/graph_linker.py:316,341), which writes structural
+--     provenance. weight<1.0 is the signature of `DecisionGraphLinker`
+--     (nous/handlers/decision_graph_linker.py:118,161; cosine-derived).
+--     Backfill only the latter.
 --
---   - `link_episode_deterministic` in nous/brain/graph_linker.py:316,341
---     writes weight=1.0 literally — structural provenance.
---   - `DecisionGraphLinker` in
---     nous/handlers/decision_graph_linker.py:118,161 writes
---     weight=float(cosine_similarity) — cosine-derived, statistically
---     always strictly < 1.0.
+--   - For every other auto_linker relation (related_to, evidence_for,
+--     supports, caused_by, informed_by): there is no structural
+--     writer. Every auto_linked row is cosine-derived, regardless of
+--     weight. The weight predicate does NOT apply here, so cosine
+--     writes that happen to land at weight=1.0 (identical embeddings —
+--     duplicate-content facts the dedup pass missed) still get
+--     backfilled. Without this, the same writer would produce split
+--     provenance based on row age (Codex P1 round 3, 2026-05-23).
 --
--- Without the weight predicate, two distinct concerns would collide:
+--   - `supersedes` / `contradicts`: already classified by relation
+--     in migration 047 (deterministic / inferred). The relation
+--     filter is belt-and-braces.
 --
---   1. Codex P1 round 1 (2026-05-23): excluding discussed_in /
---      extracted_from entirely from the backfill protects legacy
---      structural rows but ALSO skips legacy COSINE rows of those same
---      relations. After the migration, the same cosine writer would
---      produce split provenance depending on whether the row pre-dates
---      this migration.
+-- Refresher on why `refines` isn't a concern: it is written by
+-- `Facts._create_graph_edge` at nous/heart/facts.py:564 with
+-- auto_linked=true + weight=0.8, but the ck_edges_relation CHECK
+-- constraint rejects it. The surrounding try/except swallows the
+-- failure, so zero `refines` rows exist in either prod or eval DB
+-- (verified 2026-05-23).
 --
---   2. Codex P1 round 2 (2026-05-23): the weight-based split picks up
---      the legacy cosine discussed_in / extracted_from rows while
---      leaving structural rows alone.
---
--- supersedes / contradicts already have correct extraction_method
--- from migration 047 (relation-based), so the relation filter is
--- belt-and-braces.
---
--- A future migration may want to additionally promote weight=1.0
--- discussed_in / extracted_from rows from 'heuristic' to
--- 'deterministic' to fully reflect their structural provenance, but
--- that is orthogonal to F065 and out of scope here.
+-- A future migration may promote the weight=1.0 structural
+-- discussed_in/extracted_from rows from 'heuristic' to 'deterministic'
+-- to fully reflect their structural provenance, but that is orthogonal
+-- to F065 and out of scope here.
 
 BEGIN;
 
@@ -55,7 +54,15 @@ UPDATE brain.graph_edges
 SET extraction_method = 'inferred'
 WHERE auto_linked = true
   AND extraction_method = 'heuristic'
-  AND weight < 1.0
-  AND relation NOT IN ('supersedes', 'contradicts');
+  AND relation NOT IN ('supersedes', 'contradicts')
+  AND (
+      -- Cosine-derived discussed_in / extracted_from rows:
+      -- DecisionGraphLinker writes weight=float(similarity), < 1.0.
+      -- Structural writes (link_episode_deterministic) use weight=1.0.
+      (relation IN ('discussed_in', 'extracted_from') AND weight < 1.0)
+      -- All other auto_linker relations have no structural writer;
+      -- weight is irrelevant for routing.
+      OR relation NOT IN ('discussed_in', 'extracted_from')
+  );
 
 COMMIT;

--- a/sql/migrations/049_f065_auto_linker_inferred.sql
+++ b/sql/migrations/049_f065_auto_linker_inferred.sql
@@ -14,23 +14,40 @@
 -- `inferred`. This migration backfills the EXISTING rows that were
 -- written by the same code paths pre-fix.
 --
--- Discriminator: auto_linked=true AND extraction_method='heuristic' AND
--- relation NOT IN the structural-provenance set:
---   - 'supersedes' and 'contradicts' are already classified by
---     migration 047 (supersedes→deterministic, contradicts→inferred);
---     re-running over them would be a no-op anyway.
---   - 'discussed_in' and 'extracted_from' are written by
---     `link_episode_deterministic` in nous/brain/graph_linker.py:320,345
---     which calls classify(..., source='structural') for new writes,
---     yielding 'deterministic'. But rows created before migration 047
---     were backfilled to 'heuristic' (relation-only rule). Codex P1
---     (2026-05-23): without excluding those relations here, the
---     backfill would silently flip legacy structural edges to
---     'inferred', applying the F065 penalty to deterministic
---     provenance.
+-- Discriminator: auto_linked=true AND extraction_method='heuristic'
+-- AND weight < 1.0 AND relation NOT IN ('supersedes', 'contradicts').
 --
--- F027 supersedes/contradicts writes also set auto_linked=true (see
--- nous/heart/facts.py:179) but the relation filter above protects them.
+-- The weight predicate splits the two writers that produce
+-- discussed_in / extracted_from rows:
+--
+--   - `link_episode_deterministic` in nous/brain/graph_linker.py:316,341
+--     writes weight=1.0 literally — structural provenance.
+--   - `DecisionGraphLinker` in
+--     nous/handlers/decision_graph_linker.py:118,161 writes
+--     weight=float(cosine_similarity) — cosine-derived, statistically
+--     always strictly < 1.0.
+--
+-- Without the weight predicate, two distinct concerns would collide:
+--
+--   1. Codex P1 round 1 (2026-05-23): excluding discussed_in /
+--      extracted_from entirely from the backfill protects legacy
+--      structural rows but ALSO skips legacy COSINE rows of those same
+--      relations. After the migration, the same cosine writer would
+--      produce split provenance depending on whether the row pre-dates
+--      this migration.
+--
+--   2. Codex P1 round 2 (2026-05-23): the weight-based split picks up
+--      the legacy cosine discussed_in / extracted_from rows while
+--      leaving structural rows alone.
+--
+-- supersedes / contradicts already have correct extraction_method
+-- from migration 047 (relation-based), so the relation filter is
+-- belt-and-braces.
+--
+-- A future migration may want to additionally promote weight=1.0
+-- discussed_in / extracted_from rows from 'heuristic' to
+-- 'deterministic' to fully reflect their structural provenance, but
+-- that is orthogonal to F065 and out of scope here.
 
 BEGIN;
 
@@ -38,9 +55,7 @@ UPDATE brain.graph_edges
 SET extraction_method = 'inferred'
 WHERE auto_linked = true
   AND extraction_method = 'heuristic'
-  AND relation NOT IN (
-      'supersedes', 'contradicts',         -- already classified by relation
-      'discussed_in', 'extracted_from'      -- structural per graph_linker
-  );
+  AND weight < 1.0
+  AND relation NOT IN ('supersedes', 'contradicts');
 
 COMMIT;

--- a/tests/eval/test_retrieval_runner.py
+++ b/tests/eval/test_retrieval_runner.py
@@ -60,17 +60,18 @@ def _pr(uid, type_: str = "fact", score: float = 0.8) -> PipelineResult:
     )
 
 
-async def _fake_pipeline_hit(query, heart, brain, settings, limit, memory_types):
+async def _fake_pipeline_hit(query, heart, brain, settings, limit, memory_types, **kwargs):
     """Return a hit at rank 1 for any query."""
     uid = uuid4()
     return [_pr(uid)], PipelineStats()
 
 
-async def _fake_pipeline_miss(query, heart, brain, settings, limit, memory_types):
+async def _fake_pipeline_miss(query, heart, brain, settings, limit, memory_types, **kwargs):
     return [], PipelineStats()
 
 
-async def _fake_pipeline_raises(query, heart, brain, settings, limit, memory_types):
+
+async def _fake_pipeline_raises(query, heart, brain, settings, limit, memory_types, **kwargs):
     raise RuntimeError("synthetic failure from fake pipeline")
 
 
@@ -257,7 +258,7 @@ async def test_score_rank_first_gold_match() -> None:
     gold = uuid4()
     other = uuid4()
 
-    async def _pipeline(query, heart, brain, settings, limit, memory_types):
+    async def _pipeline(query, heart, brain, settings, limit, memory_types, **kwargs):
         return [_pr(other), _pr(gold), _pr(uuid4())], PipelineStats()
 
     cfgs = [RetrievalConfig(name="baseline", flags={})]

--- a/tests/test_f065_storage.py
+++ b/tests/test_f065_storage.py
@@ -68,17 +68,51 @@ class TestClassify:
         assert classify("extracted_from", source="structural") == "deterministic"
         assert classify("discussed_in", source="structural") == "deterministic"
 
-    def test_source_structural_overrides_inferred(self) -> None:
-        # Edge case: structural source wins even when relation would be
-        # 'inferred'. This shouldn't happen in production but documents
-        # the precedence rule.
-        assert classify("contradicts", source="structural") == "deterministic"
+    def test_relation_contradicts_wins_over_source_structural(self) -> None:
+        # 2026-05-23: precedence rule reversed as part of F065 phase 4
+        # follow-up. The relation `contradicts` is inherently
+        # LLM-classifier inferred — calling it `deterministic` because
+        # someone tagged the writer as `structural` would lie about how
+        # the edge was determined. Structurally-deterministic relations
+        # (supersedes) win over source; for other relations the source
+        # tag is the disambiguator. Hypothetical case; no caller passes
+        # this combination in production today.
+        assert classify("contradicts", source="structural") == "inferred"
 
     def test_unknown_source_is_ignored(self) -> None:
         # Defense in depth: an unknown source value must NOT silently
-        # change behavior. Only 'structural' is recognized.
+        # change behavior. Only the registered values are recognized.
         assert classify("related_to", source="experimental") == "heuristic"
         assert classify("supersedes", source="experimental") == "deterministic"
+
+    def test_source_auto_linker_routes_to_inferred(self) -> None:
+        # F065 phase 4 follow-up (2026-05-23): cosine-derived auto-linker
+        # writes get the `inferred` tier so the F065 penalty multiplier
+        # actually has a population to apply to in prod (the F027
+        # classifier writes ~0 contradicts rows by design — see
+        # nous/heart/facts.py:35).
+        assert classify("related_to", source="auto_linker") == "inferred"
+        assert classify("evidence_for", source="auto_linker") == "inferred"
+        assert classify("informed_by", source="auto_linker") == "inferred"
+
+    def test_source_ce_backfill_routes_to_inferred(self) -> None:
+        # F040 sleep-cycle cross-encoder backfill is also cosine-derived
+        # and shares the same trust tier as the live auto-linker.
+        assert classify("related_to", source="ce_backfill") == "inferred"
+        assert classify("evidence_for", source="ce_backfill") == "inferred"
+
+    def test_relation_supersedes_overrides_source_auto_linker(self) -> None:
+        # Precedence: structural-provenance relations win over any
+        # source tag. A theoretical caller passing source='auto_linker'
+        # with relation='supersedes' must still classify as
+        # deterministic — supersedes encodes structural provenance in
+        # the relation itself.
+        assert classify("supersedes", source="auto_linker") == "deterministic"
+
+    def test_relation_contradicts_keeps_inferred_under_auto_linker(self) -> None:
+        # Both rules agree on `inferred` here; the precedence ordering
+        # just shouldn't shift it to anything else.
+        assert classify("contradicts", source="auto_linker") == "inferred"
 
     def test_extraction_method_literal_type(self) -> None:
         # Type-level smoke: classify's return type is the ExtractionMethod

--- a/tests/test_retrieval_pipeline.py
+++ b/tests/test_retrieval_pipeline.py
@@ -266,6 +266,81 @@ class TestRunRecallPipeline:
         assert DECISION_TWO_ID in d1.contradicts
 
     @pytest.mark.asyncio
+    async def test_rerank_by_score_merges_graph_into_top_k(self):
+        """F065 follow-up (2026-05-23): when rerank_by_score=True, the
+        assembled list is stably re-sorted by score descending. Graph-
+        expanded items whose score exceeds a heart_result's score should
+        be able to rank into the top window — the whole point of the flag.
+        Stable sort preserves stage order for equal scores so the snapshot-
+        protected default path is untouched.
+        """
+        # Build a heart pool with a LOW score and a graph_expanded with a
+        # HIGH score. Without the flag the graph item ends up last; with
+        # the flag it should leapfrog into rank 1.
+        low_score_heart = RecallResult(
+            type="fact",
+            id=FACT_ID,
+            summary="low-scored heart hit",
+            score=0.10,
+        )
+        heart = _make_heart(recall_results=[low_score_heart])
+        # Brain neighbors with a high edge_weight so the score after
+        # decay (0.7 default) is still ~0.9 — beats the heart item.
+        high_score_neighbor = NeighborResult(
+            id=HEART_GRAPH_DECISION_ID,
+            node_type="decision",
+            description="high-scoring graph neighbor",
+            edge_relation="supports",
+            edge_weight=1.3,  # 1.3 * 0.7 decay = 0.91, beats 0.10
+            created_at=datetime.now(UTC),
+        )
+        brain = _make_brain(
+            neighbors_by_node={
+                FACT_ID: [high_score_neighbor],
+                EPISODE_ID: [],
+            },
+            contradictions=[],
+            decision_results=[],
+        )
+        settings = _make_settings()
+
+        # Baseline (rerank_by_score=False, default): stage order — heart first.
+        baseline_results, _ = await run_recall_pipeline(
+            query="anything",
+            heart=heart,
+            brain=brain,
+            settings=settings,
+            limit=10,
+        )
+        assert baseline_results[0].id == FACT_ID, "default path keeps stage order"
+
+        # Reset mocks so the heart.recall returns the same result on the
+        # opt-in call.
+        heart = _make_heart(recall_results=[low_score_heart])
+        brain = _make_brain(
+            neighbors_by_node={
+                FACT_ID: [high_score_neighbor],
+                EPISODE_ID: [],
+            },
+            contradictions=[],
+            decision_results=[],
+        )
+
+        # Opt-in (rerank_by_score=True): score-sorted — graph item climbs.
+        merged_results, _ = await run_recall_pipeline(
+            query="anything",
+            heart=heart,
+            brain=brain,
+            settings=settings,
+            limit=10,
+            rerank_by_score=True,
+        )
+        assert merged_results[0].id == HEART_GRAPH_DECISION_ID, (
+            "rerank_by_score=True must place the high-scored graph item at rank 1"
+        )
+        assert merged_results[1].id == FACT_ID
+
+    @pytest.mark.asyncio
     async def test_decisions_only_skips_heart(self):
         heart = _make_heart(recall_results=[])
         brain = _make_brain(


### PR DESCRIPTION
## Summary

Three changes that together attempt to make the F065 penalty A/B empirically measurable on the F051 harness. The findings are durable and local-only until reviewed.

### Step 1 — F051 pipeline assembly fix
- `run_recall_pipeline(rerank_by_score=False)` parameter added. When True, the assembled stage outputs are stably re-sorted by score descending so graph-expanded items can compete with heart_results for the top-K window.
- Default `False` preserves the `recall_deep` tool's byte-identical snapshot (committed in fixtures).
- The F051 harness opts in via `retrieval_runner._run_one`.
- Without this, graph-expanded items always land at position 11+ in the stage-order concatenation — making **every** graph-touching feature (F022 spreading, F030 MMR-after-graph, F065 penalty) invisible to a top-K=10 eval regardless of corpus or scoring.

### Step 2 — eval-only synthesis script
- `nous_eval/synthesize_inferred_edges.py` mutates the eval DB to relabel auto-linker rows as `inferred`. Used to validate the impact dry-run before committing to step 3's prod migration.

### Step 3 — writer-identity classification (prod-ready)
- `edge_provenance.classify` now accepts `source='auto_linker'` / `'ce_backfill'` routing to `inferred`.
- All cosine-derived call sites in `nous/brain/graph_linker.py` + the related_to writer in `nous/brain/brain.py` + defensive Brain._link tagging now pass the writer identity.
- Precedence reversed: relation-deterministic (`supersedes`) and relation-inferred (`contradicts`) win over source tag — the relation itself encodes structural provenance.
- New migration `049_f065_auto_linker_inferred.sql` backfills existing rows where `auto_linked=true AND extraction_method='heuristic' AND relation NOT IN ('supersedes','contradicts')` → `inferred`.

## Empirical findings (eval DB, probes corpus, top-K=10)

After all 3 steps applied:

| config           | MRR   | P@1   | nDCG@10 |
|------------------|-------|-------|---------|
| baseline         | 0.376 | 0.292 | 0.265   |
| f065_penalty_on  | 0.376 | 0.292 | 0.265   |

**Δ across every metric: +0.0%.** The F065 penalty hypothesis (down-weighting cosine-auto-linker edges improves retrieval) is **NOT empirically supported** on this corpus + pipeline.

Why: even with the merge fix exposing graph items to top-K, the CE-reranked heart_results dominate the top window. Graph items rarely reach top-K to be affected by the penalty. The 1957 newly-inferred edges (was 0 pre-migration) get penalized but never matter for ranking.

## Decision matrix

- **Step 1 (pipeline merge)**: clear value — unblocks ALL future graph-feature evaluation. Ship if you trust the per-feature scoring; default flag is off so `recall_deep` tool output is unchanged.
- **Step 2 (synthesis script)**: eval-only tool, no prod impact. Useful for dry-running future migrations.
- **Step 3 (writer-identity + migration)**: classification IS correct now (cosine auto-linker writes are inherently "inferred"-tier in nature). But the F065 penalty itself adds no measurable value given current evidence. Two options:
  - Ship step 3 as-is + keep `graph_inferred_edge_penalty=1.0` default. Plumbing aligned with reality, penalty stays dormant.
  - Drop F065 phase 4 (the penalty multiplier) entirely, keep step 3 for classification correctness only.

## Test plan
- [x] `pytest tests/test_f065_storage.py tests/test_f065_writer_coverage.py tests/test_retrieval_pipeline.py tests/test_f065_hub_shift.py` — 57/57 passing.
- [x] Migration 049 applied on eval DB — reclassified 1034 rows; final state {deterministic:9, inferred:1957}.
- [x] End-to-end F051 baseline vs f065_penalty_on with merged pipeline — Δ=0.0% confirmed.
- [ ] No prod migration applied. PR is the decision artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)