### PR TITLE
fix(F066.1): expose fix nodes through dag_create tool surface

### DIFF
--- a/nous/api/tools.py
+++ b/nous/api/tools.py
@@ -2739,7 +2739,7 @@ def register_dag_tools(
                         # when type='fix'; the DAGCreateRequest validator
                         # enforces parent_node + non-empty fix_actions for
                         # fix nodes and rejects these fields on non-fix nodes.
-                        "parent_node": {"type": "string", "description": "F066.1 (type='fix' only): name of the node this fix attaches to. Fires when the parent transitions to 'failed'. The matching 'on_failure' edge must have this node's name as from_node."},
+                        "parent_node": {"type": "string", "description": "F066.1 (type='fix' only): name of the node this fix attaches to. Fires when the parent transitions to 'failed'. The matching 'on_failure' edge MUST point from the parent to this fix node — i.e. from_node = (this parent_node value), to_node = (the fix node's own name). Pointing the edge the other direction fails validation."},
                         "fix_actions": {
                             "type": "array",
                             "items": {"type": "string", "enum": ["retry_as_is", "retry_with_amended_prompt", "mark_unrecoverable", "skip_and_continue"]},

--- a/nous/api/tools.py
+++ b/nous/api/tools.py
@@ -2562,20 +2562,44 @@ def register_dag_tools(
             # Parse nodes
             node_specs: list[DAGNodeSpec] = []
             for n in kwargs.get("nodes", []):
-                node_specs.append(DAGNodeSpec(
-                    name=n["name"],
-                    type=DAGNodeType(n["type"]),
-                    instructions=n.get("instructions", ""),
-                    description=n.get("description", ""),
-                    tools=n.get("tools"),
-                    frame_type=n.get("frame_type"),
-                    model=n.get("model"),
-                    timeout_seconds=n.get("timeout_seconds"),
-                    completion_condition=n.get("completion_condition"),
-                    completion_check=n.get("completion_check"),
-                    completion_check_interval=n.get("completion_check_interval"),
-                    max_check_attempts=n.get("max_check_attempts"),
-                ))
+                # F066.1 (2026-05-23): the orchestrator + schemas + migration
+                # shipped fix-node support, but this handler historically only
+                # threaded a fixed set of fields into DAGNodeSpec — so fix-node
+                # fields (parent_node, fix_actions, max_fix_attempts,
+                # expected_modes) were silently dropped at the tool surface,
+                # making fix nodes unauthorable via dag_create. Same silent-
+                # drop pattern affected F064.1's stall_timeout_seconds. The
+                # block below threads every field the schema accepts so
+                # future field additions to DAGNodeSpec land in dag_create
+                # automatically as long as the tool schema description in
+                # register() also exposes them.
+                node_data: dict[str, Any] = {
+                    "name": n["name"],
+                    "type": DAGNodeType(n["type"]),
+                    "instructions": n.get("instructions", ""),
+                    "description": n.get("description", ""),
+                    "tools": n.get("tools"),
+                    "frame_type": n.get("frame_type"),
+                    "model": n.get("model"),
+                    "timeout_seconds": n.get("timeout_seconds"),
+                    "completion_condition": n.get("completion_condition"),
+                    "completion_check": n.get("completion_check"),
+                    "completion_check_interval": n.get("completion_check_interval"),
+                    "max_check_attempts": n.get("max_check_attempts"),
+                    "stall_timeout_seconds": n.get("stall_timeout_seconds"),
+                    # F066.1 fix-node fields. Optional except for type='fix';
+                    # the DAGCreateRequest validator enforces parent_node +
+                    # non-empty fix_actions when type=='fix'.
+                    "parent_node": n.get("parent_node"),
+                    "fix_actions": n.get("fix_actions"),
+                    "expected_modes": n.get("expected_modes", []),
+                }
+                # max_fix_attempts has no nullable type (ge=1, le=3). Only
+                # forward it if the caller supplied a value so pydantic's
+                # default (1) applies otherwise.
+                if "max_fix_attempts" in n:
+                    node_data["max_fix_attempts"] = n["max_fix_attempts"]
+                node_specs.append(DAGNodeSpec(**node_data))
 
             # Parse edges
             edge_specs: list[DAGEdgeSpec] = []
@@ -2690,8 +2714,59 @@ def register_dag_tools(
         "properties": {
             "name": {"type": "string", "description": "DAG name"},
             "description": {"type": "string"},
-            "nodes": {"type": "array", "items": {"type": "object", "properties": {"name": {"type": "string"}, "type": {"type": "string", "enum": ["subtask", "check", "gate", "callback"]}, "instructions": {"type": "string"}, "tools": {"type": "array", "items": {"type": "string"}}, "frame_type": {"type": "string"}, "model": {"type": "string"}, "timeout_seconds": {"type": "integer", "minimum": 1, "description": "Execution timeout in seconds (default: NOUS_DAG_NODE_DEFAULT_TIMEOUT, ceiling: NOUS_DAG_NODE_MAX_TIMEOUT)"}, "completion_condition": {"type": "string"}, "completion_check": {"type": "string", "description": "Shell command polled each tick. Exit 0 = success, 1 = failed, 2 = still running."}, "completion_check_interval": {"type": "integer", "description": "Seconds between completion check polls (default: every tick)"}, "max_check_attempts": {"type": "integer", "description": "Max poll attempts before node fails"}}, "required": ["name", "type", "instructions"]}},
-            "edges": {"type": "array", "items": {"type": "object", "properties": {"from_node": {"type": "string"}, "to_node": {"type": "string"}, "edge_type": {"type": "string", "enum": ["dependency", "cancel_cascade", "context_flow"]}}, "required": ["from_node", "to_node"]}},
+            "nodes": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        # F066.1 (2026-05-23): added "fix" so fix-stage
+                        # recovery nodes are authorable. Phase 1 ships
+                        # rule-based dispatch; Phase 1.5 (NOUS_DAG_FIX_LLM_
+                        # DISPATCH_ENABLED) routes to Haiku tool-use.
+                        "type": {"type": "string", "enum": ["subtask", "check", "gate", "callback", "fix"]},
+                        "instructions": {"type": "string"},
+                        "tools": {"type": "array", "items": {"type": "string"}},
+                        "frame_type": {"type": "string"},
+                        "model": {"type": "string"},
+                        "timeout_seconds": {"type": "integer", "minimum": 1, "description": "Execution timeout in seconds (default: NOUS_DAG_NODE_DEFAULT_TIMEOUT, ceiling: NOUS_DAG_NODE_MAX_TIMEOUT)"},
+                        "stall_timeout_seconds": {"type": "integer", "minimum": 0, "description": "F064.1: max seconds without activity before failing this node. 0 = disabled for this node. Unset = inherit NOUS_DAG_NODE_DEFAULT_STALL_TIMEOUT."},
+                        "completion_condition": {"type": "string"},
+                        "completion_check": {"type": "string", "description": "Shell command polled each tick. Exit 0 = success, 1 = failed, 2 = still running."},
+                        "completion_check_interval": {"type": "integer", "description": "Seconds between completion check polls (default: every tick)"},
+                        "max_check_attempts": {"type": "integer", "description": "Max poll attempts before node fails"},
+                        # F066.1 — fix-stage recovery fields. Only meaningful
+                        # when type='fix'; the DAGCreateRequest validator
+                        # enforces parent_node + non-empty fix_actions for
+                        # fix nodes and rejects these fields on non-fix nodes.
+                        "parent_node": {"type": "string", "description": "F066.1 (type='fix' only): name of the node this fix attaches to. Fires when the parent transitions to 'failed'. The matching 'on_failure' edge must have this node's name as from_node."},
+                        "fix_actions": {
+                            "type": "array",
+                            "items": {"type": "string", "enum": ["retry_as_is", "retry_with_amended_prompt", "mark_unrecoverable", "skip_and_continue"]},
+                            "description": "F066.1 (type='fix' only): allowed action vocabulary. Phase 1 dispatcher rules: incomplete/validation_failed errors → retry_as_is; timed_out → skip_and_continue (or mark_unrecoverable); other errors → skip_and_continue then mark_unrecoverable as final fallback. retry_with_amended_prompt only acts when NOUS_DAG_FIX_LLM_DISPATCH_ENABLED=true."
+                        },
+                        "max_fix_attempts": {"type": "integer", "minimum": 1, "maximum": 3, "description": "F066.1 (type='fix' only): max fix attempts per parent failure. Default 1."},
+                        "expected_modes": {"type": "array", "items": {"type": "string"}, "description": "F066.1 (type='fix' only): declared failure modes for typed dispatch (Phase 2). Phase 1 ignores this field."},
+                    },
+                    "required": ["name", "type", "instructions"],
+                },
+            },
+            "edges": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "from_node": {"type": "string"},
+                        "to_node": {"type": "string"},
+                        # F066.1: added "on_failure" so the fix-node attach
+                        # edge is authorable. The validator requires exactly
+                        # one on_failure inbound edge per fix node, with
+                        # from_node == fix.parent_node.
+                        "edge_type": {"type": "string", "enum": ["dependency", "cancel_cascade", "context_flow", "on_failure"]},
+                    },
+                    "required": ["from_node", "to_node"],
+                },
+            },
             "source": {"type": "string"},
             "token_budget": {"type": "integer"},
         },

--- a/tests/test_dag_tools.py
+++ b/tests/test_dag_tools.py
@@ -133,6 +133,92 @@ class TestDagCreateTool:
         assert isinstance(result["content"][0]["text"], str)
 
     @pytest.mark.asyncio
+    async def test_dag_create_authors_fix_node(self, tools, dag_store):
+        """F066.1 (2026-05-23): dag_create must thread fix-node fields
+        (parent_node, fix_actions, max_fix_attempts, expected_modes) into
+        DAGNodeSpec. The historical handler dropped them silently — the
+        DAG appeared to create cleanly but the fix node was unreachable
+        because its required fields were lost at the tool surface.
+        """
+        handler = tools._handlers["dag_create"]
+        result = await handler(
+            name="fix-node-dag",
+            nodes=[
+                {"name": "fetch", "type": "subtask", "instructions": "Fetch data"},
+                {
+                    "name": "fix-fetch",
+                    "type": "fix",
+                    "instructions": "Recover from fetch failure",
+                    "parent_node": "fetch",
+                    "fix_actions": ["retry_as_is", "skip_and_continue"],
+                    "max_fix_attempts": 2,
+                    "expected_modes": ["timed_out"],
+                },
+            ],
+            edges=[
+                {"from_node": "fetch", "to_node": "fix-fetch", "edge_type": "on_failure"},
+            ],
+        )
+        text = result["content"][0]["text"]
+        # Handler reports success — not "Error".
+        assert "Error" not in text, f"dag_create unexpectedly failed: {text}"
+        assert "fix-node-dag" in text
+
+        # The fix-node fields actually landed in the persisted DAG.
+        dags = await dag_store.get_active_dags()
+        fix_node_dag = next(d for d in dags if d.name == "fix-node-dag")
+        fix_node = next(n for n in fix_node_dag.nodes if n.name == "fix-fetch")
+        assert fix_node.node_type == "fix"
+        assert fix_node.parent_node == "fetch"
+        assert fix_node.fix_actions == ["retry_as_is", "skip_and_continue"]
+        assert fix_node.max_fix_attempts == 2
+        assert fix_node.expected_modes == ["timed_out"]
+
+    @pytest.mark.asyncio
+    async def test_dag_create_fix_node_missing_parent_node_errors(self, tools):
+        """A fix node without parent_node should be rejected by the
+        DAGCreateRequest validator and surfaced as an error — not silently
+        accepted. Guards against the prior bug where parent_node was
+        dropped: an LLM that omits it accidentally would have gotten a
+        "running" DAG with a broken fix node."""
+        handler = tools._handlers["dag_create"]
+        result = await handler(
+            name="broken-fix",
+            nodes=[
+                {"name": "task", "type": "subtask", "instructions": "Do it"},
+                {
+                    "name": "fix-task",
+                    "type": "fix",
+                    "instructions": "Recover",
+                    # parent_node MISSING — must fail loudly
+                    "fix_actions": ["mark_unrecoverable"],
+                },
+            ],
+            edges=[
+                {"from_node": "task", "to_node": "fix-task", "edge_type": "on_failure"},
+            ],
+        )
+        text = result["content"][0]["text"]
+        assert "Error" in text
+        assert "parent_node" in text
+
+    @pytest.mark.asyncio
+    async def test_dag_create_tool_schema_advertises_fix_surface(self, tools):
+        """The tool's JSON schema (consumed by Anthropic tool-use
+        validation) must list 'fix' in node.type.enum and 'on_failure'
+        in edge.edge_type.enum, plus the four fix-node fields under
+        node.properties. Without these, the LLM can't even attempt to
+        author a fix node — the API rejects the call before the handler
+        sees it."""
+        schema = tools._schemas["dag_create"]
+        node_props = schema["properties"]["nodes"]["items"]["properties"]
+        assert "fix" in node_props["type"]["enum"]
+        for field in ("parent_node", "fix_actions", "max_fix_attempts", "expected_modes"):
+            assert field in node_props, f"node schema missing {field}"
+        edge_enum = schema["properties"]["edges"]["items"]["properties"]["edge_type"]["enum"]
+        assert "on_failure" in edge_enum
+
+    @pytest.mark.asyncio
     async def test_dag_create_handles_db_error(self, tools, dag_store, dag_orchestrator):
         """dag_create catches non-ValueError exceptions and returns clean error."""
         original_create = dag_store.create


### PR DESCRIPTION
## Summary
Closes the silent-drop gap between F066.1's shipped orchestrator/schema (PRs #433 + #435) and the \`dag_create\` tool surface in \`nous/api/tools.py\`. Without this fix, fix-stage recovery is unauthorable via normal agent flow — the Anthropic tool-use JSON-schema validator rejects \`\"type\": \"fix\"\` at the API edge, and even bypassing the LLM, the handler silently drops the four fix-specific fields.

## Bugs fixed

### 1. Tool schema enums missing values (rejected by Anthropic API)
\`\`\`diff
- "type": {"enum": ["subtask", "check", "gate", "callback"]}
+ "type": {"enum": ["subtask", "check", "gate", "callback", "fix"]}
- "edge_type": {"enum": ["dependency", "cancel_cascade", "context_flow"]}
+ "edge_type": {"enum": ["dependency", "cancel_cascade", "context_flow", "on_failure"]}
\`\`\`

### 2. Handler dropped fix-specific fields
\`DAGNodeSpec(...)\` construction at \`tools.py:2565-2578\` only forwarded a fixed set of fields. The schema-level fields \`parent_node\`, \`fix_actions\`, \`max_fix_attempts\`, \`expected_modes\` (F066.1) and \`stall_timeout_seconds\` (F064.1) were silently dropped — so even direct MCP calls bypassing the LLM produced a broken fix node.

Handler now threads every field DAGNodeSpec accepts, with \`max_fix_attempts\` conditionally forwarded so its pydantic default (1) applies when the caller omits it.

### 3. Schema didn't document the surface
Added per-field \`description\` blocks so the LLM knows when each fix-node field applies (only when \`type=='fix'\`), what \`fix_actions\` are allowed, and how Phase 1 dispatcher rules interact with them.

## Test plan
- [x] \`test_dag_create_authors_fix_node\` — end-to-end: create a DAG with a fix node, assert all four fix-specific fields landed in the persisted node.
- [x] \`test_dag_create_fix_node_missing_parent_node_errors\` — missing \`parent_node\` on a fix node now surfaces an error (vs the prior silent-success-with-broken-fix-node behavior).
- [x] \`test_dag_create_tool_schema_advertises_fix_surface\` — JSON-schema regression guard: \`fix\` in node.type.enum, \`on_failure\` in edge.edge_type.enum, and the four fix-node fields present in node.properties.
- [x] \`pytest tests/test_dag_tools.py tests/test_dag_schemas.py tests/test_dag_store.py tests/test_dag_orchestrator.py\` — 117/117 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)