### PR TITLE
feat(F067): log chunk surfacing per recall_deep call

### DIFF
--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -78,6 +78,12 @@ class PipelineStats:
     graph_expansion_used: bool = False
     spreading_activation_used: bool = False
     contradiction_checks_ran: bool = False
+    # F067 observability: True iff the chunk-recall stage was eligible
+    # AND attempted. Mirrors ``_PipelineAccumulator.chunks_searched`` —
+    # surfaced here so callers (recall_deep logger, eval harness) can
+    # distinguish "feature flag off / ineligible memory_types" from
+    # "stage ran but produced 0 chunks in top-K".
+    chunks_searched: bool = False
     n_heart_results: int = 0
     n_brain_results: int = 0
     n_graph_expanded: int = 0
@@ -233,6 +239,7 @@ async def run_recall_pipeline(
         graph_expansion_used=acc.graph_expansion_used,
         spreading_activation_used=acc.spreading_activation_used,
         contradiction_checks_ran=acc.contradiction_checks_ran,
+        chunks_searched=acc.chunks_searched,  # F067 observability
         n_heart_results=len(acc.heart_results),
         n_brain_results=len(acc.decision_results),
         n_graph_expanded=len(acc.graph_expanded),

--- a/nous/api/tools.py
+++ b/nous/api/tools.py
@@ -615,6 +615,26 @@ def create_nous_tools(brain: Brain, heart: Heart, settings: Settings | None = No
                 residual_activations=residual_activations or None,  # F055
                 rerank_by_score=chunks_rerank,
             )
+            # F067 observability: one INFO line per recall_deep call so
+            # operators can grep for chunk surfacing in prod without
+            # turning on F055 residual_activation. Logs the gate state
+            # (chunks_searched), how many chunks made the final top-K,
+            # and the total result count for quick eyeball checks.
+            n_chunks_in_topk = sum(
+                1 for r in results if getattr(r, "type", None) == "chunk"
+            )
+            logger.info(
+                "recall_deep agent=%s query_chars=%d limit=%d "
+                "chunks_enabled=%s chunks_searched=%s n_chunk_results=%d "
+                "n_total=%d",
+                brain.agent_id,
+                len(query or ""),
+                limit,
+                getattr(settings, "episode_chunks_enabled", False),
+                stats.chunks_searched,
+                n_chunks_in_topk,
+                len(results),
+            )
             # F067 Phase 2: optionally fetch parent episode summaries for
             # facts in the result set. Failures are non-fatal — the formatter
             # falls back to legacy output when parent_episodes is empty.

--- a/tests/test_recall_deep_chunk_logging.py
+++ b/tests/test_recall_deep_chunk_logging.py
@@ -1,0 +1,117 @@
+"""F067 observability: pin the recall_deep chunk-surfacing log line.
+
+The log line is the only direct visibility we have into whether the
+chunk-recall leg is alive in prod (F055 residual_activation can carry
+the same info but couples observability to a behavior-changing feature
+flag). Operators grep ``docker logs nous-agent`` for ``recall_deep``
+to spot-check chunk counts in real traffic.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nous.api.tools import create_nous_tools
+
+
+@pytest.fixture
+def mixed_pipeline_results():
+    """A small mix of fact + chunk results to assert the n_chunk count."""
+    from nous.api.retrieval_pipeline import PipelineResult, PipelineStats
+    results = [
+        PipelineResult(id=uuid.uuid4(), type="fact", description="f1",
+                       score=0.5, source="heart"),
+        PipelineResult(id=uuid.uuid4(), type="chunk", description="c1",
+                       score=0.9, source="heart"),
+        PipelineResult(id=uuid.uuid4(), type="chunk", description="c2",
+                       score=0.85, source="heart"),
+        PipelineResult(id=uuid.uuid4(), type="episode", description="e1",
+                       score=0.7, source="heart"),
+    ]
+    stats = PipelineStats(chunks_searched=True)
+    return results, stats
+
+
+def _make_settings(chunks_enabled: bool):
+    s = MagicMock()
+    s.episode_chunks_enabled = chunks_enabled
+    s.residual_activation_enabled = False
+    s.action_gating_enabled = False
+    s.claim_verification_enabled = False
+    s.context_compaction_enabled = False
+    s.execution_ledger_enabled = False
+    s.action_gating_external_only = False
+    s.action_gating_mode = "off"
+    s.claim_verification_mode = "off"
+    s.recall_include_parent_episodes = False
+    return s
+
+
+@pytest.mark.asyncio
+async def test_recall_deep_logs_chunk_surfacing_when_chunks_present(
+    mixed_pipeline_results, caplog
+):
+    """The INFO line must include chunks_enabled, chunks_searched, and
+    n_chunk_results — these are the three signals operators care about.
+    """
+    brain = MagicMock()
+    brain.agent_id = "test-agent"
+    heart = MagicMock()
+    settings = _make_settings(chunks_enabled=True)
+
+    tools = create_nous_tools(brain, heart, settings=settings)
+    recall_deep = tools["recall_deep"]
+
+    with patch(
+        "nous.api.retrieval_pipeline.run_recall_pipeline",
+        new=AsyncMock(return_value=mixed_pipeline_results),
+    ), caplog.at_level(logging.INFO, logger="nous.api.tools"):
+        await recall_deep(query="hello world", limit=10)
+
+    log_lines = [
+        rec.getMessage() for rec in caplog.records if "recall_deep" in rec.getMessage()
+    ]
+    assert log_lines, "expected at least one 'recall_deep' INFO log line"
+    msg = log_lines[-1]
+    assert "agent=test-agent" in msg
+    assert "chunks_enabled=True" in msg
+    assert "chunks_searched=True" in msg
+    assert "n_chunk_results=2" in msg
+    assert "n_total=4" in msg
+
+
+@pytest.mark.asyncio
+async def test_recall_deep_logs_zero_chunks_when_disabled(caplog):
+    """Counterpart: chunks off → flags reflect that. Operators rely on
+    zero counts being explicit, not absent."""
+    from nous.api.retrieval_pipeline import PipelineResult, PipelineStats
+    results = [
+        PipelineResult(id=uuid.uuid4(), type="fact", description=f"f{i}",
+                       score=0.5, source="heart")
+        for i in range(3)
+    ]
+    stats = PipelineStats(chunks_searched=False)
+
+    brain = MagicMock()
+    brain.agent_id = "test-agent"
+    heart = MagicMock()
+    settings = _make_settings(chunks_enabled=False)
+
+    tools = create_nous_tools(brain, heart, settings=settings)
+    recall_deep = tools["recall_deep"]
+
+    with patch(
+        "nous.api.retrieval_pipeline.run_recall_pipeline",
+        new=AsyncMock(return_value=(results, stats)),
+    ), caplog.at_level(logging.INFO, logger="nous.api.tools"):
+        await recall_deep(query="hi", limit=10)
+
+    msg = [
+        rec.getMessage() for rec in caplog.records if "recall_deep" in rec.getMessage()
+    ][-1]
+    assert "chunks_enabled=False" in msg
+    assert "chunks_searched=False" in msg
+    assert "n_chunk_results=0" in msg


### PR DESCRIPTION
## Summary

Operators have no visibility into whether the F067 chunk-recall leg is alive in prod. The only adjacent signal today is F055 residual activation surfacings written to ``heart.working_memory.items``, but that couples observability to a behavior-changing feature flag.

Adds one INFO log line per ``recall_deep`` call emitting agent_id, query length, limit, ``chunks_enabled``, ``chunks_searched``, ``n_chunk_results``, ``n_total``.

The three signals together cleanly distinguish:
- flag off → ``chunks_enabled=False, chunks_searched=False, n_chunk_results=0``
- flag on, ineligible memory_types → ``chunks_enabled=True, chunks_searched=False``
- flag on, eligible, but chunks lost top-K → ``chunks_searched=True, n_chunk_results=0``
- flag on, chunks in top-K → ``chunks_searched=True, n_chunk_results>0``

Threads ``chunks_searched`` from ``_PipelineAccumulator`` to ``PipelineStats`` so the API surface carries it.

Pure additive change — no behavior modification, byte-identical recall output preserved (snapshot test still passes).

## Test plan
- [x] 2 new tests pin both branches (chunks present → log has correct counts; chunks disabled → flags reflect that)
- [x] All 17 F067-adjacent tests pass (chunks_topk + chunk_logging + retrieval_pipeline)
- [x] Snapshot test still byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)