### PR TITLE
feat(F067): log chunk rank position, not just count

### DIFF
--- a/nous/api/tools.py
+++ b/nous/api/tools.py
@@ -618,21 +618,33 @@ def create_nous_tools(brain: Brain, heart: Heart, settings: Settings | None = No
             # F067 observability: one INFO line per recall_deep call so
             # operators can grep for chunk surfacing in prod without
             # turning on F055 residual_activation. Logs the gate state
-            # (chunks_searched), how many chunks made the final top-K,
-            # and the total result count for quick eyeball checks.
-            n_chunks_in_topk = sum(
+            # (chunks_searched), how many chunks reach the top-of-list,
+            # and where the first chunk lands in the global result order
+            # so we can spot "chunks retrieved but buried" cases.
+            n_chunks_total = sum(
                 1 for r in results if getattr(r, "type", None) == "chunk"
+            )
+            n_chunks_top10 = sum(
+                1 for r in results[:10] if getattr(r, "type", None) == "chunk"
+            )
+            first_chunk_rank = next(
+                (i + 1 for i, r in enumerate(results)
+                 if getattr(r, "type", None) == "chunk"),
+                None,
             )
             logger.info(
                 "recall_deep agent=%s query_chars=%d limit=%d "
-                "chunks_enabled=%s chunks_searched=%s n_chunk_results=%d "
+                "chunks_enabled=%s chunks_searched=%s "
+                "n_chunks_total=%d n_chunks_top10=%d first_chunk_rank=%s "
                 "n_total=%d",
                 brain.agent_id,
                 len(query or ""),
                 limit,
                 getattr(settings, "episode_chunks_enabled", False),
                 stats.chunks_searched,
-                n_chunks_in_topk,
+                n_chunks_total,
+                n_chunks_top10,
+                first_chunk_rank if first_chunk_rank is not None else "n/a",
                 len(results),
             )
             # F067 Phase 2: optionally fetch parent episode summaries for

--- a/tests/test_recall_deep_chunk_logging.py
+++ b/tests/test_recall_deep_chunk_logging.py
@@ -19,17 +19,37 @@ from nous.api.tools import create_nous_tools
 
 @pytest.fixture
 def mixed_pipeline_results():
-    """A small mix of fact + chunk results to assert the n_chunk count."""
+    """Order matters for first_chunk_rank: chunks at positions 2 and 3
+    (1-indexed) within a 4-item list."""
     from nous.api.retrieval_pipeline import PipelineResult, PipelineStats
     results = [
         PipelineResult(id=uuid.uuid4(), type="fact", description="f1",
-                       score=0.5, source="heart"),
+                       score=0.95, source="heart"),
         PipelineResult(id=uuid.uuid4(), type="chunk", description="c1",
                        score=0.9, source="heart"),
         PipelineResult(id=uuid.uuid4(), type="chunk", description="c2",
                        score=0.85, source="heart"),
         PipelineResult(id=uuid.uuid4(), type="episode", description="e1",
                        score=0.7, source="heart"),
+    ]
+    stats = PipelineStats(chunks_searched=True)
+    return results, stats
+
+
+@pytest.fixture
+def chunks_buried_results():
+    """Chunks at positions 11 and 12 of a 12-item list — simulating the
+    prod-observed case where chunks score lower than facts/decisions and
+    sit at the bottom of the global result list."""
+    from nous.api.retrieval_pipeline import PipelineResult, PipelineStats
+    results = [
+        PipelineResult(id=uuid.uuid4(), type="fact", description=f"f{i}",
+                       score=0.9 - i * 0.01, source="heart")
+        for i in range(10)
+    ] + [
+        PipelineResult(id=uuid.uuid4(), type="chunk", description=f"c{i}",
+                       score=0.5 - i * 0.01, source="heart")
+        for i in range(2)
     ]
     stats = PipelineStats(chunks_searched=True)
     return results, stats
@@ -79,8 +99,43 @@ async def test_recall_deep_logs_chunk_surfacing_when_chunks_present(
     assert "agent=test-agent" in msg
     assert "chunks_enabled=True" in msg
     assert "chunks_searched=True" in msg
-    assert "n_chunk_results=2" in msg
+    # 2 chunks total in the 4-item list
+    assert "n_chunks_total=2" in msg
+    # Both are in positions 2 and 3, so both fall within top-10
+    assert "n_chunks_top10=2" in msg
+    # First chunk is at rank 2 (1-indexed)
+    assert "first_chunk_rank=2" in msg
     assert "n_total=4" in msg
+
+
+@pytest.mark.asyncio
+async def test_recall_deep_logs_buried_chunks_at_correct_rank(
+    chunks_buried_results, caplog
+):
+    """Prod-observed pattern: chunks retrieved but buried at positions
+    11-12 behind facts. Top-10 count should be 0 even though
+    n_chunks_total=2."""
+    brain = MagicMock()
+    brain.agent_id = "test-agent"
+    heart = MagicMock()
+    settings = _make_settings(chunks_enabled=True)
+
+    tools = create_nous_tools(brain, heart, settings=settings)
+    recall_deep = tools["recall_deep"]
+
+    with patch(
+        "nous.api.retrieval_pipeline.run_recall_pipeline",
+        new=AsyncMock(return_value=chunks_buried_results),
+    ), caplog.at_level(logging.INFO, logger="nous.api.tools"):
+        await recall_deep(query="hello", limit=10)
+
+    msg = [
+        rec.getMessage() for rec in caplog.records if "recall_deep" in rec.getMessage()
+    ][-1]
+    assert "n_chunks_total=2" in msg
+    assert "n_chunks_top10=0" in msg
+    assert "first_chunk_rank=11" in msg
+    assert "n_total=12" in msg
 
 
 @pytest.mark.asyncio
@@ -114,4 +169,6 @@ async def test_recall_deep_logs_zero_chunks_when_disabled(caplog):
     ][-1]
     assert "chunks_enabled=False" in msg
     assert "chunks_searched=False" in msg
-    assert "n_chunk_results=0" in msg
+    assert "n_chunks_total=0" in msg
+    assert "n_chunks_top10=0" in msg
+    assert "first_chunk_rank=n/a" in msg


### PR DESCRIPTION
## Summary

PR #444's ``recall_deep`` log line emitted ``n_chunk_results=N`` which counted chunks anywhere in the result list. A live prod probe revealed ``n_chunk_results=10 n_total=44`` looked like "chunks reach the top" but actually meant "chunks are present somewhere" — in those prod calls all 10 chunks were buried at positions 16-25 of the Heart section, ranked below facts and procedures.

Replace ``n_chunk_results`` with three more honest fields:
- ``n_chunks_total``: count of chunk-type results anywhere in the list
- ``n_chunks_top10``: count of chunks in the first 10 results (what a top-K=10 consumer / quick-glance LLM actually sees first)
- ``first_chunk_rank``: 1-indexed position of the first chunk, or "n/a" if none

These three together let operators distinguish:
- chunks retrieved AND ranked high → ``first_chunk_rank`` low, ``top10`` > 0
- chunks retrieved but buried → ``top10=0, first_chunk_rank=11+``
- chunks not retrieved at all → ``first_chunk_rank=n/a``

Critical for spotting score-scale issues like the one observed today where facts/procedures systematically outrank chunks by 0.05-0.10.

## Test plan
- [x] 3 tests pin the three states (chunks present and ranked high, chunks buried, chunks absent)
- [x] All 9 F067-adjacent tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)