### PR TITLE
feat(F070): chunk-aware sleep consolidation (v1: edges only)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -499,6 +499,16 @@ DB connection vars are **unprefixed** (shared with docker-compose). All others u
 | `NOUS_RECALL_INCLUDE_PARENT_EPISODES` | `false` | F067 Phase 2. When true, `recall_deep` appends up to `recall_max_parent_episodes` parent episode summaries to its text output. **Validated on per-question isolation only; opt-in for prod.** |
 | `NOUS_RECALL_MAX_PARENT_EPISODES` | `2` | F067 cap on parent episode summaries appended (deduplicated). |
 | `NOUS_RECALL_PARENT_EPISODE_TRUNCATE` | `500` | F067 per-parent-episode summary char truncation. |
+| `NOUS_CHUNK_CONSOLIDATION_ENABLED` | `false` | F070 master switch. When true, `GraphDensifier.run_backfill_cycle` (and the standalone `scripts/backfill_f070_chunks.py`) build chunk→episode `part_of`, chunk→fact `summarized_by` (same-episode), and chunk↔chunk `related_to` edges. Required to populate the chunk-graph that Path A's Stage 2b consumes. |
+| `NOUS_GRAPH_BACKFILL_MAX_CHUNKS` | `100` | F070 per-cycle cap on orphan chunks the densifier picks up. Used as the default batch size by `backfill_orphan_chunks` when no `max_count` override is passed. |
+| `NOUS_GRAPH_THRESHOLD_CHUNK_FACT` | `0.55` | F070 cosine threshold for chunk→fact `summarized_by` edges (same-episode only in v1). |
+| `NOUS_GRAPH_THRESHOLD_CHUNK_CHUNK_INTRA` | `0.70` | F070 cosine threshold for non-adjacent intra-episode chunk↔chunk edges. Adjacent chunks (chunk_index ± 1) always link at structural weight 1.0 regardless. |
+| `NOUS_GRAPH_THRESHOLD_CHUNK_CHUNK_CROSS` | `0.85` | F070 cosine threshold for cross-episode chunk↔chunk edges. Reserved; v1 does not yet write these (deferred to F070.1). |
+| `NOUS_HEART_GRAPH_ALL_TYPES_ENABLED` | `false` | F070 Path A master switch. When true, `run_recall_pipeline` Stage 2b expands fact/episode/chunk seeds to neighbors of all non-decision types (fact, episode, chunk, procedure) — required to activate F022 cross-type + F040 + F070 edges that today have no other consumer. Stage 2 (decision-only) is unaffected. |
+| `NOUS_HEART_GRAPH_NEIGHBORS_PER_SEED` | `3` | Path A per-(seed, neighbor_type) LIMIT for Stage 2b's `brain.neighbors` fan-out. Each fact/episode/chunk seed pulls up to N rows of each of {fact, episode, chunk, procedure} via separate calls (mirrors the SQL-pushdown discipline from Stage 2). |
+| `NOUS_SESSION_GROUP_HEART_SECTION` | `false` | When true, `_format_pipeline_text` groups Heart Memory items by source session_id with `-- Session abc12345 --` headers. Helps multi-session LLM synthesis. `_attach_fact_source_episodes` only fires when this flag is on (otherwise the source-episode lookup is a wasted DB roundtrip). |
+| `NOUS_GRAPH_ADJACENCY_BOOST_ENABLED` | `false` | When true, `run_recall_pipeline` applies a gbrain-style multiplicative boost to candidates connected via `brain.graph_edges` to other candidates in the same batch. Excludes `contradicts` edges. Inert until enough cross-candidate edges exist (F040/F070 backfill is the prereq). |
+| `NOUS_GRAPH_ADJACENCY_BOOST_ALPHA` | `0.15` | Max boost as a fraction of original score for the most-connected candidate. |
 
 ### REST Endpoints
 

--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -365,10 +365,18 @@ async def _run_stages(
         for hr in acc.heart_results[:3]:
             if hr.type in ("fact", "episode"):
                 try:
+                    # F070 fix: push the decision filter into SQL so
+                    # ``LIMIT 2`` returns 2 decisions, not 2 of (decisions
+                    # + chunks + facts + ...) which the Python filter
+                    # below would then mostly discard. With F070 adding
+                    # ~37K chunk→fact summarized_by edges, the un-filtered
+                    # union frequently returned 2 chunks → 0 decisions →
+                    # silent decision-expansion loss.
                     neighbors = await brain.neighbors(
                         hr.id,
                         node_type=hr.type,
                         limit=2,
+                        neighbor_type="decision",
                     )
                     for n in neighbors:
                         if n.node_type == "decision" and n.id not in seen_graph_ids:

--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -143,8 +143,9 @@ class _PipelineAccumulator:
     # Stage 5: contradiction edges (source_id, source_type, target_id, target_type)
     contradictions: list[tuple[UUID, str, UUID, str]] = field(default_factory=list)
 
-    # F067 Stage 1.5: chunk-recall results (id, content, score)
-    chunk_results: list[tuple[UUID, str, float]] = field(default_factory=list)
+    # F067 Stage 1.5: chunk-recall results
+    # Shape: (id, content, score, episode_id) — see _search_episode_chunks.
+    chunk_results: list[tuple[UUID, str, float, UUID]] = field(default_factory=list)
 
     # Flags
     searched_decisions: bool = False
@@ -416,7 +417,10 @@ async def _run_stages(
             mem_limit = max(1, int(settings.heart_graph_neighbors_per_seed))
             seen_mem_ids: set[UUID] = set()
             heart_ids: set[UUID] = {hr.id for hr in acc.heart_results}
-            chunk_ids: set[UUID] = {cid for cid, _, _ in acc.chunk_results}
+            # acc.chunk_results carries (id, content, score, episode_id) per
+            # _search_episode_chunks at line 825. Use star-unpack so future
+            # tuple shape changes don't crash this hot loop.
+            chunk_ids: set[UUID] = {item[0] for item in acc.chunk_results}
             # Heart seeds: top-K fact/episode results.
             mem_seeds: list[tuple[UUID, str]] = [
                 (hr.id, hr.type) for hr in acc.heart_results[:3]
@@ -425,7 +429,7 @@ async def _run_stages(
             # Chunk seeds: top-K F067 chunk-recall results (when present).
             # Chunks have rich same-episode neighborhoods via F070.
             mem_seeds.extend(
-                (cid, "chunk") for cid, _content, _score in acc.chunk_results[:3]
+                (item[0], "chunk") for item in acc.chunk_results[:3]
             )
             # Per-type fan-out — one ``LIMIT`` window per neighbor type so
             # chunks don't crowd facts/episodes (or vice versa) out of a

--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -126,6 +126,13 @@ class _PipelineAccumulator:
 
     # Stage 2: cross-type graph neighbors from Heart seeds (F022 Phase 2)
     heart_graph_decisions: list["NeighborResult"] = field(default_factory=list)
+    # Stage 2b: non-decision graph neighbors from Heart/chunk seeds.
+    # Path A (heart_graph_all_types_enabled): when set, this collects
+    # fact/episode/chunk/procedure neighbors that previously had no consumer.
+    # Kept distinct from heart_graph_decisions so the existing
+    # decision-focused stage's downstream formatter/scorer shape is
+    # unchanged when the flag is off.
+    heart_graph_memory_neighbors: list["NeighborResult"] = field(default_factory=list)
 
     # Stage 3: Brain decision results
     decision_results: list["DecisionSummary"] = field(default_factory=list)
@@ -207,6 +214,12 @@ async def run_recall_pipeline(
     # naturally co-displayed). Empty when feature flag is off.
     results.extend(_chunks_to_pipeline(acc.chunk_results))
     results.extend(_heart_graph_to_pipeline(acc.heart_graph_decisions, settings))
+    # Path A: non-decision neighbors land in the same stage-order slot as the
+    # decision-only graph results so subsequent ``rerank_by_score`` reorders
+    # them uniformly with everything else.
+    results.extend(_heart_graph_memory_to_pipeline(
+        acc.heart_graph_memory_neighbors, settings,
+    ))
     results.extend(_decisions_to_pipeline(acc.decision_results))
     # P1.1: batch-resolve source_episode_id for fact-type results so the
     # formatter can session-group the Heart section. Episodes already carry
@@ -388,6 +401,83 @@ async def _run_stages(
                     acc.stage_errors["heart_graph_neighbors"] = (
                         acc.stage_errors.get("heart_graph_neighbors", 0) + 1
                     )
+
+        # ------------------------------------------------------------------
+        # Stage 2b (Path A): non-decision graph neighbors from Heart seeds.
+        # Path-A activates F022 cross-type / F040 / F070 edges that today
+        # have no consumer beyond adjacency_boost. Each fact/episode/chunk
+        # seed fans out one ``brain.neighbors`` call per target neighbor
+        # type so a small ``LIMIT`` returns N rows of THAT type, not N
+        # rows that the dedup below would mostly throw away. Mirrors the
+        # Stage 2 SQL-pushdown fix (F070 review round 6) one floor up.
+        # Flag-gated so prod retrieval shape is unchanged by default.
+        # ------------------------------------------------------------------
+        if settings.heart_graph_all_types_enabled:
+            mem_limit = max(1, int(settings.heart_graph_neighbors_per_seed))
+            seen_mem_ids: set[UUID] = set()
+            heart_ids: set[UUID] = {hr.id for hr in acc.heart_results}
+            chunk_ids: set[UUID] = {cid for cid, _, _ in acc.chunk_results}
+            # Heart seeds: top-K fact/episode results.
+            mem_seeds: list[tuple[UUID, str]] = [
+                (hr.id, hr.type) for hr in acc.heart_results[:3]
+                if hr.type in ("fact", "episode")
+            ]
+            # Chunk seeds: top-K F067 chunk-recall results (when present).
+            # Chunks have rich same-episode neighborhoods via F070.
+            mem_seeds.extend(
+                (cid, "chunk") for cid, _content, _score in acc.chunk_results[:3]
+            )
+            # Per-type fan-out — one ``LIMIT`` window per neighbor type so
+            # chunks don't crowd facts/episodes (or vice versa) out of a
+            # single small union limit. Order is irrelevant; the global
+            # rerank handles final ordering.
+            mem_neighbor_types = ("fact", "episode", "chunk", "procedure")
+            for seed_id, seed_type in mem_seeds:
+                for nbr_type in mem_neighbor_types:
+                    try:
+                        mem_neighbors = await brain.neighbors(
+                            seed_id,
+                            node_type=seed_type,
+                            limit=mem_limit,
+                            neighbor_type=nbr_type,
+                        )
+                    except Exception:
+                        # Mirror chunk-recall (Stage 1.5) pattern: log + count.
+                        # ``stage_errors`` is discarded by prod callers
+                        # (recall_deep tool), so the log is the operator's
+                        # only signal that Path A is broken in prod.
+                        logger.warning(
+                            "Path A: heart_graph_memory_neighbors brain.neighbors "
+                            "failed for agent=%s seed=%s seed_type=%s nbr_type=%s "
+                            "(non-fatal, this fan-out path contributes nothing this turn)",
+                            brain.agent_id, seed_id, seed_type, nbr_type,
+                            exc_info=True,
+                        )
+                        acc.stage_errors["heart_graph_memory_neighbors"] = (
+                            acc.stage_errors.get("heart_graph_memory_neighbors", 0) + 1
+                        )
+                        continue
+                    for n in mem_neighbors:
+                        # Decision neighbors are handled by Stage 2 above; even
+                        # though we passed neighbor_type=nbr_type (non-decision),
+                        # keep the guard for defense against future filter drift.
+                        if n.node_type == "decision":
+                            continue
+                        if n.id in seen_mem_ids:
+                            continue
+                        # Skip duplicates against existing candidate pool. Track
+                        # duplicates as a separate counter so eval can distinguish
+                        # "graph found nothing new" from "graph corroborated a
+                        # direct hit" — the latter is signal, not noise.
+                        if n.id in heart_ids or n.id in chunk_ids:
+                            acc.stage_errors["heart_graph_memory_duplicates"] = (
+                                acc.stage_errors.get(
+                                    "heart_graph_memory_duplicates", 0,
+                                ) + 1
+                            )
+                            continue
+                        acc.heart_graph_memory_neighbors.append(n)
+                        seen_mem_ids.add(n.id)
 
     # ------------------------------------------------------------------
     # Stage 3+4: Brain decisions + graph expansion
@@ -783,6 +873,31 @@ def _heart_graph_to_pipeline(
             metadata={"stage_origin": "heart_graph"},
         )
         for n in heart_graph
+    ]
+
+
+def _heart_graph_memory_to_pipeline(
+    memory_neighbors: list["NeighborResult"], settings: "Settings"
+) -> list[PipelineResult]:
+    """Path A: non-decision graph-neighbor results.
+
+    Carries the neighbor's actual ``node_type`` (fact/episode/chunk/procedure)
+    so the formatter and downstream scorers can route them like any other
+    memory candidate. Scoring uses the same decay + F065 provenance penalty
+    pattern as the decision-neighbor path.
+    """
+    decay = settings.graph_recall_decay
+    return [
+        PipelineResult(
+            id=n.id,
+            type=n.node_type,
+            description=n.description,
+            score=_f065_provenance_penalty(n, n.edge_weight, decay, settings),
+            source="graph_expanded",
+            edge_relation=n.edge_relation,
+            metadata={"stage_origin": "heart_graph_memory"},
+        )
+        for n in memory_neighbors
     ]
 
 

--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -212,7 +212,10 @@ async def run_recall_pipeline(
     # formatter can session-group the Heart section. Episodes already carry
     # their id as the session; chunks got their episode_id from the chunk
     # search query. Facts need a follow-up lookup.
-    results = await _attach_fact_source_episodes(heart, results)
+    # Codex round-5 P2: gated behind the consumer flag so the extra
+    # DB round-trip doesn't run on every recall when the feature is off.
+    if getattr(settings, "session_group_heart_section", False):
+        results = await _attach_fact_source_episodes(heart, results)
 
     # P2: graph-adjacency boost (gbrain-inspired). When connected via
     # sleep-built edges (F040), candidates reinforce each other. Gated
@@ -575,10 +578,15 @@ async def _apply_graph_adjacency_boost(
     candidate_ids = [str(r.id) for r in results]
     try:
         async with brain.db.session() as s:
+            # Codex round-5 P2: exclude `contradicts` so mutually
+            # inconsistent candidates don't reinforce each other.
+            # Aligns with the spreading-activation filter at
+            # spreading_activation.py:103.
             rows = (await s.execute(sa_text(
                 "SELECT source_id::text, target_id::text, weight "
                 "FROM brain.graph_edges "
                 "WHERE agent_id = :a "
+                "  AND relation != 'contradicts' "
                 "  AND source_id = ANY(CAST(:ids AS uuid[])) "
                 "  AND target_id = ANY(CAST(:ids AS uuid[]))"
             ), {"a": brain.agent_id, "ids": candidate_ids})).all()

--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -208,6 +208,20 @@ async def run_recall_pipeline(
     results.extend(_chunks_to_pipeline(acc.chunk_results))
     results.extend(_heart_graph_to_pipeline(acc.heart_graph_decisions, settings))
     results.extend(_decisions_to_pipeline(acc.decision_results))
+    # P1.1: batch-resolve source_episode_id for fact-type results so the
+    # formatter can session-group the Heart section. Episodes already carry
+    # their id as the session; chunks got their episode_id from the chunk
+    # search query. Facts need a follow-up lookup.
+    results = await _attach_fact_source_episodes(heart, results)
+
+    # P2: graph-adjacency boost (gbrain-inspired). When connected via
+    # sleep-built edges (F040), candidates reinforce each other. Gated
+    # by feature flag; default off.
+    if getattr(settings, "graph_adjacency_boost_enabled", False):
+        alpha = float(getattr(settings, "graph_adjacency_boost_alpha", 0.15))
+        results = await _apply_graph_adjacency_boost(
+            brain, results, alpha=alpha,
+        )
     results.extend(_graph_expanded_to_pipeline(acc.graph_expanded, settings))
 
     # Attach contradiction links to matching results
@@ -530,24 +544,143 @@ def _heart_results_to_pipeline(
     ]
 
 
+async def _apply_graph_adjacency_boost(
+    brain: "Brain",
+    results: list[PipelineResult],
+    *,
+    alpha: float = 0.15,
+) -> list[PipelineResult]:
+    """Boost candidates connected to other candidates via graph edges.
+
+    Hypothesis (gbrain-inspired): when several retrieved items belong to
+    the same semantic cluster (connected by sleep-built inferred edges,
+    F040 graph densification), they reinforce each other — the cluster
+    is more likely to be the right answer.
+
+    Algorithm:
+        1. Find edges in ``brain.graph_edges`` where BOTH endpoints are in
+           the candidate set.
+        2. Sum edge weights per candidate to get an "adjacency degree".
+        3. Apply multiplicative boost: ``score *= (1 + alpha * d/max_d)``.
+        4. Re-sort by boosted score.
+
+    Fails open: any DB error returns the original list unchanged.
+    """
+    from dataclasses import replace
+    from sqlalchemy import text as sa_text
+
+    if not results or len(results) < 2:
+        return results
+
+    candidate_ids = [str(r.id) for r in results]
+    try:
+        async with brain.db.session() as s:
+            rows = (await s.execute(sa_text(
+                "SELECT source_id::text, target_id::text, weight "
+                "FROM brain.graph_edges "
+                "WHERE agent_id = :a "
+                "  AND source_id = ANY(CAST(:ids AS uuid[])) "
+                "  AND target_id = ANY(CAST(:ids AS uuid[]))"
+            ), {"a": brain.agent_id, "ids": candidate_ids})).all()
+    except Exception:
+        return results  # fail-open — adjacency boost is a refinement
+
+    degree: dict[str, float] = {}
+    for src, tgt, w in rows:
+        w = float(w or 0.0)
+        degree[src] = degree.get(src, 0.0) + w
+        degree[tgt] = degree.get(tgt, 0.0) + w
+
+    if not degree:
+        return results
+    max_deg = max(degree.values())
+    if max_deg <= 0:
+        return results
+
+    boosted = []
+    for r in results:
+        d = degree.get(str(r.id), 0.0)
+        boost = 1.0 + alpha * (d / max_deg)
+        boosted.append(replace(r, score=(r.score or 0.0) * boost))
+    boosted.sort(key=lambda r: r.score or 0.0, reverse=True)
+    return boosted
+
+
+async def _attach_fact_source_episodes(
+    heart: "Heart", results: list[PipelineResult],
+) -> list[PipelineResult]:
+    """P1.1: batch-attach source_episode_id to fact-type PipelineResults.
+
+    Used by the formatter to session-group the Heart Memory section. One
+    SQL query for all fact IDs; failures (DB error, missing fact) leave
+    metadata unchanged so the formatter falls back to flat listing.
+
+    Chunks already carry source_episode_id from _search_episode_chunks.
+    Episodes use their own id as the session. Procedures/decisions don't
+    belong to a session — left untouched.
+    """
+    from dataclasses import replace
+    from sqlalchemy import text as sa_text
+    fact_ids = [str(r.id) for r in results if r.type == "fact"]
+    if not fact_ids:
+        return results
+    src_map: dict[str, str | None] = {}
+    try:
+        async with heart.db.session() as s:
+            res = await s.execute(sa_text(
+                "SELECT id::text, source_episode_id::text FROM heart.facts "
+                "WHERE id = ANY(CAST(:ids AS uuid[])) AND agent_id = :a"
+            ), {"ids": fact_ids, "a": heart.agent_id})
+            rows = res.all()
+        for fid, src in rows:
+            src_map[fid] = src
+    except Exception:
+        # Fail-open: formatter will fall back to flat listing.
+        # Also catches test fixtures where heart.db.session() returns mocks
+        # that don't fully implement the async context-manager protocol.
+        return results
+
+    out = []
+    for r in results:
+        if r.type == "fact":
+            src = src_map.get(str(r.id))
+            if src and not r.metadata.get("source_episode_id"):
+                new_md = dict(r.metadata)
+                new_md["source_episode_id"] = src
+                out.append(replace(r, metadata=new_md))
+            else:
+                out.append(r)
+        else:
+            out.append(r)
+    return out
+
+
 def _chunks_to_pipeline(
-    chunk_results: list[tuple[UUID, str, float]],
+    chunk_results: list,
 ) -> list[PipelineResult]:
     """F067: convert chunk-search rows into PipelineResult.
 
     Chunks are tagged ``type="chunk"`` and ``source="heart"`` so they appear
     in the legacy Heart Memory section of the formatter without extra logic.
+
+    P1.1: accepts both 3-tuples ``(id, content, score)`` (legacy) and
+    4-tuples ``(id, content, score, episode_id)`` (new from
+    _search_episode_chunks). When episode_id is present, stash it in
+    metadata so the formatter can session-group.
     """
-    return [
-        PipelineResult(
-            id=cid,
-            type="chunk",
-            description=content,
-            score=score,
-            source="heart",
-        )
-        for cid, content, score in chunk_results
-    ]
+    out = []
+    for row in chunk_results:
+        if len(row) >= 4:
+            cid, content, score, episode_id = row[0], row[1], row[2], row[3]
+            md = {"source_episode_id": episode_id} if episode_id else {}
+        else:
+            cid, content, score = row[0], row[1], row[2]
+            md = {}
+        out.append(PipelineResult(
+            id=cid, type="chunk", description=content, score=score,
+            source="heart", metadata=md,
+        ))
+    return out
 
 
 async def _search_episode_chunks(
@@ -575,14 +708,15 @@ async def _search_episode_chunks(
         return []
     vec_lit = "[" + ",".join(f"{v:.6f}" for v in query_vec) + "]"
     async with heart.db.session() as s:
+        # P1.1: include episode_id so the formatter can session-group chunks.
         rows = (await s.execute(sa_text(
-            "SELECT id, content, 1 - (embedding <=> CAST(:v AS vector)) AS sim "
+            "SELECT id, content, 1 - (embedding <=> CAST(:v AS vector)) AS sim, episode_id "
             "FROM heart.episode_chunks "
             "WHERE agent_id = :a AND embedding IS NOT NULL "
             "ORDER BY embedding <=> CAST(:v AS vector) "
             "LIMIT :k"
         ), {"v": vec_lit, "a": agent_id, "k": limit})).all()
-    return [(r[0], r[1], float(r[2])) for r in rows]
+    return [(r[0], r[1], float(r[2]), r[3]) for r in rows]
 
 
 def _f065_provenance_penalty(

--- a/nous/api/tools.py
+++ b/nous/api/tools.py
@@ -218,6 +218,7 @@ def _format_pipeline_text(
     stats: "Any",  # PipelineStats
     search_types: list[str],
     parent_episodes: list[tuple[str, str]] | None = None,
+    session_group_heart: bool = False,
 ) -> str:
     """Format ``run_recall_pipeline`` output into legacy ``recall_deep`` text.
 
@@ -247,11 +248,51 @@ def _format_pipeline_text(
     if heart_section_eligible:
         if heart_results:
             results_text.append("=== Heart Memory ===")
-            for i, result in enumerate(heart_results, 1):
-                results_text.append(
-                    f"{i}. [{result.type}] {result.description} "
-                    f"(id: {result.id}, score: {result.score:.3f})"
-                )
+            if session_group_heart:
+                # P1.1: group facts/chunks/episodes by source session_id so
+                # the LLM sees session boundaries — helps multi-session
+                # reasoning. Sessions ordered by first-appearance in the
+                # ranked list. Procedures/censors don't belong to a session
+                # and are appended flat at the end of the bucket.
+                session_buckets: "dict[str, list]" = {}
+                no_session: list = []
+                for result in heart_results:
+                    if result.type == "episode":
+                        sess = str(result.id)
+                    elif result.type in ("fact", "chunk"):
+                        sess = result.metadata.get("source_episode_id")
+                        sess = str(sess) if sess else None
+                    else:
+                        sess = None
+                    if sess:
+                        session_buckets.setdefault(sess, []).append(result)
+                    else:
+                        no_session.append(result)
+                i = 1
+                for sess_id, items in session_buckets.items():
+                    results_text.append(f"-- Session {sess_id[:8]} --")
+                    for result in items:
+                        results_text.append(
+                            f"{i}. [{result.type}] {result.description} "
+                            f"(id: {result.id}, score: {result.score:.3f})"
+                        )
+                        i += 1
+                if no_session:
+                    if session_buckets:
+                        results_text.append("-- Other --")
+                    for result in no_session:
+                        results_text.append(
+                            f"{i}. [{result.type}] {result.description} "
+                            f"(id: {result.id}, score: {result.score:.3f})"
+                        )
+                        i += 1
+            else:
+                # Legacy flat output (byte-identical to pre-P1.1)
+                for i, result in enumerate(heart_results, 1):
+                    results_text.append(
+                        f"{i}. [{result.type}] {result.description} "
+                        f"(id: {result.id}, score: {result.score:.3f})"
+                    )
         else:
             results_text.append("=== Heart Memory ===\nNo results found.")
 
@@ -672,6 +713,7 @@ def create_nous_tools(brain: Brain, heart: Heart, settings: Settings | None = No
                     parent_episodes = []
             text = _format_pipeline_text(
                 results, stats, search_types, parent_episodes=parent_episodes,
+                session_group_heart=getattr(settings, "session_group_heart_section", False),
             )
 
             # F055: fire-and-forget record_surfaced so the request returns

--- a/nous/brain/_entity_config.py
+++ b/nous/brain/_entity_config.py
@@ -33,4 +33,8 @@ _ENTITY_CONFIG: dict[str, tuple[str, str, str, str]] = {
         "t.active = true",
     ),
     "procedure": ("heart.procedures", "procedure", "t.description", "t.active = true"),
+    # F070 (2026-05-25): chunk node type. heart.episode_chunks has no `active`
+    # column (deferred to F070.1), so the extra_where is the always-true
+    # placeholder. content_col is `t.content` (raw transcript fragment).
+    "chunk": ("heart.episode_chunks", "chunk", "t.content", "1=1"),
 }

--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -44,8 +44,12 @@ from nous.storage.models import (
     DecisionBridge,
     DecisionReason,
     DecisionTag,
+    Episode,
+    EpisodeChunk,
     Event,
+    Fact,
     GraphEdge,
+    Procedure,
     Thought,
 )
 
@@ -1210,23 +1214,98 @@ class Brain:
             method = r.extraction_method or "heuristic"  # F065: NULL → fail-open heuristic
             edge_map[r.neighbor_id] = (r.neighbor_type, r.edge_relation, r.edge_weight or 1.0, method)
 
-        # Resolve decision neighbors
-        decision_ids = [r.neighbor_id for r in rows if r.neighbor_type == "decision"]
+        # Resolve content per node type via one batched SELECT per type.
+        # Pre-Path-A, only ``decision`` was resolved and other types were
+        # rendered as ``"[<ntype>] <uuid>"`` placeholders — useful for
+        # decision-only consumers but useless once we let fact/episode/chunk/
+        # procedure neighbors reach retrieval (heart_graph_all_types_enabled).
+        ids_by_type: dict[str, list[UUID]] = defaultdict(list)
+        for r in rows:
+            ids_by_type[r.neighbor_type].append(r.neighbor_id)
+
         descriptions: dict[UUID, tuple[str, datetime]] = {}
-        if decision_ids:
+
+        # Decision: existing behavior, kept verbatim so consumers that only
+        # use decision neighbors observe no change.
+        if ids_by_type.get("decision"):
             dec_result = await session.execute(
                 select(Decision.id, Decision.description, Decision.created_at)
-                .where(Decision.id.in_(decision_ids))
+                .where(Decision.id.in_(ids_by_type["decision"]))
             )
             for d in dec_result.all():
                 descriptions[d.id] = (d.description, d.created_at)
 
+        # Fact: heart.facts.content
+        if ids_by_type.get("fact"):
+            f_result = await session.execute(
+                select(Fact.id, Fact.content, Fact.created_at)
+                .where(Fact.id.in_(ids_by_type["fact"]))
+            )
+            for f in f_result.all():
+                descriptions[f.id] = (f.content, f.created_at)
+
+        # Episode: heart.episodes.summary (matches _ENTITY_CONFIG fallback;
+        # structured_summary preferred at densifier time but plain summary
+        # is always populated).
+        if ids_by_type.get("episode"):
+            e_result = await session.execute(
+                select(Episode.id, Episode.summary, Episode.created_at)
+                .where(Episode.id.in_(ids_by_type["episode"]))
+            )
+            for e in e_result.all():
+                descriptions[e.id] = (e.summary, e.created_at)
+
+        # Chunk: heart.episode_chunks.content (F067 raw transcript fragment).
+        if ids_by_type.get("chunk"):
+            c_result = await session.execute(
+                select(EpisodeChunk.id, EpisodeChunk.content, EpisodeChunk.created_at)
+                .where(EpisodeChunk.id.in_(ids_by_type["chunk"]))
+            )
+            for c in c_result.all():
+                descriptions[c.id] = (c.content, c.created_at)
+
+        # Procedure: heart.procedures.description
+        if ids_by_type.get("procedure"):
+            p_result = await session.execute(
+                select(Procedure.id, Procedure.description, Procedure.created_at)
+                .where(Procedure.id.in_(ids_by_type["procedure"]))
+            )
+            for p in p_result.all():
+                # Procedure.description is nullable — fall back to placeholder
+                # so consumers don't get None.
+                desc_text = p.description or f"[procedure] {p.id}"
+                descriptions[p.id] = (desc_text, p.created_at)
+
         # Build results
+        # Node types where the content column is declared NOT NULL in models.py
+        # (Fact.content, Episode.summary, EpisodeChunk.content). An empty
+        # resolved description for these types means a data integrity issue
+        # (NOT NULL bypass, or a manual insert with empty string) — log it
+        # rather than silently shipping a placeholder candidate to rerank.
+        _NOT_NULL_CONTENT_TYPES = {"fact", "episode", "chunk"}
         results = []
         for r in rows:
             ntype, rel, weight, method = edge_map[r.neighbor_id]
-            if ntype == "decision" and r.neighbor_id in descriptions:
+            if r.neighbor_id in descriptions:
                 desc, created = descriptions[r.neighbor_id]
+                # Defensive: keep placeholder if resolved description is empty
+                # (DB rows with NULL/empty content shouldn't crash retrieval).
+                if not desc:
+                    if ntype in _NOT_NULL_CONTENT_TYPES:
+                        logger.warning(
+                            "brain._neighbors: empty/NULL content on "
+                            "%s id=%s (column is declared NOT NULL — "
+                            "data integrity issue)",
+                            ntype, r.neighbor_id,
+                        )
+                    desc = f"[{ntype}] {r.neighbor_id}"
+                if created is None:
+                    logger.warning(
+                        "brain._neighbors: NULL created_at on %s id=%s "
+                        "(column has server_default — possible migration bug)",
+                        ntype, r.neighbor_id,
+                    )
+                    created = datetime.now(UTC)
             else:
                 desc = f"[{ntype}] {r.neighbor_id}"
                 created = datetime.now(UTC)

--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -1126,12 +1126,28 @@ class Brain:
         relation: str | None = None,
         limit: int = 10,
         session: AsyncSession | None = None,
+        *,
+        neighbor_type: str | None = None,
     ) -> list[NeighborResult]:
-        """Get nodes connected to the given node via graph edges."""
+        """Get nodes connected to the given node via graph edges.
+
+        ``neighbor_type`` filters the SQL union to a single target node
+        type (e.g. ``"decision"``). Required to prevent F070's chunk
+        edges from crowding decisions out of small ``LIMIT`` windows in
+        ``heart_graph_neighbors`` — without it, ``LIMIT 2`` over the
+        full union can return zero decisions when a fact also has
+        ``summarized_by`` chunk neighbors.
+        """
         if session is None:
             async with self.db.session() as session:
-                return await self._neighbors(node_id, node_type, relation, limit, session)
-        return await self._neighbors(node_id, node_type, relation, limit, session)
+                return await self._neighbors(
+                    node_id, node_type, relation, limit, session,
+                    neighbor_type=neighbor_type,
+                )
+        return await self._neighbors(
+            node_id, node_type, relation, limit, session,
+            neighbor_type=neighbor_type,
+        )
 
     async def _neighbors(
         self,
@@ -1140,6 +1156,8 @@ class Brain:
         relation: str | None,
         limit: int,
         session: AsyncSession,
+        *,
+        neighbor_type: str | None = None,
     ) -> list[NeighborResult]:
         # Find edges where this node is source or target, matching node type.
         # F065: SELECT extraction_method so neighbors carry provenance tier
@@ -1171,6 +1189,13 @@ class Brain:
         if relation:
             source_q = source_q.where(GraphEdge.relation == relation)
             target_q = target_q.where(GraphEdge.relation == relation)
+
+        # F070 fix: push the neighbor-type filter into SQL so LIMIT N
+        # returns N rows of the requested type, not N rows that may all
+        # be filtered out by a downstream Python check.
+        if neighbor_type:
+            source_q = source_q.where(GraphEdge.target_type == neighbor_type)
+            target_q = target_q.where(GraphEdge.source_type == neighbor_type)
 
         union_q = source_q.union_all(target_q).limit(limit)
         result = await session.execute(union_q)

--- a/nous/brain/graph_densifier.py
+++ b/nous/brain/graph_densifier.py
@@ -605,6 +605,7 @@ class GraphDensifier:
                 "WHERE c.id = :chunk_id "
                 "  AND c.agent_id = :a "
                 "  AND f.agent_id = :a "
+                "  AND f.active = true "
                 "  AND f.source_episode_id = :ep_id "
                 "  AND f.embedding IS NOT NULL "
                 "  AND c.embedding IS NOT NULL "

--- a/nous/brain/graph_densifier.py
+++ b/nous/brain/graph_densifier.py
@@ -659,7 +659,12 @@ class GraphDensifier:
             return 0
         self_idx = self_row.chunk_index
 
-        # Fetch sibling chunks (same episode, different chunk_index)
+        # Fetch sibling chunks (same episode, different chunk_index).
+        # Don't filter by embedding presence: adjacent siblings must link
+        # even when their embedding is NULL (sequential adjacency is
+        # structural, not embedding-derived). For non-adjacent siblings
+        # without an embedding, the cosine yields NULL → sim=0 → blocked
+        # by the threshold gate below.
         siblings = (await session.execute(
             text(
                 "SELECT id, chunk_index, "
@@ -670,8 +675,7 @@ class GraphDensifier:
                 "FROM heart.episode_chunks "
                 "WHERE episode_id = :ep_id "
                 "  AND agent_id = :a "
-                "  AND id != :i "
-                "  AND embedding IS NOT NULL"
+                "  AND id != :i"
             ),
             {"i": chunk_id, "ep_id": episode_id, "a": self._agent_id},
         )).all()

--- a/nous/brain/graph_densifier.py
+++ b/nous/brain/graph_densifier.py
@@ -575,6 +575,8 @@ class GraphDensifier:
                     relation="part_of",
                     weight=1.0,
                     session=session,
+                    # FK-derived anchor — deterministic, not cosine-inferred.
+                    provenance_source="structural",
                 )
                 if edge is not None:
                     total += 1
@@ -705,11 +707,14 @@ class GraphDensifier:
                 # weight matches the documented structural anchor.
                 weight = 1.0
                 multiplier_override: float | None = 1.0
+                # chunk_index ± 1 is structural, not cosine-inferred.
+                provenance: str = "structural"
             elif sim >= cosine_threshold:
                 # Non-adjacent but similar enough — cosine drives weight;
                 # let the global related_to multiplier (0.8) discount it.
                 weight = sim
                 multiplier_override = None
+                provenance = "auto_linker"
             else:
                 continue
             edge = await self._linker.create_edge(
@@ -721,6 +726,7 @@ class GraphDensifier:
                 weight=weight,
                 session=session,
                 weight_multiplier_override=multiplier_override,
+                provenance_source=provenance,
             )
             if edge is not None:
                 created += 1

--- a/nous/brain/graph_densifier.py
+++ b/nous/brain/graph_densifier.py
@@ -40,6 +40,10 @@ _RELATION_MAP: dict[tuple[str, str], str] = {
     ("episode", "episode"): "related_to",
     ("episode", "procedure"): "related_to",
     ("procedure", "procedure"): "related_to",
+    # F070 (2026-05-25): chunk relations
+    ("chunk", "fact"): "summarized_by",       # chunk text → fact extracted from same episode
+    ("chunk", "episode"): "part_of",          # chunk → its source episode
+    ("chunk", "chunk"): "related_to",         # intra/cross-episode chunk similarity
 }
 
 
@@ -501,6 +505,202 @@ class GraphDensifier:
         logger.info("F040: backfill_orphan_episodes created %d edges from %d orphans", total, len(orphans))
         return total
 
+    async def backfill_orphan_chunks(
+        self,
+        max_count: int | None = None,
+    ) -> int:
+        """F070: find orphan chunks and build their graph edges.
+
+        Chunks live in ``heart.episode_chunks`` and are tightly coupled to a
+        source episode (``episode_id`` FK). Unlike facts/decisions/episodes
+        which use hybrid search to find candidates, chunk-backfill is
+        structurally local: edges target same-episode facts and same-episode
+        chunks. v1 builds:
+
+          - chunk → episode (always, weight=1.0)
+          - chunk → fact same-episode (cosine ≥ threshold_chunk_fact)
+          - chunk ↔ chunk intra-episode (sequential at weight=1.0 +
+            non-adjacent at cosine ≥ threshold_chunk_chunk_intra)
+
+        v1 does NOT build cross-episode chunk↔chunk dedup edges yet —
+        that requires hybrid search across the full chunks table and is
+        deferred to F070.1 along with the persistent-dedup column.
+        """
+        if not self._settings.chunk_consolidation_enabled:
+            return 0
+        if not self._settings.graph_backfill_enabled:
+            return 0
+
+        limit = max_count or self._settings.graph_backfill_max_chunks
+        thresh_chunk_fact = self._settings.graph_threshold_chunk_fact
+        thresh_chunk_chunk_intra = self._settings.graph_threshold_chunk_chunk_intra
+        total = 0
+
+        async with self.db.session() as session:
+            orphans = await self.find_orphans("chunk", limit, session)
+            for orphan_id, _content in orphans:
+                if self._interrupted:
+                    break
+
+                # 1. chunk → episode (always; FK guarantees the episode exists)
+                ep_row = (await session.execute(
+                    text(
+                        "SELECT episode_id FROM heart.episode_chunks "
+                        "WHERE id = :i AND agent_id = :a"
+                    ),
+                    {"i": orphan_id, "a": self._agent_id},
+                )).first()
+                if not ep_row or not ep_row.episode_id:
+                    continue
+                episode_id: UUID = ep_row.episode_id
+                edge = await self._linker.create_edge(
+                    source_id=orphan_id,
+                    target_id=episode_id,
+                    source_type="chunk",
+                    target_type="episode",
+                    relation="part_of",
+                    weight=1.0,
+                    session=session,
+                )
+                if edge is not None:
+                    total += 1
+
+                # 2. chunk → fact same-episode (cosine-ranked)
+                fact_edges = await self._link_chunk_to_same_episode_facts(
+                    orphan_id, episode_id, thresh_chunk_fact, session,
+                )
+                total += fact_edges
+
+                # 3. chunk ↔ chunk intra-episode (sequential + non-adjacent)
+                chunk_edges = await self._link_chunk_to_intra_episode_chunks(
+                    orphan_id, episode_id, thresh_chunk_chunk_intra, session,
+                )
+                total += chunk_edges
+
+            await session.commit()
+
+        logger.info(
+            "F070: backfill_orphan_chunks created %d edges from %d orphans",
+            total, len(orphans),
+        )
+        return total
+
+    async def _link_chunk_to_same_episode_facts(
+        self,
+        chunk_id: UUID,
+        episode_id: UUID,
+        threshold: float,
+        session: AsyncSession,
+    ) -> int:
+        """Link a chunk to facts extracted from the same episode.
+
+        Cosine similarity between chunk embedding and fact embedding; one
+        edge per fact above ``threshold``. Returns count of edges created.
+        """
+        rows = (await session.execute(
+            text(
+                "SELECT f.id, "
+                "  1 - (c.embedding <=> f.embedding) AS sim "
+                "FROM heart.episode_chunks c, heart.facts f "
+                "WHERE c.id = :chunk_id "
+                "  AND c.agent_id = :a "
+                "  AND f.agent_id = :a "
+                "  AND f.source_episode_id = :ep_id "
+                "  AND f.embedding IS NOT NULL "
+                "  AND c.embedding IS NOT NULL "
+                "  AND (1 - (c.embedding <=> f.embedding)) >= :thresh "
+                "ORDER BY sim DESC"
+            ),
+            {
+                "chunk_id": chunk_id, "ep_id": episode_id,
+                "a": self._agent_id, "thresh": threshold,
+            },
+        )).all()
+        created = 0
+        for row in rows:
+            edge = await self._linker.create_edge(
+                source_id=chunk_id,
+                target_id=row.id,
+                source_type="chunk",
+                target_type="fact",
+                relation="summarized_by",
+                weight=float(row.sim),
+                session=session,
+            )
+            if edge is not None:
+                created += 1
+        return created
+
+    async def _link_chunk_to_intra_episode_chunks(
+        self,
+        chunk_id: UUID,
+        episode_id: UUID,
+        cosine_threshold: float,
+        session: AsyncSession,
+    ) -> int:
+        """Link a chunk to other chunks in the same episode.
+
+        Two edge types:
+        - Adjacent chunks (chunk_index ± 1): always linked, weight=1.0
+        - Non-adjacent: cosine ≥ ``cosine_threshold``
+
+        Returns count of edges created.
+        """
+        # Fetch this chunk's index for sequential check
+        self_row = (await session.execute(
+            text(
+                "SELECT chunk_index FROM heart.episode_chunks "
+                "WHERE id = :i AND agent_id = :a"
+            ),
+            {"i": chunk_id, "a": self._agent_id},
+        )).first()
+        if not self_row:
+            return 0
+        self_idx = self_row.chunk_index
+
+        # Fetch sibling chunks (same episode, different chunk_index)
+        siblings = (await session.execute(
+            text(
+                "SELECT id, chunk_index, "
+                "  1 - (embedding <=> ("
+                "    SELECT embedding FROM heart.episode_chunks "
+                "    WHERE id = :i AND agent_id = :a"
+                "  )) AS sim "
+                "FROM heart.episode_chunks "
+                "WHERE episode_id = :ep_id "
+                "  AND agent_id = :a "
+                "  AND id != :i "
+                "  AND embedding IS NOT NULL"
+            ),
+            {"i": chunk_id, "ep_id": episode_id, "a": self._agent_id},
+        )).all()
+
+        created = 0
+        for row in siblings:
+            sibling_idx = row.chunk_index
+            sim = float(row.sim or 0.0)
+            is_adjacent = abs(sibling_idx - self_idx) == 1
+            if is_adjacent:
+                # Sequential link — always create, weight=1.0
+                weight = 1.0
+            elif sim >= cosine_threshold:
+                # Non-adjacent but similar enough — use cosine as weight
+                weight = sim
+            else:
+                continue
+            edge = await self._linker.create_edge(
+                source_id=chunk_id,
+                target_id=row.id,
+                source_type="chunk",
+                target_type="chunk",
+                relation="related_to",
+                weight=weight,
+                session=session,
+            )
+            if edge is not None:
+                created += 1
+        return created
+
     async def backfill_orphan_procedures(
         self,
         max_count: int | None = None,
@@ -577,6 +777,13 @@ class GraphDensifier:
             return _log_and_return(aborted=True)
 
         results["procedures"] = await self.backfill_orphan_procedures(ce_stats=ce_stats)
+        if self._interrupted:
+            return _log_and_return(aborted=True)
+
+        # F070 (2026-05-25): chunk consolidation. Gated by separate flag
+        # (chunk_consolidation_enabled) so it can ship independently of the
+        # main F040 backfill master switch.
+        results["chunks"] = await self.backfill_orphan_chunks()
         return _log_and_return(aborted=False)
 
     async def discover_clusters(self, max_bridges: int = 20) -> int:

--- a/nous/brain/graph_densifier.py
+++ b/nous/brain/graph_densifier.py
@@ -129,23 +129,31 @@ class GraphDensifier:
         entity_type: str,
         limit: int,
         session: AsyncSession,
+        *,
+        require_embedding: bool = True,
     ) -> list[tuple[UUID, str]]:
         """Find nodes with no graph edges (orphans).
 
         Returns list of (id, content_text) tuples for orphan nodes.
+
+        ``require_embedding=False`` allows F070 chunks whose embed call
+        failed to still receive structural edges (e.g. ``part_of``) that
+        don't depend on embeddings. Default keeps existing semantics for
+        all other entity types (cosine-driven backfill requires embeddings).
         """
         config = _ENTITY_CONFIG.get(entity_type)
         if not config:
             return []
 
         table, type_name, content_col, extra_where = config
+        embedding_clause = "AND t.embedding IS NOT NULL" if require_embedding else ""
 
         sql = text(f"""
             SELECT t.id, {content_col} AS content
             FROM {table} t
             WHERE t.agent_id = :agent_id
               AND {extra_where}
-              AND t.embedding IS NOT NULL
+              {embedding_clause}
               AND NOT EXISTS (
                   SELECT 1 FROM brain.graph_edges e
                   WHERE e.agent_id = :agent_id
@@ -537,7 +545,13 @@ class GraphDensifier:
         total = 0
 
         async with self.db.session() as session:
-            orphans = await self.find_orphans("chunk", limit, session)
+            # F070: chunks must always get the structural ``part_of`` edge,
+            # even when the embed call failed (heart.episode_chunks.embedding
+            # is nullable). Cosine-gated sub-stages return zero rows naturally
+            # when the source embedding is NULL.
+            orphans = await self.find_orphans(
+                "chunk", limit, session, require_embedding=False,
+            )
             for orphan_id, _content in orphans:
                 if self._interrupted:
                     break
@@ -686,11 +700,16 @@ class GraphDensifier:
             sim = float(row.sim or 0.0)
             is_adjacent = abs(sibling_idx - self_idx) == 1
             if is_adjacent:
-                # Sequential link — always create, weight=1.0
+                # Sequential link — always create, structural weight=1.0.
+                # Override the related_to multiplier (0.8) so the persisted
+                # weight matches the documented structural anchor.
                 weight = 1.0
+                multiplier_override: float | None = 1.0
             elif sim >= cosine_threshold:
-                # Non-adjacent but similar enough — use cosine as weight
+                # Non-adjacent but similar enough — cosine drives weight;
+                # let the global related_to multiplier (0.8) discount it.
                 weight = sim
+                multiplier_override = None
             else:
                 continue
             edge = await self._linker.create_edge(
@@ -701,6 +720,7 @@ class GraphDensifier:
                 relation="related_to",
                 weight=weight,
                 session=session,
+                weight_multiplier_override=multiplier_override,
             )
             if edge is not None:
                 created += 1

--- a/nous/brain/graph_linker.py
+++ b/nous/brain/graph_linker.py
@@ -94,6 +94,7 @@ class GraphLinker:
         session: AsyncSession,
         *,
         weight_multiplier_override: float | None = None,
+        provenance_source: str = "auto_linker",
     ) -> GraphEdgeInfo | None:
         """Create a graph edge with relation-aware weight multiplier.
 
@@ -106,6 +107,13 @@ class GraphLinker:
         sequential chunk adjacency, which is structural (weight=1.0) but
         reuses the ``related_to`` relation (multiplier 0.8). Without the
         override, the persisted weight would be 0.8, not 1.0.
+
+        ``provenance_source`` is the writer-identity tag forwarded to F065's
+        ``classify(relation, source=...)`` to set ``extraction_method``.
+        Default ``"auto_linker"`` preserves existing behavior. Pass
+        ``"structural"`` for FK-derived / index-derived anchors (F070
+        chunk→episode part_of and chunk→chunk sequential adjacency) so
+        ``graph_inferred_edge_penalty`` does not down-weight them.
         """
         multiplier = (
             weight_multiplier_override
@@ -125,7 +133,7 @@ class GraphLinker:
                 relation=relation,
                 weight=adjusted_weight,
                 auto_linked=True,
-                extraction_method=classify(relation, source="auto_linker"),  # F065
+                extraction_method=classify(relation, source=provenance_source),  # F065
             )
             .on_conflict_do_nothing(index_elements=["source_id", "target_id", "relation"])
         )

--- a/nous/brain/graph_linker.py
+++ b/nous/brain/graph_linker.py
@@ -36,6 +36,12 @@ RELATION_WEIGHT_MULTIPLIERS: dict[str, float] = {
     "evidence_for": 1.0,
     "discussed_in": 0.7,
     "extracted_from": 0.7,
+    # F070: chunk graph edges. `part_of` is a structural anchor (FK as edge);
+    # we want the full passed weight to survive. `summarized_by` already has
+    # cosine similarity baked into `weight` at the call site, so no extra
+    # discount needed beyond the (already empirical) cosine gating.
+    "part_of": 1.0,
+    "summarized_by": 1.0,
 }
 
 

--- a/nous/brain/graph_linker.py
+++ b/nous/brain/graph_linker.py
@@ -92,14 +92,26 @@ class GraphLinker:
         relation: str,
         weight: float,
         session: AsyncSession,
+        *,
+        weight_multiplier_override: float | None = None,
     ) -> GraphEdgeInfo | None:
         """Create a graph edge with relation-aware weight multiplier.
 
         Applies RELATION_WEIGHT_MULTIPLIERS to the raw weight and uses
         ON CONFLICT DO NOTHING to skip duplicates.  Returns the edge info
         on success, or None if the edge already exists.
+
+        ``weight_multiplier_override`` skips the relation-table lookup for
+        callers that need to bypass the per-relation discount — e.g. F070
+        sequential chunk adjacency, which is structural (weight=1.0) but
+        reuses the ``related_to`` relation (multiplier 0.8). Without the
+        override, the persisted weight would be 0.8, not 1.0.
         """
-        multiplier = RELATION_WEIGHT_MULTIPLIERS.get(relation, 0.8)
+        multiplier = (
+            weight_multiplier_override
+            if weight_multiplier_override is not None
+            else RELATION_WEIGHT_MULTIPLIERS.get(relation, 0.8)
+        )
         adjusted_weight = weight * multiplier
 
         stmt = (

--- a/nous/brain/schemas.py
+++ b/nous/brain/schemas.py
@@ -18,8 +18,10 @@ OutcomeType = Literal["pending", "success", "partial", "failure"]
 RelationType = Literal[
     "supports", "contradicts", "supersedes", "related_to", "caused_by",
     "informed_by", "evidence_for", "discussed_in", "extracted_from",
+    # F070 (2026-05-25): chunk graph edges
+    "part_of", "summarized_by",
 ]
-NodeType = Literal["decision", "fact", "episode", "procedure"]
+NodeType = Literal["decision", "fact", "episode", "procedure", "chunk"]
 ReasonType = Literal[
     "analysis",
     "pattern",

--- a/nous/config.py
+++ b/nous/config.py
@@ -1015,6 +1015,26 @@ class Settings(BaseSettings):
         default=0.15,
         description="P2: max boost as a fraction of original score (default 0.15 = +15% for the most-connected candidate).",
     )
+    heart_graph_all_types_enabled: bool = Field(
+        default=False,
+        description=(
+            "When true, the heart_graph_neighbors stage expands fact/episode "
+            "seeds to neighbors of ALL node types (fact, episode, chunk, "
+            "procedure, decision) instead of decisions only. Required to "
+            "activate F022 cross-type + F040 densification + F070 chunk edges "
+            "that today have no consumer in retrieval. Opt-in until eval "
+            "validates on the F051 harness; ships disabled in prod."
+        ),
+    )
+    heart_graph_neighbors_per_seed: int = Field(
+        default=3,
+        description=(
+            "When heart_graph_all_types_enabled is true, this is the per-seed "
+            "neighbor limit (vs the 2 used by the decision-only path). Higher "
+            "default reflects the larger candidate pool when all types are "
+            "surfaced."
+        ),
+    )
     # =========================================================================
     # F070 — Chunk-aware sleep consolidation (v1: edges only, no schema change)
     # =========================================================================

--- a/nous/config.py
+++ b/nous/config.py
@@ -687,7 +687,12 @@ class Settings(BaseSettings):
 
     # F042: Cross-encoder reranking
     cross_encoder_enabled: bool = False
-    cross_encoder_model: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+    # BGE reranker-v2-m3 empirically beats MiniLM by +18.4pp chunks_off /
+    # +3.3pp baseline hit@5 on per_haystack K=5 (LME N=60, eval runs
+    # 2026-05-25T20-14-07 vs 22-34-46). Previously set via env var in
+    # ad-hoc shell sessions; now persisted as the default so the win
+    # doesn't silently regress when no override is supplied.
+    cross_encoder_model: str = "BAAI/bge-reranker-v2-m3"
     cross_encoder_max_candidates: int = 30
     cross_encoder_text_limit: int = 512
 

--- a/nous/config.py
+++ b/nous/config.py
@@ -992,6 +992,35 @@ class Settings(BaseSettings):
         default=500,
         description="F067 per-parent-episode summary char truncation.",
     )
+    # =========================================================================
+    # F070 — Chunk-aware sleep consolidation (v1: edges only, no schema change)
+    # =========================================================================
+    chunk_consolidation_enabled: bool = Field(
+        default=False,
+        description=(
+            "F070 (2026-05-25). When true, sleep cycle and EpisodeSummarizer "
+            "build graph edges to/from heart.episode_chunks rows. Fixes the "
+            "gap that chunks have zero edges (audit 2026-05-25 found 1,775 "
+            "edges, all fact↔fact / procedure↔procedure). Required for "
+            "adjacency boost and F022 spreading activation to reach chunks."
+        ),
+    )
+    graph_backfill_max_chunks: int = Field(
+        default=100,
+        description="F070: max orphan chunks processed per sleep cycle (caps embedding/LLM cost).",
+    )
+    graph_threshold_chunk_fact: float = Field(
+        default=0.55,
+        description="F070: cosine floor for chunk→fact same-episode edges.",
+    )
+    graph_threshold_chunk_chunk_intra: float = Field(
+        default=0.70,
+        description="F070: cosine floor for non-adjacent intra-episode chunk↔chunk edges. Adjacent pairs always linked (sequential edge_type, weight=1.0).",
+    )
+    graph_threshold_chunk_chunk_cross: float = Field(
+        default=0.85,
+        description="F070: cosine floor for cross-episode chunk↔chunk dedup edges.",
+    )
 
     @model_validator(mode="after")
     def _detect_explicit_overrides(self) -> "Settings":

--- a/nous/config.py
+++ b/nous/config.py
@@ -992,6 +992,29 @@ class Settings(BaseSettings):
         default=500,
         description="F067 per-parent-episode summary char truncation.",
     )
+    session_group_heart_section: bool = Field(
+        default=False,
+        description=(
+            "P1.1 (2026-05-25). When true, recall_deep groups Heart Memory "
+            "section items (facts/chunks/episodes) by source session_id, "
+            "with section headers ('-- Session abc12345 --'). Helps the LLM "
+            "synthesize across sessions for multi-session questions. "
+            "Validated on labeled LME eval; opt-in for prod until A/B confirms."
+        ),
+    )
+    graph_adjacency_boost_enabled: bool = Field(
+        default=False,
+        description=(
+            "P2 (2026-05-25). When true, retrieval applies a multiplicative "
+            "score boost to candidates connected via brain.graph_edges to "
+            "other candidates in the same batch. Inspired by gbrain's "
+            "adjacency-aware ranking. Leverages F040 sleep-built edges."
+        ),
+    )
+    graph_adjacency_boost_alpha: float = Field(
+        default=0.15,
+        description="P2: max boost as a fraction of original score (default 0.15 = +15% for the most-connected candidate).",
+    )
     # =========================================================================
     # F070 — Chunk-aware sleep consolidation (v1: edges only, no schema change)
     # =========================================================================

--- a/nous_eval/ingest_longmemeval.py
+++ b/nous_eval/ingest_longmemeval.py
@@ -593,9 +593,10 @@ def _parse_args(argv: list[str] | None) -> IngestLMEConfig:
     p.add_argument("--skip-download", action="store_true")
     p.add_argument("--seed", type=int, default=0)
     p.add_argument(
-        "--max-sessions-per-question", type=int, default=10,
-        help="F051.5 cost guardrail. LongMemEval haystacks can have 30-50 sessions; "
-             "default 10 caps Sonnet spend at ~$15-25 for N=20.",
+        "--max-sessions-per-question", type=int, default=50,
+        help="F051.5 cost guardrail. Bumped to 50 (2026-05-25) so the ingest "
+             "covers the median ~48-session haystack the LongMemEval paper "
+             "assumes; the earlier cap of 10 masked distractor difficulty.",
     )
     p.add_argument(
         "--inter-question-sleep-seconds", type=float, default=0.0,

--- a/nous_eval/ingest_longmemeval.py
+++ b/nous_eval/ingest_longmemeval.py
@@ -88,7 +88,11 @@ class IngestLMEConfig:
     scratch_db_url: str = "postgresql+asyncpg://nous:nous_eval@localhost:5433/nous_eval_scratch"
     skip_download: bool = False
     seed: int = 0
-    max_sessions_per_question: int = 10  # F051.5: cost guardrail (devil P2)
+    # F051.5 cost guardrail. Bumped to 50 (2026-05-24) so the ingest covers
+    # the median-ish 48-session haystack the LongMemEval paper assumes.
+    # The earlier 10-cap masked a lot of distractor difficulty; re-running
+    # with chunks + parent episodes wants paper-realistic numbers.
+    max_sessions_per_question: int = 50
     # F051.5.x: paced batching. Default 0 = no sleep (matches original behavior).
     # When >0, replay sleeps for this many seconds after every
     # `inter_question_batch` questions complete, spreading Sonnet load and
@@ -105,6 +109,25 @@ class LMEIngestStats:
     n_sessions_reused: int = 0  # F051.5: cross-question episode dedup hits
     n_facts_extracted: int = 0
     n_episodes_summarised: int = 0
+
+
+def _parse_lme_date(date_str: str) -> "datetime | None":
+    """Parse a LongMemEval haystack date like '2023/05/20 (Sat) 02:21' to a
+    timezone-aware datetime (UTC). Returns None on parse failure.
+
+    Format observed in the cleaned dataset: ``YYYY/MM/DD (DayAbbrev) HH:MM``.
+    The day-of-week token is informational; we strip it before parsing.
+    """
+    import re
+    from datetime import datetime, timezone
+    # Drop the parenthetical day-of-week
+    cleaned = re.sub(r"\s*\([A-Za-z]+\)\s*", " ", date_str).strip()
+    try:
+        return datetime.strptime(cleaned, "%Y/%m/%d %H:%M").replace(
+            tzinfo=timezone.utc
+        )
+    except ValueError:
+        return None
 
 
 def _session_to_transcript(session: list | dict) -> str:
@@ -232,7 +255,7 @@ def _stratify(
 async def _replay_sessions_into_scratch(
     picked: list[dict[str, Any]],
     scratch_db_url: str,
-    max_sessions_per_question: int = 10,
+    max_sessions_per_question: int = 50,
     inter_question_sleep_seconds: float = 0.0,
     inter_question_batch: int = 5,
 ) -> tuple[LMEIngestStats, dict[str, dict[int, dict[str, list]]]]:
@@ -328,6 +351,12 @@ async def _replay_sessions_into_scratch(
             # field — fall back to integer-index keying for back-compat.
             session_ids = q.get("haystack_session_ids") or []
             answer_sids = set(q.get("answer_session_ids") or [])
+            # 2026-05-24 fix: preserve LongMemEval's haystack_dates so temporal
+            # reasoning has real timestamps. Each session has its own date
+            # (e.g. "2023/05/20 (Sat) 02:21") spanning days/weeks/months
+            # apart; without this, all episodes land within minutes of ingest
+            # time and "which came first" becomes unanswerable. Parsed below.
+            haystack_dates = q.get("haystack_dates") or []
 
             # F051.5 hotfix: prioritize answer-bearing sessions when capping.
             # Without this, --max-sessions-per-question=10 drops most
@@ -377,6 +406,25 @@ async def _replay_sessions_into_scratch(
                     trigger="lme_replay",
                     tags=["longmemeval", q.get("question_type", "")],
                 ))
+                # 1a. 2026-05-24: backdate episode to the LongMemEval session
+                # date so temporal-reasoning questions get real timestamps.
+                # heart.start_episode sets started_at=now(); we overwrite via
+                # raw SQL because the Heart API doesn't expose started_at.
+                session_date_str = (
+                    haystack_dates[session_idx]
+                    if session_idx < len(haystack_dates)
+                    else None
+                )
+                if session_date_str:
+                    parsed_date = _parse_lme_date(session_date_str)
+                    if parsed_date is not None:
+                        from sqlalchemy import text as sa_text
+                        async with db.session() as ds:
+                            await ds.execute(sa_text(
+                                "UPDATE heart.episodes SET started_at = :t "
+                                "WHERE id = :i"
+                            ), {"t": parsed_date, "i": ep.id})
+                            await ds.commit()
 
                 # 2. Summarize directly. Returns None on early-return / LLM error.
                 summary = await summarizer.summarize_episode(

--- a/scripts/backfill_f070_chunks.py
+++ b/scripts/backfill_f070_chunks.py
@@ -1,0 +1,245 @@
+"""F070 chunk-edge backfill (prod-safe).
+
+Iteratively densifies orphan chunks until either every chunk has at least
+one ``brain.graph_edges`` row (chunk -> *) or ``--max-batches`` is hit.
+Idempotent: ``find_orphans`` excludes any chunk that already has an edge,
+so re-running this script after a partial run continues from where the
+last batch stopped.
+
+Prereqs (in order):
+  1. PR #448 is merged and the nous service has restarted at least once
+     so ``Settings()`` picks up the new fields.
+  2. Migration ``sql/migrations/051_f070_chunk_graph_edges.sql`` is
+     applied (extends ``ck_edges_{source_type,target_type,relation}``).
+  3. The agent corpus has ``heart.episode_chunks`` rows produced by F067
+     (``NOUS_EPISODE_CHUNKS_ENABLED=true`` during session end). If chunks
+     are absent, this script does nothing.
+
+Usage::
+
+    # one-shot, prod nous (read DB from env or .env)
+    NOUS_CHUNK_CONSOLIDATION_ENABLED=true \
+        uv run python scripts/backfill_f070_chunks.py \
+        --agent-id nous-default
+
+    # dry run — count orphans only, no writes
+    uv run python scripts/backfill_f070_chunks.py \
+        --agent-id nous-default --dry-run
+
+    # cap the run (useful for first prod attempt)
+    uv run python scripts/backfill_f070_chunks.py \
+        --agent-id nous-default --max-batches 5 --batch-size 500
+
+What it writes (per orphan chunk):
+  * chunk -> episode  relation=part_of      (always, structural anchor)
+  * chunk -> fact     relation=summarized_by  (same-episode, cosine ≥ threshold)
+  * chunk -> chunk    relation=related_to     (sequential adjacency + intra-episode cosine ≥ threshold)
+
+Empirical (eval DB, 35,768 orphans, BATCH=2000): ~30 sec per batch,
+~6 edges per chunk on average, ~9 min end-to-end. Prod corpus is
+smaller; expect proportionally less.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+import time
+
+from sqlalchemy import text
+
+from nous.brain.embeddings import EmbeddingProvider
+from nous.brain.graph_densifier import GraphDensifier
+from nous.brain.graph_linker import GraphLinker
+from nous.config import Settings
+from nous.storage.database import Database
+
+logger = logging.getLogger("f070-backfill")
+
+
+async def _count_orphan_chunks(db: Database, agent_id: str) -> int:
+    """Count chunks for the given agent that have NO graph edges yet.
+
+    Mirrors ``GraphDensifier.find_orphans('chunk', ..., require_embedding=False)``
+    so the count + the densifier's selection stay consistent.
+    """
+    async with db.engine.begin() as conn:
+        r = await conn.execute(
+            text(
+                "SELECT COUNT(*) FROM heart.episode_chunks t "
+                "WHERE t.agent_id = :a AND NOT EXISTS ("
+                "  SELECT 1 FROM brain.graph_edges e "
+                "  WHERE e.agent_id = :a AND ("
+                "    (e.source_id = t.id AND e.source_type = 'chunk')"
+                "    OR (e.target_id = t.id AND e.target_type = 'chunk')"
+                "  )"
+                ")"
+            ),
+            {"a": agent_id},
+        )
+        return int(r.scalar() or 0)
+
+
+async def _summarize_chunk_edges(db: Database, agent_id: str) -> dict[str, int]:
+    """Return {relation_label: count} for every chunk edge belonging to
+    the agent. Used for the post-run summary print."""
+    async with db.engine.begin() as conn:
+        rows = (await conn.execute(
+            text(
+                "SELECT source_type || ' -> ' || target_type || ' [' "
+                "       || relation || ']' AS label, COUNT(*) AS cnt "
+                "FROM brain.graph_edges "
+                "WHERE agent_id = :a "
+                "  AND (source_type = 'chunk' OR target_type = 'chunk') "
+                "GROUP BY label ORDER BY cnt DESC"
+            ),
+            {"a": agent_id},
+        )).all()
+    return {row.label: int(row.cnt) for row in rows}
+
+
+async def run_backfill(
+    *, agent_id: str, batch_size: int, max_batches: int | None,
+    dry_run: bool,
+) -> int:
+    settings = Settings()
+
+    if not settings.chunk_consolidation_enabled:
+        print(
+            "WARN: NOUS_CHUNK_CONSOLIDATION_ENABLED is False. "
+            "GraphDensifier.backfill_orphan_chunks() short-circuits to 0 "
+            "edges in this mode. Set the env var to 'true' before running.",
+            file=sys.stderr,
+        )
+        return 1
+    if not settings.graph_backfill_enabled:
+        print(
+            "WARN: NOUS_GRAPH_BACKFILL_ENABLED is False. Same problem — "
+            "the densifier short-circuits without it. Set both flags.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Override the densifier's class-level cap with the CLI batch size so
+    # each call processes the requested number of orphans even when the
+    # operator left NOUS_GRAPH_BACKFILL_MAX_CHUNKS at its default.
+    effective_batch = batch_size
+
+    db = Database(settings)
+    await db.connect()
+    try:
+        before = await _count_orphan_chunks(db, agent_id)
+        print(
+            f"Agent {agent_id}: {before} orphan chunks "
+            f"(batch_size={effective_batch}, max_batches="
+            f"{max_batches if max_batches is not None else 'unbounded'})"
+        )
+        if dry_run:
+            print("--dry-run set; not writing edges. Exiting.")
+            return 0
+        if before == 0:
+            print("Nothing to backfill — every chunk already has at least "
+                  "one graph edge.")
+            return 0
+
+        embedder = EmbeddingProvider(settings)
+        linker = GraphLinker(
+            db=db, embedder=embedder, settings=settings, agent_id=agent_id,
+        )
+        densifier = GraphDensifier(
+            db=db, graph_linker=linker, embedder=embedder,
+            settings=settings, agent_id=agent_id,
+        )
+
+        total_edges = 0
+        batch_n = 0
+        start = time.time()
+        while True:
+            if max_batches is not None and batch_n >= max_batches:
+                print(f"--max-batches={max_batches} hit; stopping.")
+                break
+            orphans_before = await _count_orphan_chunks(db, agent_id)
+            if orphans_before == 0:
+                break
+            batch_n += 1
+            t0 = time.time()
+            created = await densifier.backfill_orphan_chunks(
+                max_count=effective_batch,
+            )
+            dt = time.time() - t0
+            total_edges += created
+            orphans_after = await _count_orphan_chunks(db, agent_id)
+            processed = orphans_before - orphans_after
+            elapsed = (time.time() - start) / 60.0
+            print(
+                f"batch {batch_n:3d}: orphans {orphans_before:>7d} -> "
+                f"{orphans_after:>7d}  (-{processed:>5d})  "
+                f"+{created:>6d} edges in {dt:5.1f}s  "
+                f"[total {total_edges:>7d} edges, {elapsed:.1f} min]",
+                flush=True,
+            )
+            if created == 0 and processed == 0:
+                print(
+                    "WARN: batch made no progress (0 edges, 0 orphans "
+                    "consumed). Stopping to avoid an infinite loop.",
+                    file=sys.stderr,
+                )
+                break
+
+        breakdown = await _summarize_chunk_edges(db, agent_id)
+        print()
+        print("Final chunk-edge breakdown:")
+        for label, cnt in breakdown.items():
+            print(f"  {label:<40} {cnt}")
+        print(f"Total chunk edges for agent={agent_id}: {sum(breakdown.values())}")
+        return 0
+    finally:
+        await db.disconnect()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill F070 chunk graph edges for a single agent.",
+    )
+    parser.add_argument(
+        "--agent-id", required=True,
+        help="Agent identifier whose chunks to densify (e.g. nous-default).",
+    )
+    parser.add_argument(
+        "--batch-size", type=int, default=2000,
+        help="Orphan chunks processed per call to backfill_orphan_chunks. "
+             "Higher = fewer round-trips, lower = smoother memory. "
+             "Eval default was 2000 / batch_dt≈30s.",
+    )
+    parser.add_argument(
+        "--max-batches", type=int, default=None,
+        help="Stop after this many batches even if orphans remain. "
+             "Omit for unbounded. Useful for capping a first prod run.",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print the orphan count and exit without writing.",
+    )
+    parser.add_argument(
+        "--log-level", default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    rc = asyncio.run(run_backfill(
+        agent_id=args.agent_id,
+        batch_size=args.batch_size,
+        max_batches=args.max_batches,
+        dry_run=args.dry_run,
+    ))
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/sql/migrations/051_f070_chunk_graph_edges.sql
+++ b/sql/migrations/051_f070_chunk_graph_edges.sql
@@ -1,0 +1,45 @@
+-- F070 (2026-05-25): Allow chunk node type and new chunk relations in brain.graph_edges
+--
+-- Existing check constraints (added by migration 016) restrict:
+--   source_type / target_type to ('decision', 'fact', 'episode', 'procedure')
+--   relation to ('supports', 'contradicts', 'supersedes', 'related_to',
+--                'caused_by', 'informed_by', 'evidence_for', 'discussed_in',
+--                'extracted_from')
+--
+-- F070 adds 'chunk' as a node type and two new relations:
+--   'part_of'         — chunk -> source episode (FK encoded as graph edge)
+--   'summarized_by'   — chunk -> fact extracted from same episode
+--
+-- Migration is purely additive: existing edges remain valid. No data changes.
+
+-- Note: 016 added ck_edges_* but didn't drop the auto-named CHECK constraints
+-- from init.sql (graph_edges_*_check). Both are active. We need to drop both.
+
+-- 1. Extend source_type
+ALTER TABLE brain.graph_edges DROP CONSTRAINT IF EXISTS ck_edges_source_type;
+ALTER TABLE brain.graph_edges DROP CONSTRAINT IF EXISTS graph_edges_source_type_check;
+ALTER TABLE brain.graph_edges
+    ADD CONSTRAINT ck_edges_source_type CHECK (
+        source_type IN ('decision', 'fact', 'episode', 'procedure', 'chunk')
+    );
+
+-- 2. Extend target_type
+ALTER TABLE brain.graph_edges DROP CONSTRAINT IF EXISTS ck_edges_target_type;
+ALTER TABLE brain.graph_edges DROP CONSTRAINT IF EXISTS graph_edges_target_type_check;
+ALTER TABLE brain.graph_edges
+    ADD CONSTRAINT ck_edges_target_type CHECK (
+        target_type IN ('decision', 'fact', 'episode', 'procedure', 'chunk')
+    );
+
+-- 3. Extend relation
+ALTER TABLE brain.graph_edges DROP CONSTRAINT IF EXISTS ck_edges_relation;
+ALTER TABLE brain.graph_edges DROP CONSTRAINT IF EXISTS graph_edges_relation_check;
+ALTER TABLE brain.graph_edges
+    ADD CONSTRAINT ck_edges_relation CHECK (
+        relation IN (
+            'supports', 'contradicts', 'supersedes', 'related_to', 'caused_by',
+            'informed_by', 'evidence_for', 'discussed_in', 'extracted_from',
+            -- F070 additions:
+            'part_of', 'summarized_by'
+        )
+    );

--- a/tests/test_brain.py
+++ b/tests/test_brain.py
@@ -478,6 +478,64 @@ async def test_neighbors(brain, session):
 
 
 # ---------------------------------------------------------------------------
+# 18a. test_neighbors_neighbor_type_filter
+# ---------------------------------------------------------------------------
+
+
+async def test_neighbors_neighbor_type_filter(brain, session):
+    """F070 fix: ``neighbor_type`` pushes the filter into SQL so a small
+    ``limit`` returns rows of the requested type, not rows of arbitrary
+    types that a downstream Python filter would discard.
+
+    Pre-fix: querying a fact with 5 chunk neighbors + 1 decision neighbor
+    at ``limit=2`` could return 2 chunks → caller's Python ``decision``
+    filter discarded both → 0 decisions surfaced even though one exists.
+    Post-fix: ``neighbor_type="decision"`` returns the 1 decision.
+    """
+    # Build a fact with mixed-type neighbors.
+    # We insert raw GraphEdge rows so we don't need Heart/chunks fixtures.
+    from uuid import uuid4
+
+    from nous.storage.models import GraphEdge
+
+    fact_id = uuid4()
+    decision = await brain.record(_record_input(description="real decision"), session=session)
+
+    # 5 chunk neighbors via summarized_by (the F070 case that crowds decisions).
+    chunk_ids = [uuid4() for _ in range(5)]
+    for cid in chunk_ids:
+        session.add(GraphEdge(
+            source_id=cid, target_id=fact_id,
+            source_type="chunk", target_type="fact",
+            agent_id=brain.agent_id, relation="summarized_by",
+            weight=0.8, auto_linked=True,
+            extraction_method="inferred",
+        ))
+    # 1 decision neighbor via informed_by.
+    session.add(GraphEdge(
+        source_id=fact_id, target_id=decision.id,
+        source_type="fact", target_type="decision",
+        agent_id=brain.agent_id, relation="informed_by",
+        weight=0.9, auto_linked=True,
+        extraction_method="heuristic",
+    ))
+    await session.flush()
+
+    # Without filter, limit=2 over 6 edges can return any mix.
+    # WITH filter, limit=2 must return only decisions (we have 1).
+    neighbors = await brain.neighbors(
+        fact_id, node_type="fact", limit=2, session=session,
+        neighbor_type="decision",
+    )
+    assert len(neighbors) == 1, (
+        f"neighbor_type='decision' must return only the decision row, "
+        f"got {[(n.node_type, n.id) for n in neighbors]}"
+    )
+    assert neighbors[0].node_type == "decision"
+    assert neighbors[0].id == decision.id
+
+
+# ---------------------------------------------------------------------------
 # 18b. test_link_with_types
 # ---------------------------------------------------------------------------
 

--- a/tests/test_brain.py
+++ b/tests/test_brain.py
@@ -536,6 +536,147 @@ async def test_neighbors_neighbor_type_filter(brain, session):
 
 
 # ---------------------------------------------------------------------------
+# 18a-Path-A. test_neighbors_resolves_content_for_all_node_types
+# ---------------------------------------------------------------------------
+
+
+async def test_neighbors_resolves_content_for_all_node_types(brain, session):
+    """Path A: brain._neighbors must resolve real description text for
+    fact / episode / chunk / procedure / decision neighbors, not the
+    pre-Path-A ``f'[{ntype}] {uuid}'`` placeholder. Without this, every
+    chunk-edge consumer would receive useless placeholder strings."""
+    from uuid import uuid4
+
+    from nous.storage.models import (
+        Episode, EpisodeChunk, Fact, GraphEdge, Procedure,
+    )
+
+    seed = await brain.record(
+        _record_input(description="Seed decision text"), session=session,
+    )
+
+    # Build one of each non-decision node type with known content.
+    fact_id = uuid4()
+    session.add(Fact(
+        id=fact_id, agent_id=brain.agent_id, content="FACT_CONTENT_TOKEN",
+        active=True,
+    ))
+    ep_id = uuid4()
+    session.add(Episode(
+        id=ep_id, agent_id=brain.agent_id, summary="EPISODE_SUMMARY_TOKEN",
+        active=True,
+    ))
+    chunk_id = uuid4()
+    session.add(EpisodeChunk(
+        id=chunk_id, agent_id=brain.agent_id, episode_id=ep_id,
+        chunk_index=0, content="CHUNK_CONTENT_TOKEN",
+    ))
+    proc_id = uuid4()
+    session.add(Procedure(
+        id=proc_id, agent_id=brain.agent_id, name="proc",
+        description="PROCEDURE_DESC_TOKEN", active=True,
+    ))
+    # Link seed decision to each via graph_edges.
+    for tgt_id, tgt_type, rel in [
+        (fact_id, "fact", "informed_by"),
+        (ep_id, "episode", "discussed_in"),
+        (chunk_id, "chunk", "summarized_by"),
+        (proc_id, "procedure", "related_to"),
+    ]:
+        session.add(GraphEdge(
+            source_id=seed.id, target_id=tgt_id,
+            source_type="decision", target_type=tgt_type,
+            agent_id=brain.agent_id, relation=rel,
+            weight=0.8, auto_linked=True, extraction_method="heuristic",
+        ))
+    await session.flush()
+
+    neighbors = await brain.neighbors(
+        seed.id, node_type="decision", limit=10, session=session,
+    )
+    by_type = {n.node_type: n.description for n in neighbors}
+
+    assert by_type.get("fact") == "FACT_CONTENT_TOKEN", (
+        f"fact content unresolved: {by_type.get('fact')!r}"
+    )
+    assert by_type.get("episode") == "EPISODE_SUMMARY_TOKEN", (
+        f"episode summary unresolved: {by_type.get('episode')!r}"
+    )
+    assert by_type.get("chunk") == "CHUNK_CONTENT_TOKEN", (
+        f"chunk content unresolved: {by_type.get('chunk')!r}"
+    )
+    assert by_type.get("procedure") == "PROCEDURE_DESC_TOKEN", (
+        f"procedure description unresolved: {by_type.get('procedure')!r}"
+    )
+    # Tighter assertion: every resolved description must NOT be the
+    # placeholder format ``[<ntype>] <uuid>``. Pre-Path-A code emitted that
+    # for all non-decision types; this regression-tests against reverting.
+    for n in neighbors:
+        assert not (n.description or "").startswith(f"[{n.node_type}]"), (
+            f"placeholder leaked for {n.node_type}: {n.description!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 18a-Path-A.2. test_neighbors_falls_back_to_placeholder_for_empty_content
+# ---------------------------------------------------------------------------
+
+
+async def test_neighbors_falls_back_to_placeholder_for_empty_content(
+    brain, session, caplog,
+):
+    """Path A defensive: when a resolved row has empty/NULL content (the
+    NOT-NULL bypass / data corruption case), _neighbors falls back to the
+    ``[<ntype>] <uuid>`` placeholder AND logs WARNING — silent passthrough
+    would let a useless candidate land in rerank with no operator signal."""
+    import logging
+    from uuid import uuid4
+
+    from nous.storage.models import Episode, Fact, GraphEdge
+
+    seed = await brain.record(
+        _record_input(description="seed"), session=session,
+    )
+    # Fact with empty content (simulates NOT-NULL bypass via empty string).
+    bad_fact_id = uuid4()
+    session.add(Fact(
+        id=bad_fact_id, agent_id=brain.agent_id, content="", active=True,
+    ))
+    # Episode with empty summary.
+    bad_ep_id = uuid4()
+    session.add(Episode(
+        id=bad_ep_id, agent_id=brain.agent_id, summary="", active=True,
+    ))
+    for tgt_id, tgt_type in [(bad_fact_id, "fact"), (bad_ep_id, "episode")]:
+        session.add(GraphEdge(
+            source_id=seed.id, target_id=tgt_id,
+            source_type="decision", target_type=tgt_type,
+            agent_id=brain.agent_id, relation="related_to",
+            weight=0.8, auto_linked=True, extraction_method="heuristic",
+        ))
+    await session.flush()
+
+    with caplog.at_level(logging.WARNING, logger="nous.brain.brain"):
+        neighbors = await brain.neighbors(
+            seed.id, node_type="decision", limit=10, session=session,
+        )
+
+    by_id = {n.id: n for n in neighbors}
+    # Both fall back to placeholder rather than empty string.
+    assert by_id[bad_fact_id].description == f"[fact] {bad_fact_id}"
+    assert by_id[bad_ep_id].description == f"[episode] {bad_ep_id}"
+    # And both emit a WARN (one per offending row).
+    warns = [r for r in caplog.records if r.levelname == "WARNING"]
+    warn_texts = "\n".join(r.getMessage() for r in warns)
+    assert "fact" in warn_texts and str(bad_fact_id) in warn_texts, (
+        f"expected WARN for empty fact, got: {warn_texts!r}"
+    )
+    assert "episode" in warn_texts and str(bad_ep_id) in warn_texts, (
+        f"expected WARN for empty episode, got: {warn_texts!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # 18b. test_link_with_types
 # ---------------------------------------------------------------------------
 

--- a/tests/test_graph_densifier.py
+++ b/tests/test_graph_densifier.py
@@ -24,7 +24,8 @@ from nous.config import Settings
 
 class TestEntityConfig:
     def test_all_types_present(self):
-        assert set(_ENTITY_CONFIG.keys()) == {"fact", "decision", "episode", "procedure"}
+        # F070 (2026-05-25): 'chunk' added for chunk-aware sleep consolidation.
+        assert set(_ENTITY_CONFIG.keys()) == {"fact", "decision", "episode", "procedure", "chunk"}
 
     def test_fact_config(self):
         table, type_name, content_col, extra = _ENTITY_CONFIG["fact"]
@@ -145,6 +146,55 @@ async def _insert_decision(session: AsyncSession, agent_id: str, description: st
         "embedding": embedding_str,
     })
     return dec_id
+
+
+async def _insert_episode(session: AsyncSession, agent_id: str, summary: str) -> str:
+    """F070 test helper: insert an episode and return its ID."""
+    ep_id = uuid4()
+    await session.execute(text("""
+        INSERT INTO heart.episodes (id, agent_id, summary, active, started_at)
+        VALUES (:id, :agent_id, :summary, true, NOW())
+    """), {
+        "id": ep_id, "agent_id": agent_id, "summary": summary,
+    })
+    return ep_id
+
+
+async def _insert_chunk(
+    session: AsyncSession, agent_id: str,
+    episode_id, chunk_index: int, content: str, embedding: list[float],
+) -> str:
+    """F070 test helper: insert an episode_chunks row and return its ID."""
+    chunk_id = uuid4()
+    embedding_str = "[" + ",".join(str(float(v)) for v in embedding) + "]"
+    await session.execute(text("""
+        INSERT INTO heart.episode_chunks
+            (id, agent_id, episode_id, chunk_index, content, embedding)
+        VALUES
+            (:id, :agent_id, :ep_id, :idx, :content, CAST(:embedding AS vector))
+    """), {
+        "id": chunk_id, "agent_id": agent_id, "ep_id": episode_id,
+        "idx": chunk_index, "content": content, "embedding": embedding_str,
+    })
+    return chunk_id
+
+
+async def _insert_fact_with_episode(
+    session: AsyncSession, agent_id: str,
+    content: str, embedding: list[float], source_episode_id,
+) -> str:
+    """F070 test helper: insert a fact with source_episode_id set."""
+    fact_id = uuid4()
+    embedding_str = "[" + ",".join(str(float(v)) for v in embedding) + "]"
+    await session.execute(text("""
+        INSERT INTO heart.facts
+            (id, agent_id, content, active, embedding, source_episode_id)
+        VALUES (:id, :agent_id, :content, true, CAST(:emb AS vector), :ep_id)
+    """), {
+        "id": fact_id, "agent_id": agent_id, "content": content,
+        "emb": embedding_str, "ep_id": source_episode_id,
+    })
+    return fact_id
 
 
 async def _insert_edge(session: AsyncSession, agent_id: str, source_id, target_id, source_type: str, target_type: str) -> None:
@@ -677,3 +727,180 @@ async def test_backfill_uses_ce_mode_threshold_end_to_end(
         f"CE-mode fact_fact=0.01 should always pass. Got {edges} edges, "
         f"ce_stats={ce_stats}."
     )
+
+
+# ============================================================================
+# F070 — Chunk-aware sleep consolidation
+# ============================================================================
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_chunk_consolidation_disabled_skips(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint,
+):
+    """F070: master flag off → backfill returns 0, no edges created."""
+    agent_id = f"test-chunk-disabled-{uuid4().hex[:8]}"
+    settings_local = settings.model_copy(update={
+        "chunk_consolidation_enabled": False,
+        "graph_backfill_enabled": True,
+    })
+    linker = GraphLinker(db, mock_embeddings, settings_local, agent_id)
+    d = GraphDensifier(db, linker, mock_embeddings, settings_local, agent_id)
+
+    async with db.session() as s:
+        ep = await _insert_episode(s, agent_id, "test")
+        emb = await mock_embeddings.embed("chunk content")
+        await _insert_chunk(s, agent_id, ep, 0, "chunk content", emb)
+        await s.commit()
+
+    edges = await d.backfill_orphan_chunks()
+    assert edges == 0
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_chunk_to_episode_edge_created(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint,
+):
+    """F070: orphan chunk gets a chunk→episode 'part_of' edge."""
+    agent_id = f"test-chunk-ep-{uuid4().hex[:8]}"
+    settings_local = settings.model_copy(update={
+        "chunk_consolidation_enabled": True,
+        "graph_backfill_enabled": True,
+        "graph_backfill_max_chunks": 10,
+    })
+    linker = GraphLinker(db, mock_embeddings, settings_local, agent_id)
+    d = GraphDensifier(db, linker, mock_embeddings, settings_local, agent_id)
+
+    async with db.session() as s:
+        ep = await _insert_episode(s, agent_id, "test")
+        emb = await mock_embeddings.embed("chunk content here is long enough to be real")
+        chunk_id = await _insert_chunk(s, agent_id, ep, 0, "chunk content here is long enough to be real", emb)
+        await s.commit()
+
+    edges_created = await d.backfill_orphan_chunks()
+    assert edges_created >= 1
+
+    async with db.session() as s:
+        rows = (await s.execute(text(
+            "SELECT source_id::text, target_id::text, source_type, target_type, relation "
+            "FROM brain.graph_edges WHERE agent_id = :a"
+        ), {"a": agent_id})).all()
+    # Should have a chunk→episode edge
+    chunk_ep = [r for r in rows
+                if r.source_type == "chunk" and r.target_type == "episode"]
+    assert len(chunk_ep) == 1
+    assert chunk_ep[0].source_id == str(chunk_id)
+    assert chunk_ep[0].target_id == str(ep)
+    assert chunk_ep[0].relation == "part_of"
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_chunk_to_fact_same_episode_links(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint,
+):
+    """F070: chunk gets chunk→fact edge to facts with same source_episode_id
+    where cosine ≥ threshold. Cross-episode facts must NOT be linked."""
+    agent_id = f"test-chunk-fact-{uuid4().hex[:8]}"
+    settings_local = settings.model_copy(update={
+        "chunk_consolidation_enabled": True,
+        "graph_backfill_enabled": True,
+        "graph_threshold_chunk_fact": 0.5,
+    })
+    linker = GraphLinker(db, mock_embeddings, settings_local, agent_id)
+    d = GraphDensifier(db, linker, mock_embeddings, settings_local, agent_id)
+
+    async with db.session() as s:
+        ep_a = await _insert_episode(s, agent_id, "ep A")
+        ep_b = await _insert_episode(s, agent_id, "ep B")
+        # Same embedding for chunk and same-episode fact (high cosine)
+        ident_emb = await mock_embeddings.embed("user likes dark roast coffee")
+        chunk_a = await _insert_chunk(
+            s, agent_id, ep_a, 0,
+            "user likes dark roast coffee in this snippet",
+            ident_emb,
+        )
+        # Same-episode fact (should link)
+        same_ep_fact = await _insert_fact_with_episode(
+            s, agent_id, "user likes dark roast coffee", ident_emb, ep_a,
+        )
+        # Cross-episode fact (must NOT link even with same embedding)
+        cross_ep_fact = await _insert_fact_with_episode(
+            s, agent_id, "user likes dark roast coffee", ident_emb, ep_b,
+        )
+        await s.commit()
+
+    await d.backfill_orphan_chunks()
+
+    async with db.session() as s:
+        rows = (await s.execute(text(
+            "SELECT target_id::text FROM brain.graph_edges "
+            "WHERE agent_id = :a AND source_type = 'chunk' "
+            "  AND target_type = 'fact' AND source_id = :c "
+        ), {"a": agent_id, "c": chunk_a})).all()
+    fact_targets = {r.target_id for r in rows}
+    assert str(same_ep_fact) in fact_targets, "same-episode fact should link"
+    assert str(cross_ep_fact) not in fact_targets, "cross-episode fact must NOT link"
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_chunk_intra_episode_sequential_always_linked(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint,
+):
+    """F070: adjacent chunks (chunk_index ± 1) always get linked at weight=1.0
+    regardless of cosine similarity."""
+    agent_id = f"test-chunk-seq-{uuid4().hex[:8]}"
+    settings_local = settings.model_copy(update={
+        "chunk_consolidation_enabled": True,
+        "graph_backfill_enabled": True,
+        # Very high threshold so cosine alone won't link adjacent chunks
+        "graph_threshold_chunk_chunk_intra": 0.99,
+    })
+    linker = GraphLinker(db, mock_embeddings, settings_local, agent_id)
+    d = GraphDensifier(db, linker, mock_embeddings, settings_local, agent_id)
+
+    async with db.session() as s:
+        ep = await _insert_episode(s, agent_id, "test")
+        # Different embeddings — would NOT pass cosine threshold
+        emb_a = await mock_embeddings.embed("apple")
+        emb_b = await mock_embeddings.embed("zebra")
+        c0 = await _insert_chunk(s, agent_id, ep, 0, "apple chunk content here", emb_a)
+        c1 = await _insert_chunk(s, agent_id, ep, 1, "zebra chunk content here", emb_b)
+        await s.commit()
+
+    await d.backfill_orphan_chunks()
+
+    async with db.session() as s:
+        rows = (await s.execute(text(
+            "SELECT source_id::text, target_id::text, weight "
+            "FROM brain.graph_edges "
+            "WHERE agent_id = :a AND source_type = 'chunk' AND target_type = 'chunk'"
+        ), {"a": agent_id})).all()
+    # Expect at least one chunk↔chunk edge between c0 and c1 (sequential)
+    pair = {(str(c0), str(c1)), (str(c1), str(c0))}
+    found = [(r.source_id, r.target_id, r.weight) for r in rows]
+    has_pair = any((s_id, t_id) in pair for s_id, t_id, _ in found)
+    assert has_pair, f"sequential adjacent chunks must link, got {found}"
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_run_backfill_cycle_includes_chunks_key(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint,
+):
+    """F070: run_backfill_cycle results dict includes a 'chunks' entry."""
+    agent_id = f"test-cycle-chunks-{uuid4().hex[:8]}"
+    settings_local = settings.model_copy(update={
+        "graph_backfill_enabled": True,
+        "chunk_consolidation_enabled": True,
+    })
+    linker = GraphLinker(db, mock_embeddings, settings_local, agent_id)
+    d = GraphDensifier(db, linker, mock_embeddings, settings_local, agent_id)
+
+    result = await d.run_backfill_cycle()
+    assert "chunks" in result
+    # _ce_stats prefix-underscored — must not be confused with per-type entries
+    assert "chunks" in {k for k in result if not k.startswith("_")}

--- a/tests/test_graph_densifier.py
+++ b/tests/test_graph_densifier.py
@@ -1078,6 +1078,56 @@ async def test_sequential_chunk_edge_persisted_at_weight_1_0(
 
 @pytest.mark.postgres_only
 @pytest.mark.asyncio
+async def test_structural_chunk_edges_tagged_deterministic(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint,
+):
+    """F070 (codex P2): structural chunk edges (chunk→episode part_of and
+    adjacent chunk→chunk) must persist with extraction_method='deterministic'
+    so `graph_inferred_edge_penalty` does not down-weight them at recall time.
+    Cosine-derived chunk→fact summarized_by stays 'inferred' (auto_linker)."""
+    agent_id = f"test-prov-{uuid4().hex[:8]}"
+    settings_local = settings.model_copy(update={
+        "chunk_consolidation_enabled": True,
+        "graph_backfill_enabled": True,
+        "graph_threshold_chunk_fact": 0.5,
+        "graph_threshold_chunk_chunk_intra": 0.99,  # only adjacency fires
+    })
+    linker = GraphLinker(db, mock_embeddings, settings_local, agent_id)
+    d = GraphDensifier(db, linker, mock_embeddings, settings_local, agent_id)
+
+    async with db.session() as s:
+        ep = await _insert_episode(s, agent_id, "ep")
+        ident_emb = await mock_embeddings.embed("user likes dark roast coffee")
+        c0 = await _insert_chunk(s, agent_id, ep, 0, "coffee chunk", ident_emb)
+        c1 = await _insert_chunk(s, agent_id, ep, 1, "next chunk", ident_emb)
+        fact = await _insert_fact_with_episode(
+            s, agent_id, "user likes dark roast coffee", ident_emb, ep,
+        )
+        await s.commit()
+
+    await d.backfill_orphan_chunks()
+
+    async with db.session() as s:
+        rows = (await s.execute(text(
+            "SELECT target_id::text, target_type, relation, extraction_method "
+            "FROM brain.graph_edges "
+            "WHERE agent_id = :a AND source_id = :c0 AND source_type = 'chunk'"
+        ), {"a": agent_id, "c0": c0})).all()
+    by_target = {(r.target_id, r.relation): r.extraction_method for r in rows}
+    assert by_target.get((str(ep), "part_of")) == "deterministic", (
+        f"chunk→episode part_of must be deterministic, got {by_target}"
+    )
+    assert by_target.get((str(c1), "related_to")) == "deterministic", (
+        f"adjacent chunk→chunk must be deterministic, got {by_target}"
+    )
+    assert by_target.get((str(fact), "summarized_by")) == "inferred", (
+        f"cosine-derived chunk→fact summarized_by must remain inferred, "
+        f"got {by_target}"
+    )
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
 async def test_run_backfill_cycle_includes_chunks_key(
     db, settings, mock_embeddings, _fix_stale_relation_constraint,
 ):

--- a/tests/test_graph_densifier.py
+++ b/tests/test_graph_densifier.py
@@ -182,6 +182,7 @@ async def _insert_chunk(
 async def _insert_fact_with_episode(
     session: AsyncSession, agent_id: str,
     content: str, embedding: list[float], source_episode_id,
+    *, active: bool = True,
 ) -> str:
     """F070 test helper: insert a fact with source_episode_id set."""
     fact_id = uuid4()
@@ -189,9 +190,10 @@ async def _insert_fact_with_episode(
     await session.execute(text("""
         INSERT INTO heart.facts
             (id, agent_id, content, active, embedding, source_episode_id)
-        VALUES (:id, :agent_id, :content, true, CAST(:emb AS vector), :ep_id)
+        VALUES (:id, :agent_id, :content, :active, CAST(:emb AS vector), :ep_id)
     """), {
         "id": fact_id, "agent_id": agent_id, "content": content,
+        "active": active,
         "emb": embedding_str, "ep_id": source_episode_id,
     })
     return fact_id
@@ -843,6 +845,54 @@ async def test_chunk_to_fact_same_episode_links(
     fact_targets = {r.target_id for r in rows}
     assert str(same_ep_fact) in fact_targets, "same-episode fact should link"
     assert str(cross_ep_fact) not in fact_targets, "cross-episode fact must NOT link"
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_chunk_to_fact_skips_inactive_facts(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint,
+):
+    """F070 (codex P2): inactive facts (active=false, e.g. superseded) must
+    NOT be linked even if they meet the cosine threshold."""
+    agent_id = f"test-chunk-inactive-{uuid4().hex[:8]}"
+    settings_local = settings.model_copy(update={
+        "chunk_consolidation_enabled": True,
+        "graph_backfill_enabled": True,
+        "graph_threshold_chunk_fact": 0.5,
+    })
+    linker = GraphLinker(db, mock_embeddings, settings_local, agent_id)
+    d = GraphDensifier(db, linker, mock_embeddings, settings_local, agent_id)
+
+    async with db.session() as s:
+        ep = await _insert_episode(s, agent_id, "ep")
+        ident_emb = await mock_embeddings.embed("user likes dark roast coffee")
+        chunk_id = await _insert_chunk(
+            s, agent_id, ep, 0,
+            "user likes dark roast coffee in this snippet", ident_emb,
+        )
+        active_fact = await _insert_fact_with_episode(
+            s, agent_id, "user likes dark roast coffee", ident_emb, ep,
+            active=True,
+        )
+        superseded_fact = await _insert_fact_with_episode(
+            s, agent_id, "user likes dark roast coffee", ident_emb, ep,
+            active=False,
+        )
+        await s.commit()
+
+    await d.backfill_orphan_chunks()
+
+    async with db.session() as s:
+        rows = (await s.execute(text(
+            "SELECT target_id::text FROM brain.graph_edges "
+            "WHERE agent_id = :a AND source_type = 'chunk' "
+            "  AND target_type = 'fact' AND source_id = :c "
+        ), {"a": agent_id, "c": chunk_id})).all()
+    fact_targets = {r.target_id for r in rows}
+    assert str(active_fact) in fact_targets, "active fact should link"
+    assert str(superseded_fact) not in fact_targets, (
+        "inactive (superseded) fact must NOT link"
+    )
 
 
 @pytest.mark.postgres_only

--- a/tests/test_graph_densifier.py
+++ b/tests/test_graph_densifier.py
@@ -162,20 +162,36 @@ async def _insert_episode(session: AsyncSession, agent_id: str, summary: str) ->
 
 async def _insert_chunk(
     session: AsyncSession, agent_id: str,
-    episode_id, chunk_index: int, content: str, embedding: list[float],
+    episode_id, chunk_index: int, content: str,
+    embedding: list[float] | None,
 ) -> str:
-    """F070 test helper: insert an episode_chunks row and return its ID."""
+    """F070 test helper: insert an episode_chunks row and return its ID.
+
+    Pass ``embedding=None`` to model the real-world case where embed
+    generation failed (column is nullable).
+    """
     chunk_id = uuid4()
-    embedding_str = "[" + ",".join(str(float(v)) for v in embedding) + "]"
-    await session.execute(text("""
-        INSERT INTO heart.episode_chunks
-            (id, agent_id, episode_id, chunk_index, content, embedding)
-        VALUES
-            (:id, :agent_id, :ep_id, :idx, :content, CAST(:embedding AS vector))
-    """), {
-        "id": chunk_id, "agent_id": agent_id, "ep_id": episode_id,
-        "idx": chunk_index, "content": content, "embedding": embedding_str,
-    })
+    if embedding is None:
+        await session.execute(text("""
+            INSERT INTO heart.episode_chunks
+                (id, agent_id, episode_id, chunk_index, content, embedding)
+            VALUES
+                (:id, :agent_id, :ep_id, :idx, :content, NULL)
+        """), {
+            "id": chunk_id, "agent_id": agent_id, "ep_id": episode_id,
+            "idx": chunk_index, "content": content,
+        })
+    else:
+        embedding_str = "[" + ",".join(str(float(v)) for v in embedding) + "]"
+        await session.execute(text("""
+            INSERT INTO heart.episode_chunks
+                (id, agent_id, episode_id, chunk_index, content, embedding)
+            VALUES
+                (:id, :agent_id, :ep_id, :idx, :content, CAST(:embedding AS vector))
+        """), {
+            "id": chunk_id, "agent_id": agent_id, "ep_id": episode_id,
+            "idx": chunk_index, "content": content, "embedding": embedding_str,
+        })
     return chunk_id
 
 
@@ -934,6 +950,48 @@ async def test_chunk_intra_episode_sequential_always_linked(
     found = [(r.source_id, r.target_id, r.weight) for r in rows]
     has_pair = any((s_id, t_id) in pair for s_id, t_id, _ in found)
     assert has_pair, f"sequential adjacent chunks must link, got {found}"
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_adjacent_chunk_links_even_when_sibling_embedding_null(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint,
+):
+    """F070 (codex P2): adjacency is structural, not embedding-derived.
+    When an adjacent sibling chunk has NULL embedding (e.g. embed call
+    failed), the guaranteed sequential edge must still be created."""
+    agent_id = f"test-chunk-null-emb-{uuid4().hex[:8]}"
+    settings_local = settings.model_copy(update={
+        "chunk_consolidation_enabled": True,
+        "graph_backfill_enabled": True,
+        "graph_threshold_chunk_chunk_intra": 0.5,
+    })
+    linker = GraphLinker(db, mock_embeddings, settings_local, agent_id)
+    d = GraphDensifier(db, linker, mock_embeddings, settings_local, agent_id)
+
+    async with db.session() as s:
+        ep = await _insert_episode(s, agent_id, "test-null-emb")
+        emb = await mock_embeddings.embed("apple")
+        # c0 has embedding (orphan that find_orphans will pick up),
+        # c1 is its adjacent sibling but has NULL embedding (embed failed).
+        c0 = await _insert_chunk(s, agent_id, ep, 0, "apple chunk", emb)
+        c1 = await _insert_chunk(s, agent_id, ep, 1, "zebra chunk", None)
+        await s.commit()
+
+    await d.backfill_orphan_chunks()
+
+    async with db.session() as s:
+        rows = (await s.execute(text(
+            "SELECT source_id::text, target_id::text "
+            "FROM brain.graph_edges "
+            "WHERE agent_id = :a AND source_type='chunk' AND target_type='chunk'"
+        ), {"a": agent_id})).all()
+    pair = {(str(c0), str(c1)), (str(c1), str(c0))}
+    found = {(r.source_id, r.target_id) for r in rows}
+    assert pair & found, (
+        f"adjacent chunks must link even when sibling embedding is NULL, "
+        f"got {found}"
+    )
 
 
 @pytest.mark.postgres_only

--- a/tests/test_graph_densifier.py
+++ b/tests/test_graph_densifier.py
@@ -996,6 +996,88 @@ async def test_adjacent_chunk_links_even_when_sibling_embedding_null(
 
 @pytest.mark.postgres_only
 @pytest.mark.asyncio
+async def test_null_embedding_chunk_still_gets_part_of_edge(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint,
+):
+    """F070 (codex P2): chunks whose embed call failed (embedding IS NULL)
+    must still receive the structural chunk→episode part_of edge — that's
+    the whole point of v1 being 'edges only, embedding-tolerant'."""
+    agent_id = f"test-null-emb-orphan-{uuid4().hex[:8]}"
+    settings_local = settings.model_copy(update={
+        "chunk_consolidation_enabled": True,
+        "graph_backfill_enabled": True,
+    })
+    linker = GraphLinker(db, mock_embeddings, settings_local, agent_id)
+    d = GraphDensifier(db, linker, mock_embeddings, settings_local, agent_id)
+
+    async with db.session() as s:
+        ep = await _insert_episode(s, agent_id, "ep")
+        # Chunk with NULL embedding (failed embed call scenario).
+        chunk = await _insert_chunk(s, agent_id, ep, 0, "content here", None)
+        await s.commit()
+
+    await d.backfill_orphan_chunks()
+
+    async with db.session() as s:
+        rows = (await s.execute(text(
+            "SELECT target_id::text, relation FROM brain.graph_edges "
+            "WHERE agent_id = :a AND source_id = :c "
+            "  AND source_type = 'chunk'"
+        ), {"a": agent_id, "c": chunk})).all()
+    relations = {(r.target_id, r.relation) for r in rows}
+    assert (str(ep), "part_of") in relations, (
+        f"NULL-embedded chunk must still receive chunk→episode part_of edge, "
+        f"got {relations}"
+    )
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_sequential_chunk_edge_persisted_at_weight_1_0(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint,
+):
+    """F070 (codex P2): adjacent chunk→chunk edges use the related_to
+    relation (multiplier 0.8) but the documented structural weight is 1.0.
+    Verify the multiplier override on create_edge keeps the persisted
+    weight at 1.0 for sequential pairs."""
+    agent_id = f"test-seq-weight-{uuid4().hex[:8]}"
+    settings_local = settings.model_copy(update={
+        "chunk_consolidation_enabled": True,
+        "graph_backfill_enabled": True,
+        # High cosine threshold so only the adjacency branch fires.
+        "graph_threshold_chunk_chunk_intra": 0.99,
+    })
+    linker = GraphLinker(db, mock_embeddings, settings_local, agent_id)
+    d = GraphDensifier(db, linker, mock_embeddings, settings_local, agent_id)
+
+    async with db.session() as s:
+        ep = await _insert_episode(s, agent_id, "ep")
+        emb_a = await mock_embeddings.embed("apple")
+        emb_b = await mock_embeddings.embed("zebra")
+        c0 = await _insert_chunk(s, agent_id, ep, 0, "apple chunk", emb_a)
+        c1 = await _insert_chunk(s, agent_id, ep, 1, "zebra chunk", emb_b)
+        await s.commit()
+
+    await d.backfill_orphan_chunks()
+
+    async with db.session() as s:
+        rows = (await s.execute(text(
+            "SELECT weight FROM brain.graph_edges "
+            "WHERE agent_id = :a AND source_type = 'chunk' "
+            "  AND target_type = 'chunk' "
+            "  AND ((source_id = :c0 AND target_id = :c1) "
+            "    OR (source_id = :c1 AND target_id = :c0))"
+        ), {"a": agent_id, "c0": c0, "c1": c1})).all()
+    assert rows, "sequential edge should exist"
+    weights = [float(r.weight) for r in rows]
+    assert all(abs(w - 1.0) < 1e-6 for w in weights), (
+        f"sequential chunk edges must persist at structural weight 1.0, "
+        f"got {weights}"
+    )
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
 async def test_run_backfill_cycle_includes_chunks_key(
     db, settings, mock_embeddings, _fix_stale_relation_constraint,
 ):

--- a/tests/test_retrieval_pipeline.py
+++ b/tests/test_retrieval_pipeline.py
@@ -159,16 +159,37 @@ class _FakeSession:
         return _FakeExecuteResult(self._contradictions)
 
 
-def _make_brain(*, neighbors_by_node, contradictions, decision_results):
-    """Build a MagicMock Brain whose .neighbors and .query are AsyncMocks."""
+def _make_brain(
+    *, neighbors_by_node, contradictions, decision_results,
+    neighbors_side_effect_override=None,
+):
+    """Build a MagicMock Brain whose .neighbors and .query are AsyncMocks.
+
+    ``neighbors_by_node`` maps node_id → list[NeighborResult]. When the caller
+    passes a ``neighbor_type``, the mock honors the SQL pushdown contract by
+    filtering the per-node list down to that type — exactly as
+    ``Brain._neighbors`` does in real life. This is critical for Path A's
+    Stage 2b fan-out test, which calls ``brain.neighbors`` once per neighbor
+    type at a small LIMIT.
+
+    ``neighbors_side_effect_override`` accepts a custom async callable that
+    fully replaces the lookup logic — used by the exception-path test.
+    """
     brain = MagicMock()
     brain.agent_id = "nous-test-agent"
     brain.query = AsyncMock(return_value=decision_results)
 
-    async def neighbors_side_effect(node_id, node_type="decision", limit=10):
-        return neighbors_by_node.get(node_id, [])
+    async def neighbors_side_effect(
+        node_id, node_type="decision", limit=10, *, neighbor_type=None,
+    ):
+        rows = neighbors_by_node.get(node_id, [])
+        if neighbor_type:
+            rows = [r for r in rows if r.node_type == neighbor_type]
+        return rows[:limit]
 
-    brain.neighbors = AsyncMock(side_effect=neighbors_side_effect)
+    brain.neighbors = AsyncMock(
+        side_effect=neighbors_side_effect_override or neighbors_side_effect,
+    )
 
     # brain.db.session() returns an async context manager; same _FakeSession
     # is used for the (skipped) density check AND the contradictions SELECT.
@@ -192,6 +213,10 @@ def _make_settings(
     graph_recall_decay=0.7,
     graph_recall_max_expand=5,
     graph_recall_max_neighbors=3,
+    heart_graph_all_types_enabled=False,
+    heart_graph_neighbors_per_seed=3,
+    episode_chunks_enabled=False,
+    episode_chunk_recall_limit=10,
 ):
     return SimpleNamespace(
         graph_recall_enabled=graph_recall_enabled,
@@ -201,6 +226,10 @@ def _make_settings(
         graph_recall_decay=graph_recall_decay,
         graph_recall_max_expand=graph_recall_max_expand,
         graph_recall_max_neighbors=graph_recall_max_neighbors,
+        heart_graph_all_types_enabled=heart_graph_all_types_enabled,
+        heart_graph_neighbors_per_seed=heart_graph_neighbors_per_seed,
+        episode_chunks_enabled=episode_chunks_enabled,
+        episode_chunk_recall_limit=episode_chunk_recall_limit,
     )
 
 
@@ -385,6 +414,223 @@ class TestRunRecallPipeline:
         assert len(results) == 1
         assert results[0].type == "fact"
         assert stats.n_brain_results == 0
+
+
+# ---------------------------------------------------------------------------
+# Path A Stage 2b: heart_graph_memory_neighbors
+# ---------------------------------------------------------------------------
+
+
+class TestPathAStage2b:
+    """Path A (heart_graph_all_types_enabled) — Stage 2b emits non-decision
+    graph neighbors from fact/episode/chunk seeds. All tests use real Settings
+    flag via _make_settings(heart_graph_all_types_enabled=True)."""
+
+    @pytest.mark.asyncio
+    async def test_flag_off_byte_identical_to_baseline(self):
+        """Path A must be invisible when the flag is off — no extra items,
+        no extra brain.neighbors calls beyond the decision-only Stage 2."""
+        heart = _make_heart(recall_results=_make_recall_results())
+        brain = _make_brain(
+            neighbors_by_node={
+                FACT_ID: _make_neighbors_for_heart_seed(),
+                EPISODE_ID: [],
+            },
+            contradictions=[],
+            decision_results=[],
+        )
+        settings = _make_settings(heart_graph_all_types_enabled=False)
+
+        results, stats = await run_recall_pipeline(
+            query="anything", heart=heart, brain=brain,
+            settings=settings, limit=10,
+        )
+        # No memory-neighbor results in pipeline output
+        assert all(
+            r.metadata.get("stage_origin") != "heart_graph_memory"
+            for r in results
+        ), "Stage 2b emitted results with flag off"
+        # No memory-neighbor stage_errors created
+        assert "heart_graph_memory_neighbors" not in stats.n_stage_errors
+        assert "heart_graph_memory_duplicates" not in stats.n_stage_errors
+
+    @pytest.mark.asyncio
+    async def test_flag_on_appends_mixed_type_neighbors(self):
+        """Path A happy path: with the flag on, fact-seed mem_neighbors of
+        every non-decision type land in pipeline output with the correct
+        ``type`` (not hardcoded to 'decision'), source='graph_expanded',
+        and stage_origin='heart_graph_memory'."""
+        from uuid import uuid4
+
+        fact_nbr_id = uuid4()
+        ep_nbr_id = uuid4()
+        chunk_nbr_id = uuid4()
+        proc_nbr_id = uuid4()
+        # Mix of types neighboring FACT_ID seed.
+        nbrs = [
+            NeighborResult(
+                id=fact_nbr_id, node_type="fact",
+                description="FACT-NBR-DESC",
+                edge_relation="related_to", edge_weight=0.8,
+                created_at=datetime.now(UTC),
+            ),
+            NeighborResult(
+                id=ep_nbr_id, node_type="episode",
+                description="EP-NBR-DESC",
+                edge_relation="discussed_in", edge_weight=0.7,
+                created_at=datetime.now(UTC),
+            ),
+            NeighborResult(
+                id=chunk_nbr_id, node_type="chunk",
+                description="CHUNK-NBR-DESC",
+                edge_relation="summarized_by", edge_weight=0.9,
+                created_at=datetime.now(UTC),
+            ),
+            NeighborResult(
+                id=proc_nbr_id, node_type="procedure",
+                description="PROC-NBR-DESC",
+                edge_relation="related_to", edge_weight=0.6,
+                created_at=datetime.now(UTC),
+            ),
+        ]
+        heart = _make_heart(recall_results=_make_recall_results())
+        brain = _make_brain(
+            neighbors_by_node={FACT_ID: nbrs, EPISODE_ID: nbrs},
+            contradictions=[], decision_results=[],
+        )
+        settings = _make_settings(heart_graph_all_types_enabled=True)
+
+        results, _stats = await run_recall_pipeline(
+            query="anything", heart=heart, brain=brain,
+            settings=settings, limit=20,
+        )
+        memory_results = [
+            r for r in results
+            if r.metadata.get("stage_origin") == "heart_graph_memory"
+        ]
+        types = {r.type for r in memory_results}
+        # All four non-decision types present.
+        assert types == {"fact", "episode", "chunk", "procedure"}, (
+            f"expected all 4 non-decision types, got {types}"
+        )
+        # Each entry has source='graph_expanded' and a real description
+        # (proves we're not emitting placeholders).
+        for r in memory_results:
+            assert r.source == "graph_expanded"
+            assert "NBR-DESC" in (r.description or ""), (
+                f"description not propagated for {r.type}: {r.description!r}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_skips_decisions_and_dedups_against_pool(self):
+        """Stage 2b must (1) skip neighbors of type='decision' (already
+        handled by Stage 2), (2) skip duplicates already in heart_results,
+        (3) skip duplicates already in chunk_results, (4) count the
+        chunk/heart duplicates as heart_graph_memory_duplicates so eval
+        can distinguish corroboration from noise."""
+        from uuid import uuid4
+
+        dup_chunk_id = uuid4()  # will already be in chunk_results
+        fresh_fact_id = uuid4()  # should make it through
+        decision_neighbor_id = uuid4()  # must be skipped
+        nbrs = [
+            NeighborResult(
+                id=fresh_fact_id, node_type="fact", description="FRESH",
+                edge_relation="related_to", edge_weight=0.8,
+                created_at=datetime.now(UTC),
+            ),
+            NeighborResult(
+                id=FACT_ID, node_type="fact", description="DUP-HEART",
+                edge_relation="related_to", edge_weight=0.7,
+                created_at=datetime.now(UTC),
+            ),
+            NeighborResult(
+                id=dup_chunk_id, node_type="chunk", description="DUP-CHUNK",
+                edge_relation="summarized_by", edge_weight=0.9,
+                created_at=datetime.now(UTC),
+            ),
+            NeighborResult(
+                id=decision_neighbor_id, node_type="decision",
+                description="MUST-SKIP-DECISION",
+                edge_relation="informed_by", edge_weight=0.9,
+                created_at=datetime.now(UTC),
+            ),
+        ]
+        heart = _make_heart(recall_results=_make_recall_results())
+        brain = _make_brain(
+            neighbors_by_node={FACT_ID: nbrs, EPISODE_ID: nbrs},
+            contradictions=[], decision_results=[],
+        )
+        # Enable the F067 chunk-search leg so acc.chunk_results gets populated,
+        # exercising Stage 2b's chunk-result dedup branch.
+        settings = _make_settings(
+            heart_graph_all_types_enabled=True,
+            episode_chunks_enabled=True,
+        )
+        # Pre-load a chunk result that matches dup_chunk_id to test the
+        # chunk_results dedup branch.
+        original_search_chunks_path = (
+            "nous.api.retrieval_pipeline._search_episode_chunks"
+        )
+        with patch(original_search_chunks_path, new=AsyncMock(
+            return_value=[(dup_chunk_id, "dup chunk content", 0.5)],
+        )):
+            results, stats = await run_recall_pipeline(
+                query="anything", heart=heart, brain=brain,
+                settings=settings, limit=20,
+            )
+
+        mem = [
+            r for r in results
+            if r.metadata.get("stage_origin") == "heart_graph_memory"
+        ]
+        mem_ids = {r.id for r in mem}
+        assert fresh_fact_id in mem_ids, "fresh non-dup fact must pass"
+        assert FACT_ID not in mem_ids, "heart-result dup must be filtered"
+        assert dup_chunk_id not in mem_ids, "chunk-result dup must be filtered"
+        assert decision_neighbor_id not in mem_ids, (
+            "decision neighbor must be skipped (Stage 2's territory)"
+        )
+        # Duplicate counter fired (FACT_ID + dup_chunk_id each observed
+        # once per seed × once per neighbor_type they match).
+        dup_count = stats.n_stage_errors.get("heart_graph_memory_duplicates", 0)
+        assert dup_count >= 2, (
+            f"expected >=2 dedup events (heart + chunk), got {dup_count}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_brain_neighbors_exception_increments_counter(self):
+        """When brain.neighbors raises, Stage 2b logs+counts per-(seed, nbr_type)
+        and continues with the next seed. Counter must surface to stats."""
+        async def always_raise(*args, **kwargs):
+            raise RuntimeError("simulated brain.neighbors failure")
+
+        heart = _make_heart(recall_results=_make_recall_results())
+        brain = _make_brain(
+            neighbors_by_node={},
+            contradictions=[],
+            decision_results=[],
+            neighbors_side_effect_override=always_raise,
+        )
+        settings = _make_settings(heart_graph_all_types_enabled=True)
+
+        # Should NOT propagate the exception — pipeline returns normally.
+        results, stats = await run_recall_pipeline(
+            query="anything", heart=heart, brain=brain,
+            settings=settings, limit=10,
+        )
+        # Heart results still flow through; only Stage 2 + 2b were affected.
+        assert any(r.source == "heart" for r in results), (
+            "heart_results must still arrive when brain.neighbors fails"
+        )
+        # Counter incremented at least once. The fan-out runs N seeds ×
+        # 4 nbr_types per seed; with 2 heart seeds (fact + episode), that's
+        # 8 expected exception events.
+        count = stats.n_stage_errors.get("heart_graph_memory_neighbors", 0)
+        assert count >= 1, (
+            f"expected heart_graph_memory_neighbors counter to increment, "
+            f"got {stats.n_stage_errors}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_retrieval_pipeline.py
+++ b/tests/test_retrieval_pipeline.py
@@ -572,8 +572,17 @@ class TestPathAStage2b:
         original_search_chunks_path = (
             "nous.api.retrieval_pipeline._search_episode_chunks"
         )
+        # _search_episode_chunks returns 4-tuples (id, content, score,
+        # episode_id) — see retrieval_pipeline.py:825. The earlier draft
+        # of this test used a 3-tuple, which prevented the test from
+        # catching the production unpacking bug (`{cid for cid, _, _ in
+        # acc.chunk_results}` against 4-tuples). Match the real shape.
+        from uuid import uuid4 as _u
+        dup_chunk_episode_id = _u()
         with patch(original_search_chunks_path, new=AsyncMock(
-            return_value=[(dup_chunk_id, "dup chunk content", 0.5)],
+            return_value=[(
+                dup_chunk_id, "dup chunk content", 0.5, dup_chunk_episode_id,
+            )],
         )):
             results, stats = await run_recall_pipeline(
                 query="anything", heart=heart, brain=brain,


### PR DESCRIPTION
## Summary

Closes the orphan-chunks gap. 2026-05-25 audit found 1,775 graph edges in
`brain.graph_edges`, **all** fact↔fact / procedure↔procedure — zero
involving chunks. Adjacency boost and F022 spreading activation can't
reach chunks until edges exist.

This PR makes chunks a first-class graph node and lets the sleep cycle
densify chunk neighborhoods. Spec: `docs/features/F070-chunk-aware-sleep.md` (#447).

## What this changes

**New node type & relations** (`nous/brain/schemas.py`):
- `NodeType` admits `"chunk"`
- `RelationType` admits `"part_of"` and `"summarized_by"`

**Wired into densifier** (`nous/brain/graph_densifier.py`, `_entity_config.py`):
- `chunk → episode` `[part_of]` — always created (provenance FK as edge)
- `chunk → fact` `[summarized_by]` — same-episode, gated on `graph_threshold_chunk_fact`
- `chunk → chunk` `[related_to]` — sequential adjacency always linked; non-adjacent gated on `graph_threshold_chunk_chunk_intra` (intra-episode) / `..._cross` (cross-episode)
- `backfill_orphan_chunks` slotted into `run_backfill_cycle` alongside facts/decisions/episodes/procedures

**Schema migration 051**: extends `ck_edges_{source_type,target_type,relation}` to admit the new values. Drops both the auto-named `graph_edges_*_check` constraints (from `init.sql`) and the `ck_edges_*` names added by migration 016 — fresh-DB compose-up tested.

**Settings** (`nous/config.py`) — all opt-in:
- `NOUS_CHUNK_CONSOLIDATION_ENABLED` (default `False`)
- `NOUS_GRAPH_BACKFILL_MAX_CHUNKS` (default `100`)
- `NOUS_GRAPH_THRESHOLD_CHUNK_FACT` (default `0.55`)
- `NOUS_GRAPH_THRESHOLD_CHUNK_CHUNK_INTRA` (default `0.70`)
- `NOUS_GRAPH_THRESHOLD_CHUNK_CHUNK_CROSS` (default `0.85`)

## Validation

**Smoke on eval DB** (`nous_eval_scratch`, agent `nous-lme-corpus`, 35,804 chunks):
Ran one densifier cycle with the flag on. Result on 30 orphan chunks:

| Relation | Count |
|----------|-------|
| chunk → chunk `[related_to]` | 109 |
| chunk → episode `[part_of]` | 42 |
| chunk → fact `[summarized_by]` | 34 |
| **Total new chunk edges** | **185** |

**Unit tests**: 5 new tests in `tests/test_graph_densifier.py`, all pass against real Postgres.

## Scope notes

- **v1 ships edges only.** Chunk dedup-marking and stale-pruning deferred to F070.1 per codex P1 review (chunks have no `superseded_by` / `active` columns yet).
- **Pre-existing test failures** (3 `TestGetThreshold` tests) are an `.env`-isolation bug unrelated to F070 — local `.env` has `NOUS_CE_BACKFILL_ENABLED=true` leaking into `Settings()`. Did not fix per surgical-changes discipline.
- **EpisodeSummarizer (session-end) hook intentionally not wired in v1.** At session-end, fact extraction has not yet run (handled by event bus), so chunk→fact edges would all be empty. Sleep cycle fires after the fact-extraction event lands, which is the right point to build the edges. Adding the session-end hook is harmless but redundant for v1 — keep until F070.1.

## Test plan

- [ ] Apply migration 051 to prod DB
- [ ] Enable `NOUS_CHUNK_CONSOLIDATION_ENABLED=true` on prod
- [ ] Confirm next sleep cycle writes chunk edges (`SELECT count(*) FROM brain.graph_edges WHERE 'chunk' IN (source_type, target_type)`)
- [ ] Re-run adjacency-boost A/B once chunks have edges to consult — F070 unblocks the prior null result
- [ ] @codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)