### PR TITLE
spec(F070.1): cross-episode chunk graph edges

### DIFF
--- a/docs/features/F070.1-cross-episode-chunk-edges.md
+++ b/docs/features/F070.1-cross-episode-chunk-edges.md
@@ -1,0 +1,280 @@
+# F070.1 — Cross-episode chunk graph edges
+
+**Status**: spec
+**Depends on**: F070 v1 (merged 2026-05-26, PR #448)
+**Spec author**: Claude + Tim, 2026-05-25
+**Branch when implementing**: `feat/F070.1-cross-episode-chunk-edges`
+
+
+## Problem
+
+F070 v1 wrote 229K chunk graph edges on the LME eval corpus and a smaller
+number on prod, but **every edge is same-episode**: `chunk → fact summarized_by`
+requires `f.source_episode_id = chunk.episode_id`; `chunk → chunk related_to`
+uses sequential adjacency + intra-episode cosine.
+
+That decision was load-bearing for v1's scope (no embedding fan-out across the
+full chunk table). It also means F070's retrieval consumers are
+**structurally inert on session-level recall**. We proved this empirically:
+
+| Eval | chunks_off | baseline |
+|---|---|---|
+| BGE only (no chunk edges consulted) | 0.917 | 0.950 |
+| BGE + Path A (Stage 2b consumes chunk edges) | 0.917 | 0.950 |
+| BGE + adjacency_boost (in-batch reweighting) | 0.917 | 0.950 |
+
+Direct probe confirmed Path A fires and surfaces chunk neighbors via
+`summarized_by` — but those neighbors are always same-episode as the seed,
+so same-session, so they add zero new sessions to top-K. Session-level
+recall counts unique sessions in top-K, so the metric is structurally
+blind to within-session corroboration.
+
+**The lever to actually move retrieval is cross-episode chunk edges.**
+
+
+## Goals
+
+1. **`chunk → fact summarized_by` across episodes** — when a chunk
+   semantically resembles a fact extracted from a *different* episode at
+   cosine ≥ `graph_threshold_chunk_fact_cross`. Lets a single fact-seed
+   surface chunks from other sessions via Path A's existing fan-out.
+
+2. **`chunk ↔ chunk related_to` across episodes** — chunks of episode A
+   linking to similar chunks of episode B at cosine ≥
+   `graph_threshold_chunk_chunk_cross` (the reserved-but-unused env var
+   from F070 v1, default 0.85). Lets a chunk-seed surface similar chunks
+   from other sessions.
+
+3. **Backfill script targets chunks lacking cross-episode edges**. The
+   existing `find_orphans` excludes any chunk with ANY edge → unusable
+   for retrofitting cross-episode edges on already-linked chunks. New
+   finder needed.
+
+4. **Idempotent end-to-end** so a partial run can resume.
+
+5. **No retrieval-side code changes**. Path A v1 (PR #448) already
+   consumes any chunk neighbor without an episode filter — F070.1's
+   cross-episode edges just appear there automatically.
+
+
+## Non-goals
+
+- **Multi-hop expansion** — Stage 2b stays 1-hop. Walking from chunk →
+  chunk → fact is a separate feature.
+- **`chunk → episode part_of` cross-episode** — semantically wrong; a
+  chunk belongs to exactly one episode.
+- **Schema migration** — F070 v1's migration 051 already admits the
+  needed types/relations.
+- **Chunk staleness / dedup-marking** — still deferred (originally to
+  F070.1; now to F070.2 along with the `superseded_by` column on
+  `heart.episode_chunks`).
+- **New retrieval flags** — Path A's existing
+  `NOUS_HEART_GRAPH_ALL_TYPES_ENABLED` is the only consumer-side switch.
+
+
+## Design
+
+### 1. New densifier methods on `nous/brain/graph_densifier.py`
+
+Two methods that mirror the v1 same-episode pair, but invert the
+`source_episode_id` constraint and bound the candidate scan via the
+existing HNSW vector index on `embedding`:
+
+```python
+async def _link_chunk_to_cross_episode_facts(
+    self, chunk_id: UUID, source_episode_id: UUID,
+    threshold: float, top_k: int, session: AsyncSession,
+) -> int:
+    """Cross-episode chunk → fact summarized_by edges.
+
+    Vector-index-bounded scan: take the top_k facts by cosine excluding
+    the source's own episode, then threshold-gate. HNSW index makes this
+    fast even on the full corpus.
+    """
+```
+
+```python
+async def _link_chunk_to_cross_episode_chunks(
+    self, chunk_id: UUID, source_episode_id: UUID,
+    threshold: float, top_k: int, session: AsyncSession,
+) -> int:
+    """Cross-episode chunk ↔ chunk related_to edges (deduplication).
+
+    Same pattern. Excludes same-episode siblings (handled by v1
+    `_link_chunk_to_intra_episode_chunks`).
+    """
+```
+
+Both use `provenance_source="auto_linker"` → `extraction_method='inferred'`
+(cosine-derived, not structural). Matches F040/F043 cross-type linking
+provenance tier.
+
+### 2. New orphan finder for retrofit
+
+`find_orphans` filters by `NOT EXISTS (any edge involving this chunk)`.
+After F070 v1 backfill, every chunk has at least the `part_of` edge → no
+"orphans" remain → cross-episode backfill picks up zero candidates.
+
+Add a parallel finder:
+
+```python
+async def find_chunks_lacking_cross_episode_edges(
+    self, limit: int, session: AsyncSession,
+) -> list[tuple[UUID, str, UUID]]:
+    """Return chunks that have at least one edge but no cross-episode
+    one. ``(chunk_id, content, source_episode_id)`` tuples.
+
+    SQL: ``WHERE EXISTS (any chunk-edge) AND NOT EXISTS (cross-episode chunk-edge)``
+    where "cross-episode" is detected by joining graph_edges to either
+    heart.facts or heart.episode_chunks on the target ID and comparing
+    episode IDs.
+    """
+```
+
+### 3. New top-level entry point
+
+`backfill_orphan_chunks_cross_episode(max_count)` parallels the v1
+`backfill_orphan_chunks`:
+
+```python
+async def backfill_orphan_chunks_cross_episode(
+    self, max_count: int | None = None,
+) -> int:
+    """F070.1: add cross-episode summarized_by + related_to edges.
+
+    Idempotent: ON CONFLICT DO NOTHING + the cross-episode-orphan finder
+    skips chunks that already have cross-episode edges from a prior run.
+    """
+```
+
+NOT wired into `run_backfill_cycle` (which is the sleep-cycle phase).
+F070.1's first run is operator-triggered via the backfill script; future
+sleep cycles can pick it up after we've validated on prod.
+
+### 4. CE rerank
+
+**Decision: don't use CE in v1.** Rationale:
+
+- v1 same-episode uses pure cosine, no CE. F070.1 should match the
+  v1 pattern for consistency.
+- Cross-episode candidate pool is bounded by the top-K HNSW scan (default
+  20). At threshold 0.75 (chunk→fact_cross) most candidates already
+  exceed cosine 0.75, so the precision filter is already tight.
+- CE adds 4-6× per-chunk latency on a 1,200-chunk prod corpus
+  (~10 minutes vs ~2 minutes). Marginal precision gain on already-tight
+  threshold doesn't pay back.
+- If post-deploy eval shows the cross-episode edges are noisy, F070.1.1
+  can add CE rerank as an opt-in flag (reuse F043's `_run_ce_backfill`
+  helper).
+
+### 5. New settings (`nous/config.py`)
+
+```python
+graph_threshold_chunk_fact_cross: float = Field(
+    default=0.75,
+    description=(
+        "F070.1: cosine threshold for chunk → fact summarized_by edges "
+        "across episodes. Stricter than same-episode (0.55) because "
+        "cross-episode is a noisier candidate pool — only strong "
+        "semantic matches should bridge sessions."
+    ),
+)
+graph_backfill_max_chunks_cross_episode: int = Field(
+    default=2000,
+    description=(
+        "F070.1: per-cycle cap on chunks processed by the cross-episode "
+        "backfill (mirrors graph_backfill_max_chunks for v1)."
+    ),
+)
+chunk_cross_episode_top_k: int = Field(
+    default=20,
+    description=(
+        "F070.1: HNSW-bounded LIMIT for the cross-episode cosine scan "
+        "per chunk. Higher = more candidates to threshold-gate, lower = "
+        "tighter. 20 lands ~5 surviving neighbors per chunk in eval."
+    ),
+)
+```
+
+Reuses `graph_threshold_chunk_chunk_cross` (already env-tunable from v1).
+
+### 6. Backfill-script changes (`scripts/backfill_f070_chunks.py`)
+
+Add a `--mode {same-episode,cross-episode,all}` flag (default
+`same-episode` for backwards-compat with the v1 prod run that already
+happened). Cross-episode mode iterates the new finder.
+
+```
+NOUS_CHUNK_CONSOLIDATION_ENABLED=true \
+    uv run python scripts/backfill_f070_chunks.py \
+    --agent-id nous-default --mode cross-episode
+```
+
+### 7. Code touch points
+
+- `nous/brain/graph_densifier.py` — 3 new methods (+ ~150 LOC)
+- `nous/config.py` — 3 new settings (+ ~20 LOC)
+- `scripts/backfill_f070_chunks.py` — `--mode` flag + cross-episode loop (+ ~50 LOC)
+- `tests/test_graph_densifier.py` — 4-5 new tests (cross-episode happy
+  path, threshold gate, exclude-same-episode, idempotent re-run)
+- `CLAUDE.md` — 3 new env vars added to the table
+- `docs/features/INDEX.md` — F070.1 entry
+
+
+## Migration
+
+No schema changes. Migration 051 (F070 v1) already admits `chunk` node
+type and `summarized_by` / `related_to` relations.
+
+
+## Rollout
+
+1. Merge F070.1 PR.
+2. Restart nous-agent on prod (no-op DB-wise since no migration).
+3. Run backfill: `python scripts/backfill_f070_chunks.py --agent-id
+   nous-default --mode cross-episode`. Expected: ~5-10 min on prod's
+   1,262 chunks (each chunk does 1 HNSW LIMIT-20 + threshold filter +
+   edge insert).
+4. Verify with `SELECT source_type, target_type, relation, COUNT(*)`
+   grouped — expect both same- and cross-episode rows.
+5. Re-run `eval_session_level_recall.py --mode per_haystack --k 5` on
+   the eval corpus (after the same backfill there) with Path A enabled
+   (`NOUS_HEART_GRAPH_ALL_TYPES_ENABLED=true`).
+6. **Expected lift on the per_haystack benchmark**: hit@5 0.950 → 0.96–0.97
+   on baseline, with the multi-session + knowledge-update categories
+   carrying most of the lift. chunks_off probably stays at 0.917 (it
+   doesn't traverse chunks). If lift doesn't appear at all, the
+   structural hypothesis was wrong and F070.2 needs to layer something
+   else on top (multi-hop, CE rerank, different threshold).
+
+
+## Open questions
+
+1. **Threshold tuning.** Default 0.75 for chunk→fact_cross is a guess
+   informed by F040's cross-type defaults (fact→fact 0.82, fact→decision
+   0.72). Worth one quick eval sweep at {0.70, 0.75, 0.80} before
+   declaring the default. Reuse the same single-variable A/B discipline
+   we used for BGE.
+
+2. **Backfill scope.** Should cross-episode backfill be added to
+   `run_backfill_cycle` so it runs on every sleep cycle, or stay
+   operator-triggered? Recommend operator-triggered for v1 — we have no
+   evidence it's worth the per-cycle cost yet.
+
+3. **Density consequences.** Path A's per-seed fan-out cap
+   (`heart_graph_neighbors_per_seed`, default 3) was tuned for v1's
+   bounded-by-episode neighborhood. With cross-episode edges the
+   neighbor pool per seed is much bigger; the LIMIT 3 may now be too
+   tight. Possibly need to bump to 5–10 after F070.1 lands.
+
+
+## Provenance
+
+- F070 v1 PR #448 (merged 2026-05-26, squash 5eaf3248): data layer +
+  Path A + BGE default + 6 codex rounds. Same-episode constraint
+  explicitly scoped to v1.
+- 3-way retrieval consumer test (Path A, adjacency_boost, session_group)
+  empirically confirmed F070 v1's session-level recall ceiling on
+  2026-05-25T22-34-46 / 00-29-49 / 00-54-47.
+- Memory: `project_f070_shipped.md` documents the inert-on-session-recall
+  finding and named F070.1 as the next lever.

--- a/docs/features/F070.1-cross-episode-chunk-edges.md
+++ b/docs/features/F070.1-cross-episode-chunk-edges.md
@@ -268,42 +268,25 @@ type and `summarized_by` / `related_to` relations.
    tight. Possibly need to bump to 5–10 after F070.1 lands.
 
 
-## gbrain inspiration
+## Deferred from F070.1 scope
 
-This design is the second half of the gbrain-inspired retrieval architecture
-we began landing in F067 (chunk granularity) and F070 v1 (chunk graph data
-layer). gbrain reports R@5 = 0.976 on LongMemEval — the SOTA benchmark our
-0.96-0.97 hypothesis target deliberately approaches.
+Several adjacent ideas are real levers but out of scope for this PR:
 
-Specific gbrain patterns this spec adopts:
-
-1. **Corpus-wide cosine-weighted chunk graph** (not document-local). The
-   whole point of cross-episode edges is to let memory items reinforce
-   each other across documents/sessions — gbrain's central retrieval
-   insight. F070 v1's same-episode constraint deliberately deferred this
-   to keep v1 small; F070.1 closes the gap.
-2. **HNSW top-K + threshold gate** (not full pairwise compare). Matches
-   gbrain's per-chunk neighborhood cap. `chunk_cross_episode_top_k=20`
-   mirrors the order of magnitude they cite.
-3. **Adjacency-aware ranking on top of the dense graph**. We already
-   restored `graph_adjacency_boost_enabled` in PR #448 — that IS gbrain's
-   pattern; currently inert because v1's same-episode edges don't add
-   new sessions to top-K. F070.1 makes it testable for the first time.
-
-Specific gbrain patterns this spec does **NOT** adopt (deferred):
-
-- **God-nodes / hub-shifting**: gbrain identifies high-degree nodes and
-  seeds expansion from them. F065 already ships `Brain.top_hubs(...)`
+- **God-nodes / hub-shifting**: F065 already ships `Brain.top_hubs(...)`
   (brain.py:1224) but Path A's seed selection doesn't consult it.
   Candidate for an F070.2 follow-up once F070.1's cross-episode density
-  is real (otherwise top_hubs returns mostly fact-fact same-cluster nodes
-  with no cross-session value).
-- **Multi-tier chunk sizes** (large/medium/small). gbrain runs 3
-  parallel chunkers. We have one (600ch sliding 80ch). Out of F070.1
-  scope; would be F067.2.
-- **Re-ranking with a learned model trained on gbrain-style features**.
-  F042 cross-encoder reranker partially overlaps; full feature-trained
-  re-ranking is out of scope.
+  is real (otherwise top_hubs returns mostly fact-fact same-cluster
+  nodes with no cross-session value).
+- **Multi-tier chunk sizes** (large/medium/small). We currently use a
+  single 600ch sliding 80ch chunker. If F070.1 leaves specific category
+  gaps (e.g. temporal-reasoning still floored), multi-tier chunks are
+  the most likely next lever — F067.2 spec deferred until we have
+  category-level diagnosis from the F070.1 eval.
+- **Graph-feature-aware re-ranker**. F042 cross-encoder
+  (BGE-reranker-v2-m3) is trained on generic text-pair relevance, not on
+  graph/structural features. A custom score blend (cosine + graph-degree
+  + edge-weight) or a small learned re-ranker on outcome data would
+  amplify F070.1's edges. Out of scope here.
 
 
 ## Provenance
@@ -316,6 +299,3 @@ Specific gbrain patterns this spec does **NOT** adopt (deferred):
   2026-05-25T22-34-46 / 00-29-49 / 00-54-47.
 - Memory: `project_f070_shipped.md` documents the inert-on-session-recall
   finding and named F070.1 as the next lever.
-- gbrain: Garry Tan's knowledge brain, the LME R@5 SOTA reference. We
-  log-comp metrics against it; chunks_on hit@5 0.917 vs gbrain R@5
-  0.976 is the gap F070.1 targets.

--- a/docs/features/F070.1-cross-episode-chunk-edges.md
+++ b/docs/features/F070.1-cross-episode-chunk-edges.md
@@ -268,6 +268,44 @@ type and `summarized_by` / `related_to` relations.
    tight. Possibly need to bump to 5–10 after F070.1 lands.
 
 
+## gbrain inspiration
+
+This design is the second half of the gbrain-inspired retrieval architecture
+we began landing in F067 (chunk granularity) and F070 v1 (chunk graph data
+layer). gbrain reports R@5 = 0.976 on LongMemEval — the SOTA benchmark our
+0.96-0.97 hypothesis target deliberately approaches.
+
+Specific gbrain patterns this spec adopts:
+
+1. **Corpus-wide cosine-weighted chunk graph** (not document-local). The
+   whole point of cross-episode edges is to let memory items reinforce
+   each other across documents/sessions — gbrain's central retrieval
+   insight. F070 v1's same-episode constraint deliberately deferred this
+   to keep v1 small; F070.1 closes the gap.
+2. **HNSW top-K + threshold gate** (not full pairwise compare). Matches
+   gbrain's per-chunk neighborhood cap. `chunk_cross_episode_top_k=20`
+   mirrors the order of magnitude they cite.
+3. **Adjacency-aware ranking on top of the dense graph**. We already
+   restored `graph_adjacency_boost_enabled` in PR #448 — that IS gbrain's
+   pattern; currently inert because v1's same-episode edges don't add
+   new sessions to top-K. F070.1 makes it testable for the first time.
+
+Specific gbrain patterns this spec does **NOT** adopt (deferred):
+
+- **God-nodes / hub-shifting**: gbrain identifies high-degree nodes and
+  seeds expansion from them. F065 already ships `Brain.top_hubs(...)`
+  (brain.py:1224) but Path A's seed selection doesn't consult it.
+  Candidate for an F070.2 follow-up once F070.1's cross-episode density
+  is real (otherwise top_hubs returns mostly fact-fact same-cluster nodes
+  with no cross-session value).
+- **Multi-tier chunk sizes** (large/medium/small). gbrain runs 3
+  parallel chunkers. We have one (600ch sliding 80ch). Out of F070.1
+  scope; would be F067.2.
+- **Re-ranking with a learned model trained on gbrain-style features**.
+  F042 cross-encoder reranker partially overlaps; full feature-trained
+  re-ranking is out of scope.
+
+
 ## Provenance
 
 - F070 v1 PR #448 (merged 2026-05-26, squash 5eaf3248): data layer +
@@ -278,3 +316,6 @@ type and `summarized_by` / `related_to` relations.
   2026-05-25T22-34-46 / 00-29-49 / 00-54-47.
 - Memory: `project_f070_shipped.md` documents the inert-on-session-recall
   finding and named F070.1 as the next lever.
+- gbrain: Garry Tan's knowledge brain, the LME R@5 SOTA reference. We
+  log-comp metrics against it; chunks_on hit@5 0.917 vs gbrain R@5
+  0.976 is the gap F070.1 targets.

--- a/docs/features/F070.1-cross-episode-chunk-edges.md
+++ b/docs/features/F070.1-cross-episode-chunk-edges.md
@@ -124,10 +124,61 @@ async def find_chunks_lacking_cross_episode_edges(
     """Return chunks that have at least one edge but no cross-episode
     one. ``(chunk_id, content, source_episode_id)`` tuples.
 
-    SQL: ``WHERE EXISTS (any chunk-edge) AND NOT EXISTS (cross-episode chunk-edge)``
-    where "cross-episode" is detected by joining graph_edges to either
-    heart.facts or heart.episode_chunks on the target ID and comparing
-    episode IDs.
+    **Critical** (codex P1 review): cross-episode detection must check
+    BOTH directions of chunk↔chunk edges. The chunk's id may appear as
+    either ``source_id`` or ``target_id``, so a finder that only joins
+    on one side misclassifies chunks with cross-episode connectivity
+    as "lacking" and re-processes them on every run — defeating
+    idempotency.
+
+    Three cross-episode paths the finder must cover:
+
+    1. ``chunk → fact (summarized_by)`` where ``f.source_episode_id !=
+       chunk.episode_id``.
+    2. ``chunk → chunk (related_to)`` where the current chunk is SOURCE
+       and the other chunk's ``episode_id != current.episode_id``.
+    3. ``chunk → chunk (related_to)`` where the current chunk is TARGET
+       and the other chunk's ``episode_id != current.episode_id``.
+
+    Suggested SQL shape (implementation may restructure for index-
+    friendliness; what matters is all three paths covered):
+
+    ```sql
+    SELECT c.id, c.content, c.episode_id
+    FROM heart.episode_chunks c
+    WHERE c.agent_id = :a
+      AND EXISTS (  -- has at least one edge in either direction
+          SELECT 1 FROM brain.graph_edges e
+          WHERE e.agent_id = :a
+            AND ((e.source_id = c.id AND e.source_type = 'chunk')
+                 OR (e.target_id = c.id AND e.target_type = 'chunk'))
+      )
+      AND NOT EXISTS (  -- no cross-episode edge in EITHER direction
+          SELECT 1 FROM brain.graph_edges e
+          LEFT JOIN heart.facts f
+              ON e.target_id = f.id AND e.target_type = 'fact'
+          LEFT JOIN heart.episode_chunks cc_target
+              ON e.target_id = cc_target.id AND e.target_type = 'chunk'
+                 AND e.source_id = c.id
+          LEFT JOIN heart.episode_chunks cc_source
+              ON e.source_id = cc_source.id AND e.source_type = 'chunk'
+                 AND e.target_id = c.id
+          WHERE e.agent_id = :a
+            AND (
+                -- (1) chunk→fact cross-episode
+                (e.source_id = c.id AND e.source_type = 'chunk'
+                 AND f.source_episode_id IS NOT NULL
+                 AND f.source_episode_id != c.episode_id)
+                -- (2) chunk→chunk where current is SOURCE, target is other ep
+                OR (cc_target.episode_id IS NOT NULL
+                    AND cc_target.episode_id != c.episode_id)
+                -- (3) chunk→chunk where current is TARGET, source is other ep
+                OR (cc_source.episode_id IS NOT NULL
+                    AND cc_source.episode_id != c.episode_id)
+            )
+      )
+    LIMIT :limit
+    ```
     """
 ```
 
@@ -231,12 +282,46 @@ type and `summarized_by` / `related_to` relations.
 
 1. Merge F070.1 PR.
 2. Restart nous-agent on prod (no-op DB-wise since no migration).
-3. Run backfill: `python scripts/backfill_f070_chunks.py --agent-id
-   nous-default --mode cross-episode`. Expected: ~5-10 min on prod's
-   1,262 chunks (each chunk does 1 HNSW LIMIT-20 + threshold filter +
-   edge insert).
-4. Verify with `SELECT source_type, target_type, relation, COUNT(*)`
-   grouped — expect both same- and cross-episode rows.
+3. Run backfill (codex P2 review: the env flag must be in the command —
+   the script aborts when `chunk_consolidation_enabled` is false, and
+   the code default is false):
+
+   ```bash
+   NOUS_CHUNK_CONSOLIDATION_ENABLED=true \
+       uv run python scripts/backfill_f070_chunks.py \
+       --agent-id nous-default --mode cross-episode
+   ```
+
+   Expected: ~5-10 min on prod's 1,262 chunks (each chunk does 1 HNSW
+   LIMIT-20 + threshold filter + edge insert).
+4. Verify cross-episode edges exist (codex P2: a plain
+   `GROUP BY source_type, target_type, relation` does NOT distinguish
+   same-episode from cross-episode and can pass even when zero
+   cross-episode rows were created). Use an episode-aware query:
+
+   ```sql
+   -- chunk→fact cross-episode count (must be > 0)
+   SELECT COUNT(*) AS cross_episode_chunk_fact
+   FROM brain.graph_edges e
+   JOIN heart.episode_chunks c ON e.source_id = c.id
+   JOIN heart.facts f          ON e.target_id = f.id
+   WHERE e.agent_id = 'nous-default'
+     AND e.source_type = 'chunk' AND e.target_type = 'fact'
+     AND e.relation   = 'summarized_by'
+     AND f.source_episode_id != c.episode_id;
+
+   -- chunk↔chunk cross-episode count (must be > 0)
+   SELECT COUNT(*) AS cross_episode_chunk_chunk
+   FROM brain.graph_edges e
+   JOIN heart.episode_chunks cs ON e.source_id = cs.id
+   JOIN heart.episode_chunks ct ON e.target_id = ct.id
+   WHERE e.agent_id = 'nous-default'
+     AND e.source_type = 'chunk' AND e.target_type = 'chunk'
+     AND e.relation   = 'related_to'
+     AND cs.episode_id != ct.episode_id;
+   ```
+
+   Both must return non-zero for the rollout to be considered healthy.
 5. Re-run `eval_session_level_recall.py --mode per_haystack --k 5` on
    the eval corpus (after the same backfill there) with Path A enabled
    (`NOUS_HEART_GRAPH_ALL_TYPES_ENABLED=true`).


### PR DESCRIPTION
## Summary

Spec for the next chunk-graph layer after F070 v1.

F070 v1 (PR #448, merged 2026-05-26) shipped the chunk-edge data layer + Path A retrieval consumer. Empirical result on LME N=60 K=5 per_haystack: F070's chunk edges are **consumed correctly** but the metric doesn't move — the same-episode constraint means within-session corroboration, and session-level recall is structurally insensitive to that.

F070.1 adds the missing piece: **cross-episode edges**, which let a fact-seed surface chunks from *other* sessions via Path A's already-shipped fan-out.

## Scope

- `chunk → fact summarized_by` ACROSS episodes (cosine ≥ 0.75)
- `chunk ↔ chunk related_to` ACROSS episodes (cosine ≥ 0.85, reuses `graph_threshold_chunk_chunk_cross` env var that v1 reserved-but-didn't-use)
- 3 new densifier methods + new orphan finder
- 3 new settings (`graph_threshold_chunk_fact_cross`, `graph_backfill_max_chunks_cross_episode`, `chunk_cross_episode_top_k`)
- Backfill script gets `--mode {same-episode, cross-episode, all}` flag
- No retrieval-side changes — Path A consumes these automatically
- No schema migration — v1's migration 051 already admits the relations
- No CE rerank in v1 (matches F070 v1's pattern; defer to F070.1.1 if eval shows noise)

## Hypothesis

Baseline hit@5 lifts from 0.950 toward 0.96-0.97, concentrated in multi-session + knowledge-update categories. chunks_off probably stays at 0.917 (it doesn't traverse chunks).

If lift fails to materialize, the structural hypothesis was wrong and F070.2 needs to layer something else (multi-hop walk, CE rerank, etc.).

## Review focus

- Threshold defaults (0.75 chunk→fact_cross, reuse 0.85 chunk↔chunk_cross from v1)
- Whether to use CE rerank in v1 (spec says no — explain why)
- The new finder approach (`find_chunks_lacking_cross_episode_edges` vs reusing `find_orphans`)
- Whether cross-episode backfill should be added to `run_backfill_cycle` or stay operator-triggered

## Test plan

- [ ] @codex review the spec
- [ ] If approved, implement on `feat/F070.1-cross-episode-chunk-edges`

🤖 Generated with [Claude Code](https://claude.com/claude-code)