### PR TITLE
feat(F070.1): cross-episode chunk graph edges

### DIFF
--- a/nous/brain/graph_densifier.py
+++ b/nous/brain/graph_densifier.py
@@ -732,6 +732,246 @@ class GraphDensifier:
                 created += 1
         return created
 
+    # ------------------------------------------------------------------
+    # F070.1 — Cross-episode chunk graph edges
+    # ------------------------------------------------------------------
+
+    async def find_chunks_lacking_cross_episode_edges(
+        self,
+        limit: int,
+        session: AsyncSession,
+    ) -> list[tuple[UUID, str, UUID]]:
+        """F070.1: chunks that have at least one edge but no cross-episode one.
+
+        Returns ``(chunk_id, content, episode_id)`` tuples.
+
+        Cross-episode detection covers THREE paths (codex P1 review): chunk
+        may be source OR target of a chunk↔chunk cross-edge, plus chunk→fact.
+        Missing any path would re-process already-linked chunks on every
+        run, defeating idempotency.
+
+        Implementation note: uses three separate ``NOT EXISTS`` clauses
+        correlated on ``c.id``. This lets the Postgres planner short-circuit
+        per row — as soon as ANY one cross-episode path matches for a given
+        chunk, the row is excluded without evaluating the others. The
+        earlier attempts (UNION + NOT IN, big NOT EXISTS with multi-table
+        LEFT JOIN) materialized intermediate sets and stalled on the
+        real eval corpus (35K chunks × 229K edges).
+        """
+        sql = text(
+            """
+            SELECT c.id, c.content, c.episode_id
+            FROM heart.episode_chunks c
+            WHERE c.agent_id = :a
+              AND EXISTS (
+                  SELECT 1 FROM brain.graph_edges e
+                  WHERE e.agent_id = :a
+                    AND ((e.source_id = c.id AND e.source_type = 'chunk')
+                         OR (e.target_id = c.id AND e.target_type = 'chunk'))
+              )
+              -- Path 1: chunk → fact in another episode
+              AND NOT EXISTS (
+                  SELECT 1 FROM brain.graph_edges e
+                  JOIN heart.facts f
+                      ON e.target_id = f.id AND f.agent_id = :a
+                  WHERE e.agent_id = :a
+                    AND e.source_id = c.id
+                    AND e.source_type = 'chunk'
+                    AND e.target_type = 'fact'
+                    AND f.source_episode_id IS NOT NULL
+                    AND f.source_episode_id != c.episode_id
+              )
+              -- Path 2: chunk → other-chunk where current chunk is SOURCE
+              AND NOT EXISTS (
+                  SELECT 1 FROM brain.graph_edges e
+                  JOIN heart.episode_chunks other
+                      ON e.target_id = other.id AND other.agent_id = :a
+                  WHERE e.agent_id = :a
+                    AND e.source_id = c.id
+                    AND e.source_type = 'chunk'
+                    AND e.target_type = 'chunk'
+                    AND other.episode_id != c.episode_id
+              )
+              -- Path 3: chunk → other-chunk where current chunk is TARGET
+              AND NOT EXISTS (
+                  SELECT 1 FROM brain.graph_edges e
+                  JOIN heart.episode_chunks other
+                      ON e.source_id = other.id AND other.agent_id = :a
+                  WHERE e.agent_id = :a
+                    AND e.target_id = c.id
+                    AND e.target_type = 'chunk'
+                    AND e.source_type = 'chunk'
+                    AND other.episode_id != c.episode_id
+              )
+            ORDER BY c.created_at DESC NULLS LAST
+            LIMIT :lim
+            """
+        )
+        result = await session.execute(sql, {"a": self._agent_id, "lim": limit})
+        return [(row.id, row.content or "", row.episode_id) for row in result.all()]
+
+    async def _link_chunk_to_cross_episode_facts(
+        self,
+        chunk_id: UUID,
+        source_episode_id: UUID,
+        threshold: float,
+        top_k: int,
+        session: AsyncSession,
+    ) -> int:
+        """F070.1: chunk → fact summarized_by ACROSS episodes.
+
+        HNSW-bounded scan: take the top_k facts (excluding the source's own
+        episode) by cosine, then threshold-gate. Returns count of edges created.
+        Inferred provenance — cosine-derived, not structural.
+        """
+        rows = (await session.execute(
+            text(
+                "SELECT f.id, "
+                "  1 - (c.embedding <=> f.embedding) AS sim "
+                "FROM heart.episode_chunks c, heart.facts f "
+                "WHERE c.id = :chunk_id "
+                "  AND c.agent_id = :a "
+                "  AND f.agent_id = :a "
+                "  AND f.active = true "
+                "  AND f.source_episode_id IS NOT NULL "
+                "  AND f.source_episode_id != :ep_id "
+                "  AND f.embedding IS NOT NULL "
+                "  AND c.embedding IS NOT NULL "
+                "ORDER BY c.embedding <=> f.embedding "
+                "LIMIT :top_k"
+            ),
+            {
+                "chunk_id": chunk_id, "ep_id": source_episode_id,
+                "a": self._agent_id, "top_k": top_k,
+            },
+        )).all()
+        created = 0
+        for row in rows:
+            sim = float(row.sim or 0.0)
+            if sim < threshold:
+                continue
+            edge = await self._linker.create_edge(
+                source_id=chunk_id,
+                target_id=row.id,
+                source_type="chunk",
+                target_type="fact",
+                relation="summarized_by",
+                weight=sim,
+                session=session,
+                # Cosine-derived → 'inferred' tier (matches v1 same-episode).
+                provenance_source="auto_linker",
+            )
+            if edge is not None:
+                created += 1
+        return created
+
+    async def _link_chunk_to_cross_episode_chunks(
+        self,
+        chunk_id: UUID,
+        source_episode_id: UUID,
+        threshold: float,
+        top_k: int,
+        session: AsyncSession,
+    ) -> int:
+        """F070.1: chunk ↔ chunk related_to ACROSS episodes (dedup).
+
+        Same HNSW pattern. Excludes the source chunk's own id (so a chunk
+        doesn't link to itself) and same-episode siblings (handled by v1
+        intra-episode method). Cosine-derived → inferred provenance.
+        """
+        rows = (await session.execute(
+            text(
+                "SELECT other.id, other.episode_id, "
+                "  1 - (c.embedding <=> other.embedding) AS sim "
+                "FROM heart.episode_chunks c, heart.episode_chunks other "
+                "WHERE c.id = :chunk_id "
+                "  AND c.agent_id = :a "
+                "  AND other.agent_id = :a "
+                "  AND other.id != :chunk_id "
+                "  AND other.episode_id != :ep_id "
+                "  AND other.embedding IS NOT NULL "
+                "  AND c.embedding IS NOT NULL "
+                "ORDER BY c.embedding <=> other.embedding "
+                "LIMIT :top_k"
+            ),
+            {
+                "chunk_id": chunk_id, "ep_id": source_episode_id,
+                "a": self._agent_id, "top_k": top_k,
+            },
+        )).all()
+        created = 0
+        for row in rows:
+            sim = float(row.sim or 0.0)
+            if sim < threshold:
+                continue
+            edge = await self._linker.create_edge(
+                source_id=chunk_id,
+                target_id=row.id,
+                source_type="chunk",
+                target_type="chunk",
+                relation="related_to",
+                weight=sim,
+                session=session,
+                # Cross-episode chunk↔chunk is cosine-only → inferred.
+                provenance_source="auto_linker",
+            )
+            if edge is not None:
+                created += 1
+        return created
+
+    async def backfill_orphan_chunks_cross_episode(
+        self,
+        max_count: int | None = None,
+    ) -> int:
+        """F070.1: add cross-episode summarized_by + related_to edges.
+
+        Idempotent: ``find_chunks_lacking_cross_episode_edges`` skips any
+        chunk that already has cross-episode edges; create_edge uses
+        ON CONFLICT DO NOTHING under the hood. Re-running after a partial
+        run continues from where the last batch stopped.
+
+        Returns count of edges created.
+        """
+        if not self._settings.chunk_consolidation_enabled:
+            return 0
+        if not self._settings.graph_backfill_enabled:
+            return 0
+
+        limit = max_count or self._settings.graph_backfill_max_chunks_cross_episode
+        thresh_fact = self._settings.graph_threshold_chunk_fact_cross
+        thresh_chunk = self._settings.graph_threshold_chunk_chunk_cross
+        top_k = self._settings.chunk_cross_episode_top_k
+        total = 0
+
+        async with self.db.session() as session:
+            candidates = await self.find_chunks_lacking_cross_episode_edges(
+                limit, session,
+            )
+            for chunk_id, _content, episode_id in candidates:
+                if self._interrupted:
+                    break
+                if episode_id is None:
+                    continue  # chunk with no parent episode — skip
+
+                fact_edges = await self._link_chunk_to_cross_episode_facts(
+                    chunk_id, episode_id, thresh_fact, top_k, session,
+                )
+                total += fact_edges
+
+                chunk_edges = await self._link_chunk_to_cross_episode_chunks(
+                    chunk_id, episode_id, thresh_chunk, top_k, session,
+                )
+                total += chunk_edges
+
+            await session.commit()
+
+        logger.info(
+            "F070.1: backfill_orphan_chunks_cross_episode created %d edges "
+            "from %d candidates",
+            total, len(candidates),
+        )
+        return total
+
     async def backfill_orphan_procedures(
         self,
         max_count: int | None = None,

--- a/nous/brain/graph_densifier.py
+++ b/nous/brain/graph_densifier.py
@@ -740,29 +740,43 @@ class GraphDensifier:
         self,
         limit: int,
         session: AsyncSession,
+        offset: int = 0,
     ) -> list[tuple[UUID, str, UUID]]:
         """F070.1: chunks that have at least one edge but no cross-episode one.
 
         Returns ``(chunk_id, content, episode_id)`` tuples.
 
-        Cross-episode detection covers THREE paths (codex P1 review): chunk
-        may be source OR target of a chunk↔chunk cross-edge, plus chunk→fact.
-        Missing any path would re-process already-linked chunks on every
-        run, defeating idempotency.
+        Cross-episode detection covers THREE paths (codex round-1 P1):
+        chunk may be source OR target of a chunk↔chunk cross-edge, plus
+        chunk→fact. Missing any path would re-process already-linked chunks
+        on every run, defeating idempotency.
 
-        Implementation note: uses three separate ``NOT EXISTS`` clauses
-        correlated on ``c.id``. This lets the Postgres planner short-circuit
-        per row — as soon as ANY one cross-episode path matches for a given
-        chunk, the row is excluded without evaluating the others. The
-        earlier attempts (UNION + NOT IN, big NOT EXISTS with multi-table
-        LEFT JOIN) materialized intermediate sets and stalled on the
-        real eval corpus (35K chunks × 229K edges).
+        Codex round-2 P2: also filters ``c.embedding IS NOT NULL`` because
+        both cross-episode link queries require embeddings — NULL-embedded
+        chunks could never produce cross-episode edges and would otherwise
+        occupy the LIMIT window forever, blocking progress.
+
+        Codex round-2 P1: ``offset`` parameter so the caller can paginate
+        past hard-negative windows. Without it, if the newest LIMIT
+        candidates all happen to have no above-threshold cross-episode
+        neighbors, the backfill loop's no-progress break fires and
+        terminates with older candidates still un-linked. The script
+        advances ``offset += batch_size`` each iteration to expose new
+        candidates.
+
+        Implementation note: three separate ``NOT EXISTS`` clauses
+        correlated on ``c.id``. This lets the Postgres planner short-
+        circuit per row — as soon as ANY one cross-episode path matches
+        for a given chunk, the row is excluded. Earlier attempts (UNION
+        + NOT IN, big NOT EXISTS with multi-table LEFT JOIN) materialized
+        intermediate sets and stalled on real corpus sizes.
         """
         sql = text(
             """
             SELECT c.id, c.content, c.episode_id
             FROM heart.episode_chunks c
             WHERE c.agent_id = :a
+              AND c.embedding IS NOT NULL
               AND EXISTS (
                   SELECT 1 FROM brain.graph_edges e
                   WHERE e.agent_id = :a
@@ -804,10 +818,13 @@ class GraphDensifier:
                     AND other.episode_id != c.episode_id
               )
             ORDER BY c.created_at DESC NULLS LAST
-            LIMIT :lim
+            LIMIT :lim OFFSET :off
             """
         )
-        result = await session.execute(sql, {"a": self._agent_id, "lim": limit})
+        result = await session.execute(
+            sql,
+            {"a": self._agent_id, "lim": limit, "off": offset},
+        )
         return [(row.id, row.content or "", row.episode_id) for row in result.all()]
 
     async def _link_chunk_to_cross_episode_facts(
@@ -922,6 +939,7 @@ class GraphDensifier:
     async def backfill_orphan_chunks_cross_episode(
         self,
         max_count: int | None = None,
+        offset: int = 0,
     ) -> int:
         """F070.1: add cross-episode summarized_by + related_to edges.
 
@@ -929,6 +947,13 @@ class GraphDensifier:
         chunk that already has cross-episode edges; create_edge uses
         ON CONFLICT DO NOTHING under the hood. Re-running after a partial
         run continues from where the last batch stopped.
+
+        ``offset`` lets the caller paginate past hard-negative windows
+        (codex round-2 P1). When all candidates in the current LIMIT
+        window have no above-threshold neighbors, the caller advances
+        ``offset += max_count`` and tries the next slice. Without this,
+        the script's no-progress break would terminate the whole job
+        even though older candidates may still be linkable.
 
         Returns count of edges created.
         """
@@ -945,7 +970,7 @@ class GraphDensifier:
 
         async with self.db.session() as session:
             candidates = await self.find_chunks_lacking_cross_episode_edges(
-                limit, session,
+                limit, session, offset=offset,
             )
             for chunk_id, _content, episode_id in candidates:
                 if self._interrupted:

--- a/nous/brain/graph_densifier.py
+++ b/nous/brain/graph_densifier.py
@@ -740,7 +740,7 @@ class GraphDensifier:
         self,
         limit: int,
         session: AsyncSession,
-        offset: int = 0,
+        exclude_ids: set[UUID] | frozenset[UUID] | None = None,
     ) -> list[tuple[UUID, str, UUID]]:
         """F070.1: chunks that have at least one edge but no cross-episode one.
 
@@ -756,13 +756,14 @@ class GraphDensifier:
         chunks could never produce cross-episode edges and would otherwise
         occupy the LIMIT window forever, blocking progress.
 
-        Codex round-2 P1: ``offset`` parameter so the caller can paginate
-        past hard-negative windows. Without it, if the newest LIMIT
-        candidates all happen to have no above-threshold cross-episode
-        neighbors, the backfill loop's no-progress break fires and
-        terminates with older candidates still un-linked. The script
-        advances ``offset += batch_size`` each iteration to expose new
-        candidates.
+        Codex round-3 P1: ``exclude_ids`` is the correct abstraction for
+        paginating past hard-negative chunks. The earlier ``offset``
+        approach skipped real candidates when a batch successfully linked
+        some rows — those linked rows shifted out of the result set, and
+        an offset advance jumped past their (still-unlinked) neighbors.
+        Caller tracks the ``attempted`` set across batches and passes it
+        here; every chunk is visited at most once per run, regardless of
+        whether linking succeeded or failed.
 
         Implementation note: three separate ``NOT EXISTS`` clauses
         correlated on ``c.id``. This lets the Postgres planner short-
@@ -771,12 +772,23 @@ class GraphDensifier:
         + NOT IN, big NOT EXISTS with multi-table LEFT JOIN) materialized
         intermediate sets and stalled on real corpus sizes.
         """
+        params: dict[str, object] = {"a": self._agent_id, "lim": limit}
+        exclude_clause = ""
+        if exclude_ids:
+            # Cast each UUID to text for a TEXT[] parameter so asyncpg
+            # binds it as a single array — avoids the "expanding IN list
+            # via SQL string interpolation" footgun.
+            params["excl"] = [str(uid) for uid in exclude_ids]
+            exclude_clause = (
+                "AND c.id::text != ALL(CAST(:excl AS text[]))"
+            )
         sql = text(
-            """
+            f"""
             SELECT c.id, c.content, c.episode_id
             FROM heart.episode_chunks c
             WHERE c.agent_id = :a
               AND c.embedding IS NOT NULL
+              {exclude_clause}
               AND EXISTS (
                   SELECT 1 FROM brain.graph_edges e
                   WHERE e.agent_id = :a
@@ -818,13 +830,10 @@ class GraphDensifier:
                     AND other.episode_id != c.episode_id
               )
             ORDER BY c.created_at DESC NULLS LAST
-            LIMIT :lim OFFSET :off
+            LIMIT :lim
             """
         )
-        result = await session.execute(
-            sql,
-            {"a": self._agent_id, "lim": limit, "off": offset},
-        )
+        result = await session.execute(sql, params)
         return [(row.id, row.content or "", row.episode_id) for row in result.all()]
 
     async def _link_chunk_to_cross_episode_facts(
@@ -939,42 +948,48 @@ class GraphDensifier:
     async def backfill_orphan_chunks_cross_episode(
         self,
         max_count: int | None = None,
-        offset: int = 0,
-    ) -> int:
+        exclude_ids: set[UUID] | frozenset[UUID] | None = None,
+    ) -> tuple[int, list[UUID]]:
         """F070.1: add cross-episode summarized_by + related_to edges.
 
-        Idempotent: ``find_chunks_lacking_cross_episode_edges`` skips any
-        chunk that already has cross-episode edges; create_edge uses
-        ON CONFLICT DO NOTHING under the hood. Re-running after a partial
-        run continues from where the last batch stopped.
+        Returns ``(edges_created, attempted_chunk_ids)``. The caller is
+        expected to extend its ``attempted`` set with the returned IDs
+        and pass that set back as ``exclude_ids`` on the next call —
+        ensures every chunk is visited at most once per run regardless
+        of per-batch link success/failure (codex round-3 P1; the prior
+        offset-based pagination skipped chunks when batches succeeded).
 
-        ``offset`` lets the caller paginate past hard-negative windows
-        (codex round-2 P1). When all candidates in the current LIMIT
-        window have no above-threshold neighbors, the caller advances
-        ``offset += max_count`` and tries the next slice. Without this,
-        the script's no-progress break would terminate the whole job
-        even though older candidates may still be linkable.
+        Idempotent across runs: ``find_chunks_lacking_cross_episode_edges``
+        skips any chunk that already has cross-episode edges; ``create_edge``
+        uses ON CONFLICT DO NOTHING under the hood. Re-running after a
+        partial run picks up where the last run left off.
 
-        Returns count of edges created.
+        Returns ``(0, [])`` when ``chunk_consolidation_enabled`` or
+        ``graph_backfill_enabled`` is False.
         """
         if not self._settings.chunk_consolidation_enabled:
-            return 0
+            return 0, []
         if not self._settings.graph_backfill_enabled:
-            return 0
+            return 0, []
 
         limit = max_count or self._settings.graph_backfill_max_chunks_cross_episode
         thresh_fact = self._settings.graph_threshold_chunk_fact_cross
         thresh_chunk = self._settings.graph_threshold_chunk_chunk_cross
         top_k = self._settings.chunk_cross_episode_top_k
         total = 0
+        attempted: list[UUID] = []
 
         async with self.db.session() as session:
             candidates = await self.find_chunks_lacking_cross_episode_edges(
-                limit, session, offset=offset,
+                limit, session, exclude_ids=exclude_ids,
             )
             for chunk_id, _content, episode_id in candidates:
                 if self._interrupted:
                     break
+                # Track attempted regardless of skip/fail/success so the
+                # caller can exclude these chunks from the next batch
+                # (codex round-3 P1 — every chunk visited at most once).
+                attempted.append(chunk_id)
                 if episode_id is None:
                     continue  # chunk with no parent episode — skip
 
@@ -995,7 +1010,7 @@ class GraphDensifier:
             "from %d candidates",
             total, len(candidates),
         )
-        return total
+        return total, attempted
 
     async def backfill_orphan_procedures(
         self,

--- a/nous/config.py
+++ b/nous/config.py
@@ -1069,6 +1069,34 @@ class Settings(BaseSettings):
         default=0.85,
         description="F070: cosine floor for cross-episode chunk↔chunk dedup edges.",
     )
+    # =========================================================================
+    # F070.1 — Cross-episode chunk graph edges (extends F070 v1 same-episode)
+    # =========================================================================
+    graph_threshold_chunk_fact_cross: float = Field(
+        default=0.75,
+        description=(
+            "F070.1: cosine floor for chunk → fact summarized_by edges ACROSS "
+            "episodes. Stricter than same-episode (0.55) because cross-episode "
+            "is a noisier candidate pool — only strong semantic matches should "
+            "bridge sessions."
+        ),
+    )
+    graph_backfill_max_chunks_cross_episode: int = Field(
+        default=2000,
+        description=(
+            "F070.1: per-cycle cap on chunks processed by the cross-episode "
+            "backfill (mirrors graph_backfill_max_chunks for v1's same-episode "
+            "pass)."
+        ),
+    )
+    chunk_cross_episode_top_k: int = Field(
+        default=20,
+        description=(
+            "F070.1: HNSW-bounded LIMIT for the cross-episode cosine scan "
+            "per chunk. Higher = more candidates to threshold-gate; lower = "
+            "tighter. 20 lands ~5 surviving neighbors per chunk in eval."
+        ),
+    )
 
     @model_validator(mode="after")
     def _detect_explicit_overrides(self) -> "Settings":

--- a/scripts/backfill_f070_chunks.py
+++ b/scripts/backfill_f070_chunks.py
@@ -87,13 +87,16 @@ async def _count_chunks_lacking_cross_episode_edges(
     """F070.1: count chunks that have edges but no cross-episode ones.
 
     Mirrors the row-correlated NOT-EXISTS shape used in
-    ``GraphDensifier.find_chunks_lacking_cross_episode_edges`` so the
-    planner short-circuits per chunk instead of materializing a UNION.
+    ``GraphDensifier.find_chunks_lacking_cross_episode_edges``. Codex
+    round-2 P2: filters ``c.embedding IS NOT NULL`` because chunks
+    without embeddings can't be cross-episode-linked and would otherwise
+    inflate the count + occupy LIMIT slots indefinitely.
     """
     sql = text(
         """
         SELECT COUNT(*) FROM heart.episode_chunks c
         WHERE c.agent_id = :a
+          AND c.embedding IS NOT NULL
           AND EXISTS (
               SELECT 1 FROM brain.graph_edges e
               WHERE e.agent_id = :a
@@ -286,7 +289,18 @@ async def run_backfill(
             if before == 0:
                 print("Nothing to backfill in cross-episode phase.")
             else:
+                # Codex round-2 P1: advance an offset window per batch so
+                # a hard-negative slice (no above-threshold neighbors for
+                # ANY chunk in the window) doesn't terminate the whole
+                # phase. The previous break-on-no-progress treated such
+                # slices as "done" even when older candidates remained.
+                # When a chunk in an earlier window successfully links,
+                # subsequent counts shift down; the offset is intentionally
+                # NOT decremented for that case — the worst case is that
+                # we skip the just-vacated slot, which is fine since the
+                # next batch's window covers it via the offset advance.
                 batch_n = 0
+                offset = 0
                 while True:
                     if max_batches is not None and batch_n >= max_batches:
                         print(f"--max-batches={max_batches} hit; stopping cross-episode phase.")
@@ -296,10 +310,25 @@ async def run_backfill(
                     )
                     if candidates_before == 0:
                         break
+                    if offset >= candidates_before:
+                        # Walked past every remaining candidate without
+                        # producing a single edge in this pass. Stop.
+                        print(
+                            "WARN: cross-episode phase walked the full "
+                            "candidate pool without creating any new edges. "
+                            "Likely threshold too strict — every chunk's "
+                            "top-K cosine fell below "
+                            "NOUS_GRAPH_THRESHOLD_CHUNK_FACT_CROSS and "
+                            "NOUS_GRAPH_THRESHOLD_CHUNK_CHUNK_CROSS. Consider "
+                            "lowering thresholds and re-running.",
+                            file=sys.stderr,
+                        )
+                        break
                     batch_n += 1
                     t0 = time.time()
                     created = await densifier.backfill_orphan_chunks_cross_episode(
                         max_count=effective_batch,
+                        offset=offset,
                     )
                     dt = time.time() - t0
                     total_edges += created
@@ -312,20 +341,16 @@ async def run_backfill(
                         f"  cross-ep batch {batch_n:3d}: candidates "
                         f"{candidates_before:>7d} -> {candidates_after:>7d}  "
                         f"(-{processed:>5d})  +{created:>6d} edges in "
-                        f"{dt:5.1f}s  [total {total_edges:>7d} edges, "
-                        f"{elapsed:.1f} min]",
+                        f"{dt:5.1f}s  offset={offset}  "
+                        f"[total {total_edges:>7d} edges, {elapsed:.1f} min]",
                         flush=True,
                     )
-                    if created == 0 and processed == 0:
-                        print(
-                            "WARN: cross-episode batch made no progress. "
-                            "Stopping phase. (May indicate threshold too "
-                            "strict — every candidate's top-K cosine fell "
-                            "below NOUS_GRAPH_THRESHOLD_CHUNK_FACT_CROSS and "
-                            "NOUS_GRAPH_THRESHOLD_CHUNK_CHUNK_CROSS.)",
-                            file=sys.stderr,
-                        )
-                        break
+                    # Advance the window regardless of progress. If the
+                    # batch did produce edges, those chunks dropped out
+                    # of the pool and the next window naturally exposes
+                    # new candidates anyway. If it produced zero, the
+                    # advance moves us past the hard-negative slice.
+                    offset += effective_batch
 
         breakdown = await _summarize_chunk_edges(db, agent_id)
         print()

--- a/scripts/backfill_f070_chunks.py
+++ b/scripts/backfill_f070_chunks.py
@@ -289,18 +289,18 @@ async def run_backfill(
             if before == 0:
                 print("Nothing to backfill in cross-episode phase.")
             else:
-                # Codex round-2 P1: advance an offset window per batch so
-                # a hard-negative slice (no above-threshold neighbors for
-                # ANY chunk in the window) doesn't terminate the whole
-                # phase. The previous break-on-no-progress treated such
-                # slices as "done" even when older candidates remained.
-                # When a chunk in an earlier window successfully links,
-                # subsequent counts shift down; the offset is intentionally
-                # NOT decremented for that case — the worst case is that
-                # we skip the just-vacated slot, which is fine since the
-                # next batch's window covers it via the offset advance.
+                # Codex round-3 P1: track an ``attempted`` set across
+                # batches and exclude those chunks from each subsequent
+                # query. The earlier offset-based pagination had a bug:
+                # when a batch successfully linked some chunks, those
+                # chunks dropped out of the ordered result set, so
+                # advancing offset by ``effective_batch`` jumped past
+                # their (still-unlinked) neighbors. With exclusion
+                # tracking, every chunk is visited at most once per
+                # run regardless of per-batch success, and the loop
+                # terminates when no un-attempted candidate remains.
                 batch_n = 0
-                offset = 0
+                attempted: set = set()
                 while True:
                     if max_batches is not None and batch_n >= max_batches:
                         print(f"--max-batches={max_batches} hit; stopping cross-episode phase.")
@@ -310,26 +310,28 @@ async def run_backfill(
                     )
                     if candidates_before == 0:
                         break
-                    if offset >= candidates_before:
-                        # Walked past every remaining candidate without
-                        # producing a single edge in this pass. Stop.
-                        print(
-                            "WARN: cross-episode phase walked the full "
-                            "candidate pool without creating any new edges. "
-                            "Likely threshold too strict — every chunk's "
-                            "top-K cosine fell below "
-                            "NOUS_GRAPH_THRESHOLD_CHUNK_FACT_CROSS and "
-                            "NOUS_GRAPH_THRESHOLD_CHUNK_CHUNK_CROSS. Consider "
-                            "lowering thresholds and re-running.",
-                            file=sys.stderr,
-                        )
-                        break
                     batch_n += 1
                     t0 = time.time()
-                    created = await densifier.backfill_orphan_chunks_cross_episode(
-                        max_count=effective_batch,
-                        offset=offset,
+                    created, attempted_ids = (
+                        await densifier.backfill_orphan_chunks_cross_episode(
+                            max_count=effective_batch,
+                            exclude_ids=attempted,
+                        )
                     )
+                    if not attempted_ids:
+                        # No un-attempted candidate remained — we've
+                        # visited every linkable chunk this run.
+                        print(
+                            "Cross-episode phase: all candidates attempted "
+                            "this run. Stopping. (If candidate count is "
+                            "still > 0, those chunks were attempted and "
+                            "either fell below "
+                            "NOUS_GRAPH_THRESHOLD_CHUNK_FACT_CROSS / "
+                            "NOUS_GRAPH_THRESHOLD_CHUNK_CHUNK_CROSS — "
+                            "consider lowering thresholds and re-running.)"
+                        )
+                        break
+                    attempted.update(attempted_ids)
                     dt = time.time() - t0
                     total_edges += created
                     candidates_after = await _count_chunks_lacking_cross_episode_edges(
@@ -341,16 +343,10 @@ async def run_backfill(
                         f"  cross-ep batch {batch_n:3d}: candidates "
                         f"{candidates_before:>7d} -> {candidates_after:>7d}  "
                         f"(-{processed:>5d})  +{created:>6d} edges in "
-                        f"{dt:5.1f}s  offset={offset}  "
+                        f"{dt:5.1f}s  attempted_set={len(attempted)}  "
                         f"[total {total_edges:>7d} edges, {elapsed:.1f} min]",
                         flush=True,
                     )
-                    # Advance the window regardless of progress. If the
-                    # batch did produce edges, those chunks dropped out
-                    # of the pool and the next window naturally exposes
-                    # new candidates anyway. If it produced zero, the
-                    # advance moves us past the hard-negative slice.
-                    offset += effective_batch
 
         breakdown = await _summarize_chunk_edges(db, agent_id)
         print()

--- a/scripts/backfill_f070_chunks.py
+++ b/scripts/backfill_f070_chunks.py
@@ -81,6 +81,60 @@ async def _count_orphan_chunks(db: Database, agent_id: str) -> int:
         return int(r.scalar() or 0)
 
 
+async def _count_chunks_lacking_cross_episode_edges(
+    db: Database, agent_id: str,
+) -> int:
+    """F070.1: count chunks that have edges but no cross-episode ones.
+
+    Mirrors the row-correlated NOT-EXISTS shape used in
+    ``GraphDensifier.find_chunks_lacking_cross_episode_edges`` so the
+    planner short-circuits per chunk instead of materializing a UNION.
+    """
+    sql = text(
+        """
+        SELECT COUNT(*) FROM heart.episode_chunks c
+        WHERE c.agent_id = :a
+          AND EXISTS (
+              SELECT 1 FROM brain.graph_edges e
+              WHERE e.agent_id = :a
+                AND ((e.source_id = c.id AND e.source_type = 'chunk')
+                     OR (e.target_id = c.id AND e.target_type = 'chunk'))
+          )
+          AND NOT EXISTS (
+              SELECT 1 FROM brain.graph_edges e
+              JOIN heart.facts f
+                  ON e.target_id = f.id AND f.agent_id = :a
+              WHERE e.agent_id = :a
+                AND e.source_id = c.id
+                AND e.source_type = 'chunk' AND e.target_type = 'fact'
+                AND f.source_episode_id IS NOT NULL
+                AND f.source_episode_id != c.episode_id
+          )
+          AND NOT EXISTS (
+              SELECT 1 FROM brain.graph_edges e
+              JOIN heart.episode_chunks other
+                  ON e.target_id = other.id AND other.agent_id = :a
+              WHERE e.agent_id = :a
+                AND e.source_id = c.id
+                AND e.source_type = 'chunk' AND e.target_type = 'chunk'
+                AND other.episode_id != c.episode_id
+          )
+          AND NOT EXISTS (
+              SELECT 1 FROM brain.graph_edges e
+              JOIN heart.episode_chunks other
+                  ON e.source_id = other.id AND other.agent_id = :a
+              WHERE e.agent_id = :a
+                AND e.target_id = c.id
+                AND e.target_type = 'chunk' AND e.source_type = 'chunk'
+                AND other.episode_id != c.episode_id
+          )
+        """
+    )
+    async with db.engine.begin() as conn:
+        r = await conn.execute(sql, {"a": agent_id})
+        return int(r.scalar() or 0)
+
+
 async def _summarize_chunk_edges(db: Database, agent_id: str) -> dict[str, int]:
     """Return {relation_label: count} for every chunk edge belonging to
     the agent. Used for the post-run summary print."""
@@ -101,15 +155,26 @@ async def _summarize_chunk_edges(db: Database, agent_id: str) -> dict[str, int]:
 
 async def run_backfill(
     *, agent_id: str, batch_size: int, max_batches: int | None,
-    dry_run: bool,
+    dry_run: bool, mode: str = "same-episode",
 ) -> int:
+    """Run the chunk-graph backfill.
+
+    ``mode``:
+      - ``same-episode`` — F070 v1 behavior; builds chunk→episode part_of,
+        chunk→fact summarized_by (same-episode only), and chunk↔chunk
+        related_to (sequential + intra-episode cosine).
+      - ``cross-episode`` — F070.1 only; builds chunk→fact summarized_by
+        ACROSS episodes and chunk↔chunk related_to ACROSS episodes.
+      - ``all`` — run same-episode first, then cross-episode. Useful for
+        a clean first deploy that hasn't had any backfill yet.
+    """
     settings = Settings()
 
     if not settings.chunk_consolidation_enabled:
         print(
             "WARN: NOUS_CHUNK_CONSOLIDATION_ENABLED is False. "
-            "GraphDensifier.backfill_orphan_chunks() short-circuits to 0 "
-            "edges in this mode. Set the env var to 'true' before running.",
+            "Both backfill paths short-circuit to 0 edges in this mode. "
+            "Set the env var to 'true' before running.",
             file=sys.stderr,
         )
         return 1
@@ -121,6 +186,10 @@ async def run_backfill(
         )
         return 1
 
+    if mode not in ("same-episode", "cross-episode", "all"):
+        print(f"ERROR: invalid --mode {mode!r}", file=sys.stderr)
+        return 2
+
     # Override the densifier's class-level cap with the CLI batch size so
     # each call processes the requested number of orphans even when the
     # operator left NOUS_GRAPH_BACKFILL_MAX_CHUNKS at its default.
@@ -129,18 +198,18 @@ async def run_backfill(
     db = Database(settings)
     await db.connect()
     try:
-        before = await _count_orphan_chunks(db, agent_id)
-        print(
-            f"Agent {agent_id}: {before} orphan chunks "
-            f"(batch_size={effective_batch}, max_batches="
-            f"{max_batches if max_batches is not None else 'unbounded'})"
-        )
+        # Dry-run shows BOTH counts so the operator knows where work lives.
         if dry_run:
+            same_n = await _count_orphan_chunks(db, agent_id)
+            cross_n = await _count_chunks_lacking_cross_episode_edges(
+                db, agent_id,
+            )
+            print(
+                f"Agent {agent_id} (mode={mode}):\n"
+                f"  same-episode orphans:               {same_n}\n"
+                f"  cross-episode candidates (existing): {cross_n}"
+            )
             print("--dry-run set; not writing edges. Exiting.")
-            return 0
-        if before == 0:
-            print("Nothing to backfill — every chunk already has at least "
-                  "one graph edge.")
             return 0
 
         embedder = EmbeddingProvider(settings)
@@ -153,39 +222,110 @@ async def run_backfill(
         )
 
         total_edges = 0
-        batch_n = 0
         start = time.time()
-        while True:
-            if max_batches is not None and batch_n >= max_batches:
-                print(f"--max-batches={max_batches} hit; stopping.")
-                break
-            orphans_before = await _count_orphan_chunks(db, agent_id)
-            if orphans_before == 0:
-                break
-            batch_n += 1
-            t0 = time.time()
-            created = await densifier.backfill_orphan_chunks(
-                max_count=effective_batch,
-            )
-            dt = time.time() - t0
-            total_edges += created
-            orphans_after = await _count_orphan_chunks(db, agent_id)
-            processed = orphans_before - orphans_after
-            elapsed = (time.time() - start) / 60.0
+
+        # -----------------------------------------------------------
+        # Phase 1: same-episode (F070 v1) — only when mode != cross-episode
+        # -----------------------------------------------------------
+        if mode in ("same-episode", "all"):
+            before = await _count_orphan_chunks(db, agent_id)
             print(
-                f"batch {batch_n:3d}: orphans {orphans_before:>7d} -> "
-                f"{orphans_after:>7d}  (-{processed:>5d})  "
-                f"+{created:>6d} edges in {dt:5.1f}s  "
-                f"[total {total_edges:>7d} edges, {elapsed:.1f} min]",
-                flush=True,
+                f"== same-episode phase ==\n"
+                f"Agent {agent_id}: {before} orphan chunks "
+                f"(batch_size={effective_batch}, max_batches="
+                f"{max_batches if max_batches is not None else 'unbounded'})"
             )
-            if created == 0 and processed == 0:
-                print(
-                    "WARN: batch made no progress (0 edges, 0 orphans "
-                    "consumed). Stopping to avoid an infinite loop.",
-                    file=sys.stderr,
-                )
-                break
+            if before == 0:
+                print("Nothing to backfill in same-episode phase.")
+            else:
+                batch_n = 0
+                while True:
+                    if max_batches is not None and batch_n >= max_batches:
+                        print(f"--max-batches={max_batches} hit; stopping same-episode phase.")
+                        break
+                    orphans_before = await _count_orphan_chunks(db, agent_id)
+                    if orphans_before == 0:
+                        break
+                    batch_n += 1
+                    t0 = time.time()
+                    created = await densifier.backfill_orphan_chunks(
+                        max_count=effective_batch,
+                    )
+                    dt = time.time() - t0
+                    total_edges += created
+                    orphans_after = await _count_orphan_chunks(db, agent_id)
+                    processed = orphans_before - orphans_after
+                    elapsed = (time.time() - start) / 60.0
+                    print(
+                        f"  same-ep batch {batch_n:3d}: orphans "
+                        f"{orphans_before:>7d} -> {orphans_after:>7d}  "
+                        f"(-{processed:>5d})  +{created:>6d} edges in "
+                        f"{dt:5.1f}s  [total {total_edges:>7d} edges, "
+                        f"{elapsed:.1f} min]",
+                        flush=True,
+                    )
+                    if created == 0 and processed == 0:
+                        print(
+                            "WARN: same-episode batch made no progress. "
+                            "Stopping phase.",
+                            file=sys.stderr,
+                        )
+                        break
+
+        # -----------------------------------------------------------
+        # Phase 2: cross-episode (F070.1) — only when mode != same-episode
+        # -----------------------------------------------------------
+        if mode in ("cross-episode", "all"):
+            before = await _count_chunks_lacking_cross_episode_edges(db, agent_id)
+            print(
+                f"== cross-episode phase ==\n"
+                f"Agent {agent_id}: {before} chunks lacking cross-episode "
+                f"edges (batch_size={effective_batch}, max_batches="
+                f"{max_batches if max_batches is not None else 'unbounded'})"
+            )
+            if before == 0:
+                print("Nothing to backfill in cross-episode phase.")
+            else:
+                batch_n = 0
+                while True:
+                    if max_batches is not None and batch_n >= max_batches:
+                        print(f"--max-batches={max_batches} hit; stopping cross-episode phase.")
+                        break
+                    candidates_before = await _count_chunks_lacking_cross_episode_edges(
+                        db, agent_id,
+                    )
+                    if candidates_before == 0:
+                        break
+                    batch_n += 1
+                    t0 = time.time()
+                    created = await densifier.backfill_orphan_chunks_cross_episode(
+                        max_count=effective_batch,
+                    )
+                    dt = time.time() - t0
+                    total_edges += created
+                    candidates_after = await _count_chunks_lacking_cross_episode_edges(
+                        db, agent_id,
+                    )
+                    processed = candidates_before - candidates_after
+                    elapsed = (time.time() - start) / 60.0
+                    print(
+                        f"  cross-ep batch {batch_n:3d}: candidates "
+                        f"{candidates_before:>7d} -> {candidates_after:>7d}  "
+                        f"(-{processed:>5d})  +{created:>6d} edges in "
+                        f"{dt:5.1f}s  [total {total_edges:>7d} edges, "
+                        f"{elapsed:.1f} min]",
+                        flush=True,
+                    )
+                    if created == 0 and processed == 0:
+                        print(
+                            "WARN: cross-episode batch made no progress. "
+                            "Stopping phase. (May indicate threshold too "
+                            "strict — every candidate's top-K cosine fell "
+                            "below NOUS_GRAPH_THRESHOLD_CHUNK_FACT_CROSS and "
+                            "NOUS_GRAPH_THRESHOLD_CHUNK_CHUNK_CROSS.)",
+                            file=sys.stderr,
+                        )
+                        break
 
         breakdown = await _summarize_chunk_edges(db, agent_id)
         print()
@@ -219,7 +359,19 @@ def main() -> None:
     )
     parser.add_argument(
         "--dry-run", action="store_true",
-        help="Print the orphan count and exit without writing.",
+        help="Print the orphan count(s) and exit without writing.",
+    )
+    parser.add_argument(
+        "--mode", default="same-episode",
+        choices=["same-episode", "cross-episode", "all"],
+        help=(
+            "Which densification phase to run. "
+            "'same-episode' (default) = F070 v1 behavior (chunk→episode "
+            "part_of, chunk→fact same-episode, chunk↔chunk intra). "
+            "'cross-episode' = F070.1 only (chunk→fact + chunk↔chunk "
+            "ACROSS episodes; assumes same-episode has already been "
+            "backfilled). 'all' = both phases in sequence."
+        ),
     )
     parser.add_argument(
         "--log-level", default="INFO",
@@ -237,6 +389,7 @@ def main() -> None:
         batch_size=args.batch_size,
         max_batches=args.max_batches,
         dry_run=args.dry_run,
+        mode=args.mode,
     ))
     sys.exit(rc)
 

--- a/tests/test_graph_densifier.py
+++ b/tests/test_graph_densifier.py
@@ -1144,3 +1144,235 @@ async def test_run_backfill_cycle_includes_chunks_key(
     assert "chunks" in result
     # _ce_stats prefix-underscored — must not be confused with per-type entries
     assert "chunks" in {k for k in result if not k.startswith("_")}
+
+
+# ---------------------------------------------------------------------------
+# F070.1 — Cross-episode chunk graph edges
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_cross_episode_links_chunk_to_fact_in_other_episode(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint,
+):
+    """F070.1: chunk → fact summarized_by must fire for facts in
+    OTHER episodes when cosine ≥ threshold. Same-episode facts handled
+    by F070 v1 path; cross-episode is the new code path."""
+    agent_id = f"test-f070-1-cef-{uuid4().hex[:8]}"
+    settings_local = settings.model_copy(update={
+        "chunk_consolidation_enabled": True,
+        "graph_backfill_enabled": True,
+        "graph_threshold_chunk_fact_cross": 0.4,
+        "chunk_cross_episode_top_k": 10,
+    })
+    linker = GraphLinker(db, mock_embeddings, settings_local, agent_id)
+    d = GraphDensifier(db, linker, mock_embeddings, settings_local, agent_id)
+
+    async with db.session() as s:
+        ep_a = await _insert_episode(s, agent_id, "episode A")
+        ep_b = await _insert_episode(s, agent_id, "episode B")
+        ident_emb = await mock_embeddings.embed("coffee preferences")
+        chunk_a = await _insert_chunk(
+            s, agent_id, ep_a, 0, "user likes coffee strong", ident_emb,
+        )
+        # Fact lives in DIFFERENT episode (ep_b) — must still link.
+        other_ep_fact = await _insert_fact_with_episode(
+            s, agent_id, "user prefers dark roast coffee", ident_emb, ep_b,
+        )
+        # Give chunk_a a part_of edge so it's NOT classified as same-ep
+        # orphan (avoids it being picked up by the wrong path).
+        await _insert_edge(s, agent_id, chunk_a, ep_a, "chunk", "episode")
+        await s.commit()
+
+    created = await d.backfill_orphan_chunks_cross_episode()
+    assert created >= 1, "expected at least 1 cross-episode chunk→fact edge"
+
+    async with db.session() as s:
+        rows = (await s.execute(text(
+            "SELECT target_id::text, relation, extraction_method "
+            "FROM brain.graph_edges "
+            "WHERE agent_id = :a AND source_id = :c "
+            "  AND source_type = 'chunk' AND target_type = 'fact'"
+        ), {"a": agent_id, "c": chunk_a})).all()
+    edges = {(r.target_id, r.relation, r.extraction_method) for r in rows}
+    assert (str(other_ep_fact), "summarized_by", "inferred") in edges, (
+        f"cross-episode chunk→fact missing or wrong tier: {edges}"
+    )
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_cross_episode_links_chunk_to_chunk_in_other_episode(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint,
+):
+    """F070.1: chunk ↔ chunk related_to ACROSS episodes when cosine ≥
+    threshold. Same-episode siblings handled by F070 v1 intra path."""
+    agent_id = f"test-f070-1-cec-{uuid4().hex[:8]}"
+    settings_local = settings.model_copy(update={
+        "chunk_consolidation_enabled": True,
+        "graph_backfill_enabled": True,
+        "graph_threshold_chunk_chunk_cross": 0.4,
+        "chunk_cross_episode_top_k": 10,
+    })
+    linker = GraphLinker(db, mock_embeddings, settings_local, agent_id)
+    d = GraphDensifier(db, linker, mock_embeddings, settings_local, agent_id)
+
+    async with db.session() as s:
+        ep_a = await _insert_episode(s, agent_id, "episode A")
+        ep_b = await _insert_episode(s, agent_id, "episode B")
+        emb = await mock_embeddings.embed("shared topic")
+        c_a = await _insert_chunk(s, agent_id, ep_a, 0, "topic content A", emb)
+        c_b = await _insert_chunk(s, agent_id, ep_b, 0, "topic content B", emb)
+        # Both already have a part_of edge → cross-episode orphans, not v1 orphans.
+        await _insert_edge(s, agent_id, c_a, ep_a, "chunk", "episode")
+        await _insert_edge(s, agent_id, c_b, ep_b, "chunk", "episode")
+        await s.commit()
+
+    created = await d.backfill_orphan_chunks_cross_episode()
+    assert created >= 1
+
+    async with db.session() as s:
+        rows = (await s.execute(text(
+            "SELECT source_id::text, target_id::text "
+            "FROM brain.graph_edges "
+            "WHERE agent_id = :a AND source_type = 'chunk' "
+            "  AND target_type = 'chunk' AND relation = 'related_to'"
+        ), {"a": agent_id})).all()
+    pair = {(str(c_a), str(c_b)), (str(c_b), str(c_a))}
+    found = {(r.source_id, r.target_id) for r in rows}
+    assert pair & found, (
+        f"cross-episode chunk↔chunk missing, got {found}"
+    )
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_cross_episode_skips_below_threshold(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint,
+):
+    """F070.1: candidates below the cosine threshold must NOT be linked
+    even when they're in the top-K HNSW scan."""
+    agent_id = f"test-f070-1-thr-{uuid4().hex[:8]}"
+    settings_local = settings.model_copy(update={
+        "chunk_consolidation_enabled": True,
+        "graph_backfill_enabled": True,
+        "graph_threshold_chunk_fact_cross": 0.99,  # very high — nothing should pass
+        "graph_threshold_chunk_chunk_cross": 0.99,
+        "chunk_cross_episode_top_k": 10,
+    })
+    linker = GraphLinker(db, mock_embeddings, settings_local, agent_id)
+    d = GraphDensifier(db, linker, mock_embeddings, settings_local, agent_id)
+
+    async with db.session() as s:
+        ep_a = await _insert_episode(s, agent_id, "ep A")
+        ep_b = await _insert_episode(s, agent_id, "ep B")
+        emb_a = await mock_embeddings.embed("apple")
+        emb_b = await mock_embeddings.embed("zebra")  # different embedding
+        c_a = await _insert_chunk(s, agent_id, ep_a, 0, "apple", emb_a)
+        f_b = await _insert_fact_with_episode(
+            s, agent_id, "zebra story", emb_b, ep_b,
+        )
+        c_b = await _insert_chunk(s, agent_id, ep_b, 0, "zebra", emb_b)
+        await _insert_edge(s, agent_id, c_a, ep_a, "chunk", "episode")
+        await _insert_edge(s, agent_id, c_b, ep_b, "chunk", "episode")
+        await s.commit()
+
+    created = await d.backfill_orphan_chunks_cross_episode()
+
+    async with db.session() as s:
+        rows = (await s.execute(text(
+            "SELECT COUNT(*) AS n FROM brain.graph_edges "
+            "WHERE agent_id = :a AND source_type = 'chunk' "
+            "  AND (target_type = 'fact' OR target_type = 'chunk') "
+            "  AND relation IN ('summarized_by', 'related_to')"
+        ), {"a": agent_id})).all()
+    assert rows[0].n == 0, (
+        f"expected 0 cross-ep edges with 0.99 threshold and dissimilar "
+        f"embeddings, got {rows[0].n} (created counter said {created})"
+    )
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_cross_episode_finder_covers_both_chunk_chunk_directions(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint,
+):
+    """F070.1 (codex P1): find_chunks_lacking_cross_episode_edges must
+    detect cross-episode connectivity whether the chunk is on the SOURCE
+    or TARGET side of a chunk→chunk edge. Otherwise idempotency breaks
+    and the script re-processes the same chunk forever."""
+    agent_id = f"test-f070-1-dir-{uuid4().hex[:8]}"
+    settings_local = settings.model_copy(update={
+        "chunk_consolidation_enabled": True,
+        "graph_backfill_enabled": True,
+    })
+    linker = GraphLinker(db, mock_embeddings, settings_local, agent_id)
+    d = GraphDensifier(db, linker, mock_embeddings, settings_local, agent_id)
+
+    async with db.session() as s:
+        ep_a = await _insert_episode(s, agent_id, "ep A")
+        ep_b = await _insert_episode(s, agent_id, "ep B")
+        emb = await mock_embeddings.embed("x")
+        # c_a has cross-episode edge where c_a is SOURCE (c_a → c_b).
+        c_a = await _insert_chunk(s, agent_id, ep_a, 0, "A", emb)
+        # c_b has cross-episode edge where c_b is TARGET (c_a → c_b).
+        c_b = await _insert_chunk(s, agent_id, ep_b, 0, "B", emb)
+        # Both have at-least-one-edge (the cross-episode edge itself
+        # satisfies the EXISTS clause).
+        await _insert_edge(s, agent_id, c_a, c_b, "chunk", "chunk")
+        await s.commit()
+
+    async with db.session() as s:
+        candidates = await d.find_chunks_lacking_cross_episode_edges(
+            limit=100, session=s,
+        )
+    candidate_ids = {str(cid) for cid, _content, _ep in candidates}
+    assert str(c_a) not in candidate_ids, (
+        f"c_a (source of cross-ep edge) wrongly classified as lacking "
+        f"cross-ep edges: {candidate_ids}"
+    )
+    assert str(c_b) not in candidate_ids, (
+        f"c_b (target of cross-ep edge) wrongly classified as lacking "
+        f"cross-ep edges: {candidate_ids}"
+    )
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_cross_episode_idempotent_rerun(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint,
+):
+    """F070.1: re-running backfill_orphan_chunks_cross_episode must NOT
+    create duplicate edges (ON CONFLICT DO NOTHING) and the second call
+    must return 0 since find_chunks_lacking_cross_episode_edges now
+    excludes already-linked chunks."""
+    agent_id = f"test-f070-1-idem-{uuid4().hex[:8]}"
+    settings_local = settings.model_copy(update={
+        "chunk_consolidation_enabled": True,
+        "graph_backfill_enabled": True,
+        "graph_threshold_chunk_fact_cross": 0.4,
+        "graph_threshold_chunk_chunk_cross": 0.4,
+        "chunk_cross_episode_top_k": 10,
+    })
+    linker = GraphLinker(db, mock_embeddings, settings_local, agent_id)
+    d = GraphDensifier(db, linker, mock_embeddings, settings_local, agent_id)
+
+    async with db.session() as s:
+        ep_a = await _insert_episode(s, agent_id, "ep A")
+        ep_b = await _insert_episode(s, agent_id, "ep B")
+        emb = await mock_embeddings.embed("shared")
+        c_a = await _insert_chunk(s, agent_id, ep_a, 0, "shared content A", emb)
+        f_b = await _insert_fact_with_episode(
+            s, agent_id, "shared content B", emb, ep_b,
+        )
+        # Pre-existing part_of edges (post-F070 v1 backfill state).
+        await _insert_edge(s, agent_id, c_a, ep_a, "chunk", "episode")
+        await s.commit()
+
+    first = await d.backfill_orphan_chunks_cross_episode()
+    second = await d.backfill_orphan_chunks_cross_episode()
+    assert first >= 1, "first run must create edges"
+    assert second == 0, (
+        f"second run must be a no-op (idempotent), created {second}"
+    )

--- a/tests/test_graph_densifier.py
+++ b/tests/test_graph_densifier.py
@@ -1185,7 +1185,7 @@ async def test_cross_episode_links_chunk_to_fact_in_other_episode(
         await _insert_edge(s, agent_id, chunk_a, ep_a, "chunk", "episode")
         await s.commit()
 
-    created = await d.backfill_orphan_chunks_cross_episode()
+    created, _attempted = await d.backfill_orphan_chunks_cross_episode()
     assert created >= 1, "expected at least 1 cross-episode chunk→fact edge"
 
     async with db.session() as s:
@@ -1229,7 +1229,7 @@ async def test_cross_episode_links_chunk_to_chunk_in_other_episode(
         await _insert_edge(s, agent_id, c_b, ep_b, "chunk", "episode")
         await s.commit()
 
-    created = await d.backfill_orphan_chunks_cross_episode()
+    created, _attempted = await d.backfill_orphan_chunks_cross_episode()
     assert created >= 1
 
     async with db.session() as s:
@@ -1278,7 +1278,7 @@ async def test_cross_episode_skips_below_threshold(
         await _insert_edge(s, agent_id, c_b, ep_b, "chunk", "episode")
         await s.commit()
 
-    created = await d.backfill_orphan_chunks_cross_episode()
+    created, _attempted = await d.backfill_orphan_chunks_cross_episode()
 
     async with db.session() as s:
         rows = (await s.execute(text(
@@ -1370,11 +1370,15 @@ async def test_cross_episode_idempotent_rerun(
         await _insert_edge(s, agent_id, c_a, ep_a, "chunk", "episode")
         await s.commit()
 
-    first = await d.backfill_orphan_chunks_cross_episode()
-    second = await d.backfill_orphan_chunks_cross_episode()
-    assert first >= 1, "first run must create edges"
-    assert second == 0, (
-        f"second run must be a no-op (idempotent), created {second}"
+    first_created, _first_attempted = await d.backfill_orphan_chunks_cross_episode()
+    second_created, second_attempted = await d.backfill_orphan_chunks_cross_episode()
+    assert first_created >= 1, "first run must create edges"
+    assert second_created == 0, (
+        f"second run must be a no-op (idempotent), created {second_created}"
+    )
+    assert second_attempted == [], (
+        f"second run must report no attempted chunks (all already linked), "
+        f"got {second_attempted}"
     )
 
 
@@ -1423,14 +1427,14 @@ async def test_cross_episode_finder_excludes_null_embedding_chunks(
 
 @pytest.mark.postgres_only
 @pytest.mark.asyncio
-async def test_cross_episode_finder_honors_offset(
+async def test_cross_episode_finder_honors_exclude_ids(
     db, settings, mock_embeddings, _fix_stale_relation_constraint,
 ):
-    """F070.1 (codex round-2 P1): the finder accepts an ``offset`` so
-    the script can paginate past hard-negative windows. With 3 candidates
-    inserted, offset=0/1/2 each return a distinct leading row and
-    offset=3 returns empty."""
-    agent_id = f"test-f070-1-offset-{uuid4().hex[:8]}"
+    """F070.1 (codex round-3 P1): the finder accepts an ``exclude_ids``
+    set so callers can paginate without skipping unprocessed candidates.
+    Insert 3 candidates and verify each batch with cumulative exclusion
+    returns a previously-unseen row, with the 4th call empty."""
+    agent_id = f"test-f070-1-excl-{uuid4().hex[:8]}"
     settings_local = settings.model_copy(update={
         "chunk_consolidation_enabled": True,
         "graph_backfill_enabled": True,
@@ -1445,25 +1449,91 @@ async def test_cross_episode_finder_honors_offset(
         for i in range(3):
             cid = await _insert_chunk(s, agent_id, ep, i, f"chunk {i}", emb)
             await _insert_edge(s, agent_id, cid, ep, "chunk", "episode")
-            chunk_ids.append(str(cid))
+            chunk_ids.append(cid)
         await s.commit()
 
-    seen_first: set[str] = set()
+    seen: set = set()
     async with db.session() as s:
-        for offset in (0, 1, 2):
+        for _ in range(3):
             results = await d.find_chunks_lacking_cross_episode_edges(
-                limit=1, session=s, offset=offset,
+                limit=1, session=s, exclude_ids=seen,
             )
             assert len(results) == 1, (
-                f"offset={offset} must return 1, got {len(results)}"
+                f"expected 1 row with exclude_ids={seen}, got {len(results)}"
             )
-            seen_first.add(str(results[0][0]))
+            seen.add(results[0][0])
         empty = await d.find_chunks_lacking_cross_episode_edges(
-            limit=1, session=s, offset=3,
+            limit=1, session=s, exclude_ids=seen,
         )
-        assert empty == [], f"offset=3 must be empty, got {empty}"
+        assert empty == [], f"empty result expected with all excluded, got {empty}"
 
-    assert seen_first == set(chunk_ids), (
-        f"offsets 0/1/2 must expose each chunk once; got {seen_first} "
-        f"vs expected {set(chunk_ids)}"
+    assert seen == set(chunk_ids), (
+        f"three exclusion-paginated batches must expose each chunk once; "
+        f"got {seen} vs expected {set(chunk_ids)}"
+    )
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_cross_episode_backfill_visits_every_chunk_even_when_some_link(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint,
+):
+    """F070.1 (codex round-3 P1): regression for the bug where
+    successful batches caused the offset-based pager to skip
+    still-unlinked candidates. Scenario: 3 candidates A, B, C.
+    A and C have matching cross-episode neighbors (will link);
+    B does NOT (hard negative — only same-episode neighbors).
+    With ``effective_batch=2`` over multiple batches and
+    ``exclude_ids`` tracking, all 3 chunks must be ATTEMPTED — the
+    backfill must not exit while B is still un-visited.
+    """
+    agent_id = f"test-f070-1-visit-all-{uuid4().hex[:8]}"
+    settings_local = settings.model_copy(update={
+        "chunk_consolidation_enabled": True,
+        "graph_backfill_enabled": True,
+        "graph_threshold_chunk_fact_cross": 0.4,
+        "graph_threshold_chunk_chunk_cross": 0.4,
+        "chunk_cross_episode_top_k": 10,
+    })
+    linker = GraphLinker(db, mock_embeddings, settings_local, agent_id)
+    d = GraphDensifier(db, linker, mock_embeddings, settings_local, agent_id)
+
+    async with db.session() as s:
+        ep_a = await _insert_episode(s, agent_id, "ep A")
+        ep_b = await _insert_episode(s, agent_id, "ep B")
+        # Three chunks in ep_a. A and C share embedding with a fact in
+        # ep_b → both will link cross-episode. B has a unique embedding
+        # with no cross-episode neighbor → hard negative.
+        emb_shared = await mock_embeddings.embed("shared topic")
+        emb_unique = await mock_embeddings.embed("zebra unique content")
+        chunk_a = await _insert_chunk(s, agent_id, ep_a, 0, "shared A", emb_shared)
+        chunk_b = await _insert_chunk(s, agent_id, ep_a, 1, "zebra B", emb_unique)
+        chunk_c = await _insert_chunk(s, agent_id, ep_a, 2, "shared C", emb_shared)
+        # Cross-episode fact in ep_b that matches A and C.
+        await _insert_fact_with_episode(
+            s, agent_id, "shared topic content", emb_shared, ep_b,
+        )
+        for cid, ep in [(chunk_a, ep_a), (chunk_b, ep_a), (chunk_c, ep_a)]:
+            await _insert_edge(s, agent_id, cid, ep, "chunk", "episode")
+        await s.commit()
+
+    # Simulate the script's loop with effective_batch=2 + exclude_ids tracking.
+    attempted: set = set()
+    total_created = 0
+    seen_attempted: list = []
+    for _ in range(5):  # safety cap
+        created, attempted_ids = await d.backfill_orphan_chunks_cross_episode(
+            max_count=2, exclude_ids=attempted,
+        )
+        if not attempted_ids:
+            break
+        attempted.update(attempted_ids)
+        seen_attempted.extend(attempted_ids)
+        total_created += created
+
+    attempted_str = {str(x) for x in attempted}
+    expected = {str(chunk_a), str(chunk_b), str(chunk_c)}
+    assert attempted_str == expected, (
+        f"every candidate must be attempted at least once across batches; "
+        f"got {attempted_str} vs expected {expected} (created={total_created})"
     )

--- a/tests/test_graph_densifier.py
+++ b/tests/test_graph_densifier.py
@@ -1376,3 +1376,94 @@ async def test_cross_episode_idempotent_rerun(
     assert second == 0, (
         f"second run must be a no-op (idempotent), created {second}"
     )
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_cross_episode_finder_excludes_null_embedding_chunks(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint,
+):
+    """F070.1 (codex round-2 P2): chunks without embeddings can never
+    produce cross-episode edges (both link queries require embedding
+    NOT NULL). The finder must exclude them so they don't occupy the
+    LIMIT window forever."""
+    agent_id = f"test-f070-1-nullemb-{uuid4().hex[:8]}"
+    settings_local = settings.model_copy(update={
+        "chunk_consolidation_enabled": True,
+        "graph_backfill_enabled": True,
+    })
+    linker = GraphLinker(db, mock_embeddings, settings_local, agent_id)
+    d = GraphDensifier(db, linker, mock_embeddings, settings_local, agent_id)
+
+    async with db.session() as s:
+        ep_a = await _insert_episode(s, agent_id, "ep A")
+        ep_b = await _insert_episode(s, agent_id, "ep B")
+        emb = await mock_embeddings.embed("topic")
+        null_emb_chunk = await _insert_chunk(
+            s, agent_id, ep_a, 0, "missing embedding", None,
+        )
+        ok_chunk = await _insert_chunk(s, agent_id, ep_b, 0, "ok content", emb)
+        await _insert_edge(s, agent_id, null_emb_chunk, ep_a, "chunk", "episode")
+        await _insert_edge(s, agent_id, ok_chunk, ep_b, "chunk", "episode")
+        await s.commit()
+
+    async with db.session() as s:
+        candidates = await d.find_chunks_lacking_cross_episode_edges(
+            limit=100, session=s,
+        )
+    candidate_ids = {str(cid) for cid, _content, _ep in candidates}
+    assert str(null_emb_chunk) not in candidate_ids, (
+        f"NULL-embedded chunk must NOT be returned by finder; got "
+        f"{candidate_ids}"
+    )
+    assert str(ok_chunk) in candidate_ids, (
+        f"embedded chunk must be returned by finder; got {candidate_ids}"
+    )
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_cross_episode_finder_honors_offset(
+    db, settings, mock_embeddings, _fix_stale_relation_constraint,
+):
+    """F070.1 (codex round-2 P1): the finder accepts an ``offset`` so
+    the script can paginate past hard-negative windows. With 3 candidates
+    inserted, offset=0/1/2 each return a distinct leading row and
+    offset=3 returns empty."""
+    agent_id = f"test-f070-1-offset-{uuid4().hex[:8]}"
+    settings_local = settings.model_copy(update={
+        "chunk_consolidation_enabled": True,
+        "graph_backfill_enabled": True,
+    })
+    linker = GraphLinker(db, mock_embeddings, settings_local, agent_id)
+    d = GraphDensifier(db, linker, mock_embeddings, settings_local, agent_id)
+
+    async with db.session() as s:
+        ep = await _insert_episode(s, agent_id, "ep")
+        emb = await mock_embeddings.embed("topic")
+        chunk_ids = []
+        for i in range(3):
+            cid = await _insert_chunk(s, agent_id, ep, i, f"chunk {i}", emb)
+            await _insert_edge(s, agent_id, cid, ep, "chunk", "episode")
+            chunk_ids.append(str(cid))
+        await s.commit()
+
+    seen_first: set[str] = set()
+    async with db.session() as s:
+        for offset in (0, 1, 2):
+            results = await d.find_chunks_lacking_cross_episode_edges(
+                limit=1, session=s, offset=offset,
+            )
+            assert len(results) == 1, (
+                f"offset={offset} must return 1, got {len(results)}"
+            )
+            seen_first.add(str(results[0][0]))
+        empty = await d.find_chunks_lacking_cross_episode_edges(
+            limit=1, session=s, offset=3,
+        )
+        assert empty == [], f"offset=3 must be empty, got {empty}"
+
+    assert seen_first == set(chunk_ids), (
+        f"offsets 0/1/2 must expose each chunk once; got {seen_first} "
+        f"vs expected {set(chunk_ids)}"
+    )


### PR DESCRIPTION
## Summary

Implementation of [F070.1 spec](https://github.com/tfatykhov/nous/pull/450) (still under codex review). Closes the structural gap F070 v1 had on session-level recall: v1's same-episode chunk edges don't add new sessions to top-K. Cross-episode edges let a fact-seed surface chunks from OTHER sessions via Path A's existing fan-out.

## What ships

**Code** (+696 LOC across 4 files):
- `find_chunks_lacking_cross_episode_edges` — idempotency finder. Three correlated NOT EXISTS clauses (codex P1: covers chunk→fact AND both directions of chunk↔chunk). Index-friendly: returns count on 35K chunks / 229K edges in <1s.
- `_link_chunk_to_cross_episode_facts` / `_link_chunk_to_cross_episode_chunks` — HNSW LIMIT-K scans excluding the source's own episode, threshold-gated, `extraction_method='inferred'`.
- `backfill_orphan_chunks_cross_episode(max_count)` — top-level entry, idempotent.
- 3 new settings: `graph_threshold_chunk_fact_cross=0.75`, `graph_backfill_max_chunks_cross_episode=2000`, `chunk_cross_episode_top_k=20`. Reuses `graph_threshold_chunk_chunk_cross` from v1.
- `--mode {same-episode, cross-episode, all}` flag on the backfill script.

**Tests** (5 new):
- chunk→fact cross-episode happy path
- chunk↔chunk cross-episode happy path
- threshold gate (high threshold = 0 edges)
- **finder covers both edge directions** (codex P1 regression test)
- idempotent re-run (second call returns 0)

All 5 pass on real Postgres alongside the 8 existing F070 v1 chunk tests (13 total).

## Performance journey

The finder query went through 3 rewrites:
1. `NOT EXISTS` with multi-table `LEFT JOIN` — stalled on 35K chunks × 229K edges
2. `WITH ... UNION CTE` + `NOT IN` — also stalled (materialized intermediate set)
3. **Three separate `NOT EXISTS` clauses correlated on `c.id`** — shipped. Planner short-circuits per row as soon as any one fires.

Verified on real eval-scale data: dry-run on `nous-lme-corpus` (35,804 chunks) returns the cross-episode candidate count in <1 sec.

## Hypothesis

Per the spec, baseline hit@5 lifts 0.950 → 0.96-0.97 on LME per_haystack K=5, concentrated in multi-session + knowledge-update categories. `chunks_off` stays at 0.917 (no chunk traversal). Path A flag (`NOUS_HEART_GRAPH_ALL_TYPES_ENABLED=true`) must be on at eval time to actually consume the new edges.

If the lift doesn't materialize, the F070.1 spec calls out the next levers (multi-hop expansion, graph-feature-aware re-ranker, threshold sweep).

## Test plan

- [ ] @codex review
- [ ] Run cross-episode backfill on eval DB: `... --mode cross-episode`
- [ ] Re-run `scripts/eval/eval_session_level_recall.py --mode per_haystack --k 5` with Path A on
- [ ] Verify on prod (run backfill, sanity-check via the episode-aware verification queries in the F070.1 spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)