### PR TITLE
fix(brain): auto_link referenced a constraint name that never existed

### DIFF
--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -418,7 +418,15 @@ class Brain:
             async with session.begin_nested():
                 await self._auto_link(decision.id, session)
         except Exception:
-            logger.warning("auto_link failed for decision %s, continuing", decision.id)
+            # exc_info=True so the actual failure mode is visible in prod
+            # logs. The prior log line gave no clue why auto-linking was
+            # silently a no-op (it was the missing constraint name; see
+            # _auto_link). Keep the WARN-level since auto-link is best-
+            # effort and we don't want to fail the parent record() call.
+            logger.warning(
+                "auto_link failed for decision %s, continuing",
+                decision.id, exc_info=True,
+            )
 
         # Re-fetch with eager loading to avoid lazy-load issues
         decision = await self._get_decision_orm(decision.id, session)
@@ -1564,7 +1572,19 @@ class Brain:
                     auto_linked=True,
                     extraction_method=classify("related_to", source="auto_linker"),
                 )
-                .on_conflict_do_nothing(constraint="uq_edges_src_tgt_rel")
+                .on_conflict_do_nothing(
+                    # Match the unique constraint by columns, not by name.
+                    # The actual constraint is auto-named
+                    # ``graph_edges_source_id_target_id_relation_key`` (init.sql:205,
+                    # ``UNIQUE(source_id, target_id, relation)``). The previous
+                    # ``constraint="uq_edges_src_tgt_rel"`` referenced a name that
+                    # never existed, so every ``_auto_link`` call raised
+                    # ``UndefinedObject`` and was silently swallowed by the
+                    # ``except Exception`` at line 420 — meaning auto-linking
+                    # has been a no-op since this code was written. Mirrors the
+                    # pattern used by ``GraphLinker.create_edge``.
+                    index_elements=["source_id", "target_id", "relation"],
+                )
             )
             await session.execute(stmt)
 

--- a/scripts/backfill_auto_link_decisions.py
+++ b/scripts/backfill_auto_link_decisions.py
@@ -1,0 +1,198 @@
+"""One-time backfill: retrofit auto_link for decisions that pre-date the
+constraint-name fix (see fix/auto-link-constraint-name PR).
+
+Context: ``Brain._auto_link`` referenced a Postgres constraint name that
+never existed (``uq_edges_src_tgt_rel`` vs the real auto-named
+``graph_edges_source_id_target_id_relation_key``). Every ``record_decision``
+call's auto-link attempt raised ``UndefinedObject`` silently, so no
+similarity-based decision<->decision edges have ever been written.
+
+Sleep cycle's ``backfill_orphan_decisions`` only recovers TOTAL orphans
+(decisions with zero edges). Most prod decisions acquired F022 cross-type
+edges (``evidence_for`` from facts, ``discussed_in`` from episodes) right
+after creation, making them non-orphans → sleep cycle skips them → the
+missing similarity edges stay permanently missing.
+
+This script iterates every decision for an agent and calls
+``brain.auto_link(decision_id)`` — same code path as ``record_decision``,
+just deferred. Idempotent: the now-fixed ``ON CONFLICT DO NOTHING`` skips
+edges that already exist (including any that sleep cycle recovered).
+
+Usage::
+
+    # dry run — count decisions only
+    uv run python scripts/backfill_auto_link_decisions.py \
+        --agent-id nous-default --dry-run
+
+    # full backfill (prod)
+    uv run python scripts/backfill_auto_link_decisions.py \
+        --agent-id nous-default
+
+    # capped first run
+    uv run python scripts/backfill_auto_link_decisions.py \
+        --agent-id nous-default --max-decisions 50
+
+Honesty note: this is a *historical* repair. New ``record_decision``
+calls auto-link correctly post-fix. This script is only needed once
+after the fix deploys; subsequent decisions don't require it.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+import time
+from uuid import UUID
+
+from sqlalchemy import text
+
+from nous.brain.brain import Brain
+from nous.brain.embeddings import EmbeddingProvider
+from nous.config import Settings
+from nous.storage.database import Database
+
+logger = logging.getLogger("auto-link-backfill")
+
+
+async def _all_decision_ids(
+    db: Database, agent_id: str, limit: int | None,
+) -> list[UUID]:
+    """All decision IDs for an agent that have an embedding. Decisions
+    without embeddings can't be cosine-linked anyway; auto_link short-
+    circuits on them at brain.py:1516."""
+    sql = (
+        "SELECT id FROM brain.decisions "
+        "WHERE agent_id = :a AND embedding IS NOT NULL "
+        "ORDER BY created_at ASC"
+    )
+    if limit is not None:
+        sql += " LIMIT :lim"
+    async with db.engine.begin() as conn:
+        result = await conn.execute(
+            text(sql),
+            {"a": agent_id, "lim": limit} if limit is not None else {"a": agent_id},
+        )
+        return [row.id for row in result.all()]
+
+
+async def _count_existing_auto_link_edges(db: Database, agent_id: str) -> int:
+    async with db.engine.begin() as conn:
+        r = await conn.execute(
+            text(
+                "SELECT COUNT(*) FROM brain.graph_edges "
+                "WHERE agent_id = :a AND auto_linked = true "
+                "  AND source_type = 'decision' AND target_type = 'decision' "
+                "  AND relation = 'related_to'"
+            ),
+            {"a": agent_id},
+        )
+        return int(r.scalar() or 0)
+
+
+async def run_backfill(
+    *, agent_id: str, max_decisions: int | None, dry_run: bool,
+    threshold: float | None,
+) -> int:
+    settings = Settings()
+    db = Database(settings)
+    await db.connect()
+    try:
+        ids = await _all_decision_ids(db, agent_id, max_decisions)
+        before = await _count_existing_auto_link_edges(db, agent_id)
+        print(
+            f"Agent {agent_id}: {len(ids)} decisions to process "
+            f"(currently {before} auto_linked decision<->decision edges; "
+            f"threshold={'default' if threshold is None else threshold})"
+        )
+        if dry_run:
+            print("--dry-run set; not writing edges. Exiting.")
+            return 0
+        if not ids:
+            print("Nothing to backfill.")
+            return 0
+
+        embedder = EmbeddingProvider(settings)
+        brain = Brain(db, settings, embedder)
+
+        created = 0
+        failed = 0
+        start = time.time()
+        for i, did in enumerate(ids, 1):
+            try:
+                edges = await brain.auto_link(did, threshold=threshold)
+                created += len(edges)
+            except Exception:
+                # The pre-fix bug would land here; post-fix this should
+                # only fire on genuinely unexpected errors. exc_info so
+                # we can diagnose if it happens.
+                logger.warning(
+                    "auto_link failed for decision %s during retrofit",
+                    did, exc_info=True,
+                )
+                failed += 1
+            if i % 50 == 0 or i == len(ids):
+                elapsed = (time.time() - start) / 60.0
+                print(
+                    f"  processed {i:>5d} / {len(ids):>5d}  "
+                    f"created≈{created:>5d}  failed={failed}  "
+                    f"[{elapsed:.1f} min]",
+                    flush=True,
+                )
+
+        after = await _count_existing_auto_link_edges(db, agent_id)
+        print()
+        print(
+            f"Done. auto_linked dec↔dec edges: {before} -> {after}  "
+            f"(+{after - before} new). Per-call edges reported by auto_link "
+            f"totaled {created} (some may collide via ON CONFLICT)."
+        )
+        if failed:
+            print(f"WARNING: {failed} decisions failed; see log.", file=sys.stderr)
+        return 0 if failed == 0 else 3
+    finally:
+        await db.disconnect()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="One-time auto_link retrofit for historical decisions.",
+    )
+    parser.add_argument(
+        "--agent-id", required=True,
+        help="Agent identifier whose decisions to retrofit.",
+    )
+    parser.add_argument(
+        "--max-decisions", type=int, default=None,
+        help="Cap on decisions processed. Omit for unbounded.",
+    )
+    parser.add_argument(
+        "--threshold", type=float, default=None,
+        help="Override cosine threshold. Default uses Settings.auto_link_threshold (0.85).",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print decision count and exit without writing.",
+    )
+    parser.add_argument(
+        "--log-level", default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    rc = asyncio.run(run_backfill(
+        agent_id=args.agent_id,
+        max_decisions=args.max_decisions,
+        dry_run=args.dry_run,
+        threshold=args.threshold,
+    ))
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/backfill_auto_link_decisions.py
+++ b/scripts/backfill_auto_link_decisions.py
@@ -10,7 +10,7 @@ similarity-based decision<->decision edges have ever been written.
 Sleep cycle's ``backfill_orphan_decisions`` only recovers TOTAL orphans
 (decisions with zero edges). Most prod decisions acquired F022 cross-type
 edges (``evidence_for`` from facts, ``discussed_in`` from episodes) right
-after creation, making them non-orphans → sleep cycle skips them → the
+after creation, making them non-orphans -> sleep cycle skips them -> the
 missing similarity edges stay permanently missing.
 
 This script iterates every decision for an agent and calls
@@ -113,7 +113,19 @@ async def run_backfill(
             return 0
 
         embedder = EmbeddingProvider(settings)
-        brain = Brain(db, settings, embedder)
+        # Codex P1: Brain reads agent_id from settings (Brain.__init__),
+        # and _auto_link filters/inserts under self.agent_id. If we pass
+        # the env-default Settings here, the script silently writes
+        # graph_edges rows under the WRONG agent — and reads similar
+        # decisions from a different tenant — even though we loaded
+        # decision IDs from --agent-id. Construct a Settings copy with
+        # the requested agent_id so Brain operates in the right tenant.
+        scoped_settings = settings.model_copy(update={"agent_id": agent_id})
+        brain = Brain(db, scoped_settings, embedder)
+        assert brain.agent_id == agent_id, (
+            f"Brain.agent_id ({brain.agent_id!r}) must match --agent-id "
+            f"({agent_id!r}) — refusing to write cross-tenant edges."
+        )
 
         created = 0
         failed = 0
@@ -135,7 +147,7 @@ async def run_backfill(
                 elapsed = (time.time() - start) / 60.0
                 print(
                     f"  processed {i:>5d} / {len(ids):>5d}  "
-                    f"created≈{created:>5d}  failed={failed}  "
+                    f"created={created:>5d}  failed={failed}  "
                     f"[{elapsed:.1f} min]",
                     flush=True,
                 )
@@ -143,7 +155,7 @@ async def run_backfill(
         after = await _count_existing_auto_link_edges(db, agent_id)
         print()
         print(
-            f"Done. auto_linked dec↔dec edges: {before} -> {after}  "
+            f"Done. auto_linked dec<->dec edges: {before} -> {after}  "
             f"(+{after - before} new). Per-call edges reported by auto_link "
             f"totaled {created} (some may collide via ON CONFLICT)."
         )

--- a/tests/test_brain.py
+++ b/tests/test_brain.py
@@ -183,6 +183,62 @@ async def test_record_auto_links(brain_with_embeddings, session):
     assert isinstance(edges, list)
 
 
+async def test_auto_link_uses_existing_constraint_not_bogus_name(
+    brain, session,
+):
+    """Regression: Brain._auto_link used to reference
+    ``constraint="uq_edges_src_tgt_rel"`` which doesn't exist. Every call
+    raised ``UndefinedObject`` and was silently swallowed by record()'s
+    ``except Exception``. The prior test_record_auto_links assertion
+    (``isinstance(edges, list)``) was too lenient — it passed even when
+    auto_link 100% no-op'd. This test directly invokes ``auto_link``
+    with two near-identical embeddings and asserts that an edge IS
+    inserted, which proves the ON CONFLICT clause references a real
+    constraint.
+    """
+    from uuid import uuid4
+
+    from nous.storage.models import Decision
+
+    # Two decisions with identical embeddings — cosine similarity = 1.0,
+    # easily clears auto_link_threshold (default 0.85).
+    emb = [1.0] + [0.0] * 1535
+    emb_str = "[" + ",".join(str(float(v)) for v in emb) + "]"
+    d1_id = uuid4()
+    d2_id = uuid4()
+    for did in (d1_id, d2_id):
+        session.add(Decision(
+            id=did, agent_id=brain.agent_id,
+            description=f"decision {did}",
+            confidence=0.8, category="architecture", stakes="low",
+        ))
+    await session.flush()
+    # Backfill embeddings via raw SQL (model field is JSON in some test
+    # configs; this guarantees the pgvector column is set).
+    await session.execute(text(
+        "UPDATE brain.decisions SET embedding = CAST(:e AS vector) "
+        "WHERE id IN (:a, :b)"
+    ), {"e": emb_str, "a": d1_id, "b": d2_id})
+    await session.flush()
+
+    # Call auto_link directly — if the constraint name is wrong this
+    # raises UndefinedObject and the test fails.
+    edges = await brain.auto_link(d1_id, threshold=0.5, session=session)
+
+    # And verify the edge actually persisted.
+    rows = (await session.execute(text(
+        "SELECT source_id::text, target_id::text, relation "
+        "FROM brain.graph_edges "
+        "WHERE agent_id = :a AND relation = 'related_to' "
+        "  AND ((source_id = :d1 AND target_id = :d2) "
+        "    OR (source_id = :d2 AND target_id = :d1))"
+    ), {"a": brain.agent_id, "d1": d1_id, "d2": d2_id})).all()
+    assert len(rows) >= 1, (
+        "auto_link must persist at least one edge between two cosine=1.0 "
+        f"decisions; got {rows}. Returned edges from auto_link: {edges}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # 6. test_think
 # ---------------------------------------------------------------------------

--- a/tests/test_brain.py
+++ b/tests/test_brain.py
@@ -183,6 +183,7 @@ async def test_record_auto_links(brain_with_embeddings, session):
     assert isinstance(edges, list)
 
 
+@pytest.mark.postgres_only
 async def test_auto_link_uses_existing_constraint_not_bogus_name(
     brain, session,
 ):


### PR DESCRIPTION
## Summary

Tim noticed prod logs spamming:
\`\`\`
nous.brain.brain WARNING auto_link failed for decision <uuid>, continuing
\`\`\`

## Root cause

\`Brain._auto_link\` at \`brain.py:1567\` used:
\`\`\`python
.on_conflict_do_nothing(constraint=\"uq_edges_src_tgt_rel\")
\`\`\`

But the actual unique constraint on \`brain.graph_edges\` is auto-named by Postgres as \`graph_edges_source_id_target_id_relation_key\` (init.sql:205 declares \`UNIQUE(source_id, target_id, relation)\` with no explicit name). The referenced name \`uq_edges_src_tgt_rel\` **never existed in any migration**.

Every \`_auto_link\` call therefore raised \`psycopg2.errors.UndefinedObject\` and was silently caught by the \`except Exception\` at \`brain.py:420\` — so auto-linking has been **a 100% no-op since this code was written**. \`brain.auto_link()\` returns the in-memory edges list as if writes succeeded; the WARN was the only operator signal. Existing \`test_record_auto_links\` accepted \`isinstance(edges, list)\` as success → didn't catch it.

## Fix

1. **Replace \`constraint=\"...\"\` with \`index_elements=[\"source_id\", \"target_id\", \"relation\"]\`** — matches by columns. Mirrors \`GraphLinker.create_edge\` which uses this pattern and works.
2. **Add \`exc_info=True\` to the WARN log** so future failures show the actual exception in the trace.

## Test

Regression: \`test_auto_link_uses_existing_constraint_not_bogus_name\` constructs two cosine=1.0 decisions and verifies an edge IS inserted. Pre-fix raises UndefinedObject; post-fix passes.

7/7 auto-link / neighbor tests pass on real Postgres.

## Scope

Unrelated to F070/F070.1. Pure pre-existing bug in main. Recommend merging ahead of those PRs since it's small + clear.

## Test plan

- [ ] @codex review
- [ ] Merge + restart prod nous
- [ ] Confirm \`auto_link failed for decision\` WARN stops appearing
- [ ] Check graph_edges count grows: similar decisions should now produce \`auto_linked=true related_to\` edges (it hasn't been working all this time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)