### PR TITLE
feat(dashboard): surface chunks + F070 edges + F065 provenance

### DIFF
--- a/nous/api/dashboard_queries.py
+++ b/nous/api/dashboard_queries.py
@@ -146,7 +146,7 @@ async def get_graph_data(
     result = await session.execute(
         text("""
             SELECT id, source_id, target_id, source_type, target_type,
-                   relation, weight, auto_linked, created_at
+                   relation, weight, auto_linked, extraction_method, created_at
             FROM brain.graph_edges
             WHERE agent_id = :agent_id
             ORDER BY created_at DESC
@@ -172,6 +172,8 @@ async def get_graph_data(
             "relation": e.relation,
             "weight": e.weight,
             "auto_linked": e.auto_linked,
+            # F065: deterministic / heuristic / inferred provenance.
+            "extraction_method": e.extraction_method,
         })
 
     # Build nodes from source tables
@@ -192,6 +194,14 @@ async def get_graph_data(
         "procedure": (
             "heart.procedures",
             "LEFT(name, 120) AS label, domain AS category",
+        ),
+        # F067: chunked raw transcripts. No category column on the table —
+        # surface chunk_index instead so the detail panel has something
+        # meaningful to show, but cast to text to keep the column shape
+        # uniform across types.
+        "chunk": (
+            "heart.episode_chunks",
+            "LEFT(content, 120) AS label, chunk_index::text AS category",
         ),
     }
 
@@ -223,6 +233,9 @@ async def get_graph_data(
         ("facts", "heart.facts"),
         ("episodes", "heart.episodes"),
         ("procedures", "heart.procedures"),
+        # F067: chunks are orphaned when no F070 part_of/summarized_by/related_to
+        # backfill has linked them yet.
+        ("chunks", "heart.episode_chunks"),
     ]
     for key, table in orphan_queries:
         result = await session.execute(
@@ -666,6 +679,9 @@ async def get_health_data(session: AsyncSession, agent_id: str) -> dict:
         ("facts", "heart.facts"),
         ("episodes", "heart.episodes"),
         ("procedures", "heart.procedures"),
+        # F067: include chunked transcripts so the health card reflects
+        # F070/F070.1 backfill coverage, not just the legacy 4 types.
+        ("chunks", "heart.episode_chunks"),
     ]
     for key, table in orphan_queries:
         result = await session.execute(
@@ -782,6 +798,10 @@ async def get_health_data(session: AsyncSession, agent_id: str) -> dict:
                 SELECT id, created_at FROM heart.episodes WHERE agent_id = :agent_id
                 UNION ALL
                 SELECT id, created_at FROM heart.procedures WHERE agent_id = :agent_id AND active = true
+                UNION ALL
+                -- F067: chunks must count in the daily orphan trend so the
+                -- post-F070 backfill curve is visible.
+                SELECT id, created_at FROM heart.episode_chunks WHERE agent_id = :agent_id
             ),
             daily_new_total AS (
                 SELECT CAST(created_at AS date) AS day, COUNT(*) AS cnt
@@ -1662,6 +1682,9 @@ async def get_density_data(session: AsyncSession, agent_id: str) -> dict:
         ("decision", "brain.decisions", "decision", "1=1"),
         ("episode", "heart.episodes", "episode", "1=1"),
         ("procedure", "heart.procedures", "procedure", "active = true"),
+        # F067: chunks are matched via source/target_type = 'chunk' on
+        # F070's part_of / summarized_by / related_to edges.
+        ("chunk", "heart.episode_chunks", "chunk", "1=1"),
     ]
 
     total_nodes = 0

--- a/nous/api/rest.py
+++ b/nous/api/rest.py
@@ -238,6 +238,10 @@ def create_app(
                     ("heart.facts", "total_facts"),
                     ("heart.episodes", "total_episodes"),
                     ("heart.procedures", "total_procedures"),
+                    # F067: surface chunked transcripts on /status so the
+                    # Overview tab has a parity stat card next to facts/
+                    # episodes/decisions/procedures.
+                    ("heart.episode_chunks", "total_chunks"),
                 ]:
                     result = await session.execute(
                         text(f"SELECT COUNT(*) FROM {table} WHERE agent_id = :agent_id"),
@@ -296,6 +300,7 @@ def create_app(
                         "total_facts": counts["total_facts"],
                         "total_episodes": counts["total_episodes"],
                         "total_procedures": counts["total_procedures"],
+                        "total_chunks": counts["total_chunks"],
                     },
                     "working_memory": working_memory_sessions,
                     "execution_integrity": {
@@ -462,6 +467,72 @@ def create_app(
                 })
         except Exception as e:
             logger.error("Search/browse facts error: %s", e)
+            return JSONResponse({"error": str(e)}, status_code=500)
+
+    async def list_chunks(request: Request) -> JSONResponse:
+        """GET /chunks?q=&episode_id=&limit=&offset= — browse F067 episode chunks.
+
+        Parity with /facts browse mode but read-only and direct-SQL (no
+        Heart accessor — chunk rows aren't part of the recall surface).
+        """
+        try:
+            limit = int(request.query_params.get("limit", "50"))
+            offset = int(request.query_params.get("offset", "0"))
+        except ValueError:
+            return JSONResponse({"error": "limit and offset must be integers"}, status_code=400)
+
+        q = request.query_params.get("q")
+        episode_id = request.query_params.get("episode_id")
+
+        from sqlalchemy import text as _sql_text
+        params: dict[str, Any] = {"agent_id": settings.agent_id, "limit": limit, "offset": offset}
+        where = ["agent_id = :agent_id"]
+        if q:
+            where.append("content ILIKE :q")
+            params["q"] = f"%{q}%"
+        if episode_id:
+            where.append("episode_id = :episode_id")
+            params["episode_id"] = episode_id
+        where_sql = " AND ".join(where)
+
+        try:
+            async with database.session() as session:
+                rows = await session.execute(
+                    _sql_text(f"""
+                        SELECT id::text, episode_id::text, chunk_index, content, created_at
+                        FROM heart.episode_chunks
+                        WHERE {where_sql}
+                        ORDER BY created_at DESC, chunk_index ASC
+                        LIMIT :limit OFFSET :offset
+                    """),
+                    params,
+                )
+                items = [
+                    {
+                        "id": r.id,
+                        "episode_id": r.episode_id,
+                        "chunk_index": r.chunk_index,
+                        "content": r.content,
+                        "created_at": r.created_at.isoformat() if r.created_at else None,
+                    }
+                    for r in rows
+                ]
+                # Total count under the same filters (drop limit/offset).
+                count_params = {k: v for k, v in params.items() if k not in ("limit", "offset")}
+                total_row = await session.execute(
+                    _sql_text(f"SELECT COUNT(*) AS cnt FROM heart.episode_chunks WHERE {where_sql}"),
+                    count_params,
+                )
+                total = total_row.scalar() or 0
+
+            return JSONResponse({
+                "chunks": items,
+                "total": int(total),
+                "limit": limit,
+                "offset": offset,
+            })
+        except Exception as e:
+            logger.error("List chunks error: %s", e)
             return JSONResponse({"error": str(e)}, status_code=500)
 
     async def list_censors(request: Request) -> JSONResponse:
@@ -2387,6 +2458,7 @@ def create_app(
         Route("/decisions/{id}", get_decision),
         Route("/episodes", list_episodes),
         Route("/facts", search_facts),
+        Route("/chunks", list_chunks),
         Route("/censors/{id}", update_censor, methods=["PUT"]),
         Route("/censors", list_censors),
         Route("/procedures", list_procedures),

--- a/nous/api/rest.py
+++ b/nous/api/rest.py
@@ -482,7 +482,20 @@ def create_app(
             return JSONResponse({"error": "limit and offset must be integers"}, status_code=400)
 
         q = request.query_params.get("q")
-        episode_id = request.query_params.get("episode_id")
+        episode_id_raw = request.query_params.get("episode_id")
+        # Validate episode_id is a real UUID before it reaches Postgres —
+        # otherwise the type-cast error surfaces as a 500 via the generic
+        # except below. Codex P2 (2026-05-26).
+        episode_id: str | None = None
+        if episode_id_raw:
+            import uuid as _uuid
+            try:
+                episode_id = str(_uuid.UUID(episode_id_raw))
+            except ValueError:
+                return JSONResponse(
+                    {"error": "episode_id must be a UUID"},
+                    status_code=400,
+                )
 
         from sqlalchemy import text as _sql_text
         params: dict[str, Any] = {"agent_id": settings.agent_id, "limit": limit, "offset": offset}

--- a/static/dashboard/css/dashboard.css
+++ b/static/dashboard/css/dashboard.css
@@ -19,6 +19,7 @@
     --procedure-color: #fb923c;
     --censor-color: #f87171;
     --heartbeat-color: #22d3ee;
+    --chunk-color: #06b6d4;
 
     --sidebar-width: 220px;
     --sidebar-collapsed: 56px;
@@ -537,6 +538,7 @@ body {
 .badge-decision  { background: rgba(167, 139, 250, 0.15); color: var(--decision-color); }
 .badge-procedure { background: rgba(251, 146, 60, 0.15); color: var(--procedure-color); }
 .badge-censor    { background: rgba(248, 113, 113, 0.15); color: var(--censor-color); }
+.badge-chunk     { background: rgba(6, 182, 212, 0.15);  color: var(--chunk-color); }
 
 .badge-success { background: rgba(52, 211, 153, 0.15); color: var(--green); }
 .badge-failure { background: rgba(248, 113, 113, 0.15); color: var(--red); }

--- a/static/dashboard/js/app.js
+++ b/static/dashboard/js/app.js
@@ -237,7 +237,8 @@ const Dashboard = {
             episode: '#34d399',
             decision: '#a78bfa',
             procedure: '#fb923c',
-            censor: '#f87171'
+            censor: '#f87171',
+            chunk: '#06b6d4'
         };
         return colors[type] || '#6b6b8a';
     },

--- a/static/dashboard/js/browser.js
+++ b/static/dashboard/js/browser.js
@@ -13,6 +13,7 @@ Dashboard.registerView('browser', async function(container) {
         '<div class="tab-bar" id="browser-tabs">' +
             '<button class="tab-btn active" data-tab="facts">Facts</button>' +
             '<button class="tab-btn" data-tab="episodes">Episodes</button>' +
+            '<button class="tab-btn" data-tab="chunks">Chunks</button>' +
             '<button class="tab-btn" data-tab="decisions">Decisions</button>' +
             '<button class="tab-btn" data-tab="procedures">Procedures</button>' +
             '<button class="tab-btn" data-tab="censors">Censors</button>' +
@@ -133,6 +134,7 @@ Dashboard.registerView('browser', async function(container) {
         var endpoints = {
             facts: '/facts',
             episodes: '/episodes',
+            chunks: '/chunks',
             decisions: '/decisions',
             procedures: '/procedures',
             censors: '/censors'
@@ -251,6 +253,13 @@ Dashboard.registerView('browser', async function(container) {
                     { key: 'activation_count', label: 'Activations' },
                     { key: 'active', label: 'Active', format: 'boolean' }
                 ];
+            case 'chunks':
+                return [
+                    { key: 'content', label: 'Content', cls: 'cell-truncate', truncate: 100 },
+                    { key: 'chunk_index', label: 'Idx', badge: 'badge-chunk' },
+                    { key: 'episode_id', label: 'Episode', cls: 'mono', truncate: 8 },
+                    { key: 'created_at', label: 'Created', format: 'date' }
+                ];
             default:
                 return [];
         }
@@ -336,6 +345,13 @@ Dashboard.registerView('browser', async function(container) {
                 html += detailRow('Domain', item.domain);
                 html += detailRow('Activations', item.activation_count);
                 html += detailRow('False Positives', item.false_positive_count);
+                html += detailRow('ID', null, '<span class="mono">' + escapeHtml(item.id || '') + '</span>');
+                break;
+            case 'chunks':
+                html += detailRow('Content', item.content);
+                html += detailRow('Chunk Index', item.chunk_index);
+                html += detailRow('Episode', null, '<span class="mono">' + escapeHtml(item.episode_id || '') + '</span>');
+                html += detailRow('Created', Dashboard.formatDateTime(item.created_at));
                 html += detailRow('ID', null, '<span class="mono">' + escapeHtml(item.id || '') + '</span>');
                 break;
         }

--- a/static/dashboard/js/graph.js
+++ b/static/dashboard/js/graph.js
@@ -61,7 +61,7 @@ Dashboard.registerView('graph', async function(container) {
     var allEdges = data.edges;
     var stats = data.stats || {};
     var filters = {
-        types: { fact: true, episode: true, decision: true, procedure: true },
+        types: { fact: true, episode: true, decision: true, procedure: true, chunk: true },
         minEdges: 0,
         search: ''
     };
@@ -94,7 +94,7 @@ Dashboard.registerView('graph', async function(container) {
         checksDiv.style.borderRadius = '8px';
         checksDiv.style.border = '1px solid var(--border)';
 
-        var types = ['fact', 'episode', 'decision', 'procedure'];
+        var types = ['fact', 'episode', 'decision', 'procedure', 'chunk'];
         types.forEach(function(type) {
             var label = document.createElement('label');
             label.className = 'filter-check';
@@ -208,12 +208,22 @@ Dashboard.registerView('graph', async function(container) {
             .enter().append('line')
             .attr('stroke', function(d) { return relationColor(d.relation); })
             .attr('stroke-width', function(d) { return Math.max(1, (d.weight || 0.5) * 2); })
-            .attr('stroke-opacity', 0.5)
-            .attr('stroke-dasharray', function(d) { return (d.weight || 0.5) < 0.3 ? '4,4' : 'none'; });
+            .attr('stroke-opacity', function(d) {
+                // F065: inferred edges drawn lighter than heuristic/deterministic.
+                return d.extraction_method === 'inferred' ? 0.3 : 0.5;
+            })
+            .attr('stroke-dasharray', function(d) {
+                // Dash by either low weight OR inferred provenance.
+                if (d.extraction_method === 'inferred') return '2,3';
+                return (d.weight || 0.5) < 0.3 ? '4,4' : 'none';
+            });
 
         // Link hover titles
         links.append('title')
-            .text(function(d) { return d.relation + ' (w=' + (d.weight || 0).toFixed(2) + ')'; });
+            .text(function(d) {
+                var prov = d.extraction_method ? ' · ' + d.extraction_method : '';
+                return d.relation + ' (w=' + (d.weight || 0).toFixed(2) + ')' + prov;
+            });
 
         // Nodes
         nodeGroup = g.append('g').attr('class', 'nodes');
@@ -298,7 +308,10 @@ Dashboard.registerView('graph', async function(container) {
             contradicts: '#f87171',
             supersedes: '#fb923c',
             caused_by: '#e2e2f0',
-            discussed_in: '#6b6b8a'
+            discussed_in: '#6b6b8a',
+            // F070: chunk-graph relations
+            part_of: '#22d3ee',
+            summarized_by: '#06b6d4'
         };
         return colors[relation] || '#6b6b8a';
     }

--- a/static/dashboard/js/overview.js
+++ b/static/dashboard/js/overview.js
@@ -50,6 +50,7 @@ Dashboard.registerView('overview', async function(container) {
     html += '<div class="stat-grid">';
     html += buildStatCard('Total Facts', mem.total_facts || 0, factsDelta, 'var(--fact-color)');
     html += buildStatCard('Total Episodes', mem.total_episodes || 0, episodesDelta, 'var(--episode-color)');
+    html += buildStatCard('Total Chunks', mem.total_chunks || 0, null, 'var(--chunk-color)');
     html += buildStatCard('Total Decisions', mem.total_decisions || 0, decisionsDelta, 'var(--decision-color)');
     html += buildStatCard('Active Censors', mem.active_censors || 0, null, 'var(--censor-color)');
     html += buildDensityCard(density);


### PR DESCRIPTION
## Summary

Closes the dashboard side of the F067 / F070 / F070.1 / F065 graph series. Two commits:

**1. `feat(dashboard): surface chunks + F070 edges + F065 provenance`** — Knowledge Graph + Graph Health + Density now see chunks as a first-class node type, plus F065 `extraction_method` per edge.

**2. `feat(dashboard): chunks tab in Memory Browser + Total Chunks stat card`** — Memory Browser gets a Chunks tab; Overview gets a Total Chunks stat card; new `GET /chunks` REST route.

## The bug, in prod data

Probed prod (`http://192.168.1.141:8383`) before this fix:

| Endpoint | Pre-fix | What was wrong |
|---|---|---|
| `/dashboard/graph?limit=500` | 2000 edges returned, 1986 with `source_type='chunk'`, **zero chunk nodes** in the nodes array | `type_queries` only resolved 4 source tables — chunk source IDs were dropped, force graph rendered phantom edges |
| `/dashboard/density` | `density_by_type` has 4 types, but `edge_distribution` shows `part_of: 1276` + `summarized_by: 690` | Per-type breakdown silently missed the largest node population |
| `/dashboard/health` | `orphan_trend` for 2026-05-26 reads `0` | Quiet correctness bug — `daily_new_connected` counted chunks, `daily_new_total` didn't, diff went negative, `GREATEST(...,0)` clamped to zero |
| Memory Browser | 5 hardcoded tabs (facts/episodes/decisions/procedures/censors) | No chunk surface anywhere |
| Overview stat cards | facts/episodes/decisions/procedures/censors counts only | No total_chunks card |

## Changes by file

### Commit 1: graph / health / density (4 files, +47 / −8)

**Backend — `nous/api/dashboard_queries.py`**
1. `get_graph_data.type_queries`: + `chunk` → `heart.episode_chunks` (`chunk_index::text` as category)
2. `get_graph_data` edge SELECT: + `extraction_method`, propagated to each edge dict
3. `get_graph_data.orphan_queries`: + chunks
4. `get_health_data.orphan_queries`: + chunks
5. `get_health_data` orphan-trend UNION: + `heart.episode_chunks` *(quiet correctness fix)*
6. `get_density_data.type_configs`: + chunk

**Frontend**
7. `static/dashboard/js/app.js` `typeColor`: chunk = `#06b6d4`
8. `static/dashboard/css/dashboard.css`: `--chunk-color` var + `.badge-chunk` rule
9. `static/dashboard/js/graph.js`:
   - `filters.types` + `types` array: + chunk
   - `relationColor()`: + `part_of: '#22d3ee'`, `summarized_by: '#06b6d4'`
   - Edge stroke styling reads `extraction_method`: inferred edges drawn at 0.3 opacity with `2,3` dash
   - Edge tooltip appends ` · {extraction_method}` when present

### Commit 2: browser / overview (3 files, +89 / 0)

**Backend — `nous/api/rest.py`**
- `status` endpoint: `total_chunks` added to the COUNT loop + memory dict
- New `GET /chunks?q=&episode_id=&limit=&offset=` route using direct SQL on `heart.episode_chunks`. Mirrors `/facts` browse-mode JSON shape (`chunks/total/limit/offset`).

**Frontend**
- `static/dashboard/js/browser.js`: Chunks tab (between Episodes and Decisions); columns content/idx/episode/created_at; detail row with full content + parent episode id
- `static/dashboard/js/overview.js`: Total Chunks stat card placed next to Total Episodes

## Apples-to-apples discipline

All edits are **additive** (new entries in existing structures, new endpoint, new tab). No existing chart contracts change. No type-filter default flips. No removed/renamed `/status` fields. Tests against pre-existing chunk-free fixtures stay byte-identical.

## Test plan

- [x] `uv run pytest tests/test_dashboard_queries.py tests/test_density_dashboard.py -v` against local eval Postgres — **21/21 pass** in 3.0s (both commits)
- [x] Prod `/dashboard/graph` empirical probe before fix — confirmed phantom edges (1986/2000 source_type='chunk', 0 chunk nodes in response)
- [x] Prod `/dashboard/density` probe — confirmed chunks missing from per-type breakdown
- [x] Prod `/dashboard/health` probe — confirmed orphan_trend clamp bug (2026-05-26 reads `0`)
- [x] `/chunks` route SQL shape validated against eval DB via psql probe — 3-row sample returns expected columns
- [ ] Post-deploy: refresh dashboard, confirm chunk type appears in density per-type table, in graph filter checkboxes, and in Memory Browser tab list
- [ ] Post-deploy: confirm 2026-05-26 orphan_trend reports a realistic number (currently 0 from the clamp)
- [ ] Post-deploy: confirm Overview shows Total Chunks card next to Total Episodes
- [ ] Post-deploy: `GET /chunks?limit=3` returns 200 with chunks array

## Deferred (separate decisions, not lost)

- **F065 hub-snapshot dashboard tile** — needs placement / time-window design
- **F050 query-expansion analytics tile** — same

## Forge decision

Decision `f339999b` finalized + reviewed in forge MCP (10 thoughts, advisor-validated). Catches a parallel F065 gap caught by the advisor mid-implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)