### PR TITLE
feat(F069): document-aware ingestion path Phase 1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -587,6 +587,7 @@ DB connection vars are **unprefixed** (shared with docker-compose). All others u
 | `recall_recent` | all | Retrieve recent memory items |
 | `learn_fact` | conversation, question, creative, task | Store a new fact |
 | `learn_skill` | conversation, question, task | Register a skill from URL, local path, or inline markdown |
+| `ingest_document` | conversation, question, task, debug | F069: chunk & persist a full document body (arxiv, PDF/.docx text, long markdown) to heart.episode_chunks with source_kind='document'. Use after extracting text yourself via run_python / web_fetch. |
 | `get_procedure` | all | Retrieve a specific procedure by ID |
 | `create_censor` | all | Create a guardrail censor |
 | `cache_retrieve` | all | Retrieve original content from SmartCompressed results |

--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -50,12 +50,12 @@ _OPTIONAL_DECISION_FRAMES = frozenset({"task", "debug"})
 
 # Frame-gated tool access (D5)
 FRAME_TOOLS: dict[str, list[str]] = {
-    "conversation": ["record_decision", "learn_fact", "learn_skill", "recall_deep", "recall_recent", "recall_hubs", "get_procedure", "create_censor", "bash", "read_file", "write_file", "web_search", "web_fetch", "cache_retrieve", "spawn_task", "spawn_sync", "schedule_task", "list_tasks", "cancel_task", "run_python", "send_file", "heartbeat_check_create", "heartbeat_check_manage", "dag_create", "dag_manage"],
-    "question": ["recall_deep", "recall_recent", "recall_hubs", "get_procedure", "bash", "read_file", "write_file", "record_decision", "learn_fact", "learn_skill", "create_censor", "web_search", "web_fetch", "cache_retrieve", "list_tasks", "cancel_task", "run_python", "dag_manage"],
+    "conversation": ["record_decision", "learn_fact", "learn_skill", "recall_deep", "recall_recent", "recall_hubs", "get_procedure", "create_censor", "bash", "read_file", "write_file", "web_search", "web_fetch", "cache_retrieve", "spawn_task", "spawn_sync", "schedule_task", "list_tasks", "cancel_task", "run_python", "send_file", "heartbeat_check_create", "heartbeat_check_manage", "dag_create", "dag_manage", "ingest_document"],
+    "question": ["recall_deep", "recall_recent", "recall_hubs", "get_procedure", "bash", "read_file", "write_file", "record_decision", "learn_fact", "learn_skill", "create_censor", "web_search", "web_fetch", "cache_retrieve", "list_tasks", "cancel_task", "run_python", "dag_manage", "ingest_document"],
     "decision": ["record_decision", "recall_deep", "recall_recent", "recall_hubs", "get_procedure", "create_censor", "bash", "read_file", "web_search", "web_fetch", "cache_retrieve", "list_tasks", "cancel_task", "dag_manage"],
     "creative": ["learn_fact", "recall_deep", "recall_recent", "recall_hubs", "get_procedure", "write_file", "web_search", "cache_retrieve"],
     "task": ["*"],  # All tools
-    "debug": ["record_decision", "recall_deep", "recall_recent", "recall_hubs", "get_procedure", "bash", "read_file", "learn_fact", "web_search", "web_fetch", "cache_retrieve", "spawn_task", "spawn_sync", "schedule_task", "list_tasks", "cancel_task", "run_python", "send_file", "heartbeat_check_create", "heartbeat_check_manage", "dag_create", "dag_manage"],
+    "debug": ["record_decision", "recall_deep", "recall_recent", "recall_hubs", "get_procedure", "bash", "read_file", "learn_fact", "web_search", "web_fetch", "cache_retrieve", "spawn_task", "spawn_sync", "schedule_task", "list_tasks", "cancel_task", "run_python", "send_file", "heartbeat_check_create", "heartbeat_check_manage", "dag_create", "dag_manage", "ingest_document"],
     "initiation": ["store_identity", "complete_initiation"],
 }
 

--- a/nous/api/tools.py
+++ b/nous/api/tools.py
@@ -1097,15 +1097,52 @@ def create_nous_tools(brain: Brain, heart: Heart, settings: Settings | None = No
                 logger.exception("ingest_document: embed_batch failed")
                 return {"content": [{"type": "text", "text": f"Error embedding chunks: {exc}"}]}
 
-            # 4. Insert into heart.episode_chunks. ON CONFLICT skips re-
+            # 4. Idempotency check (Codex P1, 2026-05-26): if any chunks
+            # already exist for this (episode_id, source_ref), refuse to
+            # re-ingest. Without this, retries or repeated tool calls
+            # would duplicate content indefinitely because chunk_index is
+            # computed as MAX+1 — ON CONFLICT can never fire on fresh
+            # indices. Conservative semantics: the agent must use a
+            # different source_ref or delete existing rows to re-ingest.
+            async with heart.db.session() as session:
+                existing_row = await session.execute(
+                    _sql_text(
+                        "SELECT COUNT(*) AS cnt FROM heart.episode_chunks "
+                        "WHERE agent_id = :a AND episode_id = :e "
+                        "  AND source_ref = :r"
+                    ),
+                    {
+                        "a": heart.agent_id,
+                        "e": target_episode_id,
+                        "r": source_ref,
+                    },
+                )
+                existing_cnt = int(existing_row.scalar() or 0)
+            if existing_cnt > 0:
+                return {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                f"Already ingested: {existing_cnt} chunks exist for "
+                                f"source_ref={source_ref!r} under episode "
+                                f"{target_episode_id}. Use a different source_ref "
+                                f"or delete existing rows to re-ingest."
+                            ),
+                        }
+                    ]
+                }
+
+            # Insert into heart.episode_chunks. ON CONFLICT skips re-
             # ingestion of identical (episode_id, chunk_index) pairs so the
             # call is idempotent for a given episode. Vector literal format
             # mirrors handlers/episode_summarizer.py:219 — CAST AS vector
             # avoids the pgvector.utils dependency.
             async with heart.db.session() as session:
                 # Determine starting chunk_index: append after any existing
-                # chunks for this episode so re-ingest of a different doc
-                # under the same episode does not collide.
+                # chunks for this episode so dialogue chunks (F067) +
+                # document chunks (different source_ref) under the same
+                # episode do not collide.
                 next_idx_row = await session.execute(
                     _sql_text(
                         "SELECT COALESCE(MAX(chunk_index), -1) + 1 AS next_idx "

--- a/nous/api/tools.py
+++ b/nous/api/tools.py
@@ -76,6 +76,10 @@ class ToolDispatcher:
                 args = {**args, "session_id": session_id}
             if session_id is not None and name == "run_python":
                 args = {**args, "_session_id": session_id}
+            if session_id is not None and name == "ingest_document":
+                # F069: inject session_id so the tool can resolve the
+                # active episode when the caller omits episode_id.
+                args = {**args, "_session_id": session_id}
             if session_id is not None and name == "recall_deep":
                 # F051.4 / F055: inject session_id into recall_deep so
                 # F055's Cross-Turn Residual Activation can read it via
@@ -1011,6 +1015,153 @@ def create_nous_tools(brain: Brain, heart: Heart, settings: Settings | None = No
             logger.exception("recall_hubs tool failed")
             return {"content": [{"type": "text", "text": f"Error fetching hubs: {e}"}]}
 
+    async def ingest_document(
+        content: str,
+        source_ref: str,
+        episode_id: str | None = None,
+        _session_id: str | None = None,
+    ) -> dict[str, Any]:
+        """F069: chunk and persist a full document body to heart.episode_chunks.
+
+        Unlike F067 transcript chunking (600-char dialogue window), this uses
+        the document_chunker (1500-char structure-aware split, 200-char
+        overlap). The handler writes chunks directly to the DB at full
+        fidelity, so conversation-history soft-trim does not lose content.
+
+        Args:
+            content: Full document text. The agent extracts this itself
+                (e.g. via run_python + pypdf for PDFs, python-docx for
+                .docx, plain str for arxiv HTML). Must be >= configured
+                document_chunk_min_chars.
+            source_ref: URL or workspace path the content came from.
+                Stored on every chunk for traceability.
+            episode_id: Optional explicit episode UUID. If omitted, the
+                handler attaches chunks to the active episode of the
+                current session.
+            _session_id: Auto-injected by ToolDispatcher; used to resolve
+                the active episode when episode_id is not provided.
+        """
+        from uuid import UUID as _UUID
+        from sqlalchemy import text as _sql_text
+
+        from nous.heart.document_chunker import chunk_document
+
+        if not settings.document_ingest_enabled:
+            return {"content": [{"type": "text", "text": "ingest_document is disabled (NOUS_DOCUMENT_INGEST_ENABLED=false)."}]}
+        if not content or not content.strip():
+            return {"content": [{"type": "text", "text": "Error: content is empty."}]}
+        if not source_ref or not source_ref.strip():
+            return {"content": [{"type": "text", "text": "Error: source_ref is required (URL or file path)."}]}
+
+        try:
+            # 1. Resolve target episode.
+            target_episode_id: _UUID
+            if episode_id:
+                try:
+                    target_episode_id = _UUID(episode_id)
+                except ValueError:
+                    return {"content": [{"type": "text", "text": f"Error: episode_id must be a UUID, got {episode_id!r}."}]}
+            else:
+                if not _session_id:
+                    return {"content": [{"type": "text", "text": "Error: no episode_id provided and no active session — pass episode_id explicitly."}]}
+                async with heart.db.session() as session:
+                    row = await session.execute(
+                        _sql_text(
+                            "SELECT id FROM heart.episodes "
+                            "WHERE agent_id = :a AND session_id = :s AND active = true "
+                            "ORDER BY started_at DESC LIMIT 1"
+                        ),
+                        {"a": heart.agent_id, "s": _session_id},
+                    )
+                    found = row.scalar()
+                if not found:
+                    return {"content": [{"type": "text", "text": f"Error: no active episode for session {_session_id}; pass episode_id explicitly."}]}
+                target_episode_id = found
+
+            # 2. Chunk the document.
+            chunks = chunk_document(
+                content,
+                target_size=settings.document_chunk_size,
+                overlap=settings.document_chunk_overlap,
+                min_chars=settings.document_chunk_min_chars,
+            )
+            if not chunks:
+                return {"content": [{"type": "text", "text": (
+                    f"Ingest skipped: content shorter than min_chars ({settings.document_chunk_min_chars})."
+                )}]}
+
+            # 3. Embed in one batch (cheaper than per-chunk).
+            try:
+                embeddings = await heart._embeddings.embed_batch(chunks)
+            except Exception as exc:
+                logger.exception("ingest_document: embed_batch failed")
+                return {"content": [{"type": "text", "text": f"Error embedding chunks: {exc}"}]}
+
+            # 4. Insert into heart.episode_chunks. ON CONFLICT skips re-
+            # ingestion of identical (episode_id, chunk_index) pairs so the
+            # call is idempotent for a given episode. Vector literal format
+            # mirrors handlers/episode_summarizer.py:219 — CAST AS vector
+            # avoids the pgvector.utils dependency.
+            async with heart.db.session() as session:
+                # Determine starting chunk_index: append after any existing
+                # chunks for this episode so re-ingest of a different doc
+                # under the same episode does not collide.
+                next_idx_row = await session.execute(
+                    _sql_text(
+                        "SELECT COALESCE(MAX(chunk_index), -1) + 1 AS next_idx "
+                        "FROM heart.episode_chunks "
+                        "WHERE agent_id = :a AND episode_id = :e"
+                    ),
+                    {"a": heart.agent_id, "e": target_episode_id},
+                )
+                start_idx = int(next_idx_row.scalar() or 0)
+
+                inserted = 0
+                for offset, (chunk_text, emb) in enumerate(zip(chunks, embeddings)):
+                    if not emb:
+                        # Defensive — embed_batch should never return None,
+                        # but a single bad vector should not crash the batch.
+                        continue
+                    vec_lit = "[" + ",".join(f"{v:.6f}" for v in emb) + "]"
+                    await session.execute(
+                        _sql_text(
+                            "INSERT INTO heart.episode_chunks "
+                            "(agent_id, episode_id, chunk_index, content, embedding, "
+                            " source_kind, source_ref) "
+                            "VALUES (:a, :e, :i, :c, CAST(:emb AS vector), "
+                            " 'document', :ref) "
+                            "ON CONFLICT (episode_id, chunk_index) DO NOTHING"
+                        ),
+                        {
+                            "a": heart.agent_id,
+                            "e": str(target_episode_id),
+                            "i": start_idx + offset,
+                            "c": chunk_text,
+                            "emb": vec_lit,
+                            "ref": source_ref,
+                        },
+                    )
+                    inserted += 1
+                await session.commit()
+
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": (
+                            f"Ingested {inserted} chunks from {source_ref!r} "
+                            f"into episode {target_episode_id} "
+                            f"(start_index={start_idx}, source_kind=document, "
+                            f"target_size={settings.document_chunk_size})."
+                        ),
+                    }
+                ]
+            }
+
+        except Exception as e:
+            logger.exception("ingest_document tool failed")
+            return {"content": [{"type": "text", "text": f"Error ingesting document: {e}"}]}
+
     return {
         "record_decision": record_decision,
         "learn_fact": learn_fact,
@@ -1020,6 +1171,7 @@ def create_nous_tools(brain: Brain, heart: Heart, settings: Settings | None = No
         "learn_skill": learn_skill,
         "get_procedure": get_procedure,
         "recall_hubs": recall_hubs,
+        "ingest_document": ingest_document,
     }
 
 
@@ -1245,6 +1397,47 @@ _RECALL_HUBS_SCHEMA: dict[str, Any] = {
 }
 
 
+_INGEST_DOCUMENT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": (
+        "F069: chunk and persist a full document body (arxiv paper, doc "
+        "page, parsed PDF/.docx text) to long-term memory at full fidelity. "
+        "Use after you have extracted text yourself (e.g. via run_python "
+        "with pypdf for PDFs, python-docx for .docx, or after fetching "
+        "with web_fetch at max_chars=200000 for a large HTML page). "
+        "Unlike web_fetch + dialogue chunking which retains ~1% of a paper, "
+        "this writes the full content to heart.episode_chunks with "
+        "source_kind='document' using a 1500-char structure-aware chunker."
+    ),
+    "properties": {
+        "content": {
+            "type": "string",
+            "description": (
+                "Full document body to ingest. Should already be plain text "
+                "(decode binary formats client-side via run_python). Must be "
+                "at least document_chunk_min_chars (default 100) chars."
+            ),
+        },
+        "source_ref": {
+            "type": "string",
+            "description": (
+                "URL or workspace path the document came from. Persisted on "
+                "every chunk for traceability and so the agent can recall "
+                "where a fact was sourced."
+            ),
+        },
+        "episode_id": {
+            "type": "string",
+            "description": (
+                "Optional explicit episode UUID. If omitted, chunks are "
+                "attached to the active episode of the current session."
+            ),
+        },
+    },
+    "required": ["content", "source_ref"],
+}
+
+
 def register_nous_tools(dispatcher: ToolDispatcher, brain: Brain, heart: Heart, settings: Settings | None = None) -> None:
     """Create Nous memory tools and register them with the dispatcher.
 
@@ -1261,6 +1454,7 @@ def register_nous_tools(dispatcher: ToolDispatcher, brain: Brain, heart: Heart, 
     dispatcher.register("learn_skill", closures["learn_skill"], _LEARN_SKILL_SCHEMA)
     dispatcher.register("get_procedure", closures["get_procedure"], _GET_PROCEDURE_SCHEMA)
     dispatcher.register("recall_hubs", closures["recall_hubs"], _RECALL_HUBS_SCHEMA)
+    dispatcher.register("ingest_document", closures["ingest_document"], _INGEST_DOCUMENT_SCHEMA)
 
 
 # ---------------------------------------------------------------------------

--- a/nous/api/tools.py
+++ b/nous/api/tools.py
@@ -1097,14 +1097,51 @@ def create_nous_tools(brain: Brain, heart: Heart, settings: Settings | None = No
                 logger.exception("ingest_document: embed_batch failed")
                 return {"content": [{"type": "text", "text": f"Error embedding chunks: {exc}"}]}
 
-            # 4. Idempotency check (Codex P1, 2026-05-26): if any chunks
-            # already exist for this (episode_id, source_ref), refuse to
-            # re-ingest. Without this, retries or repeated tool calls
-            # would duplicate content indefinitely because chunk_index is
-            # computed as MAX+1 — ON CONFLICT can never fire on fresh
-            # indices. Conservative semantics: the agent must use a
-            # different source_ref or delete existing rows to re-ingest.
+            # Codex P2 round 3 (2026-05-26): guard against embedder returning
+            # fewer vectors than chunks. zip() would silently truncate and
+            # drop tail chunks. Mirrors the F067 writer at
+            # handlers/episode_summarizer.py:205-211.
+            if len(embeddings) != len(chunks):
+                logger.warning(
+                    "ingest_document: embedder returned %d vectors for %d chunks "
+                    "(episode=%s, source_ref=%s); aborting to avoid partial ingest",
+                    len(embeddings), len(chunks), target_episode_id, source_ref,
+                )
+                return {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                f"Error: embedder returned {len(embeddings)} vectors "
+                                f"for {len(chunks)} chunks; refusing to write a "
+                                f"partial ingest. Retry."
+                            ),
+                        }
+                    ]
+                }
+
+            # 4. Atomic idempotency + insert (Codex P1 round 3, 2026-05-26):
+            # the prior fix did the existence check in one session and the
+            # inserts in another, leaving a race where two concurrent calls
+            # for the same (episode_id, source_ref) could both pass the
+            # check and then both append fresh chunk_index ranges.
+            #
+            # Now: single transaction with pg_advisory_xact_lock keyed on
+            # (episode_id, source_ref). Concurrent callers for the same key
+            # serialize at the DB; only the first one's COUNT sees 0 rows,
+            # so only it inserts. The second one waits, then sees the rows
+            # and returns the "already ingested" response. Vector literal
+            # format mirrors handlers/episode_summarizer.py:219.
+            lock_key = f"ingest_document:{target_episode_id}:{source_ref}"
             async with heart.db.session() as session:
+                # Advisory lock — released at COMMIT / ROLLBACK.
+                await session.execute(
+                    _sql_text(
+                        "SELECT pg_advisory_xact_lock(hashtextextended(:k, 0))"
+                    ),
+                    {"k": lock_key},
+                )
+
                 existing_row = await session.execute(
                     _sql_text(
                         "SELECT COUNT(*) AS cnt FROM heart.episode_chunks "
@@ -1118,27 +1155,24 @@ def create_nous_tools(brain: Brain, heart: Heart, settings: Settings | None = No
                     },
                 )
                 existing_cnt = int(existing_row.scalar() or 0)
-            if existing_cnt > 0:
-                return {
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": (
-                                f"Already ingested: {existing_cnt} chunks exist for "
-                                f"source_ref={source_ref!r} under episode "
-                                f"{target_episode_id}. Use a different source_ref "
-                                f"or delete existing rows to re-ingest."
-                            ),
-                        }
-                    ]
-                }
 
-            # Insert into heart.episode_chunks. ON CONFLICT skips re-
-            # ingestion of identical (episode_id, chunk_index) pairs so the
-            # call is idempotent for a given episode. Vector literal format
-            # mirrors handlers/episode_summarizer.py:219 — CAST AS vector
-            # avoids the pgvector.utils dependency.
-            async with heart.db.session() as session:
+                if existing_cnt > 0:
+                    # Release the lock by committing (no writes happened).
+                    await session.commit()
+                    return {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": (
+                                    f"Already ingested: {existing_cnt} chunks exist for "
+                                    f"source_ref={source_ref!r} under episode "
+                                    f"{target_episode_id}. Use a different source_ref "
+                                    f"or delete existing rows to re-ingest."
+                                ),
+                            }
+                        ]
+                    }
+
                 # Determine starting chunk_index: append after any existing
                 # chunks for this episode so dialogue chunks (F067) +
                 # document chunks (different source_ref) under the same

--- a/nous/api/tools.py
+++ b/nous/api/tools.py
@@ -1120,19 +1120,25 @@ def create_nous_tools(brain: Brain, heart: Heart, settings: Settings | None = No
                     ]
                 }
 
-            # 4. Atomic idempotency + insert (Codex P1 round 3, 2026-05-26):
-            # the prior fix did the existence check in one session and the
-            # inserts in another, leaving a race where two concurrent calls
-            # for the same (episode_id, source_ref) could both pass the
-            # check and then both append fresh chunk_index ranges.
+            # 4. Atomic idempotency + insert.
             #
-            # Now: single transaction with pg_advisory_xact_lock keyed on
-            # (episode_id, source_ref). Concurrent callers for the same key
-            # serialize at the DB; only the first one's COUNT sees 0 rows,
-            # so only it inserts. The second one waits, then sees the rows
-            # and returns the "already ingested" response. Vector literal
-            # format mirrors handlers/episode_summarizer.py:219.
-            lock_key = f"ingest_document:{target_episode_id}:{source_ref}"
+            # Lock is keyed on episode_id ONLY (Codex P1 round 4, 2026-05-26),
+            # NOT (episode_id, source_ref). Reason: chunk_index is allocated
+            # per-episode via MAX(chunk_index)+1. If two concurrent ingests
+            # for the same episode but DIFFERENT source_refs took separate
+            # locks, they could both pick the same start_idx, both INSERT,
+            # and ON CONFLICT (episode_id, chunk_index) DO NOTHING would
+            # silently drop one caller's rows — silent data loss.
+            #
+            # By locking at episode scope, both concurrent ingests serialize
+            # so their start_idx allocations are disjoint. The idempotency
+            # COUNT (filtered by source_ref) still works correctly inside
+            # the same transaction.
+            #
+            # Single transaction guarded by pg_advisory_xact_lock; lock
+            # auto-releases on COMMIT/ROLLBACK. Vector literal format
+            # mirrors handlers/episode_summarizer.py:219.
+            lock_key = f"ingest_document:{target_episode_id}"
             async with heart.db.session() as session:
                 # Advisory lock — released at COMMIT / ROLLBACK.
                 await session.execute(

--- a/nous/api/web_tools.py
+++ b/nous/api/web_tools.py
@@ -231,7 +231,10 @@ async def _web_fetch(
         if not is_safe:
             return _mcp_response(f"Blocked: {error}")
 
-        effective_max = min(max_chars or _settings.web_fetch_max_chars, 50000)
+        # F069 (2026-05-26): hard ceiling bumped from 50,000 -> 200,000.
+        # Lets explicit doc-ingest callers (ingest_document path) pull a
+        # full arxiv paper into one fetch instead of paginating.
+        effective_max = min(max_chars or _settings.web_fetch_max_chars, 200000)
 
         # Manual redirect following with SSRF check on each hop (P1-1 fix)
         max_redirects = 5

--- a/nous/api/web_tools.py
+++ b/nous/api/web_tools.py
@@ -349,8 +349,14 @@ _WEB_FETCH_SCHEMA: dict[str, Any] = {
         "url": {"type": "string", "description": "URL to fetch (must be http or https)"},
         "max_chars": {
             "type": "integer",
-            "description": "Maximum characters to return (default from config, max 50000)",
-            "maximum": 50000,
+            "description": (
+                "Maximum characters to return. Default 50000 (good for "
+                "most pages). Pass up to 200000 (hard ceiling) when "
+                "fetching a full document body to hand off to "
+                "ingest_document — F069 raised the ceiling so doc-ingest "
+                "calls are not silently truncated."
+            ),
+            "maximum": 200000,
         },
     },
     "required": ["url"],

--- a/nous/config.py
+++ b/nous/config.py
@@ -326,7 +326,13 @@ class Settings(BaseSettings):
     # Web tools
     brave_search_api_key: str = Field("", validation_alias="BRAVE_SEARCH_API_KEY")
     web_search_daily_limit: int = 100  # Max web searches per day
-    web_fetch_max_chars: int = 10000  # Default max chars for web_fetch
+    # F069 (2026-05-26): bumped from 10000 -> 50000 so an arxiv paper /
+    # long doc page is not silently truncated to 1-2 sections. Hard ceiling
+    # in _web_fetch raised to 200000 in lockstep so callers can pass an
+    # explicit max_chars=200000 when they intend to ingest a full document
+    # (e.g. before calling ingest_document). Pure dialogue web_fetch calls
+    # are still soft-trimmed downstream by tool_soft_trim_chars.
+    web_fetch_max_chars: int = 50000
     tavily_api_key: str = Field("", validation_alias="TAVILY_API_KEY")
     exa_api_key: str = Field("", validation_alias="EXA_API_KEY")
     search_provider: str = "auto"  # auto, tavily, exa, brave
@@ -980,6 +986,37 @@ class Settings(BaseSettings):
     episode_chunk_min_transcript_chars: int = Field(
         default=50,
         description="F067 minimum transcript length to chunk (shorter transcripts are skipped).",
+    )
+
+    # ── F069: document-aware ingestion ───────────────────────────────────
+    # Distinct from F067 because document bodies (arxiv papers, doc pages,
+    # parsed PDF/.docx text) benefit from larger, structure-aware chunks
+    # than the dialogue chunker provides. Opt-in surface: the agent calls
+    # `ingest_document(content, source_ref)` with text it has already
+    # extracted (e.g. via run_python + pypdf).
+    document_ingest_enabled: bool = Field(
+        default=True,
+        description=(
+            "F069 master switch for the ingest_document tool. When false, "
+            "the tool refuses calls; existing dialogue chunks (F067) are "
+            "unaffected. Default ON because the tool is opt-in at call "
+            "time — no auto-classification in v1."
+        ),
+    )
+    document_chunk_size: int = Field(
+        default=1500,
+        ge=200,
+        description="F069 target chunk size in chars (~250 words).",
+    )
+    document_chunk_overlap: int = Field(
+        default=200,
+        ge=0,
+        description="F069 overlap chars between document chunks.",
+    )
+    document_chunk_min_chars: int = Field(
+        default=100,
+        ge=10,
+        description="F069 minimum doc length to chunk (shorter ingests rejected).",
     )
     recall_include_parent_episodes: bool = Field(
         default=False,

--- a/nous/heart/document_chunker.py
+++ b/nous/heart/document_chunker.py
@@ -166,7 +166,16 @@ def _pack(pieces: list[str], *, target_size: int, overlap: int) -> list[str]:
             # with this one across the boundary.
             chunks.append(buf)
             tail = _overlap_tail(buf, overlap)
-            buf = f"{tail} {piece}" if tail else piece
+            seeded = f"{tail} {piece}" if tail else piece
+            # Codex P2 (2026-05-26): re-check size after seeding. If the
+            # overlap tail + new piece pushes us back over target_size,
+            # drop the tail rather than violate the chunk-size contract.
+            # The overlap is a nice-to-have for boundary context, not a
+            # hard guarantee — the size contract IS hard.
+            if len(seeded) > target_size:
+                buf = piece
+            else:
+                buf = seeded
     if buf:
         chunks.append(buf)
     return chunks

--- a/nous/heart/document_chunker.py
+++ b/nous/heart/document_chunker.py
@@ -111,36 +111,40 @@ def _recursive_split(
 ) -> list[str]:
     """Walk the delimiter hierarchy until every piece <= target_size.
 
-    Returns a flat list of pieces; their concatenation (after re-joining
-    with the discarded delimiters' inferred presence) is *not* exactly
-    ``text``, because the splitter does not re-insert the separator
-    characters. The packer downstream handles that by reading ``text``
-    boundaries when overlap is applied.
+    Returns a flat list of pieces. The original delimiter characters are
+    PRESERVED by right-attaching the delimiter to each piece (except the
+    last, which had no trailing delimiter in the source). Codex P2
+    (2026-05-26) caught the prior version that lost periods / paragraph
+    breaks because ``text.split(sep)`` discards ``sep`` tokens.
     """
     if len(text) <= target_size or not delimiters:
         return [text]
 
     head, *rest = delimiters
-    parts = text.split(head)
+    raw_parts = text.split(head)
     out: list[str] = []
-    for part in parts:
-        if not part:
+    last_idx = len(raw_parts) - 1
+    for i, part in enumerate(raw_parts):
+        # Right-attach the delimiter to every part except the final one,
+        # so the chunk content faithfully represents the source text.
+        attached = part + head if i < last_idx else part
+        if not attached:
             continue
-        if len(part) <= target_size:
-            out.append(part)
+        if len(attached) <= target_size:
+            out.append(attached)
         else:
-            out.extend(_recursive_split(part, rest, target_size))
+            out.extend(_recursive_split(attached, rest, target_size))
     return out
 
 
 def _pack(pieces: list[str], *, target_size: int, overlap: int) -> list[str]:
     """Pack pieces into chunks of approximately ``target_size`` chars.
 
-    Joins consecutive pieces with ``" "`` (a single space — deliberately
-    lossy, since the recursive splitter discarded the original delimiters).
-    Pieces that exceed target_size on their own get emitted standalone.
-    Overlap is realized by carrying the trailing ``overlap`` chars of the
-    last emitted chunk into the head of the next.
+    Concatenates consecutive pieces with NO extra separator because the
+    splitter now right-attaches the original delimiter to each piece
+    (Codex P2 fix). Pieces that exceed target_size on their own get
+    emitted standalone. Overlap is realized by carrying the trailing
+    ``overlap`` chars of the last emitted chunk into the head of the next.
     """
     chunks: list[str] = []
     buf = ""
@@ -157,7 +161,7 @@ def _pack(pieces: list[str], *, target_size: int, overlap: int) -> list[str]:
             buf = ""
             continue
 
-        candidate = piece if not buf else f"{buf} {piece}"
+        candidate = piece if not buf else f"{buf}{piece}"
         if len(candidate) <= target_size:
             buf = candidate
         else:
@@ -166,7 +170,7 @@ def _pack(pieces: list[str], *, target_size: int, overlap: int) -> list[str]:
             # with this one across the boundary.
             chunks.append(buf)
             tail = _overlap_tail(buf, overlap)
-            seeded = f"{tail} {piece}" if tail else piece
+            seeded = f"{tail}{piece}" if tail else piece
             # Codex P2 (2026-05-26): re-check size after seeding. If the
             # overlap tail + new piece pushes us back over target_size,
             # drop the tail rather than violate the chunk-size contract.

--- a/nous/heart/document_chunker.py
+++ b/nous/heart/document_chunker.py
@@ -1,0 +1,186 @@
+"""F069: structure-aware document chunker.
+
+Unlike F067's :func:`nous.heart.chunking.chunk_text` (fixed 600-char window,
+dialogue-shaped), this chunker is intended for full document bodies — arxiv
+papers, doc pages, long markdown / text files — that the agent ingests via
+the ``ingest_document`` tool after parsing them client-side (e.g. via
+``run_python`` with ``pypdf`` / ``python-docx``).
+
+Two differences from the dialogue chunker matter:
+
+1. **Bigger target window.** ~1500 chars (~250 words) preserves paragraph-
+   sized units of meaning. Dialogue's 600 chars slices academic prose
+   mid-thought; 1500 is the standard size used by langchain / llamaindex
+   recursive splitters for paper-shaped content.
+
+2. **Recursive split on natural boundaries.** The algorithm walks a
+   delimiter hierarchy (``\\n\\n`` → ``\\n`` → ``. `` → `` ``) and prefers
+   to split at the highest-priority boundary that keeps every emitted
+   chunk under ``target_size``. This avoids cutting in the middle of a
+   sentence when a paragraph break would do.
+
+Deterministic: same input + same parameters → same chunks. The function is
+pure — no DB, no embedding, no model calls. Persistence lives in the
+``ingest_document`` tool handler, which feeds these chunks into
+``heart.episode_chunks`` with ``source_kind='document'``.
+
+The chunker does NOT try to be clever about section headers (``## Methods``)
+or citations. That belongs in a v2 / Phase 2 alongside source-format-aware
+extraction — out of scope for this ship.
+"""
+from __future__ import annotations
+
+# Delimiter hierarchy, most-preferred first. Same hierarchy used by
+# langchain's RecursiveCharacterTextSplitter; kept short to avoid the
+# combinatorial blow-up of trying every separator at every level.
+_DEFAULT_DELIMITERS: tuple[str, ...] = ("\n\n", "\n", ". ", " ")
+
+
+def chunk_document(
+    text: str,
+    *,
+    target_size: int = 1500,
+    overlap: int = 200,
+    min_chars: int = 100,
+    delimiters: tuple[str, ...] = _DEFAULT_DELIMITERS,
+) -> list[str]:
+    """Recursively split ``text`` into document-shaped chunks.
+
+    Each chunk is at most ``target_size`` chars (modulo the final piece
+    of a paragraph that happens to be slightly shorter), and adjacent
+    chunks share approximately ``overlap`` trailing chars so a fact that
+    straddles a boundary surfaces in both neighbors.
+
+    Args:
+        text: The full document body. May contain ``\\n\\n`` paragraph
+            breaks, markdown headings, etc. — the chunker does not strip
+            or interpret structure beyond the delimiter hierarchy.
+        target_size: Soft cap on chunk size in chars. Default 1500
+            (~250 English words). Pieces that exceed this even after
+            splitting at the finest-grained delimiter (whitespace) are
+            emitted as-is — see ``_pack``.
+        overlap: Trailing chars of each chunk reproduced at the head of
+            the next. Default 200. Set to 0 for no overlap (e.g. tests).
+        min_chars: Short-circuit threshold. ``text`` below this length
+            returns ``[]`` so we do not pollute the chunk table with
+            single-tweet ingests.
+        delimiters: Ordered tuple of split markers. The default walks
+            paragraph → line → sentence → word. Override for plain text
+            without paragraphs.
+
+    Returns:
+        Ordered list of chunk strings. Empty for texts shorter than
+        ``min_chars`` or empty input.
+
+    Raises:
+        ValueError: if ``target_size <= 0``, ``overlap < 0``,
+        ``overlap >= target_size``, or ``delimiters`` is empty.
+    """
+    if not text or len(text) < min_chars:
+        return []
+    if target_size <= 0:
+        raise ValueError(f"target_size must be positive, got {target_size}")
+    if overlap < 0:
+        raise ValueError(f"overlap must be non-negative, got {overlap}")
+    if overlap >= target_size:
+        raise ValueError(
+            f"overlap ({overlap}) must be < target_size ({target_size}) — "
+            f"otherwise chunks would not advance"
+        )
+    if not delimiters:
+        raise ValueError("delimiters must be non-empty")
+
+    # Short-circuit: text fits in a single chunk.
+    if len(text) <= target_size:
+        return [text]
+
+    # Step 1: split on the highest-priority delimiter that produces at
+    # least one piece smaller than target_size. We greedily peel at the
+    # outermost level and only recurse into pieces that are still too big.
+    pieces = _recursive_split(text, list(delimiters), target_size)
+
+    # Step 2: pack consecutive small pieces into target_size chunks with
+    # overlap. Single oversized pieces (longer than target_size even
+    # after recursive splitting hit the last delimiter) are emitted as
+    # standalone chunks — better to keep them whole than slice arbitrarily.
+    return _pack(pieces, target_size=target_size, overlap=overlap)
+
+
+def _recursive_split(
+    text: str, delimiters: list[str], target_size: int,
+) -> list[str]:
+    """Walk the delimiter hierarchy until every piece <= target_size.
+
+    Returns a flat list of pieces; their concatenation (after re-joining
+    with the discarded delimiters' inferred presence) is *not* exactly
+    ``text``, because the splitter does not re-insert the separator
+    characters. The packer downstream handles that by reading ``text``
+    boundaries when overlap is applied.
+    """
+    if len(text) <= target_size or not delimiters:
+        return [text]
+
+    head, *rest = delimiters
+    parts = text.split(head)
+    out: list[str] = []
+    for part in parts:
+        if not part:
+            continue
+        if len(part) <= target_size:
+            out.append(part)
+        else:
+            out.extend(_recursive_split(part, rest, target_size))
+    return out
+
+
+def _pack(pieces: list[str], *, target_size: int, overlap: int) -> list[str]:
+    """Pack pieces into chunks of approximately ``target_size`` chars.
+
+    Joins consecutive pieces with ``" "`` (a single space — deliberately
+    lossy, since the recursive splitter discarded the original delimiters).
+    Pieces that exceed target_size on their own get emitted standalone.
+    Overlap is realized by carrying the trailing ``overlap`` chars of the
+    last emitted chunk into the head of the next.
+    """
+    chunks: list[str] = []
+    buf = ""
+    for piece in pieces:
+        # Oversized standalone piece — emit current buffer (if any) then
+        # the piece directly. We do NOT seed buf from its overlap tail:
+        # an oversized atom is already preserved verbatim, and the next
+        # piece (if any) starts fresh. This avoids emitting a leftover
+        # overlap-only chunk when an oversized atom is the final piece.
+        if len(piece) > target_size:
+            if buf:
+                chunks.append(buf)
+            chunks.append(piece)
+            buf = ""
+            continue
+
+        candidate = piece if not buf else f"{buf} {piece}"
+        if len(candidate) <= target_size:
+            buf = candidate
+        else:
+            # Flush buf; start a new one seeded with the overlap tail of
+            # the just-emitted chunk so the next chunk shares vocabulary
+            # with this one across the boundary.
+            chunks.append(buf)
+            tail = _overlap_tail(buf, overlap)
+            buf = f"{tail} {piece}" if tail else piece
+    if buf:
+        chunks.append(buf)
+    return chunks
+
+
+def _overlap_tail(text: str, overlap: int) -> str:
+    """Return the trailing ``overlap`` chars of ``text``, snapped to the
+    nearest preceding whitespace so we do not start the next chunk
+    mid-word. Returns ``""`` for ``overlap == 0`` or empty text."""
+    if overlap <= 0 or not text:
+        return ""
+    tail = text[-overlap:]
+    # Snap forward to first whitespace to avoid mid-word starts.
+    space_idx = tail.find(" ")
+    if space_idx == -1:
+        return tail
+    return tail[space_idx + 1:]

--- a/nous/storage/models.py
+++ b/nous/storage/models.py
@@ -430,6 +430,15 @@ class EpisodeChunk(Base):
     content: Mapped[str] = mapped_column(Text, nullable=False)
     embedding = mapped_column(Vector(1536), nullable=True)
     # search_tsv is GENERATED ALWAYS — read-only DB-side
+    # F069 (migration 052): distinguishes F067 dialogue transcript chunks
+    # from F069 document-body chunks (and reserves 'code' for future).
+    # Default 'dialogue' covers every row written before migration 052.
+    source_kind: Mapped[str] = mapped_column(
+        String(32), nullable=False, server_default="dialogue"
+    )
+    # F069: optional URL or workspace path for document chunks. NULL for
+    # dialogue chunks (transcripts have no external referent).
+    source_ref: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/sql/migrations/052_f069_document_source_kind.sql
+++ b/sql/migrations/052_f069_document_source_kind.sql
@@ -1,0 +1,34 @@
+-- Migration 052: F069 Phase 1 — document-aware ingestion
+-- Adds two columns to heart.episode_chunks that let the chunk surface
+-- distinguish dialogue transcripts (existing F067 path) from document
+-- bodies ingested via the new ingest_document tool.
+--
+-- source_kind: 'dialogue' (default, existing F067 rows) or 'document'
+--              (rows produced by ingest_document with the structure-aware
+--              chunker at 1500-char target / 200-char overlap). Reserve
+--              'code' for a future code-chunker variant.
+--
+-- source_ref:  for 'document' rows, the URL or workspace path the agent
+--              passed when calling ingest_document. Nullable for dialogue
+--              rows (transcript chunks have no external referent).
+--
+-- Backfill: every existing row gets DEFAULT 'dialogue' implicitly via
+-- the column DEFAULT. No explicit UPDATE needed — the table only contains
+-- F067 transcript chunks at the time this migration runs.
+--
+-- Index: (agent_id, source_kind) supports the future per-kind retrieval
+-- weighting (F069 Phase 3) without scanning every chunk row.
+
+BEGIN;
+
+ALTER TABLE heart.episode_chunks
+    ADD COLUMN IF NOT EXISTS source_kind VARCHAR(32) NOT NULL DEFAULT 'dialogue'
+        CHECK (source_kind IN ('dialogue', 'document', 'code'));
+
+ALTER TABLE heart.episode_chunks
+    ADD COLUMN IF NOT EXISTS source_ref TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_episode_chunks_source_kind
+    ON heart.episode_chunks(agent_id, source_kind);
+
+COMMIT;

--- a/tests/test_document_chunker.py
+++ b/tests/test_document_chunker.py
@@ -143,6 +143,44 @@ class TestOverlap:
             )
 
 
+class TestDelimiterPreservation:
+    """Codex P2 (round 2): the original delimiters (periods, paragraph
+    breaks, sentence punctuation) must survive chunking. The prior
+    implementation dropped them via text.split(sep) + rejoin-with-space."""
+
+    def test_periods_preserved_across_chunks(self):
+        # Two sentences forced to split. The sentence-ending period after
+        # "long" must survive — pre-fix, text.split(". ") discarded it.
+        text = "Sentence one is moderately long. Sentence two is also long enough."
+        chunks = chunk_document(text, target_size=40, overlap=0, min_chars=10)
+        joined = "".join(chunks)
+        # The sentence-boundary period after "long" must survive.
+        assert "long." in joined, f"period after 'long' dropped: {joined!r}"
+        # Final period preserved (was true even pre-fix; defensive).
+        assert "enough." in joined, f"trailing period dropped: {joined!r}"
+        # And the boundary should appear with a space after the period
+        # (i.e. ". " is reconstructed, not collapsed to ".").
+        assert ". " in joined, f"period+space boundary collapsed: {joined!r}"
+
+    def test_paragraph_break_preserved(self):
+        # Two paragraphs split on \n\n; the double newline must appear
+        # somewhere in the chunk stream so the source structure is
+        # not silently flattened.
+        para_a = "Alpha. " * 30  # ~210 chars
+        para_b = "Beta. " * 30   # ~180 chars
+        text = f"{para_a.strip()}\n\n{para_b.strip()}"
+        chunks = chunk_document(text, target_size=200, overlap=0, min_chars=50)
+        joined = "".join(chunks)
+        assert "\n\n" in joined, f"paragraph break dropped: {joined!r}"
+
+    def test_short_text_passthrough_preserves_exact(self):
+        # Below target_size short-circuit — original text must be byte-
+        # for-byte preserved (this was already true; defensive check).
+        text = "Hello world. Goodbye world.\n\nNew paragraph."
+        chunks = chunk_document(text, target_size=1500, overlap=200, min_chars=10)
+        assert chunks == [text]
+
+
 class TestRealisticDocument:
     def test_arxiv_paper_shape(self):
         # Synthetic arxiv-shaped doc: abstract, intro, methods, results.

--- a/tests/test_document_chunker.py
+++ b/tests/test_document_chunker.py
@@ -85,6 +85,35 @@ class TestRecursiveSplit:
         assert a == b
 
 
+class TestChunkSizeContract:
+    """Codex P2 regression: every chunk under target_size, including
+    cases where overlap-tail seeding would otherwise push the new buffer
+    above the limit. The size contract is hard; overlap is best-effort."""
+
+    def test_overlap_tail_does_not_violate_size_contract(self):
+        # Construct pieces so the second piece + overlap tail of the first
+        # chunk would exceed target_size if not re-checked.
+        # 92-char piece + 30-char tail + 1 space would be 123 > 100 target.
+        target_size = 100
+        overlap = 30
+        # First long piece flushes via paragraph break; second is ~90 chars.
+        first = ("aaa " * 25).strip()   # 99 chars
+        second = ("bbb " * 25).strip()  # 99 chars (similar)
+        text = f"{first}\n\n{second}"
+
+        chunks = chunk_document(
+            text,
+            target_size=target_size,
+            overlap=overlap,
+            min_chars=10,
+        )
+
+        for c in chunks:
+            assert len(c) <= target_size, (
+                f"chunk size {len(c)} > target_size {target_size}: {c[:60]!r}"
+            )
+
+
 class TestOverlap:
     def test_overlap_zero_no_shared_content(self):
         text = (

--- a/tests/test_document_chunker.py
+++ b/tests/test_document_chunker.py
@@ -1,0 +1,135 @@
+"""F069: tests for the document chunker.
+
+Focus on (a) correctness invariants the dialogue chunker shares with us
+(empty in -> empty out, deterministic, no chunk exceeds target_size unless
+it had to), and (b) the document-specific behavior — paragraph-boundary
+preference, overlap snapping to whitespace, oversized-piece passthrough.
+"""
+from __future__ import annotations
+
+import pytest
+
+from nous.heart.document_chunker import chunk_document
+
+
+class TestEmptyAndShort:
+    def test_empty_returns_empty(self):
+        assert chunk_document("") == []
+
+    def test_none_safe(self):
+        # mirror chunk_text — None is treated as falsy/empty
+        assert chunk_document(None) == []  # type: ignore[arg-type]
+
+    def test_below_min_returns_empty(self):
+        assert chunk_document("short", min_chars=100) == []
+
+    def test_fits_in_single_chunk(self):
+        text = "This is a short paragraph well under 1500 chars."
+        result = chunk_document(text, target_size=1500, min_chars=10)
+        assert result == [text]
+
+
+class TestParameterValidation:
+    def test_zero_target_size_raises(self):
+        with pytest.raises(ValueError, match="target_size must be positive"):
+            chunk_document("x" * 200, target_size=0)
+
+    def test_negative_overlap_raises(self):
+        with pytest.raises(ValueError, match="overlap must be non-negative"):
+            chunk_document("x" * 200, target_size=100, overlap=-1)
+
+    def test_overlap_ge_target_raises(self):
+        with pytest.raises(ValueError, match="overlap.*must be <.*target_size"):
+            chunk_document("x" * 200, target_size=100, overlap=100)
+
+    def test_empty_delimiters_raises(self):
+        with pytest.raises(ValueError, match="delimiters must be non-empty"):
+            chunk_document("x" * 5000, delimiters=())
+
+
+class TestRecursiveSplit:
+    def test_paragraph_boundary_preferred(self):
+        # Two clean paragraphs, both well under target.
+        para_a = "A" * 400
+        para_b = "B" * 400
+        text = f"{para_a}\n\n{para_b}"
+        # target_size=500 forces a split; the splitter should prefer the
+        # \n\n boundary over slicing inside either paragraph.
+        chunks = chunk_document(text, target_size=500, overlap=50)
+        assert len(chunks) >= 2
+        # Each chunk should contain content from only one paragraph
+        # (modulo overlap tails).
+        assert any("A" in c and "B" not in c for c in chunks[:1])
+        assert any("B" in c for c in chunks)
+
+    def test_long_paragraph_falls_through_to_sentence(self):
+        # One long paragraph that must be split on sentences.
+        sentences = ". ".join("Sentence " + ("x" * 50) for _ in range(20))
+        chunks = chunk_document(sentences, target_size=500, overlap=50, min_chars=10)
+        # No chunk should exceed target_size by more than a sentence.
+        for c in chunks:
+            assert len(c) <= 500 + 80, f"chunk too large: {len(c)}"
+
+    def test_oversized_atomic_piece_emitted_standalone(self):
+        # A single atomic "word" larger than target_size cannot be split
+        # by any delimiter — should be emitted as its own chunk.
+        oversized = "X" * 3000
+        chunks = chunk_document(oversized, target_size=1500, overlap=100)
+        assert len(chunks) == 1
+        assert chunks[0] == oversized
+
+    def test_deterministic(self):
+        text = "Paragraph one. " * 200 + "\n\n" + "Paragraph two. " * 200
+        a = chunk_document(text, target_size=1500, overlap=200)
+        b = chunk_document(text, target_size=1500, overlap=200)
+        assert a == b
+
+
+class TestOverlap:
+    def test_overlap_zero_no_shared_content(self):
+        text = (
+            "Alpha alpha alpha alpha alpha alpha alpha alpha alpha alpha. "
+            "Beta beta beta beta beta beta beta beta beta beta beta beta. "
+            "Gamma gamma gamma gamma gamma gamma gamma gamma gamma gamma. "
+            "Delta delta delta delta delta delta delta delta delta delta. "
+        ) * 4
+        chunks = chunk_document(text, target_size=150, overlap=0, min_chars=10)
+        # With zero overlap and big chunks, consecutive chunks should
+        # not share content prefixes.
+        if len(chunks) >= 2:
+            assert not chunks[1].startswith(chunks[0][-20:])
+
+    def test_overlap_snaps_to_word_boundary(self):
+        # Build a chunk whose tail ends mid-word. The overlap tail should
+        # snap to the next whitespace so the next chunk starts on a word.
+        text = ("word " * 500).strip()  # 500 words = 2495 chars
+        chunks = chunk_document(text, target_size=600, overlap=80, min_chars=10)
+        assert len(chunks) >= 2
+        # No chunk should start with a partial token (i.e. with non-space
+        # char immediately after the join "tail space piece").
+        for c in chunks[1:]:
+            # Acceptable starts: a complete "word" or whitespace.
+            assert c.startswith("word") or c.startswith(" "), (
+                f"chunk starts mid-token: {c[:30]!r}"
+            )
+
+
+class TestRealisticDocument:
+    def test_arxiv_paper_shape(self):
+        # Synthetic arxiv-shaped doc: abstract, intro, methods, results.
+        sections = []
+        for section in ("Abstract", "Introduction", "Methods", "Results"):
+            body = (f"{section} body. " * 80).strip()  # ~960 chars / section
+            sections.append(f"## {section}\n\n{body}")
+        text = "\n\n".join(sections)
+
+        chunks = chunk_document(text, target_size=1500, overlap=200, min_chars=100)
+
+        # Should produce several chunks but not absurdly many for ~4K chars.
+        assert 2 <= len(chunks) <= 6, f"unexpected chunk count: {len(chunks)}"
+
+        # Total content should be approximately preserved (overlap means
+        # some duplication; allow up to 50% inflation).
+        joined = " ".join(chunks)
+        assert len(joined) >= len(text), "lost content"
+        assert len(joined) <= int(len(text) * 1.5), f"too much overlap inflation: {len(joined)} vs {len(text)}"

--- a/tests/test_ingest_document_integration.py
+++ b/tests/test_ingest_document_integration.py
@@ -140,6 +140,89 @@ async def test_ingest_document_rejects_missing_episode(db, agent_id):
     assert "no active episode" in result["content"][0]["text"].lower()
 
 
+async def test_ingest_document_idempotent_for_same_source_ref(db, agent_id, fixture_episode):
+    """Codex P1 (2026-05-26): a second call with the same source_ref under
+    the same episode must NOT duplicate content. Pre-check rejects with
+    a clear message; row count stays stable."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nous.api.tools import create_nous_tools
+    from nous.config import Settings
+
+    settings = Settings().model_copy(update={"agent_id": agent_id, "document_chunk_min_chars": 50})
+    mock_embedder = MagicMock()
+    mock_embedder.embed_batch = AsyncMock(return_value=[[0.0] * 1536 for _ in range(20)])
+    heart_stub = MagicMock()
+    heart_stub.db = db
+    heart_stub.agent_id = agent_id
+    heart_stub._embeddings = mock_embedder
+    brain_stub = MagicMock()
+    tools = create_nous_tools(brain_stub, heart_stub, settings)
+    ingest_document = tools["ingest_document"]
+
+    content = "Lorem ipsum dolor sit amet. " * 100  # 2.7K chars
+
+    # First call: succeeds, writes chunks.
+    r1 = await ingest_document(
+        content=content,
+        source_ref="https://example.com/dup-test.pdf",
+        episode_id=str(fixture_episode),
+    )
+    assert "Ingested" in r1["content"][0]["text"]
+
+    async with db.session() as session:
+        cnt_row = await session.execute(
+            text(
+                "SELECT COUNT(*) FROM heart.episode_chunks "
+                "WHERE agent_id = :a AND episode_id = :e AND source_ref = :r"
+            ),
+            {"a": agent_id, "e": fixture_episode, "r": "https://example.com/dup-test.pdf"},
+        )
+        n_after_first = cnt_row.scalar() or 0
+    assert n_after_first > 0, "first call should have written chunks"
+
+    # Second call with SAME source_ref: must be rejected, no new rows.
+    r2 = await ingest_document(
+        content=content,
+        source_ref="https://example.com/dup-test.pdf",
+        episode_id=str(fixture_episode),
+    )
+    assert "Already ingested" in r2["content"][0]["text"]
+
+    async with db.session() as session:
+        cnt_row = await session.execute(
+            text(
+                "SELECT COUNT(*) FROM heart.episode_chunks "
+                "WHERE agent_id = :a AND episode_id = :e AND source_ref = :r"
+            ),
+            {"a": agent_id, "e": fixture_episode, "r": "https://example.com/dup-test.pdf"},
+        )
+        n_after_second = cnt_row.scalar() or 0
+    assert n_after_second == n_after_first, (
+        f"second call duplicated rows: {n_after_first} -> {n_after_second}"
+    )
+
+    # Third call with DIFFERENT source_ref: should succeed (different doc).
+    r3 = await ingest_document(
+        content=content,
+        source_ref="https://example.com/different-doc.pdf",
+        episode_id=str(fixture_episode),
+    )
+    assert "Ingested" in r3["content"][0]["text"]
+
+    # Cleanup
+    async with db.session() as session:
+        await session.execute(
+            text("DELETE FROM heart.episode_chunks WHERE agent_id = :a"),
+            {"a": agent_id},
+        )
+        await session.execute(
+            text("DELETE FROM heart.episodes WHERE agent_id = :a"),
+            {"a": agent_id},
+        )
+        await session.commit()
+
+
 async def test_ingest_document_rejects_short_content(db, agent_id, fixture_episode):
     """Content below min_chars → reject without DB write."""
     from unittest.mock import AsyncMock, MagicMock

--- a/tests/test_ingest_document_integration.py
+++ b/tests/test_ingest_document_integration.py
@@ -1,0 +1,175 @@
+"""F069: integration test for the ingest_document tool against real Postgres.
+
+Requires NOUS_TEST_DB=postgres (the eval scratch container is fine). Tests
+the full happy path: tool creates chunks under an episode, persists them
+to heart.episode_chunks with source_kind='document', and they're queryable
+via SQL afterwards.
+
+Tests the failure paths in test_document_chunker.py — this one is just the
+DB-roundtrip smoke.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+pytestmark = [pytest.mark.postgres_only, pytest.mark.asyncio]
+
+
+@pytest.fixture
+def agent_id() -> str:
+    return f"test-f069-{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+async def fixture_episode(db, agent_id):
+    """Insert a single active episode for the test agent."""
+    episode_id = uuid.uuid4()
+    async with db.session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO heart.episodes "
+                "(id, agent_id, session_id, summary, started_at, active) "
+                "VALUES (:i, :a, :s, 'test ep', NOW(), true)"
+            ),
+            {"i": episode_id, "a": agent_id, "s": "test-session-f069"},
+        )
+        await session.commit()
+    return episode_id
+
+
+async def test_ingest_document_creates_chunks(db, agent_id, fixture_episode):
+    """Happy path: ingest a synthetic doc, verify rows land in episode_chunks."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nous.api.tools import create_nous_tools
+    from nous.config import Settings
+
+    # Build a Heart-like stub: only needs .db, .agent_id, ._embeddings
+    settings = Settings()
+    settings = settings.model_copy(update={"agent_id": agent_id, "document_chunk_min_chars": 50})
+
+    # Mock embeddings to return a 1536-dim zero vector per chunk (cheap).
+    mock_embedder = MagicMock()
+    mock_embedder.embed_batch = AsyncMock(return_value=[[0.0] * 1536 for _ in range(20)])
+
+    heart_stub = MagicMock()
+    heart_stub.db = db
+    heart_stub.agent_id = agent_id
+    heart_stub._embeddings = mock_embedder
+
+    brain_stub = MagicMock()  # ingest_document doesn't touch brain
+    tools = create_nous_tools(brain_stub, heart_stub, settings)
+    ingest_document = tools["ingest_document"]
+
+    # Synthetic doc: 4 paragraphs of ~800 chars each = ~3.2K total.
+    paragraphs = [
+        f"Paragraph {i}. " + ("Lorem ipsum dolor sit amet. " * 30)
+        for i in range(4)
+    ]
+    content = "\n\n".join(paragraphs)
+
+    result = await ingest_document(
+        content=content,
+        source_ref="https://example.com/test-paper.pdf",
+        episode_id=str(fixture_episode),
+    )
+
+    assert "Ingested" in result["content"][0]["text"]
+    assert "chunks" in result["content"][0]["text"]
+
+    # Verify chunks landed in DB with correct source_kind and source_ref.
+    async with db.session() as session:
+        rows = await session.execute(
+            text(
+                "SELECT chunk_index, source_kind, source_ref, length(content) AS clen "
+                "FROM heart.episode_chunks "
+                "WHERE agent_id = :a AND episode_id = :e "
+                "ORDER BY chunk_index"
+            ),
+            {"a": agent_id, "e": fixture_episode},
+        )
+        chunks = rows.fetchall()
+
+    assert len(chunks) >= 2, f"expected >=2 chunks for 3.2K text, got {len(chunks)}"
+    for c in chunks:
+        assert c.source_kind == "document"
+        assert c.source_ref == "https://example.com/test-paper.pdf"
+        assert c.clen > 0
+
+    # Cleanup
+    async with db.session() as session:
+        await session.execute(
+            text("DELETE FROM heart.episode_chunks WHERE agent_id = :a"),
+            {"a": agent_id},
+        )
+        await session.execute(
+            text("DELETE FROM heart.episodes WHERE agent_id = :a"),
+            {"a": agent_id},
+        )
+        await session.commit()
+
+
+async def test_ingest_document_rejects_missing_episode(db, agent_id):
+    """No active episode, no episode_id → returns error message, no rows."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nous.api.tools import create_nous_tools
+    from nous.config import Settings
+
+    settings = Settings().model_copy(update={"agent_id": agent_id})
+    heart_stub = MagicMock()
+    heart_stub.db = db
+    heart_stub.agent_id = agent_id
+    heart_stub._embeddings = MagicMock()
+    heart_stub._embeddings.embed_batch = AsyncMock(return_value=[])
+
+    brain_stub = MagicMock()
+    tools = create_nous_tools(brain_stub, heart_stub, settings)
+    ingest_document = tools["ingest_document"]
+
+    result = await ingest_document(
+        content="x" * 200,
+        source_ref="test://nowhere",
+        _session_id="nonexistent-session",
+    )
+
+    assert "no active episode" in result["content"][0]["text"].lower()
+
+
+async def test_ingest_document_rejects_short_content(db, agent_id, fixture_episode):
+    """Content below min_chars → reject without DB write."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nous.api.tools import create_nous_tools
+    from nous.config import Settings
+
+    settings = Settings().model_copy(update={"agent_id": agent_id, "document_chunk_min_chars": 500})
+    heart_stub = MagicMock()
+    heart_stub.db = db
+    heart_stub.agent_id = agent_id
+    heart_stub._embeddings = MagicMock()
+    heart_stub._embeddings.embed_batch = AsyncMock(return_value=[])
+
+    brain_stub = MagicMock()
+    tools = create_nous_tools(brain_stub, heart_stub, settings)
+    ingest_document = tools["ingest_document"]
+
+    result = await ingest_document(
+        content="too short",
+        source_ref="test://short",
+        episode_id=str(fixture_episode),
+    )
+
+    assert "Ingest skipped" in result["content"][0]["text"]
+
+    # Cleanup
+    async with db.session() as session:
+        await session.execute(
+            text("DELETE FROM heart.episodes WHERE agent_id = :a"),
+            {"a": agent_id},
+        )
+        await session.commit()

--- a/tests/test_ingest_document_integration.py
+++ b/tests/test_ingest_document_integration.py
@@ -227,6 +227,98 @@ async def test_ingest_document_idempotent_for_same_source_ref(db, agent_id, fixt
         await session.commit()
 
 
+async def test_ingest_document_concurrent_different_source_refs_no_collision(db, agent_id, fixture_episode):
+    """Codex P1 round 4 (2026-05-26): two concurrent ingest_document
+    calls targeting the same episode with DIFFERENT source_refs must
+    not collide on chunk_index. Pre-fix: separate (episode,source_ref)
+    locks let both see the same MAX+1 start_idx, both INSERT, ON CONFLICT
+    silently dropped one caller's rows. Episode-scoped lock fixes this.
+
+    Verifies: both calls return success AND all chunks from both docs
+    end up in the DB with disjoint chunk_index ranges (no row loss).
+    """
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nous.api.tools import create_nous_tools
+    from nous.config import Settings
+
+    settings = Settings().model_copy(update={"agent_id": agent_id, "document_chunk_min_chars": 50})
+    mock_embedder = MagicMock()
+    mock_embedder.embed_batch = AsyncMock(side_effect=lambda texts: [[0.0] * 1536 for _ in texts])
+    heart_stub = MagicMock()
+    heart_stub.db = db
+    heart_stub.agent_id = agent_id
+    heart_stub._embeddings = mock_embedder
+    brain_stub = MagicMock()
+    tools = create_nous_tools(brain_stub, heart_stub, settings)
+    ingest_document = tools["ingest_document"]
+
+    content_a = "Alpha alpha alpha. " * 150  # ~2.8K chars
+    content_b = "Beta beta beta. " * 150     # ~2.4K chars
+
+    # Fire both concurrently against the same episode.
+    r_a, r_b = await asyncio.gather(
+        ingest_document(
+            content=content_a,
+            source_ref="test://doc-A.pdf",
+            episode_id=str(fixture_episode),
+        ),
+        ingest_document(
+            content=content_b,
+            source_ref="test://doc-B.pdf",
+            episode_id=str(fixture_episode),
+        ),
+    )
+
+    # Both should have succeeded (no "Already ingested" since different source_refs).
+    assert "Ingested" in r_a["content"][0]["text"], f"A: {r_a['content'][0]['text']!r}"
+    assert "Ingested" in r_b["content"][0]["text"], f"B: {r_b['content'][0]['text']!r}"
+
+    # Pull all chunks for this episode and verify (1) disjoint chunk_index
+    # ranges per source_ref, (2) no duplicate chunk_index across the two.
+    async with db.session() as session:
+        rows = await session.execute(
+            text(
+                "SELECT chunk_index, source_ref FROM heart.episode_chunks "
+                "WHERE agent_id = :a AND episode_id = :e "
+                "ORDER BY chunk_index"
+            ),
+            {"a": agent_id, "e": fixture_episode},
+        )
+        all_chunks = rows.fetchall()
+
+    chunk_indices = [c.chunk_index for c in all_chunks]
+    assert len(chunk_indices) == len(set(chunk_indices)), (
+        f"duplicate chunk_index detected (ON CONFLICT silently dropped rows): {chunk_indices}"
+    )
+
+    by_source = {}
+    for c in all_chunks:
+        by_source.setdefault(c.source_ref, []).append(c.chunk_index)
+
+    assert "test://doc-A.pdf" in by_source, "doc A wrote no chunks"
+    assert "test://doc-B.pdf" in by_source, "doc B wrote no chunks"
+
+    a_indices = sorted(by_source["test://doc-A.pdf"])
+    b_indices = sorted(by_source["test://doc-B.pdf"])
+    assert not (set(a_indices) & set(b_indices)), (
+        f"chunk_index overlap between docs: A={a_indices} B={b_indices}"
+    )
+
+    # Cleanup
+    async with db.session() as session:
+        await session.execute(
+            text("DELETE FROM heart.episode_chunks WHERE agent_id = :a"),
+            {"a": agent_id},
+        )
+        await session.execute(
+            text("DELETE FROM heart.episodes WHERE agent_id = :a"),
+            {"a": agent_id},
+        )
+        await session.commit()
+
+
 async def test_ingest_document_rejects_partial_embed_batch(db, agent_id, fixture_episode):
     """Codex P2 round 3 (2026-05-26): if embedder returns fewer vectors
     than chunks, the tool must refuse to write a partial ingest rather

--- a/tests/test_ingest_document_integration.py
+++ b/tests/test_ingest_document_integration.py
@@ -54,7 +54,9 @@ async def test_ingest_document_creates_chunks(db, agent_id, fixture_episode):
 
     # Mock embeddings to return a 1536-dim zero vector per chunk (cheap).
     mock_embedder = MagicMock()
-    mock_embedder.embed_batch = AsyncMock(return_value=[[0.0] * 1536 for _ in range(20)])
+    # Dynamic mock: return one zero-vector per input chunk so the new
+    # length-check guard in ingest_document doesn't refuse the ingest.
+    mock_embedder.embed_batch = AsyncMock(side_effect=lambda texts: [[0.0] * 1536 for _ in texts])
 
     heart_stub = MagicMock()
     heart_stub.db = db
@@ -151,7 +153,9 @@ async def test_ingest_document_idempotent_for_same_source_ref(db, agent_id, fixt
 
     settings = Settings().model_copy(update={"agent_id": agent_id, "document_chunk_min_chars": 50})
     mock_embedder = MagicMock()
-    mock_embedder.embed_batch = AsyncMock(return_value=[[0.0] * 1536 for _ in range(20)])
+    # Dynamic mock: return one zero-vector per input chunk so the new
+    # length-check guard in ingest_document doesn't refuse the ingest.
+    mock_embedder.embed_batch = AsyncMock(side_effect=lambda texts: [[0.0] * 1536 for _ in texts])
     heart_stub = MagicMock()
     heart_stub.db = db
     heart_stub.agent_id = agent_id
@@ -216,6 +220,59 @@ async def test_ingest_document_idempotent_for_same_source_ref(db, agent_id, fixt
             text("DELETE FROM heart.episode_chunks WHERE agent_id = :a"),
             {"a": agent_id},
         )
+        await session.execute(
+            text("DELETE FROM heart.episodes WHERE agent_id = :a"),
+            {"a": agent_id},
+        )
+        await session.commit()
+
+
+async def test_ingest_document_rejects_partial_embed_batch(db, agent_id, fixture_episode):
+    """Codex P2 round 3 (2026-05-26): if embedder returns fewer vectors
+    than chunks, the tool must refuse to write a partial ingest rather
+    than silently zip-truncate."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from nous.api.tools import create_nous_tools
+    from nous.config import Settings
+
+    settings = Settings().model_copy(update={"agent_id": agent_id, "document_chunk_min_chars": 50})
+    # Return ONE vector for many chunks → length mismatch.
+    mock_embedder = MagicMock()
+    mock_embedder.embed_batch = AsyncMock(return_value=[[0.0] * 1536])
+    heart_stub = MagicMock()
+    heart_stub.db = db
+    heart_stub.agent_id = agent_id
+    heart_stub._embeddings = mock_embedder
+    brain_stub = MagicMock()
+    tools = create_nous_tools(brain_stub, heart_stub, settings)
+    ingest_document = tools["ingest_document"]
+
+    # Content large enough to produce several chunks (>1 vector required).
+    content = "Sentence sentence sentence. " * 200  # ~5.6K chars
+    result = await ingest_document(
+        content=content,
+        source_ref="test://partial-embed",
+        episode_id=str(fixture_episode),
+    )
+
+    text_out = result["content"][0]["text"]
+    assert "refusing to write a partial ingest" in text_out, f"unexpected: {text_out!r}"
+
+    # No rows should have been written.
+    async with db.session() as session:
+        cnt_row = await session.execute(
+            text(
+                "SELECT COUNT(*) FROM heart.episode_chunks "
+                "WHERE agent_id = :a AND episode_id = :e"
+            ),
+            {"a": agent_id, "e": fixture_episode},
+        )
+        n = cnt_row.scalar() or 0
+    assert n == 0, f"partial ingest wrote {n} rows when it should have refused"
+
+    # Cleanup
+    async with db.session() as session:
         await session.execute(
             text("DELETE FROM heart.episodes WHERE agent_id = :a"),
             {"a": agent_id},

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -59,6 +59,7 @@ class TestCreateNousTools:
             "learn_skill",
             "get_procedure",
             "recall_hubs",  # F065
+            "ingest_document",  # F069
         }
         for name, func in tools.items():
             assert callable(func), f"{name} should be callable"

--- a/tests/test_web_tools.py
+++ b/tests/test_web_tools.py
@@ -31,7 +31,10 @@ def _make_settings(**overrides) -> MagicMock:
     defaults = {
         "brave_search_api_key": "test-brave-key",
         "web_search_daily_limit": 100,
-        "web_fetch_max_chars": 10000,
+        # F069: production default bumped 10K -> 50K. Tests can override
+        # via _make_settings(web_fetch_max_chars=...) when they need the
+        # tighter window.
+        "web_fetch_max_chars": 50000,
     }
     defaults.update(overrides)
     mock = MagicMock()
@@ -572,12 +575,12 @@ class TestWebFetch:
         assert "connect" in text.lower() or "Could not" in text
 
     @pytest.mark.asyncio
-    async def test_max_chars_capped_at_50000(self):
-        """max_chars parameter is capped at 50000 even if higher value passed."""
+    async def test_max_chars_capped_at_hard_ceiling(self):
+        """max_chars parameter is capped at the 200K hard ceiling (F069 bumped 50K -> 200K)."""
         wt = _import_web_tools()
-        settings = _make_settings(web_fetch_max_chars=100000)
-        # Content just over 50000 chars
-        long_text = "B" * 60000
+        settings = _make_settings(web_fetch_max_chars=300000)
+        # Content just over the 200K ceiling
+        long_text = "B" * 210000
         response = _mock_response(
             status_code=200,
             text=long_text,
@@ -586,7 +589,7 @@ class TestWebFetch:
         client = _mock_http_client(response)
 
         with patch.object(wt, "_is_url_safe", return_value=(True, "")):
-            result = await wt._web_fetch("https://example.com/huge", max_chars=100000, _settings=settings, _http=client)
+            result = await wt._web_fetch("https://example.com/huge", max_chars=300000, _settings=settings, _http=client)
 
         text = _extract_text(result)
         assert "truncated" in text.lower()


### PR DESCRIPTION
## Summary

Closes the doc-ingestion gap (F069 Phase 1). Two parts:

**(a)** `web_fetch` limit raised: default 10K → 50K, hard ceiling 50K → 200K so explicit doc-ingest callers can pull a full arxiv paper in one fetch.

**(b)** New `ingest_document(content, source_ref)` tool that chunks document bodies at 1500-char structure-aware boundaries and persists them to `heart.episode_chunks` with `source_kind='document'`. Bypasses soft-trim by writing directly to DB at the handler level. Nous parses PDF/.docx himself via `run_python` (`pypdf` / `python-docx` client-side) and calls `ingest_document` to persist.

## The bug, measured

| Path | Pre-fix retention | Why |
|---|---|---|
| arxiv via `web_fetch` | ~1% (1.5KB of a 300KB paper) | 10K fetch cap → 3.5K soft-trim → 6× 600-char dialogue chunks |
| Word doc via `read_file` | 0% (binary garbage) | `read_text(utf-8, errors='replace')` on a ZIP archive |
| PDF via `read_file` | 0% (binary garbage) | same |
| Long markdown via `read_file` | ~2% | 1MB read OK, but soft-trim + dialogue chunker |

## Architecture

Tool args flow through agent context **once** at emission and get persisted by the handler at full fidelity **before** soft-trim degrades the conversation copy. So even though Nous's context briefly holds the huge text, the chunks land in `heart.episode_chunks` at full fidelity and survive forever.

No auto-classification heuristic in v1 — the tool is explicit and opt-in. The agent decides what's a document.

## Changes (10 files, +786 / −9)

### Backend

- **`sql/migrations/052_f069_document_source_kind.sql`**: adds `source_kind VARCHAR(32) NOT NULL DEFAULT 'dialogue'` (check constraint: dialogue|document|code) + `source_ref TEXT NULL` + index on `(agent_id, source_kind)`. Existing F067 rows default to `'dialogue'`.
- **`nous/heart/document_chunker.py`**: recursive structure-aware splitter at 1500-char target / 200-char overlap. Walks `\n\n` → `\n` → `. ` → ` `; overlap snaps to whitespace.
- **`nous/api/tools.py`**: new `ingest_document` tool + JSON schema + dispatcher registration + `_session_id` injection.
- **`nous/api/web_tools.py`**: hard ceiling 50K → 200K.
- **`nous/config.py`**: `web_fetch_max_chars` 10K → 50K; new `document_ingest_enabled` / `document_chunk_size` / `document_chunk_overlap` / `document_chunk_min_chars`.
- **`nous/storage/models.py`**: `EpisodeChunk` gets `source_kind` + `source_ref`.

### Tests

- **`tests/test_document_chunker.py`** (new): 15 unit tests covering empty/short passthrough, parameter validation, paragraph-boundary preference, oversized-atom passthrough, overlap word-boundary snapping, deterministic output, realistic arxiv-shape document. **15/15 pass.**
- **`tests/test_ingest_document_integration.py`** (new): 3 end-to-end tests against real Postgres covering happy path, missing-episode error, short-content rejection. **3/3 pass.**
- **`tests/test_web_tools.py`**: updated factory default to 50K; renamed `test_max_chars_capped_at_50000` → `test_max_chars_capped_at_hard_ceiling` and pointed at the new 200K ceiling.

### Docs

- **`CLAUDE.md`**: `ingest_document` row added to Agent Tools table.

## Verification

- **85/85** dashboard + density + chunker + web_tools tests pass against local eval Postgres (`NOUS_TEST_DB=postgres`, :5433).
- **3/3** integration tests pass: real DB roundtrip writes `source_kind='document'` + `source_ref` rows under the target episode.
- Migration 052 applied cleanly to the eval container; existing F067 rows default to `'dialogue'` as expected.

## Apples-to-apples

All changes additive:
- New column has DEFAULT so existing F067 rows unchanged.
- New tool isolated from existing `recall_deep` / `web_fetch` flow.
- Soft-trim continues working identically for dialogue messages — only the explicitly-ingested content goes to chunks at full fidelity.
- F067 dialogue chunker (`chunk_text`) and its tests untouched.

## Deferred (separate decisions, not lost)

- **F069 Phase 2**: tool-dispatch auto-classification of web_fetch results (`classify_tool_result`) + soft-trim bypass heuristic.
- **F069 Phase 3**: per-source-kind retrieval weighting + display differentiation in `_format_pipeline_text`.

Both need a doc-QA eval to validate (LME is dialogue-shaped); spec deliberately defers them.

## Forge decision

Decision `4390e625` finalized in forge MCP after self-architecture review (pattern reference: F042 gated-optional-retrieval-feature, decision `8629d0e3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)