### PR TITLE
spec(F075): temporal fact extraction + date-aware retrieval

### DIFF
--- a/docs/features/F075-temporal-fact-extraction.md
+++ b/docs/features/F075-temporal-fact-extraction.md
@@ -1,6 +1,6 @@
 # F075 — Temporal Fact Extraction + Date-Aware Retrieval
 
-**Status:** 📝 Draft **v2.13** (2026-05-28) — incorporates arch / python-pro / devil's-advocate spec review + 13 rounds of codex PR review fixes
+**Status:** 📝 Draft **v2.14** (2026-05-28) — incorporates arch / python-pro / devil's-advocate spec review + 14 rounds of codex PR review fixes
 **Proposed by:** Tim + investigation thread
 **Date:** 2026-05-27
 **Depends on:** F002 (Heart), F022 (Cross-type linking), F040 (Graph Densifier), F047 (Actionability backfill pattern), F051 (Eval harness for measurement)
@@ -10,6 +10,14 @@
 **Reviews:** `docs/reviews/F075-spec-arch-review.md`, `F075-spec-python-pro-review.md`, `F075-spec-devil-review.md`
 
 ---
+
+## v2.14 changelog (codex re-review round 14)
+
+Codex flagged 1 P1 (lock-leak STILL not fully resolved) + 2 P2s on v2.13:
+
+- **P1 — Per-batch commit pattern still leaks the lock at batch boundaries.** Round-13 switched per-row → per-batch commits to address the round-12 lock-leak finding. Codex now points out that with MULTIPLE batches, the same problem recurs: the first batch's commit ends its transaction, the underlying connection can return to the pool, and the second batch's `execute()` may bind a *different* connection. The session-scoped advisory lock was acquired on the original connection — it stays held there while subsequent `execute()` (and the eventual `pg_advisory_unlock`) run on different connections. Lock leaks for the rest of the original connection's pool lifetime. Fixed: switched to a **two-connection pattern**. One checked-out raw connection (`engine.connect()`) holds the advisory lock for the script's full lifetime, never commits, never returns to the pool. Per-batch work uses fresh `session_factory()` sessions that DO commit per batch but never touch the lock. This eliminates the failure mode across any number of batches.
+- **P2 — Chunk-lookup cosine query missing `WHERE embedding IS NOT NULL`.** v2.13 added Python-side null-guards on `episode_id` and `embedding` (fact-side) but didn't filter chunk-side NULL embeddings. For legacy episodes whose chunks have NULL embeddings, `embedding <=> CAST(:embedding AS vector)` produces NULL distances; `LIMIT 1` can return an arbitrary chunk to the classifier → bad date stamped during backfill. Fixed: added `AND embedding IS NOT NULL` to the chunk lookup SQL. Now 3 guards: fact `episode_id is None`, fact `embedding is None`, chunk `embedding IS NOT NULL`.
+- **P2 — `happened_before` INSERT still used asyncpg `$1` placeholder.** Round-12 fixed `_process_batch` to `:name` binds and round-13 fixed the chunk lookup, but the Layer 2 `happened_before` INSERT SQL still had `WHERE a.agent_id = $1`. GraphDensifier uses `session.execute(text(...), params)` throughout — `$1` is not bound, the edge build would fail before writing any edges. Fixed: `$1` → `:agent_id` with explanatory comment.
 
 ## v2.13 changelog (codex re-review round 13)
 
@@ -398,7 +406,9 @@ JOIN LATERAL (
     ORDER BY b.event_date ASC, b.id ASC   -- deterministic tiebreaker
     LIMIT 1
 ) b ON TRUE
-WHERE a.agent_id = $1
+WHERE a.agent_id = :agent_id                -- SQLAlchemy :name bind — GraphDensifier
+                                              -- executes via session.execute(text(...), ...)
+                                              -- and does NOT support asyncpg $1 placeholders
   AND a.event_date IS NOT NULL
   AND a.active = TRUE                       -- active sources only (Heart recall default)
 ON CONFLICT (source_id, target_id, relation) DO NOTHING;
@@ -488,24 +498,54 @@ def _advisory_lock_key(agent_id: str) -> int:
 
 **Use session-scoped `pg_try_advisory_lock` + explicit `pg_advisory_unlock` at end-of-`_run_batches`, NOT the transaction-scoped `xact` variant.** Codex round-6 catch: this script's batch loop spans many per-row UPDATE transactions, each committing independently. A `pg_try_advisory_xact_lock` would release at the end of every per-row UPDATE transaction, letting a second concurrent CLI invocation acquire the lock mid-loop and interleave. F047's `actionability_backfill.py:79, 97` uses the session-scoped variant for exactly this reason. F049's working_memory sweep uses xact_lock correctly because it does all work inside one short transaction — different shape.
 
+**Hold the lock on a CHECKED-OUT raw connection, NOT an `AsyncSession`** (Codex rounds 13 + 14 catch). Session-scoped advisory locks are bound to the specific PHYSICAL connection that acquired them. With `AsyncSession`, every `commit()` ends the transaction and the underlying connection can return to the pool — leaving the lock held on a connection that's about to be reused. Subsequent `execute()` calls (next batch, eventual `pg_advisory_unlock`) may bind a *different* connection where the unlock is a no-op. The lock leaks for the rest of the original connection's pool lifetime; future invocations skip indefinitely. Round-13's per-batch commit fix is also insufficient because the same risk reappears at every batch boundary in a multi-batch run.
+
+Two-session pattern: one connection holds the lock for the script's full lifetime; row work uses separate sessions per batch (which CAN safely commit per batch since they don't hold the lock).
+
 ```python
-# Pattern (mirrors actionability_backfill.py:79-97 verbatim):
-async with db.session() as session:
-    locked = await session.execute(
-        text("SELECT pg_try_advisory_lock(:k)"),
-        {"k": _advisory_lock_key(agent_id)},
-    )
-    if not locked.scalar():
-        logger.info("F075 backfill: another process holds the lock for %s, exiting", agent_id)
-        return
-    try:
-        await _run_batches(session, agent_id, batch_size, token_budget)
-    finally:
-        await session.execute(
-            text("SELECT pg_advisory_unlock(:k)"),
-            {"k": _advisory_lock_key(agent_id)},
+# v2.14 pattern. The lock-holding connection is checked out for the
+# entire script lifetime via `engine.connect()`; per-batch work uses
+# fresh sessions that don't touch the lock.
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+async def _run_with_lock(
+    engine: AsyncEngine,
+    session_factory,            # async_sessionmaker(engine)
+    agent_id: str,
+    batch_size: int,
+    token_budget: int,
+) -> None:
+    key = _advisory_lock_key(agent_id)
+    # engine.connect() checks out one specific connection and holds it
+    # until the `async with` exits. Per-row/per-batch commits below DO
+    # NOT happen on this connection, so the pool cannot release it.
+    async with engine.connect() as lock_conn:
+        locked = await lock_conn.execute(
+            text("SELECT pg_try_advisory_lock(:k)"), {"k": key},
         )
+        if not locked.scalar():
+            logger.info("F075 backfill: another process holds the lock for %s, exiting", agent_id)
+            return
+        try:
+            budget = BudgetTracker(token_budget // _TOKENS_PER_LLM_CALL)
+            while True:
+                # Each batch opens a FRESH session against the same engine.
+                # Per-batch commit on this session is safe; it doesn't
+                # touch lock_conn.
+                async with session_factory() as work_session:
+                    updated, stop = await _process_batch(
+                        work_session, agent_id, batch_size, budget,
+                    )
+                if stop or updated == 0:
+                    break
+        finally:
+            # Unlock on the SAME connection that acquired the lock.
+            await lock_conn.execute(
+                text("SELECT pg_advisory_unlock(:k)"), {"k": key},
+            )
 ```
+
+The lock-holding connection (`lock_conn`) never commits any data, never returns to the pool, and is the only handle that ever touches `pg_try_advisory_lock` / `pg_advisory_unlock`. The work sessions handle batch SELECT/UPDATE/commit independently. This eliminates the lock-leak failure mode across any number of batches.
 
 #### Per-row UPDATE (Python P1-2 fix) + classification-state marker (Codex P1 fix)
 
@@ -570,23 +610,16 @@ async def _process_batch(
         )
         updated += 1
 
-    # Commit ONCE per batch, not per-row. Codex round-13 P2 catch: in
-    # AsyncSession with a connection pool, session.commit() can release the
-    # underlying connection back to the pool. The session-scoped advisory
-    # lock (held on the original physical connection) would stay held until
-    # the pooled connection is finally closed, while the next execute() —
-    # including the eventual pg_advisory_unlock — could bind a DIFFERENT
-    # connection where the unlock is a no-op. Per-batch commit keeps the
-    # session bound to the same connection throughout the lock+batch
-    # lifetime. Trade-off: a crash mid-batch loses the current batch's
-    # in-flight UPDATEs (≤ batch_size rows). Since eligibility is
-    # `event_date_classified_at IS NULL`, re-running the script picks up
-    # exactly those rows again — no data loss, just retry cost.
+    # Per-batch commit on the work session is safe because this session
+    # does NOT hold the advisory lock — that lives on lock_conn in
+    # _run_with_lock above. Trade-off: a crash mid-batch loses in-flight
+    # UPDATEs (≤ batch_size rows). Idempotent re-runs pick them up via
+    # event_date_classified_at IS NULL.
     await session.commit()
     return (updated, False)
 ```
 
-Single SQLAlchemy session is used for the lock acquisition (`_run_batches`), the batch SELECT, the per-row UPDATE, and the lock release — consistent API throughout. F047 follows the exact same per-batch commit pattern at `actionability_backfill.py:78-205`.
+The work session is short-lived (one batch) and never touches `pg_advisory_lock`. The lock-holding `lock_conn` (in `_run_with_lock`) is the only connection that ever issues lock/unlock calls — never commits data.
 
 `BudgetTracker` is a tiny class mirroring F047's bookkeeping (`actionability_backfill.py:48-65, 162-167`): initialized with `token_budget // _TOKENS_PER_LLM_CALL = max_calls`; `ok()` returns `remaining_calls > 0`; `consume(tokens)` decrements. The outer `_run_batches` loop exits cleanly when `_process_batch` returns `stop_requested=True`.
 
@@ -627,6 +660,12 @@ async def _fetch_chunk_context(
             FROM heart.episode_chunks
             WHERE agent_id = :agent_id
               AND episode_id = :episode_id
+              AND embedding IS NOT NULL    -- Codex round-14: legacy chunks
+                                            -- with NULL embedding produce NULL
+                                            -- cosine distances and LIMIT 1 then
+                                            -- returns an arbitrary chunk →
+                                            -- classifier sees wrong context →
+                                            -- bad date stamped at backfill time
             ORDER BY embedding <=> CAST(:embedding AS vector)
             LIMIT 1
         """),
@@ -640,7 +679,7 @@ async def _fetch_chunk_context(
     return row[0] if row else None
 ```
 
-Feeds raw chunk text (up to ~600 chars) to the classifier instead of the lossy 500-char summary slice. Works even when the subject is a paraphrase of the underlying transcript event — the embedding already captures semantic similarity. Two explicit null-guards (`episode_id is None`, `embedding is None`) protect legacy rows from issuing a malformed cosine query.
+Feeds raw chunk text (up to ~600 chars) to the classifier instead of the lossy 500-char summary slice. Three guards protect against legacy/malformed data: (1) `episode_id is None` → return None upfront; (2) `embedding is None` → return None upfront; (3) `WHERE embedding IS NOT NULL` in SQL → exclude chunks where chunk-side embedding is missing. Falls back to `fact.content` as primary classifier signal when any guard fires.
 
 #### CLI shape
 

--- a/docs/features/F075-temporal-fact-extraction.md
+++ b/docs/features/F075-temporal-fact-extraction.md
@@ -1,6 +1,6 @@
 # F075 — Temporal Fact Extraction + Date-Aware Retrieval
 
-**Status:** 📝 Draft **v2.7** (2026-05-27) — incorporates arch / python-pro / devil's-advocate spec review + 7 rounds of codex PR review fixes
+**Status:** 📝 Draft **v2.8** (2026-05-28) — incorporates arch / python-pro / devil's-advocate spec review + 8 rounds of codex PR review fixes
 **Proposed by:** Tim + investigation thread
 **Date:** 2026-05-27
 **Depends on:** F002 (Heart), F022 (Cross-type linking), F040 (Graph Densifier), F047 (Actionability backfill pattern), F051 (Eval harness for measurement)
@@ -10,6 +10,13 @@
 **Reviews:** `docs/reviews/F075-spec-arch-review.md`, `F075-spec-python-pro-review.md`, `F075-spec-devil-review.md`
 
 ---
+
+## v2.8 changelog (codex re-review round 8)
+
+Codex flagged 2 more P2s on v2.7. Both stdlib/precedent-collision gotchas:
+
+- **P2 — `date.fromisoformat()` accepts alternate ISO forms in Python 3.12.** v2.7's validator claimed strictness based on `date.fromisoformat` alone, but Python 3.12's stdlib accepts `'20240310'` (no hyphens) and `'2024-W10-7'` (ISO week date) — both contradict the prompt/schema contract of `YYYY-MM-DD`. Fixed: added explicit `re.compile(r"^\d{4}-\d{2}-\d{2}$").fullmatch` gate before calling `fromisoformat`; the regex enforces surface shape, `fromisoformat` then enforces day-validity (rejects 2024-02-30).
+- **P2 — Advisory lock key collides with F047's actionability lock.** v2.7 copied F047's key derivation exactly (`SHA-256(agent_id)`). Result: F075 backfill and F047 actionability backfill compete for the SAME advisory lock per agent — if F047 runs at startup while an operator invokes F075 backfill, F075 falsely reports "another temporal backfill holds the lock" and skips, even though the competing job is unrelated. Fixed: added a `_LOCK_NAMESPACE = "f075-temporal"` prefix that's concatenated before hashing, so only same-feature backfills exclude each other on the same agent.
 
 ## v2.7 changelog (codex re-review round 7)
 
@@ -272,18 +279,30 @@ event_date: date | None = None
 
 @field_validator("event_date", mode="before")
 @classmethod
+import re
+
+_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
 def _parse_event_date(cls, v):
     if v is None or isinstance(v, date):
         return v
     if isinstance(v, str):
+        # Codex round-8 catch: Python 3.12 date.fromisoformat() accepts
+        # alternate ISO forms like '20240310' (no hyphens) and '2024-W10-7'
+        # (ISO week date). The spec/prompt contract is strictly
+        # 'YYYY-MM-DD' — anything else must be dropped. Two-step check:
+        # (1) regex enforces the surface shape, (2) fromisoformat enforces
+        # day-validity (rejects 2024-02-30, etc).
+        if not _DATE_PATTERN.fullmatch(v):
+            return None
         try:
-            return date.fromisoformat(v)  # strict — rejects "2024-02-30" etc
+            return date.fromisoformat(v)
         except ValueError:
             return None  # fail-soft: drop bad date, keep fact
     return None
 ```
 
-`date.fromisoformat` is strict enough that we don't need a separate regex check; Python 3.12's stdlib rejects out-of-range days, malformed strings, etc.
+The regex gate is the contract enforcement: anything that didn't come out of the prompt's stated `YYYY-MM-DD` slot is rejected before `fromisoformat` gets a chance to parse it as a different ISO variant. `date.fromisoformat` is then used purely for day-validity checking on the regex-passing inputs.
 
 ### Layer 2 — `happened_before` edges (reranking reinforcer)
 
@@ -387,11 +406,21 @@ async def _apply_date_boost(
 ```python
 import hashlib
 
+_LOCK_NAMESPACE = "f075-temporal"  # Codex round-8 catch: salt by feature so
+                                    # F075 backfill doesn't collide with F047
+                                    # actionability backfill on the same agent.
+
 def _advisory_lock_key(agent_id: str) -> int:
-    """Stable signed bigint key derived from agent_id SHA-256.
-    Mirrors actionability_backfill.py:108-115.
+    """Stable signed bigint key derived from a feature-salted agent_id SHA-256.
+
+    Mirrors actionability_backfill.py:108-115 shape but adds a feature
+    namespace prefix so two unrelated backfills on the same agent do not
+    block each other. F047 hashes only the bare agent_id, so without
+    this salt a startup actionability sweep would falsely prevent an
+    operator-invoked temporal backfill from running on the same agent.
     """
-    digest = hashlib.sha256(agent_id.encode("utf-8")).digest()[:8]
+    salted = f"{_LOCK_NAMESPACE}:{agent_id}".encode("utf-8")
+    digest = hashlib.sha256(salted).digest()[:8]
     return int.from_bytes(digest, byteorder="big", signed=True)
 ```
 

--- a/docs/features/F075-temporal-fact-extraction.md
+++ b/docs/features/F075-temporal-fact-extraction.md
@@ -1,6 +1,6 @@
 # F075 — Temporal Fact Extraction + Date-Aware Retrieval
 
-**Status:** 📝 Draft **v2** (2026-05-27) — incorporates arch / python-pro / devil's-advocate spec review feedback
+**Status:** 📝 Draft **v2.1** (2026-05-27) — incorporates arch / python-pro / devil's-advocate spec review feedback + codex PR review fixes
 **Proposed by:** Tim + investigation thread
 **Date:** 2026-05-27
 **Depends on:** F002 (Heart), F022 (Cross-type linking), F040 (Graph Densifier), F047 (Actionability backfill pattern), F051 (Eval harness for measurement)
@@ -10,6 +10,13 @@
 **Reviews:** `docs/reviews/F075-spec-arch-review.md`, `F075-spec-python-pro-review.md`, `F075-spec-devil-review.md`
 
 ---
+
+## v2.1 changelog (codex PR review)
+
+Codex flagged 2 P1s on PR #460 against the v2 spec; both incorporated here:
+
+- **Codex P1 — `brain.graph_edges` schema constraints.** Layer 2's INSERT was missing `agent_id` (`NOT NULL` per `sql/init.sql:197`) and the existing relation CHECK constraint (last extended by migration `051_f070_chunk_graph_edges.sql:34-45`) does not allow `'happened_before'`. v2.1 §Schema migration now extends the CHECK to add the new relation (mirroring F070's pattern verbatim), and the INSERT includes `agent_id` + `auto_linked=TRUE`.
+- **Codex P1 — backfill starvation.** v2's eligibility predicate `WHERE event_date IS NULL` meant non-event rows (stable facts the classifier correctly returned `None` for) stayed eligible forever — the script would loop on the newest-N stable facts and never advance to older dated rows. F047 doesn't have this problem because every actionability classification produces a non-NULL TRUE/FALSE. v2.1 adds an `event_date_classified_at TIMESTAMPTZ` column written on every classification attempt regardless of outcome; eligibility becomes `event_date_classified_at IS NULL`. The live-path extractor also writes the marker so freshly-ingested facts skip backfill.
 
 ## v2 changelog
 
@@ -178,9 +185,11 @@ Per Arch P1-1's enumeration:
 | 2 | `fact_extractor.py:251-256` | `_store_candidate_facts` reads `event_date = item.get("event_date")` from dict |
 | 3 | `nous/heart/schemas.py:85-98` | `FactInput` adds `event_date: date \| None = None` |
 | 4 | `nous/heart/facts.py:428-449` | `FactManager._learn` passes `event_date` to `Fact()` ORM constructor |
-| 5 | `nous/storage/models.py:469-511` | `Fact` ORM adds `event_date: Mapped[date \| None] = mapped_column(Date, nullable=True)` |
-| 6 | `sql/migrations/053_temporal_fact_extraction.sql` | `ALTER TABLE heart.facts ADD COLUMN event_date DATE` + partial index |
+| 5 | `nous/storage/models.py:469-511` | `Fact` ORM adds `event_date: Mapped[date \| None] = mapped_column(Date, nullable=True)` AND `event_date_classified_at: Mapped[datetime \| None] = mapped_column(DateTime(timezone=True), nullable=True)` |
+| 6 | `sql/migrations/053_temporal_fact_extraction.sql` | `ALTER TABLE heart.facts ADD COLUMN event_date DATE + event_date_classified_at TIMESTAMPTZ` + partial indexes + extend `brain.graph_edges` relation CHECK to add `'happened_before'` |
 | 7 | `nous/heart/schemas.py:114-165` | `FactDetail` and `FactSummary` add `event_date: date \| None = None` |
+
+**Plus**: `FactManager._learn` sets `event_date_classified_at = datetime.now(UTC)` on every fact write whose extraction path can produce dates (i.e., the new summarizer/extractor codepath always marks the row classified, even when `event_date` ends up `None`). This keeps newly-ingested facts out of the Layer 4 backfill eligibility set.
 
 **Plus** Heart.recall surface (Python P1-4): when serializing recall results, `RecallResult.metadata["event_date"]` must be populated with the iso string (or absent if None). Without this, Layer 3 is silent no-op.
 
@@ -215,11 +224,14 @@ def _parse_event_date(cls, v):
 
 **Edge build (in `GraphDensifier.run_backfill_cycle`):**
 
+`brain.graph_edges` requires `agent_id NOT NULL` (`sql/init.sql:197`) and constrains `relation` via a CHECK clause that currently allows only the existing relation set (`sql/init.sql:198-201` + migration `051_f070_chunk_graph_edges.sql:34-45`). The schema migration (§Schema migration) must extend the CHECK to add `'happened_before'`, mirroring the pattern F070 used to add `'part_of'` and `'summarized_by'`.
+
 ```sql
 -- For all (fact_a, fact_b) pairs in same episode, chronologically adjacent
 -- on event_date — chain through ordered events, not all pairs.
-INSERT INTO brain.graph_edges (source_id, source_type, target_id, target_type, relation, weight)
-SELECT a.id, 'fact', b.id, 'fact', 'happened_before', 1.0
+INSERT INTO brain.graph_edges
+    (source_id, source_type, target_id, target_type, agent_id, relation, weight, auto_linked)
+SELECT a.id, 'fact', b.id, 'fact', a.agent_id, 'happened_before', 1.0, TRUE
 FROM heart.facts a
 JOIN heart.facts b
   ON a.agent_id = b.agent_id
@@ -237,7 +249,7 @@ WHERE a.agent_id = $1
 ON CONFLICT (source_id, target_id, relation) DO NOTHING;
 ```
 
-Result: at most N-1 edges per episode (a chain through ordered events). O(N), not O(N²).
+Result: at most N-1 edges per episode (a chain through ordered events). O(N), not O(N²). `auto_linked=TRUE` mirrors F040's sleep-cycle convention.
 
 **Consumer (already-shipped):**
 
@@ -311,9 +323,11 @@ def _advisory_lock_key(agent_id: str) -> int:
 
 `async with db.transaction()` + `SELECT pg_try_advisory_xact_lock($1)` with this key. Mirrors F047 + F049 patterns exactly.
 
-#### Per-row UPDATE (Python P1-2 fix)
+#### Per-row UPDATE (Python P1-2 fix) + classification-state marker (Codex P1 fix)
 
-v1's `WHERE id = (SELECT id FROM batch)` was broken for `LIMIT > 1`. v2 copies F047's `actionability_backfill.py:198-216` shape:
+v1's `WHERE id = (SELECT id FROM batch)` was broken for `LIMIT > 1`. v2 copies F047's `actionability_backfill.py:198-216` shape AND fixes a starvation bug Codex flagged on the spec-v2 review: F047 works because every row gets a non-NULL `actionable` verdict. F075 has a third state ("classified, no date found") that looks identical to "never classified" if we use `event_date IS NULL` as the eligibility predicate — so the script would re-process the same newest-N stable facts forever and never advance to older dated rows.
+
+Fix: the schema adds `event_date_classified_at TIMESTAMPTZ` (see §Schema migration). The backfill writes it on every classification attempt regardless of outcome. Eligibility uses `event_date_classified_at IS NULL` (not `event_date IS NULL`).
 
 ```python
 # Pseudo-code; concrete sites verified against F047
@@ -321,7 +335,9 @@ async def _process_batch(conn, agent_id: str, batch_size: int) -> int:
     rows = await conn.fetch("""
         SELECT id, content, source_episode_id
         FROM heart.facts
-        WHERE agent_id = $1 AND event_date IS NULL AND active = TRUE
+        WHERE agent_id = $1
+          AND event_date_classified_at IS NULL  -- eligibility = "never tried"
+          AND active = TRUE
         ORDER BY learned_at DESC
         LIMIT $2
     """, agent_id, batch_size)
@@ -329,18 +345,22 @@ async def _process_batch(conn, agent_id: str, batch_size: int) -> int:
     updated = 0
     for row in rows:
         result = await _classify_event_date(row)  # returns date | None
-        if result is None:
-            # Still mark as "processed" to avoid re-classification — use a
-            # sentinel? Or accept that NULL stays NULL and re-runs re-process.
-            # Per F047 pattern: NULL stays NULL; idempotent re-runs are fine.
-            continue
-        await conn.execute(
-            "UPDATE heart.facts SET event_date = $1, updated_at = NOW() WHERE id = $2",
-            result, row["id"],
-        )
+        # ALWAYS mark classified — even when no date found. This is what
+        # prevents re-processing the same stable facts on subsequent batches.
+        await conn.execute("""
+            UPDATE heart.facts
+            SET event_date = $1,
+                event_date_classified_at = NOW(),
+                updated_at = NOW()
+            WHERE id = $2
+        """, result, row["id"])  # $1 may be NULL — that's correct
         updated += 1
     return updated
 ```
+
+This makes the script terminate cleanly (every batch advances the eligibility cursor) and remains idempotent (re-runs only pick up rows still at `event_date_classified_at IS NULL`, which by definition haven't been tried).
+
+The live-path Layer 1 extractor also writes `event_date_classified_at = NOW()` whenever it stores a fact (whether or not it found a date), so newly-ingested facts never enter the backfill eligibility set.
 
 #### Classification LLM call (Python P2 — guaranteed JSON)
 
@@ -389,22 +409,51 @@ At end-of-script (post Layer 1 column populated), call `GraphDensifier.run_backf
 ```sql
 BEGIN;
 
--- F075: add event_date column to heart.facts
+-- F075: add event_date + classification-state columns to heart.facts
 ALTER TABLE heart.facts
-    ADD COLUMN IF NOT EXISTS event_date DATE DEFAULT NULL;
+    ADD COLUMN IF NOT EXISTS event_date DATE DEFAULT NULL,
+    ADD COLUMN IF NOT EXISTS event_date_classified_at TIMESTAMPTZ DEFAULT NULL;
 
 -- Index for date-range queries (Layer 3 + Layer 2 edge build)
 CREATE INDEX IF NOT EXISTS idx_facts_event_date_agent
     ON heart.facts(agent_id, event_date)
     WHERE event_date IS NOT NULL;
 
+-- Index for backfill eligibility scan (event_date_classified_at IS NULL)
+CREATE INDEX IF NOT EXISTS idx_facts_event_date_unclassified_agent
+    ON heart.facts(agent_id, learned_at)
+    WHERE event_date_classified_at IS NULL;
+
 COMMENT ON COLUMN heart.facts.event_date IS
     'F075: ISO date of the event this fact describes. NULL = stable fact (not event-anchored) OR pre-F075 row pending backfill.';
+COMMENT ON COLUMN heart.facts.event_date_classified_at IS
+    'F075: timestamp the backfill (or live extractor) classified this row for event_date. NULL = never classified, eligible for backfill. NOT NULL with event_date IS NULL = classified but no date found (terminal state, do NOT re-classify).';
+
+-- F075 Layer 2: extend brain.graph_edges relation CHECK to allow 'happened_before'.
+-- Mirrors migration 051_f070_chunk_graph_edges.sql:34-45 pattern.
+ALTER TABLE brain.graph_edges DROP CONSTRAINT IF EXISTS ck_edges_relation;
+ALTER TABLE brain.graph_edges DROP CONSTRAINT IF EXISTS graph_edges_relation_check;
+ALTER TABLE brain.graph_edges
+    ADD CONSTRAINT ck_edges_relation CHECK (
+        relation IN (
+            'supports', 'contradicts', 'supersedes', 'related_to', 'caused_by',
+            'informed_by', 'evidence_for', 'discussed_in', 'extracted_from',
+            'part_of', 'summarized_by',
+            -- F075 additions:
+            'happened_before'
+        )
+    );
 
 COMMIT;
 ```
 
-Partial index excludes NULL rows. Lookups for date-arithmetic queries scan only the small event-fact subset. Style matches `052_f069_document_source_kind.sql:22,34`.
+Partial indexes:
+- `idx_facts_event_date_agent` excludes NULL rows so date-arithmetic queries scan only the event-fact subset.
+- `idx_facts_event_date_unclassified_agent` accelerates backfill's eligibility query (`WHERE event_date_classified_at IS NULL ORDER BY learned_at DESC LIMIT N`).
+
+The relation CHECK extension is required by Layer 2's INSERT — without it the edge build raises a constraint violation. The pattern matches F070's migration 051 verbatim.
+
+Style matches `052_f069_document_source_kind.sql:22,34`.
 
 ---
 

--- a/docs/features/F075-temporal-fact-extraction.md
+++ b/docs/features/F075-temporal-fact-extraction.md
@@ -1,0 +1,592 @@
+# F075 — Temporal Fact Extraction + Date-Aware Retrieval
+
+**Status:** 📝 Draft **v2** (2026-05-27) — incorporates arch / python-pro / devil's-advocate spec review feedback
+**Proposed by:** Tim + investigation thread
+**Date:** 2026-05-27
+**Depends on:** F002 (Heart), F022 (Cross-type linking), F040 (Graph Densifier), F047 (Actionability backfill pattern), F051 (Eval harness for measurement)
+**Blocks:** F074.x re-measurement of temporal_reasoning on BEAM
+**Related:** `nous/heart/content_date_extractor.py` (untracked, retrieval-time approach — see §Alternatives)
+**Forge decision:** TBD (will record when impl plan greenlit)
+**Reviews:** `docs/reviews/F075-spec-arch-review.md`, `F075-spec-python-pro-review.md`, `F075-spec-devil-review.md`
+
+---
+
+## v2 changelog
+
+v1 → v2 incorporates 3 parallel spec reviews. Key changes:
+
+**Critical (architectural target was wrong):**
+- **Arch P1-1, Python P1-1 fixed.** v1 proposed augmenting `FactExtractor._EXTRACT_PROMPT`. That is the **fallback** path. Prod uses the 008.4 fast-path at `fact_extractor.py:143-148` where `candidate_facts` come from the **episode summarizer**. v2 targets the summarizer's `candidate_facts` schema (`episode_summarizer.py:50-56`) as **primary**, FactExtractor's prompt as **defense-in-depth**. Also: `ExtractedFact` class doesn't exist — v2 targets `FactInput` (`nous/heart/schemas.py:85-98`) and the `_store_candidate_facts` dict-unpacking loop (`fact_extractor.py:251-256`) which silently discards unknown keys today.
+- **Arch P1-2 fixed.** v1 assumed prompt change would let the LLM see dates. But the summarizer's extraction call operates on 100-150 word prose (the just-generated summary), not the raw transcript. Date-in-rate-limit-code (conv 2 Q0 case) gets compressed out. v2 directs the summarizer to extract dates from the **transcript text it already holds in scope** (`episode_summarizer.py:258`).
+- **Python P1-4 fixed.** v1 added the SQL column but missed: (a) `Fact` ORM at `storage/models.py:469-511` needs `Mapped[date | None]`, AND (b) `Heart.recall` must populate `RecallResult.metadata["event_date"]` or Layer 3 is a silent no-op forever.
+
+**Layer scope reframing:**
+- **Arch P1-3 / Devil's #3 fixed.** v1 framed Layer 2 (`happened_before` edges) as a primary retrieval lever. v2 reframes as **modest reranking reinforcer when both endpoints already retrieved**. The consumer (`graph_adjacency_boost`) is real and the F065 trap is avoided — but the consumer is default-off (`config.py:1055-1056`) AND cannot surface candidates below the retrieval cut. Impl plan must include flipping `NOUS_GRAPH_ADJACENCY_BOOST_ENABLED=true`.
+
+**Diagnostic update from Devil's #2:**
+- **Failure-mode reclassification** (verified empirically 2026-05-27 via `diag_temporal_failure_classes.py`):
+  - 2 of 5 = PATTERN_MATCH_CONV2_Q0 (conv 2 Q0, conv 4 Q1): date in chunks, missing from facts, chunk not in top-20 retrieval
+  - 2 of 5 = PARTIAL_MATCH (conv 3 Q1, conv 5 Q1): date in chunks, missing from facts, chunk IS retrieved (rank 3), but LLM doesn't compose a correct date-arithmetic answer from the prose
+  - 1 of 5 = source ambiguity (conv 2 Q1): unrelated to extractor work
+- v1's "3 of 5 retrieval-miss" was an under-classification. Extractor still helps the PARTIAL_MATCH class by creating discrete dated facts that are easier for the LLM to combine, but it's a different mechanism than for the PATTERN_MATCH class.
+
+**Python-level corrections:**
+- **Backfill SQL was malformed.** v1's `WHERE id = (SELECT id FROM batch)` crashes when LIMIT > 1. v2 copies F047's per-row pattern at `actionability_backfill.py:198-216`.
+- **Advisory lock keying.** v1 invented a keying scheme. v2 copies F047's `hashlib.sha256().digest()[:8]` → signed bigint pattern at `actionability_backfill.py:108-115`.
+- **Migration shape.** Added `BEGIN;...COMMIT;` wrapper per `052_f069_document_source_kind.sql:22,34` style.
+- **LLM client.** v2 specifies `call_background_llm_structured` from `nous/handlers/__init__.py:86` with tool_use schema for guaranteed JSON — no parse-repair logic needed.
+
+**Default flags:**
+- **Python/Arch P3 fixed.** All new flags default to `False` for consistency with prior dark-launch convention (F042, F047, F067, F071).
+
+---
+
+## Problem
+
+BEAM-100K prod-v3 measures temporal_reasoning at **0.417** (n=5 conv, decision `631cbc75`). LongMemEval N=100 paper-faithful measured temporal_reasoning at **0.583** in the same family of weakest categories. Both benchmarks expose the same gap: Nous can recall topical conversation content but **fails on date arithmetic** ("how many days between X and Y").
+
+### Diagnostic chain (decisions `0b52b37d`, `2c6c2c37`; memory `project_f074_temporal_diagnosis_2026_05_27`)
+
+Three "easy lever" hypotheses were investigated and all empirically or analytically falsified:
+
+| Lever | How falsified | Cost |
+|---|---|---|
+| `NOUS_STALENESS_HALF_LIFE_DAYS` flip 20→30 | Code-read: staleness lives in `nous/cognitive/context.py` only. BEAM harness bypasses pre_turn per F074 §5 | $0 |
+| `recall_top_k` 10→20 | n=3 empirical smoke: per-Q delta = 0.000 on all 6 temporal Qs. Aggregate −0.016, abstention −0.167 | $7.30 |
+| Inline date markers (`content_date_extractor.py`) | Annotates dates **inside retrieved snippets**; for PATTERN_MATCH_CONV2_Q0 class, the right snippet isn't retrieved | $0 (eliminated by diagnostic) |
+
+### Failure-mode classification (verified `diag_temporal_failure_classes.py`)
+
+5 prod-v3 temporal_reasoning failures (out of 10 Qs across conv 1-5) classified empirically:
+
+| Q | Class | Source-chat | Heart facts | Heart chunks | Retrieved top-20 |
+|---|---|---|---|---|---|
+| Conv 2 Q0 ("API key March 10") | **PATTERN_MATCH_CONV2_Q0** | 1× "march 10" | 0 | 1 | NO |
+| Conv 4 Q1 ("8/10 triangle score") | **PATTERN_MATCH_CONV2_Q0** | 1× "8/10" | 0 | 1 | NO |
+| Conv 3 Q1 ("planning peer review April 2") | **PARTIAL_MATCH** | 2× "April 2" | 0 | 2 | YES (rank 3) |
+| Conv 5 Q1 ("15 problems quiz") | **PARTIAL_MATCH** | 1× "15 problems" | 0 | 3 | YES (rank 3) |
+| Conv 2 Q1 ("testing period April 5") | Source ambiguity | competing dates | varied | varied | both retrieved |
+
+**Common across PATTERN_MATCH + PARTIAL_MATCH (4 of 5 failures):** the date-anchored event exists in `heart.episode_chunks` but has **0 corresponding facts in `heart.facts`**. The fact extractor produced facts about endpoints, error codes, components — but never the date-anchored event tuple.
+
+### Synthetic validation (2026-05-27, ~$0.05)
+
+Hand-injecting one fact — `"Christina obtained the OpenWeather API key on March 10, 2024."` — into `heart.facts` for `beam-100K-conv-002` with text-embedding-3-large embedding caused:
+- Synthetic fact ranked **#3 of 39** in `run_recall_pipeline` at K=20 (score 0.827)
+- LLM answer became: *"you obtained the OpenWeather API key on March 10, 2024, and completed the UI wireframe on March 12, 2024. That's **2 days** between the two events."*
+- Conv 2 Q0 score moves from 0.000 → 1.000
+
+### Root cause
+
+**The episode summarizer's `candidate_facts` schema does not capture date-anchored event tuples.** The summarizer's output prompt (`episode_summarizer.py:50-56`) instructs the LLM to emit `{"subject", "content", "category"}` per candidate fact — no slot for dates. As a result, output is biased toward stable facts (`<entity> <attribute>` form) rather than episodic events (`<entity> <action> on <date>` form). Dates survive in chunks but chunks rank low on date-arithmetic queries when chunk content is dominated by surrounding context (code, prose).
+
+This is also a **real product gap**, not benchmark-specific. Any user asking Nous "when did I do X" or "how long ago was Y" hits the same wall.
+
+---
+
+## Goals
+
+1. **Extract date-anchored events as discrete facts** during episode summarization, structured as `<entity> <action> on <ISO-date>`.
+2. **Persist `event_date: date | null`** on `heart.facts` — indexable column for date-range queries and graph edges. Surfaced into `RecallResult.metadata` for downstream consumers.
+3. **Build `happened_before` edges** during sleep cycle: chronologically-adjacent same-episode facts only. Same-episode constraint inherits F070's ceiling (see §Risks).
+4. **Date-aware retrieval boost** in `run_recall_pipeline` — detect date-language queries, gentle multiplicative boost on `event_date != NULL` facts within inferred window. *Deferred pending Layer 1+2+4 measurement.*
+5. **Retrofit existing data** via `scripts/backfill_temporal_facts.py` — re-process NULL rows under PG advisory lock with token budget (F047 pattern), using chunk context not summary prose.
+6. **Measurable**: re-run BEAM Phase 1 n=5 with this feature ON; expect temporal_reasoning ≥0.55. Validated on LongMemEval N=20 temporal-category retrieval first to avoid wasting BEAM budget.
+
+## Non-goals
+
+- **No new memory type.** Date-anchored events are still `heart.facts` rows.
+- **No multi-date facts.** One fact = one event = one `event_date`. Range events → two facts + optional `happened_before` edge. F075.2 deferred.
+- **No timezone handling.** ISO date at day granularity (`YYYY-MM-DD`).
+- **No timeline UI.** Dashboard surface is F075.1.
+- **No content_date_extractor.py wiring.** That module annotates dates at retrieval-time inside snippets; this feature operates at ingest-time on facts. The `_extract_regex` helper is reused (with commit + tests) by Layer 3's date-language detector.
+- **No removal of existing FactExtractor prompts.** Augments behavior; existing extraction continues unchanged.
+- **No reading per-message timestamps from chat metadata.** Some BEAM chats carry timestamps; prod conversations don't reliably. Dates must come from chat content.
+
+---
+
+## Design
+
+### Layer 1 — Date-anchored extraction at summarization time
+
+**Approach:** primary target is `EpisodeSummarizer.candidate_facts` schema (`nous/handlers/episode_summarizer.py:50-56`). Defense-in-depth augmentation of `FactExtractor._EXTRACT_PROMPT` for eval / direct-ingest paths that bypass the summarizer.
+
+#### Layer 1a (primary): EpisodeSummarizer
+
+`nous/handlers/episode_summarizer.py:50-56` defines the structured JSON the summarizer's LLM emits. Today's schema for each candidate fact: `{"subject", "content", "category"}`. v2 augments to optional 4th field:
+
+```python
+# Before (episode_summarizer.py:50-56, paraphrased):
+"candidate_facts": [
+  {"subject": "...", "content": "...", "category": "..."}
+]
+
+# After (F075):
+"candidate_facts": [
+  {"subject": "...", "content": "...", "category": "...",
+   "event_date": "YYYY-MM-DD"  # OPTIONAL — only when fact describes a dated event
+  }
+]
+```
+
+**Prompt addition at `episode_summarizer.py:76-77`** (the candidate-facts instruction block):
+
+```
+DATE-ANCHORED EVENTS (F075):
+When the transcript describes an event happening on a specific date — particularly
+something the user did or that was completed — capture it as a SEPARATE candidate
+fact with the date attached:
+
+  subject:    <short descriptor of the event>
+  content:    "<entity> <action verb> <object> on <full date>."
+  category:   "event" (or relevant existing category)
+  event_date: "<ISO YYYY-MM-DD>"
+
+Examples:
+  - "I got my OpenWeather API key on March 10" →
+    {"subject": "OpenWeather API key acquisition",
+     "content": "Christina obtained the OpenWeather API key on March 10, 2024.",
+     "category": "event",
+     "event_date": "2024-03-10"}
+  - "We deployed v2.1 to staging last Tuesday" (episode_start_timestamp = 2024-04-11) →
+    {"subject": "v2.1 staging deployment",
+     "content": "Team deployed v2.1 to staging on 2024-04-09.",
+     "category": "event",
+     "event_date": "2024-04-09"}
+
+CRITICAL: extract from the TRANSCRIPT text below — not from any summary you have
+generated. Dates mentioned in passing (e.g. inside code blocks or user asides) are
+just as important as headline dates. Resolve relative phrases ("yesterday", "last
+week", "3 days ago") against EPISODE_START_TIMESTAMP. If the date is ambiguous
+or unresolvable, OMIT event_date (set null) but still extract the fact without
+the date.
+```
+
+**Critical wiring detail (Arch P1-2):** the summarizer already passes the transcript content into the LLM call when constructing the summary. The prompt addition above directs the same LLM to also extract dates from that transcript — no new data is needed; the LLM just needs the instruction. This is why we target the summarizer rather than the downstream extractor.
+
+#### Layer 1b (defense-in-depth): FactExtractor
+
+`nous/handlers/fact_extractor.py:_EXTRACT_PROMPT` is the fallback path used when `candidate_facts` are absent (eval shortcuts, direct ingest tools). Same instruction block as 1a, adapted for the fact-extractor's output schema. Lower priority because production traffic always has summarizer-emitted candidates.
+
+#### Wire path (required additions across 7 hops)
+
+Per Arch P1-1's enumeration:
+
+| # | File:Line | Change |
+|---|---|---|
+| 1 | `episode_summarizer.py:50-77` | Add `event_date` to candidate_facts schema + prompt |
+| 2 | `fact_extractor.py:251-256` | `_store_candidate_facts` reads `event_date = item.get("event_date")` from dict |
+| 3 | `nous/heart/schemas.py:85-98` | `FactInput` adds `event_date: date \| None = None` |
+| 4 | `nous/heart/facts.py:428-449` | `FactManager._learn` passes `event_date` to `Fact()` ORM constructor |
+| 5 | `nous/storage/models.py:469-511` | `Fact` ORM adds `event_date: Mapped[date \| None] = mapped_column(Date, nullable=True)` |
+| 6 | `sql/migrations/053_temporal_fact_extraction.sql` | `ALTER TABLE heart.facts ADD COLUMN event_date DATE` + partial index |
+| 7 | `nous/heart/schemas.py:114-165` | `FactDetail` and `FactSummary` add `event_date: date \| None = None` |
+
+**Plus** Heart.recall surface (Python P1-4): when serializing recall results, `RecallResult.metadata["event_date"]` must be populated with the iso string (or absent if None). Without this, Layer 3 is silent no-op.
+
+#### Pydantic v2 validator
+
+In `FactInput`:
+
+```python
+from datetime import date
+from pydantic import field_validator
+
+event_date: date | None = None
+
+@field_validator("event_date", mode="before")
+@classmethod
+def _parse_event_date(cls, v):
+    if v is None or isinstance(v, date):
+        return v
+    if isinstance(v, str):
+        try:
+            return date.fromisoformat(v)  # strict — rejects "2024-02-30" etc
+        except ValueError:
+            return None  # fail-soft: drop bad date, keep fact
+    return None
+```
+
+`date.fromisoformat` is strict enough that we don't need a separate regex check; Python 3.12's stdlib rejects out-of-range days, malformed strings, etc.
+
+### Layer 2 — `happened_before` edges (reranking reinforcer)
+
+**Scope reframing per Arch P1-3 / Devil's #3:** Layer 2 is a **modest reranking reinforcer**, not a retrieval-surfacing lever. It only affects candidates already in the retrieved set. For the dominant PATTERN_MATCH failure class, the right fact is below the retrieval cut — Layer 2 cannot help that class directly. The value is on the PARTIAL_MATCH class, where both temporally-linked facts often ARE in the candidate set.
+
+**Edge build (in `GraphDensifier.run_backfill_cycle`):**
+
+```sql
+-- For all (fact_a, fact_b) pairs in same episode, chronologically adjacent
+-- on event_date — chain through ordered events, not all pairs.
+INSERT INTO brain.graph_edges (source_id, source_type, target_id, target_type, relation, weight)
+SELECT a.id, 'fact', b.id, 'fact', 'happened_before', 1.0
+FROM heart.facts a
+JOIN heart.facts b
+  ON a.agent_id = b.agent_id
+ AND a.source_episode_id = b.source_episode_id
+ AND a.event_date < b.event_date
+WHERE a.agent_id = $1
+  AND a.event_date IS NOT NULL
+  AND b.event_date IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM heart.facts c
+    WHERE c.source_episode_id = a.source_episode_id
+      AND c.event_date > a.event_date
+      AND c.event_date < b.event_date
+  )
+ON CONFLICT (source_id, target_id, relation) DO NOTHING;
+```
+
+Result: at most N-1 edges per episode (a chain through ordered events). O(N), not O(N²).
+
+**Consumer (already-shipped):**
+
+`_apply_graph_adjacency_boost` in `nous/api/retrieval_pipeline.py:243-247, 699-738`. Excludes `contradicts` only; sums all other edge relations including `happened_before`. **No new consumer code required.**
+
+**Required impl-plan step:** flip `NOUS_GRAPH_ADJACENCY_BOOST_ENABLED` from `false` to `true` (current default in `config.py:1055-1056`). Without this flip Layer 2 ships dark.
+
+**Same-episode constraint ceiling (Arch P2-3):** following F070's pattern, edges only cross facts within the same `source_episode_id`. This is acceptable for v1 because BEAM convs are single long haystacks where within-episode date arithmetic is the common case. Cross-episode `happened_before` (e.g., "how long between event in March vs event in May") deferred to F075.1.
+
+### Layer 3 — Date-aware retrieval boost (DEFERRED)
+
+**Phase decision per Arch §Phase Strategy:** defer until Layer 1+2+4 are measured. Synthetic validation showed the date-anchored fact ranks #3 of 39 on its own embedding strength — Layer 3 may be unnecessary. Gate decision on LME pre-check + BEAM measurement.
+
+**If implemented later**, design:
+
+```python
+async def _apply_date_boost(
+    results: list[PipelineResult],
+    query: str,
+    settings: Settings,
+) -> list[PipelineResult]:
+    """F075: gentle multiplicative boost for facts whose event_date is
+    within the date window implied by the query.
+    """
+    if not settings.date_aware_boost_enabled:
+        return results
+    window = _infer_query_date_window(query)  # (start, end) | None
+    if window is None:
+        return results
+
+    factor = settings.date_aware_boost_factor
+    boosted = []
+    for r in results:
+        if r.type != "fact":
+            boosted.append(r); continue
+        ed_iso = r.metadata.get("event_date")  # surfaced via Layer 1 Heart.recall change
+        if ed_iso is None:
+            boosted.append(r); continue
+        try:
+            event_date = date.fromisoformat(ed_iso)
+        except ValueError:
+            boosted.append(r); continue
+        if window[0] <= event_date <= window[1]:
+            # Match _apply_adjacency_boost coalesce pattern at retrieval_pipeline.py:736-737
+            new_score = (r.score or 0.0) * factor
+            boosted.append(replace(r, score=new_score))
+        else:
+            boosted.append(r)
+    boosted.sort(key=lambda r: (r.score or 0.0), reverse=True)
+    return boosted
+```
+
+`_infer_query_date_window` reuses the `_extract_regex` helper from `nous/heart/content_date_extractor.py`. Per Arch P3-1 / Python P3, that file must be committed and given tests before being imported in `retrieval_pipeline.py`.
+
+### Layer 4 — Retrofit script
+
+`scripts/backfill_temporal_facts.py`. F047 pattern — copies `nous/handlers/actionability_backfill.py` patterns verbatim.
+
+#### Advisory lock (copy F047 verbatim — Python P1-3)
+
+```python
+import hashlib
+
+def _advisory_lock_key(agent_id: str) -> int:
+    """Stable signed bigint key derived from agent_id SHA-256.
+    Mirrors actionability_backfill.py:108-115.
+    """
+    digest = hashlib.sha256(agent_id.encode("utf-8")).digest()[:8]
+    return int.from_bytes(digest, byteorder="big", signed=True)
+```
+
+`async with db.transaction()` + `SELECT pg_try_advisory_xact_lock($1)` with this key. Mirrors F047 + F049 patterns exactly.
+
+#### Per-row UPDATE (Python P1-2 fix)
+
+v1's `WHERE id = (SELECT id FROM batch)` was broken for `LIMIT > 1`. v2 copies F047's `actionability_backfill.py:198-216` shape:
+
+```python
+# Pseudo-code; concrete sites verified against F047
+async def _process_batch(conn, agent_id: str, batch_size: int) -> int:
+    rows = await conn.fetch("""
+        SELECT id, content, source_episode_id
+        FROM heart.facts
+        WHERE agent_id = $1 AND event_date IS NULL AND active = TRUE
+        ORDER BY learned_at DESC
+        LIMIT $2
+    """, agent_id, batch_size)
+
+    updated = 0
+    for row in rows:
+        result = await _classify_event_date(row)  # returns date | None
+        if result is None:
+            # Still mark as "processed" to avoid re-classification — use a
+            # sentinel? Or accept that NULL stays NULL and re-runs re-process.
+            # Per F047 pattern: NULL stays NULL; idempotent re-runs are fine.
+            continue
+        await conn.execute(
+            "UPDATE heart.facts SET event_date = $1, updated_at = NOW() WHERE id = $2",
+            result, row["id"],
+        )
+        updated += 1
+    return updated
+```
+
+#### Classification LLM call (Python P2 — guaranteed JSON)
+
+Use `call_background_llm_structured` from `nous/handlers/__init__.py:86` (or wherever the helper lives) with a tool_use input_schema for guaranteed JSON output. No parse-repair logic in the script.
+
+#### Context source (Arch P2-1 / Python P2 — chunk context, not summary)
+
+v1 fed `episode.summary[:500]` to the classifier. That suffers the same lossy-prose problem as Layer 1. v2 fetches the most-relevant `heart.episode_chunks` row for the fact (best chunk by content similarity OR by simply selecting the chunk whose content contains the candidate entity/action):
+
+```sql
+-- Per-row: find chunks containing the fact's subject keywords
+SELECT content
+FROM heart.episode_chunks
+WHERE agent_id = $1 AND episode_id = $2
+  AND content ILIKE '%' || $3 || '%'  -- subject as keyword
+ORDER BY chunk_index
+LIMIT 1;
+```
+
+Feeds raw chunk text (up to ~600 chars) to the classifier instead of the lossy 500-char summary slice.
+
+#### CLI shape
+
+```bash
+uv run python scripts/backfill_temporal_facts.py \
+    --agent-id nous-default \
+    --batch-size 100 \
+    --token-budget 50000 \
+    --dry-run     # estimate cost without LLM calls
+```
+
+#### Idempotence
+
+`WHERE event_date IS NULL` predicate makes re-runs safe. NULL rows only.
+
+#### Edge-build trigger
+
+At end-of-script (post Layer 1 column populated), call `GraphDensifier.run_backfill_cycle(agent_id=...)` synchronously to build `happened_before` edges. Cleaner end-state than deferring to next sleep.
+
+---
+
+## Schema migration
+
+`sql/migrations/053_temporal_fact_extraction.sql`:
+
+```sql
+BEGIN;
+
+-- F075: add event_date column to heart.facts
+ALTER TABLE heart.facts
+    ADD COLUMN IF NOT EXISTS event_date DATE DEFAULT NULL;
+
+-- Index for date-range queries (Layer 3 + Layer 2 edge build)
+CREATE INDEX IF NOT EXISTS idx_facts_event_date_agent
+    ON heart.facts(agent_id, event_date)
+    WHERE event_date IS NOT NULL;
+
+COMMENT ON COLUMN heart.facts.event_date IS
+    'F075: ISO date of the event this fact describes. NULL = stable fact (not event-anchored) OR pre-F075 row pending backfill.';
+
+COMMIT;
+```
+
+Partial index excludes NULL rows. Lookups for date-arithmetic queries scan only the small event-fact subset. Style matches `052_f069_document_source_kind.sql:22,34`.
+
+---
+
+## Settings additions (`nous/config.py`)
+
+```python
+# F075 — Temporal extraction & date-aware retrieval
+# All flags default OFF for dark-launch consistency (F042/F047/F067/F071 pattern).
+temporal_extraction_enabled: bool = Field(
+    default=False,
+    description="F075: include date-anchored event extraction in summarizer + "
+                "fact-extractor prompts. Flip to True after measurement confirms "
+                "no regression on existing test suite or LME baseline.",
+)
+date_aware_boost_enabled: bool = Field(
+    default=False,
+    description="F075 Layer 3: gentle multiplicative boost on facts with "
+                "event_date in query's inferred date window. Deferred from v2 "
+                "pending Layer 1+2+4 measurement; ship with flag default off.",
+)
+date_aware_boost_factor: float = Field(
+    default=1.20, ge=1.0, le=2.0,
+    description="F075: multiplier applied to in-window facts. 1.0 = no boost.",
+)
+date_aware_boost_window_pad_days: int = Field(
+    default=30,
+    description="F075: pad days around inferred query date window.",
+)
+temporal_backfill_default_token_budget: int = Field(
+    default=50000,
+    description="F075: default Haiku token cap for backfill script.",
+)
+```
+
+`CLAUDE.md` env-var table gets 5 new rows. Update is part of the impl PR, not separate.
+
+---
+
+## Tests
+
+**`tests/test_temporal_extractor.py`** (new):
+- Summarizer prompt produces `event_date` field when transcript explicit (mock LLM)
+- Summarizer prompt resolves relative dates against episode_start_timestamp
+- Malformed date string fails `date.fromisoformat` → field dropped, fact kept
+- Ambiguous date → field omitted, no false positive
+- Same event, same date → dedup catches duplicate (existing dedup path unchanged)
+- `_store_candidate_facts` reads `event_date` from dict and threads into `FactInput`
+- FactExtractor fallback prompt (Layer 1b) also emits event_date
+
+**`tests/test_temporal_edges.py`** (new):
+- Two facts same episode, different dates → 1 `happened_before` edge
+- Three facts in chronological order → 2 edges (chain, not all pairs)
+- Cross-episode facts → no edge
+- NULL event_date on either side → no edge
+- ON CONFLICT DO NOTHING prevents duplicate edges on re-run
+
+**`tests/test_temporal_backfill.py`** (new):
+- Advisory lock (mocked `pg_try_advisory_xact_lock`) prevents concurrent backfills
+- Token budget exhausted → clean halt, no partial-row corruption
+- Dry-run produces estimate without LLM calls
+- NULL-only filter means re-running picks up only unprocessed rows
+- Chunk context source (not summary) — verified via mock chunk lookup
+
+**`tests/test_date_aware_boost.py`** (new, Layer 3 deferred but tests stay):
+- Query "how many days between" detects as date-arithmetic
+- Query "OpenWeather endpoints" produces no window
+- Fact with event_date in window: `(score or 0.0) * factor`
+- Fact outside window untouched
+- Re-sort stable when no boosts applied; missing scores coalesce to 0.0
+
+**Integration test in `tests/test_f075_end_to_end.py`:**
+- Ingest a fixture conversation with explicit date references
+- Verify extracted facts have correct `event_date`
+- Verify `RecallResult.metadata["event_date"]` is populated for retrieved facts
+- Verify edges built via sleep cycle
+- Confirm baseline retrieval (without Layer 3) still surfaces dated fact at high rank
+
+pytest-asyncio config in `pyproject.toml:59` is already `asyncio_mode = "auto"` (verified by python reviewer); no config change needed. The repo currently has `tests/test_fact_extractor_episode_id.py` (F022-narrow); no general `test_fact_extractor.py` exists yet, so F075 establishes one.
+
+---
+
+## Acceptance criteria
+
+1. **All new tests pass.** 4 unit files + 1 integration file, ~30 tests.
+2. **Existing tests pass.** No regression in `tests/test_fact_extractor_episode_id.py`, `tests/test_heart.py`, `tests/test_graph_densifier.py`.
+3. **Migration runs cleanly on fresh DB** (`docker compose up` cold start), verified by F074 harness pattern.
+4. **LongMemEval N=20 retrieval pre-check** (cheap, ~$5): hit@10 on temporal-reasoning category questions improves by ≥+5% vs current baseline. If LME pre-check fails, do NOT proceed to BEAM.
+5. **BEAM Phase 1 re-run (n=5 conv) shows temporal_reasoning ≥ 0.55**, ideally ≥ 0.60. Other ability scores stay within ±0.05 of prod-v3 (no collateral regression like K-bump's abstention -0.167).
+6. **Per-failure-class verification** (cheap, $0.30 of synthetic-fact tests): inject hand-crafted dated facts for one PATTERN_MATCH (conv 4 Q1) and one PARTIAL_MATCH (conv 5 Q1), confirm both move from 0.000 to ≥0.5 via the same chain as the conv 2 Q0 baseline. Devil's #2 risk-mitigation: pre-implementation gate.
+7. **Retrofit script dry-run** on `nous-default` prod-snapshot reports cost estimate; full run completes within token budget; advisory lock prevents concurrent execution.
+8. **Settings docs updated** in `CLAUDE.md` env-var table.
+
+---
+
+## Cost & risk
+
+**Implementation cost:**
+- Layer 1 (summarizer + extractor prompts + schema wire path): ~110 LOC across 7 files + migration + 8 tests
+- Layer 2 (happened_before edges + flag flip): ~60 LOC in GraphDensifier + 5 tests
+- Layer 3 (date-aware boost): ~50 LOC in retrieval_pipeline + 5 tests *(deferred)*
+- Layer 4 (backfill script): ~280 LOC + 6 tests + CLI
+- Total: ~500 LOC (450 if Layer 3 deferred) + 30 tests. ~3-4 days for one engineer.
+
+**Measurement cost:**
+- Synthetic per-failure-class verification (criterion #6): ~$0.30
+- LongMemEval N=20 temporal retrieval pre-check: ~$5
+- BEAM Phase 1 n=5 re-run: ~$7
+- Total: ~$13
+
+**Backfill cost (prod):**
+- `nous-default` ~5K facts × Haiku ~10 tokens each ≈ ~$0.30
+- Plus chunk-context lookup: ~1 extra DB query per fact, negligible
+
+**Risks:**
+
+1. **Prompt-engineering collateral on summarizer.** Layer 1 modifies the summarizer prompt, which is a high-traffic shared path. Risk: existing fact-extraction behavior shifts on non-event content. **Mitigation**: integration test with known-event corpus; LME hand-label qrels comparison; explicit acceptance criterion #2.
+2. **PARTIAL_MATCH class may not move as expected.** Devil's #2 revealed 2 of 5 failures are PARTIAL_MATCH where chunks already surface but LLM doesn't compose. Discrete dated facts SHOULD help (they're easier to combine than prose), but this is unverified. **Mitigation**: acceptance criterion #6 pre-implementation synthetic verification at ~$0.30.
+3. **`happened_before` edges may bleed into wrong adjacency reinforcement.** `_apply_graph_adjacency_boost` sums ALL non-`contradicts` relations indistinguishably (`retrieval_pipeline.py:712`). If temporal_anchor neighbors mislead retrieval for non-temporal queries, we'd see collateral. **Mitigation**: monitor non-target ability scores in BEAM re-run; if regression > 0.05, revisit adjacency-boost allowlist (F075.1 candidate).
+4. **Same-episode `happened_before` ceiling.** Inherits F070 cross-episode-edge gap. Cross-session date pairs never get edges (F075.1). Acceptable for v1 because BEAM convs are single-haystack.
+5. **Source ambiguity (1 of 5)** unfixable by this work. Ceiling at ~0.7 on temporal_reasoning from extractor + edges alone.
+
+---
+
+## Alternatives considered & rejected
+
+### A1. Wire `nous/heart/content_date_extractor.py` into `_format_pipeline_text`
+
+The existing untracked module annotates retrieved snippets with `[event: YYYY-MM-DD (~N months ago)]` markers. Falsified for the PATTERN_MATCH class: the right snippet isn't retrieved, so markers have nothing to annotate. **Partially repurposed in Layer 3** — its `_extract_regex` function is reused by the date-language detector (with commit + tests added per P3).
+
+### A2. Synthetic `nous_system.date_anchors` node table
+
+A separate table where each unique date gets a UUID, then `temporal_anchor` edges target those rows. Enables graph-walk semantics ("find all facts on this date"). Deferred to F075.1 because:
+- `WHERE event_date = '2024-03-10'` already does the work via index
+- Adds a new table for a use case we don't yet have
+
+### A3. Separate `nous/handlers/temporal_fact_extractor.py` parallel pipeline
+
+Doubles LLM cost per episode. Augmenting summarizer + extractor prompts is simpler with same expressive power.
+
+### A4. Multi-date facts (start + end ranges in one fact)
+
+Reject for v1: requires schema beyond one column, complicates dedup, no rubric tests range queries. F075.2 if needed.
+
+### A5. Read timestamps from chat metadata
+
+Reject: prod doesn't reliably have message timestamps. Couples memory to ingest-time metadata.
+
+### A6. Defer Layer 3 entirely
+
+Adopted in v2. Synthetic validation showed fact embedding alone ranks #3 without boost. Ship Layers 1+2+4; measure; add Layer 3 only if temporal_reasoning lands <0.55.
+
+---
+
+## Open questions (resolved in v2)
+
+| v1 question | v2 resolution |
+|---|---|
+| Augment vs new module (Layer 1) | Augment. Primary target = EpisodeSummarizer. Defense-in-depth = FactExtractor. |
+| Layer 3 phase decision | Defer until Layer 1+2+4 measurement. |
+| `event_date` validator stringency | Fail-soft (drop field, keep fact) via `date.fromisoformat` in Pydantic v2 `field_validator`. |
+| Backfill batching | Per-row UPDATE copying F047's `actionability_backfill.py:198-216`. |
+| Edge build trigger | Synchronous at end-of-backfill-script. |
+| Token budget default | Total cap with resume, 50K Haiku tokens default. Matches F047. |
+
+---
+
+## Rollback
+
+1. Set `NOUS_TEMPORAL_EXTRACTION_ENABLED=false` — new ingests stop producing event_date facts. Existing facts retain their event_date.
+2. Set `NOUS_DATE_AWARE_BOOST_ENABLED=false` — Layer 3 disabled. (Default off.)
+3. Set `NOUS_GRAPH_ADJACENCY_BOOST_ENABLED=false` (revert prod flip) — Layer 2 reranking disabled.
+4. Migration is forward-only. To fully revert column: drop via v2 migration. Partial index is harmless to leave.
+5. Backfill outputs are idempotent and additive — no rollback path needed.
+
+Feature is **flag-gated end-to-end**. Worst case: turn off flags, behavior reverts to pre-F075. Cost = one-time backfill spend.
+
+---
+
+## Deferred to F075.x
+
+- **F075.1** — `nous_system.date_anchors` node table + true `temporal_anchor` edges (graph-walk); cross-episode `happened_before` edges (F070 ceiling fix)
+- **F075.2** — Multi-date facts (range events)
+- **F075.3** — Timeline dashboard tab
+- **F075.4** — Post-extract `dateparser` fallback (defense-in-depth on LLM extraction misses)
+- **F075.5** — Adjacency-boost allowlist (per-relation weighting); only if BEAM measurement shows collateral regression

--- a/docs/features/F075-temporal-fact-extraction.md
+++ b/docs/features/F075-temporal-fact-extraction.md
@@ -1,6 +1,6 @@
 # F075 — Temporal Fact Extraction + Date-Aware Retrieval
 
-**Status:** 📝 Draft **v2.8** (2026-05-28) — incorporates arch / python-pro / devil's-advocate spec review + 8 rounds of codex PR review fixes
+**Status:** 📝 Draft **v2.9** (2026-05-28) — incorporates arch / python-pro / devil's-advocate spec review + 9 rounds of codex PR review fixes
 **Proposed by:** Tim + investigation thread
 **Date:** 2026-05-27
 **Depends on:** F002 (Heart), F022 (Cross-type linking), F040 (Graph Densifier), F047 (Actionability backfill pattern), F051 (Eval harness for measurement)
@@ -10,6 +10,13 @@
 **Reviews:** `docs/reviews/F075-spec-arch-review.md`, `F075-spec-python-pro-review.md`, `F075-spec-devil-review.md`
 
 ---
+
+## v2.9 changelog (codex re-review round 9)
+
+Codex flagged 2 P2s on v2.8:
+
+- **P2 — Validator snippet was non-runnable.** Round-8's regex addition placed `import re` and `_DATE_PATTERN = re.compile(...)` between the `@classmethod` decorator and the `def _parse_event_date` method — invalid Python (you can't `import` mid-class-body) AND the bare `_DATE_PATTERN` reference inside the method would look up a missing module global. Fixed: snippet now explicitly shows module-scope layout (`import re`, `_DATE_PATTERN` ABOVE `class FactInput`), with a callout that the method's bare reference works because it's a module global.
+- **P2 — `event_date_classified_at` marker site was structurally wrong.** v2.8 had `FactManager._learn` stamp the marker whenever the flag is on. But `Heart.learn(FactInput(...))` is called from many non-F075 paths (`tools.py:516`, `rest.py:1722`, `knowledge_extractor.py:127`). Those facts never ran through the F075 classifier but would have been falsely marked, then skipped by backfill forever. Fixed: marker is now a `FactInput` field populated by the F075-aware producer paths only (Layer 1a `_store_candidate_facts`, Layer 1b direct `FactInput(...)`, Layer 4 backfill UPDATE). `FactManager._learn` becomes a pure sink — persists whatever's in `FactInput`, no policy. Other learn callers leave the field at its `None` default → those rows stay backfill-eligible.
 
 ## v2.8 changelog (codex re-review round 8)
 
@@ -241,17 +248,26 @@ Per Arch P1-1's enumeration:
 | 1 | `episode_summarizer.py:50-77` | Add `event_date` to candidate_facts schema + prompt |
 | 2 | `fact_extractor.py:251-256` | `_store_candidate_facts` reads `event_date = item.get("event_date")` from dict |
 | 3 | `nous/heart/schemas.py:85-98` | `FactInput` adds `event_date: date \| None = None` |
-| 4 | `nous/heart/facts.py:428-449` | `FactManager._learn` passes `event_date` to `Fact()` ORM constructor |
+| 4 | `nous/heart/facts.py:428-449` | `FactManager._learn` passes `event_date` AND `event_date_classified_at` from `FactInput` to `Fact()` ORM constructor verbatim. NO policy here — `_learn` is a pure sink. Marker policy lives in the F075 producer paths only (Layer 1a, 1b, Layer 4). |
 | 5 | `nous/storage/models.py:469-511` | `Fact` ORM adds `event_date: Mapped[date \| None] = mapped_column(Date, nullable=True)` AND `event_date_classified_at: Mapped[datetime \| None] = mapped_column(DateTime(timezone=True), nullable=True)` |
 | 6 | `sql/migrations/053_temporal_fact_extraction.sql` | `ALTER TABLE heart.facts ADD COLUMN event_date DATE + event_date_classified_at TIMESTAMPTZ` + partial indexes + extend `brain.graph_edges` relation CHECK to add `'happened_before'` |
 | 7 | `nous/heart/schemas.py:114-165` | `FactDetail` and `FactSummary` add `event_date: date \| None = None` |
 | 8 | `nous/heart/facts.py:1046, 1160, 1256, 1355` | Each `FactSummary(...)` constructor passes `event_date=fact.event_date` (4 sites). Optional field defaults to None silently otherwise → recall surface returns None even when DB column populated |
 | 9 | `nous/heart/facts.py:1459` (`_to_detail`) | Pass `event_date=fact.event_date` to `FactDetail` construction |
 | 10 | `nous/heart/facts.py` `_to_recall_result` path | `RecallResult.metadata["event_date"] = fact.event_date.isoformat() if fact.event_date else None` so Layer 3 boost has the field to read |
-| 11 | `nous/handlers/fact_extractor.py:189-196` (Layer 1b direct path) | The fallback `FactInput(...)` construction must also pass `event_date=fact.get("event_date")`. This path does NOT go through `_store_candidate_facts`, so step 2 alone doesn't cover it. Without this, eval / direct-ingest traffic that bypasses the summarizer silently discards extracted dates. |
+| 11 | `nous/handlers/fact_extractor.py:189-196` (Layer 1b direct path) | The fallback `FactInput(...)` construction must also pass `event_date=fact.get("event_date")` AND `event_date_classified_at=datetime.now(UTC)` (gated on `settings.temporal_extraction_enabled`). This path does NOT go through `_store_candidate_facts`, so step 2 alone doesn't cover it. Without this, eval / direct-ingest traffic that bypasses the summarizer silently discards extracted dates. |
 | 12 | `nous/api/retrieval_pipeline.py:659-669` (`_heart_results_to_pipeline`) | Copy `event_date` from `RecallResult.metadata` into the new `PipelineResult.metadata` dict. Today the conversion drops metadata entirely. Layer 3's `r.metadata.get("event_date")` reads from `PipelineResult`, so the field must survive the conversion. |
 
-**Plus**: when `settings.temporal_extraction_enabled = True`, `FactManager._learn` sets `event_date_classified_at = datetime.now(UTC)` on every fact write (the new codepath always marks the row classified, even when `event_date` ends up `None`). When the flag is `False`, `event_date_classified_at` stays `NULL` — the row was NOT actually classified (legacy prompt was used) so it must remain eligible for the Layer 4 backfill when the flag is later flipped on. Without this gating, dark-launched ingests would stamp the marker on rows that never saw the new extractor, then a post-launch backfill would skip them forever via the `event_date_classified_at IS NULL` predicate.
+**Plus — marker write site (Codex round-9 fix):** `event_date_classified_at` must be populated by **F075 producers only**, NOT by a generic write inside `FactManager._learn`. Multiple unrelated paths call `Heart.learn(FactInput(...))` directly — `nous/api/tools.py:516` (`learn_fact` tool), `nous/api/rest.py:1722` (REST endpoint), `nous/handlers/knowledge_extractor.py:127` (pre-prune extraction) — none of which run the F075 classifier. If `_learn` blindly stamped `event_date_classified_at = NOW()` for every write when the flag is on, those rows would be falsely marked "F075-classified" and skipped by the backfill forever.
+
+The correct design: `FactInput` carries the field optionally (default `None`), and **only the F075-aware code paths populate it**:
+
+- **Layer 1a (summarizer path):** `_store_candidate_facts` at `fact_extractor.py:251-256` sets `event_date_classified_at=datetime.now(UTC)` on the `FactInput` it constructs, gated on `settings.temporal_extraction_enabled`.
+- **Layer 1b (direct extractor path):** the `FactInput(...)` construction at `fact_extractor.py:189-196` sets the same value, gated on the same flag.
+- **Layer 4 (backfill):** the per-row `UPDATE` writes both `event_date` (date or NULL) and `event_date_classified_at = NOW()` simultaneously.
+- **All other paths** (`tools.py:516`, `rest.py:1722`, `knowledge_extractor.py:127`, any future `Heart.learn` caller) leave the field at its `None` default — those rows stay eligible for the backfill to catch up.
+
+`FactManager._learn` simply persists whatever's in `FactInput.event_date_classified_at` to the DB column — no flag check, no `now()` injection, no policy. The producer decides.
 
 **Plus (Codex v2.1 review):** the summarizer's LLM call must receive `Episode.started_at` so it can resolve relative dates ("yesterday", "last Tuesday") deterministically. Current chain `summarize_episode → _generate_summary(transcript, decision_context) → _summarize_single(transcript, decision_context)` (lines 135, 361, 394) carries neither the episode object nor `started_at`. Wire path additions for relative-date resolution — every hop must be touched, including the intermediate `_generate_summary` boundary that codex flagged in round 4:
 
@@ -269,40 +285,45 @@ Without thread-through at every hop, the prompt's "resolve relative phrases agai
 
 #### Pydantic v2 validator
 
-In `FactInput`:
+In `nous/heart/schemas.py`. Module-scope imports/constants, then the field + validator inside `FactInput`:
 
 ```python
+# nous/heart/schemas.py — module scope
+import re
 from datetime import date
 from pydantic import field_validator
 
-event_date: date | None = None
-
-@field_validator("event_date", mode="before")
-@classmethod
-import re
-
 _DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
-def _parse_event_date(cls, v):
-    if v is None or isinstance(v, date):
-        return v
-    if isinstance(v, str):
-        # Codex round-8 catch: Python 3.12 date.fromisoformat() accepts
-        # alternate ISO forms like '20240310' (no hyphens) and '2024-W10-7'
-        # (ISO week date). The spec/prompt contract is strictly
-        # 'YYYY-MM-DD' — anything else must be dropped. Two-step check:
-        # (1) regex enforces the surface shape, (2) fromisoformat enforces
-        # day-validity (rejects 2024-02-30, etc).
-        if not _DATE_PATTERN.fullmatch(v):
-            return None
-        try:
-            return date.fromisoformat(v)
-        except ValueError:
-            return None  # fail-soft: drop bad date, keep fact
-    return None
+
+class FactInput(BaseModel):
+    # ... existing fields ...
+    event_date: date | None = None
+    event_date_classified_at: datetime | None = None  # set by F075 producers only
+
+    @field_validator("event_date", mode="before")
+    @classmethod
+    def _parse_event_date(cls, v):
+        if v is None or isinstance(v, date):
+            return v
+        if isinstance(v, str):
+            # Codex round-8 catch: Python 3.12 date.fromisoformat() accepts
+            # alternate ISO forms like '20240310' (no hyphens) and
+            # '2024-W10-7' (ISO week date). The spec/prompt contract is
+            # strictly 'YYYY-MM-DD' — anything else must be dropped.
+            # Two-step check:
+            # (1) module-level _DATE_PATTERN regex enforces surface shape
+            # (2) fromisoformat enforces day-validity (rejects 2024-02-30)
+            if not _DATE_PATTERN.fullmatch(v):
+                return None
+            try:
+                return date.fromisoformat(v)
+            except ValueError:
+                return None  # fail-soft: drop bad date, keep fact
+        return None
 ```
 
-The regex gate is the contract enforcement: anything that didn't come out of the prompt's stated `YYYY-MM-DD` slot is rejected before `fromisoformat` gets a chance to parse it as a different ISO variant. `date.fromisoformat` is then used purely for day-validity checking on the regex-passing inputs.
+Layout matters: `import re` and `_DATE_PATTERN` are at module scope (above `class FactInput`), so the validator method can reference `_DATE_PATTERN` as a module global without `cls.` prefix. The regex gate is the contract enforcement: anything that didn't come out of the prompt's stated `YYYY-MM-DD` slot is rejected before `fromisoformat` gets a chance to parse it as a different ISO variant. `date.fromisoformat` is then used purely for day-validity checking on the regex-passing inputs.
 
 ### Layer 2 — `happened_before` edges (reranking reinforcer)
 

--- a/docs/features/F075-temporal-fact-extraction.md
+++ b/docs/features/F075-temporal-fact-extraction.md
@@ -1,6 +1,6 @@
 # F075 — Temporal Fact Extraction + Date-Aware Retrieval
 
-**Status:** 📝 Draft **v2.12** (2026-05-28) — incorporates arch / python-pro / devil's-advocate spec review + 12 rounds of codex PR review fixes
+**Status:** 📝 Draft **v2.13** (2026-05-28) — incorporates arch / python-pro / devil's-advocate spec review + 13 rounds of codex PR review fixes
 **Proposed by:** Tim + investigation thread
 **Date:** 2026-05-27
 **Depends on:** F002 (Heart), F022 (Cross-type linking), F040 (Graph Densifier), F047 (Actionability backfill pattern), F051 (Eval harness for measurement)
@@ -10,6 +10,13 @@
 **Reviews:** `docs/reviews/F075-spec-arch-review.md`, `F075-spec-python-pro-review.md`, `F075-spec-devil-review.md`
 
 ---
+
+## v2.13 changelog (codex re-review round 13)
+
+Codex flagged 2 P2s on v2.12 — both SQLAlchemy idiom carryovers from the round-12 AsyncSession rewrite:
+
+- **P2 — Per-row `session.commit()` can release the lock-holding connection.** In AsyncSession with a connection pool, `commit()` can return the underlying physical connection to the pool. The session-scoped advisory lock (held on the original connection) would stay held until that pooled connection eventually closes, while the next `execute()` — including the final `pg_advisory_unlock` — could bind a *different* connection where the unlock is a no-op for the held lock. Result: lock leak; future runs skip indefinitely. Fixed: per-row commit replaced with per-batch commit. The session stays bound to a single physical connection through the lock+batch+unlock lifetime. Trade-off documented: a crash mid-batch loses ≤ batch_size in-flight UPDATEs, but re-runs pick them up via `event_date_classified_at IS NULL` (no data loss, just retry cost).
+- **P2 — Chunk-lookup SQL still used asyncpg `$1/$2/$3` placeholders.** Round-12 fixed `_process_batch` SELECT/UPDATE to SQLAlchemy `:name` binds, but the chunk-lookup snippet in §Layer 4 §Context source was missed. With `session.execute(text("..."), {...})`, `$1` placeholders are not bound and the query either fails or runs without parameters. Fixed: rewrote the snippet as an async helper using `:agent_id`, `:episode_id`, `:embedding` binds with explicit null-guards on `episode_id` and `embedding` for legacy rows.
 
 ## v2.12 changelog (codex re-review round 12)
 
@@ -561,12 +568,25 @@ async def _process_batch(
             """),
             {"event_date": classified, "id": row["id"]},  # event_date may be NULL
         )
-        await session.commit()  # per-row commit so a crash mid-loop preserves progress
         updated += 1
+
+    # Commit ONCE per batch, not per-row. Codex round-13 P2 catch: in
+    # AsyncSession with a connection pool, session.commit() can release the
+    # underlying connection back to the pool. The session-scoped advisory
+    # lock (held on the original physical connection) would stay held until
+    # the pooled connection is finally closed, while the next execute() —
+    # including the eventual pg_advisory_unlock — could bind a DIFFERENT
+    # connection where the unlock is a no-op. Per-batch commit keeps the
+    # session bound to the same connection throughout the lock+batch
+    # lifetime. Trade-off: a crash mid-batch loses the current batch's
+    # in-flight UPDATEs (≤ batch_size rows). Since eligibility is
+    # `event_date_classified_at IS NULL`, re-running the script picks up
+    # exactly those rows again — no data loss, just retry cost.
+    await session.commit()
     return (updated, False)
 ```
 
-Single SQLAlchemy session is used for the lock acquisition (`_run_batches`), the batch SELECT, the per-row UPDATE, and the lock release — consistent API throughout. F047 follows the exact same pattern at `actionability_backfill.py:78-205`.
+Single SQLAlchemy session is used for the lock acquisition (`_run_batches`), the batch SELECT, the per-row UPDATE, and the lock release — consistent API throughout. F047 follows the exact same per-batch commit pattern at `actionability_backfill.py:78-205`.
 
 `BudgetTracker` is a tiny class mirroring F047's bookkeeping (`actionability_backfill.py:48-65, 162-167`): initialized with `token_budget // _TOKENS_PER_LLM_CALL = max_calls`; `ok()` returns `remaining_calls > 0`; `consume(tokens)` decrements. The outer `_run_batches` loop exits cleanly when `_process_batch` returns `stop_requested=True`.
 
@@ -582,18 +602,45 @@ Use `call_background_llm_structured` from `nous/handlers/__init__.py:86` (or whe
 
 v1 fed `episode.summary[:500]` to the classifier. That suffers the same lossy-prose problem as Layer 1. v2 fetches the most-relevant `heart.episode_chunks` row for the fact. Codex round-10 catch: an ILIKE-on-`fact.subject` lookup is too brittle because LLM-generated subjects are descriptors, not verbatim transcript substrings — the spec's own example subject `OpenWeather API key acquisition` would not match the chunk text "I got my OpenWeather API key on March 10" because `acquisition` is absent. v2 uses **cosine similarity against the fact's existing embedding**, which is the matching strategy the rest of the codebase already uses for fact↔chunk relation:
 
-```sql
--- Per-row: nearest chunk in the source episode by embedding cosine distance.
--- pgvector <=> operator returns cosine distance (smaller = closer);
--- fact.embedding is already SELECTed in the batch query above and passed as $3.
-SELECT content
-FROM heart.episode_chunks
-WHERE agent_id = $1 AND episode_id = $2
-ORDER BY embedding <=> $3::vector
-LIMIT 1;
+```python
+# Codex round-13 P2 catch: SQLAlchemy text() requires :name binds, not
+# asyncpg $1/$2/$3. The chunk lookup runs on the same locked AsyncSession
+# from _run_batches, so it must use the same binding style as the
+# _process_batch SELECT/UPDATE above.
+async def _fetch_chunk_context(
+    session: AsyncSession,
+    agent_id: str,
+    episode_id: UUID | None,
+    embedding,            # fact.embedding from the batch row; may be None
+) -> str | None:
+    """Nearest chunk in the source episode by cosine to fact.embedding.
+
+    Returns None when episode_id is NULL (legacy facts without source
+    episode), embedding is NULL (pre-large-embedding-rollout rows), or
+    no chunk matches. Callers fall back to fact.content as primary signal.
+    """
+    if episode_id is None or embedding is None:
+        return None
+    result = await session.execute(
+        text("""
+            SELECT content
+            FROM heart.episode_chunks
+            WHERE agent_id = :agent_id
+              AND episode_id = :episode_id
+            ORDER BY embedding <=> CAST(:embedding AS vector)
+            LIMIT 1
+        """),
+        {
+            "agent_id": agent_id,
+            "episode_id": episode_id,
+            "embedding": embedding,
+        },
+    )
+    row = result.first()
+    return row[0] if row else None
 ```
 
-Feeds raw chunk text (up to ~600 chars) to the classifier instead of the lossy 500-char summary slice. Works even when the subject is a paraphrase of the underlying transcript event — the embedding already captures semantic similarity. Falls back to no chunk only when the fact has no embedding (legacy rows pre-text-embedding-3-large rollout) or the episode has zero chunks; in either case the classifier still gets `fact.content` as primary signal.
+Feeds raw chunk text (up to ~600 chars) to the classifier instead of the lossy 500-char summary slice. Works even when the subject is a paraphrase of the underlying transcript event — the embedding already captures semantic similarity. Two explicit null-guards (`episode_id is None`, `embedding is None`) protect legacy rows from issuing a malformed cosine query.
 
 #### CLI shape
 

--- a/docs/features/F075-temporal-fact-extraction.md
+++ b/docs/features/F075-temporal-fact-extraction.md
@@ -1,6 +1,6 @@
 # F075 — Temporal Fact Extraction + Date-Aware Retrieval
 
-**Status:** 📝 Draft **v2.2** (2026-05-27) — incorporates arch / python-pro / devil's-advocate spec review + 2 rounds of codex PR review fixes
+**Status:** 📝 Draft **v2.3** (2026-05-27) — incorporates arch / python-pro / devil's-advocate spec review + 3 rounds of codex PR review fixes
 **Proposed by:** Tim + investigation thread
 **Date:** 2026-05-27
 **Depends on:** F002 (Heart), F022 (Cross-type linking), F040 (Graph Densifier), F047 (Actionability backfill pattern), F051 (Eval harness for measurement)
@@ -10,6 +10,13 @@
 **Reviews:** `docs/reviews/F075-spec-arch-review.md`, `F075-spec-python-pro-review.md`, `F075-spec-devil-review.md`
 
 ---
+
+## v2.3 changelog (codex re-review round 3)
+
+After v2.2 push, codex flagged 2 more P2s. All incorporated:
+
+- **P2 — Wrong `GraphDensifier.run_backfill_cycle` call shape.** v2.2's edge-build trigger wrote `densifier.run_backfill_cycle(agent_id=...)` but `run_backfill_cycle()` at `graph_densifier.py:1045` takes no args — `agent_id` is captured in the constructor (`graph_densifier.py:108-119`). Calling with `agent_id=` would `TypeError`. Fixed: §Edge-build trigger now shows the correct per-agent instantiation pattern, mirroring `sleep_handler.py:1354`.
+- **P2 — ORM `CheckConstraint` not updated alongside SQL migration.** The SQLAlchemy `GraphEdge` class at `models.py:239-244` declares its own `ck_edges_relation` that fresh-schema paths (`Base.metadata.create_all` in tests, Alembic autogenerate) honor. v2.2's spec only updated the migration SQL. Pre-existing drift: the ORM constraint was never updated for F070's `part_of`/`summarized_by` either. Fixed: §Schema migration now requires updating the ORM `CheckConstraint` to include all three missing relations (`part_of`, `summarized_by`, `happened_before`).
 
 ## v2.2 changelog (codex re-review round 2)
 
@@ -422,7 +429,19 @@ uv run python scripts/backfill_temporal_facts.py \
 
 #### Edge-build trigger
 
-At end-of-script (post Layer 1 column populated), call `GraphDensifier.run_backfill_cycle(agent_id=...)` synchronously to build `happened_before` edges. Cleaner end-state than deferring to next sleep.
+At end-of-script (post Layer 1 column populated), build `happened_before` edges synchronously. `GraphDensifier` captures `agent_id` in its constructor (`graph_densifier.py:108-119`) and `run_backfill_cycle()` itself takes no args (`graph_densifier.py:1045`) — the call shape mirrors `sleep_handler.py:1354`:
+
+```python
+# In the backfill script, after all rows have been classified for the agent:
+from nous.brain.graph_densifier import GraphDensifier
+from nous.brain.graph_linker import GraphLinker
+
+graph_linker = GraphLinker(db, embedder, settings, agent_id)
+densifier = GraphDensifier(db, graph_linker, embedder, settings, agent_id)
+result = await densifier.run_backfill_cycle()
+```
+
+The densifier instance is agent-scoped; running it post-classification ensures any `happened_before` edges between newly-dated facts are written before the script exits.
 
 ---
 
@@ -476,6 +495,21 @@ Partial indexes:
 - `idx_facts_event_date_unclassified_agent` accelerates backfill's eligibility query (`WHERE event_date_classified_at IS NULL ORDER BY learned_at DESC LIMIT N`).
 
 The relation CHECK extension is required by Layer 2's INSERT — without it the edge build raises a constraint violation. The pattern matches F070's migration 051 verbatim.
+
+**ORM CheckConstraint must also be updated** (`nous/storage/models.py:239-244`). The SQLAlchemy `GraphEdge.__table_args__` declares its own `ck_edges_relation` constraint that is currently **stale** — it still lists only the init.sql-era relations and was not updated when F070's migration 051 added `part_of` and `summarized_by`. Any fresh-schema path (tests using `Base.metadata.create_all`, future Alembic autogenerate) would reject all three relations.
+
+F075 brings the ORM fully current:
+
+```python
+# nous/storage/models.py — GraphEdge.__table_args__
+CheckConstraint(
+    "relation IN ('supports', 'contradicts', 'supersedes', 'related_to', 'caused_by', "
+    "'informed_by', 'evidence_for', 'discussed_in', 'extracted_from', "
+    "'part_of', 'summarized_by', "             # F070 catch-up
+    "'happened_before')",                       # F075 addition
+    name="ck_edges_relation",
+),
+```
 
 Style matches `052_f069_document_source_kind.sql:22,34`.
 

--- a/docs/features/F075-temporal-fact-extraction.md
+++ b/docs/features/F075-temporal-fact-extraction.md
@@ -1,6 +1,6 @@
 # F075 — Temporal Fact Extraction + Date-Aware Retrieval
 
-**Status:** 📝 Draft **v2.5** (2026-05-27) — incorporates arch / python-pro / devil's-advocate spec review + 5 rounds of codex PR review fixes
+**Status:** 📝 Draft **v2.6** (2026-05-27) — incorporates arch / python-pro / devil's-advocate spec review + 6 rounds of codex PR review fixes
 **Proposed by:** Tim + investigation thread
 **Date:** 2026-05-27
 **Depends on:** F002 (Heart), F022 (Cross-type linking), F040 (Graph Densifier), F047 (Actionability backfill pattern), F051 (Eval harness for measurement)
@@ -10,6 +10,14 @@
 **Reviews:** `docs/reviews/F075-spec-arch-review.md`, `F075-spec-python-pro-review.md`, `F075-spec-devil-review.md`
 
 ---
+
+## v2.6 changelog (codex re-review round 6)
+
+Codex flagged 3 more P2s on v2.5. All incorporated:
+
+- **P2 — Layer 3 tests in required set but Layer 3 is deferred.** v2.5 §Tests listed `tests/test_date_aware_boost.py` as required even though §Layer 3 is explicitly "If implemented later" deferred. CI would either fail against missing date-boost code or force the implementer to ship the deferred feature. Fixed: `test_date_aware_boost.py` now explicitly tagged as DEFERRED with Layer 3 — it ships when Layer 3 does.
+- **P2 — `event_date_classified_at` write also needs flag-gating.** v2.5's §Layer 1 thread-through unconditionally stamps the marker on every fact write, but when the flag is OFF the row was NOT actually classified (legacy prompt was used). A later flag-flip + backfill would skip those rows forever via `event_date_classified_at IS NULL`. Fixed: live-path write is gated on `settings.temporal_extraction_enabled` — flag-off keeps the column NULL so rows remain eligible for catch-up classification.
+- **P2 — Advisory lock variant wrong for multi-batch backfill.** v2.5 specified `pg_try_advisory_xact_lock` but that releases at the end of each per-row UPDATE transaction, letting concurrent CLI invocations interleave mid-loop. F047's `actionability_backfill.py:79, 97` uses session-scoped `pg_try_advisory_lock` + explicit `pg_advisory_unlock` for exactly this multi-batch shape. F049 uses xact_lock correctly because all work is in one short sweep — different pattern. Fixed: §Layer 4 advisory lock section now shows the F047 session-scoped pattern verbatim with explicit unlock in a try/finally.
 
 ## v2.5 changelog (codex re-review round 5)
 
@@ -229,7 +237,7 @@ Per Arch P1-1's enumeration:
 | 11 | `nous/handlers/fact_extractor.py:189-196` (Layer 1b direct path) | The fallback `FactInput(...)` construction must also pass `event_date=fact.get("event_date")`. This path does NOT go through `_store_candidate_facts`, so step 2 alone doesn't cover it. Without this, eval / direct-ingest traffic that bypasses the summarizer silently discards extracted dates. |
 | 12 | `nous/api/retrieval_pipeline.py:659-669` (`_heart_results_to_pipeline`) | Copy `event_date` from `RecallResult.metadata` into the new `PipelineResult.metadata` dict. Today the conversion drops metadata entirely. Layer 3's `r.metadata.get("event_date")` reads from `PipelineResult`, so the field must survive the conversion. |
 
-**Plus**: `FactManager._learn` sets `event_date_classified_at = datetime.now(UTC)` on every fact write whose extraction path can produce dates (i.e., the new summarizer/extractor codepath always marks the row classified, even when `event_date` ends up `None`). This keeps newly-ingested facts out of the Layer 4 backfill eligibility set.
+**Plus**: when `settings.temporal_extraction_enabled = True`, `FactManager._learn` sets `event_date_classified_at = datetime.now(UTC)` on every fact write (the new codepath always marks the row classified, even when `event_date` ends up `None`). When the flag is `False`, `event_date_classified_at` stays `NULL` — the row was NOT actually classified (legacy prompt was used) so it must remain eligible for the Layer 4 backfill when the flag is later flipped on. Without this gating, dark-launched ingests would stamp the marker on rows that never saw the new extractor, then a post-launch backfill would skip them forever via the `event_date_classified_at IS NULL` predicate.
 
 **Plus (Codex v2.1 review):** the summarizer's LLM call must receive `Episode.started_at` so it can resolve relative dates ("yesterday", "last Tuesday") deterministically. Current chain `summarize_episode → _generate_summary(transcript, decision_context) → _summarize_single(transcript, decision_context)` (lines 135, 361, 394) carries neither the episode object nor `started_at`. Wire path additions for relative-date resolution — every hop must be touched, including the intermediate `_generate_summary` boundary that codex flagged in round 4:
 
@@ -380,7 +388,26 @@ def _advisory_lock_key(agent_id: str) -> int:
     return int.from_bytes(digest, byteorder="big", signed=True)
 ```
 
-`async with db.transaction()` + `SELECT pg_try_advisory_xact_lock($1)` with this key. Mirrors F047 + F049 patterns exactly.
+**Use session-scoped `pg_try_advisory_lock` + explicit `pg_advisory_unlock` at end-of-`_run_batches`, NOT the transaction-scoped `xact` variant.** Codex round-6 catch: this script's batch loop spans many per-row UPDATE transactions, each committing independently. A `pg_try_advisory_xact_lock` would release at the end of every per-row UPDATE transaction, letting a second concurrent CLI invocation acquire the lock mid-loop and interleave. F047's `actionability_backfill.py:79, 97` uses the session-scoped variant for exactly this reason. F049's working_memory sweep uses xact_lock correctly because it does all work inside one short transaction — different shape.
+
+```python
+# Pattern (mirrors actionability_backfill.py:79-97 verbatim):
+async with db.session() as session:
+    locked = await session.execute(
+        text("SELECT pg_try_advisory_lock(:k)"),
+        {"k": _advisory_lock_key(agent_id)},
+    )
+    if not locked.scalar():
+        logger.info("F075 backfill: another process holds the lock for %s, exiting", agent_id)
+        return
+    try:
+        await _run_batches(session, agent_id, batch_size, token_budget)
+    finally:
+        await session.execute(
+            text("SELECT pg_advisory_unlock(:k)"),
+            {"k": _advisory_lock_key(agent_id)},
+        )
+```
 
 #### Per-row UPDATE (Python P1-2 fix) + classification-state marker (Codex P1 fix)
 
@@ -605,18 +632,20 @@ temporal_backfill_default_token_budget: int = Field(
 - ON CONFLICT DO NOTHING prevents duplicate edges on re-run
 
 **`tests/test_temporal_backfill.py`** (new):
-- Advisory lock (mocked `pg_try_advisory_xact_lock`) prevents concurrent backfills
+- Advisory lock (mocked `pg_try_advisory_lock` + `pg_advisory_unlock`) prevents concurrent backfills
 - Token budget exhausted → clean halt, no partial-row corruption
 - Dry-run produces estimate without LLM calls
 - NULL-only filter means re-running picks up only unprocessed rows
 - Chunk context source (not summary) — verified via mock chunk lookup
 
-**`tests/test_date_aware_boost.py`** (new, Layer 3 deferred but tests stay):
+**`tests/test_date_aware_boost.py`** — DEFERRED with Layer 3 (codex round-6 fix). The test set above and acceptance criterion #1 cover Layers 1+2+4 only. When Layer 3 ships (after measurement gate), its impl PR adds:
 - Query "how many days between" detects as date-arithmetic
 - Query "OpenWeather endpoints" produces no window
 - Fact with event_date in window: `(score or 0.0) * factor`
 - Fact outside window untouched
 - Re-sort stable when no boosts applied; missing scores coalesce to 0.0
+
+This keeps F075 v1 internally consistent — the required test set matches the implemented scope, so CI doesn't fail against missing date-boost code or force the deferred feature to ship.
 
 **Integration test in `tests/test_f075_end_to_end.py`:**
 - Ingest a fixture conversation with explicit date references

--- a/docs/features/F075-temporal-fact-extraction.md
+++ b/docs/features/F075-temporal-fact-extraction.md
@@ -1,6 +1,6 @@
 # F075 — Temporal Fact Extraction + Date-Aware Retrieval
 
-**Status:** 📝 Draft **v2.16** (2026-05-28) — incorporates arch / python-pro / devil's-advocate spec review + 16 rounds of codex PR review fixes
+**Status:** 📝 Draft **v2.17** (2026-05-28) — incorporates arch / python-pro / devil's-advocate spec review + 17 rounds of codex PR review fixes
 **Proposed by:** Tim + investigation thread
 **Date:** 2026-05-27
 **Depends on:** F002 (Heart), F022 (Cross-type linking), F040 (Graph Densifier), F047 (Actionability backfill pattern), F051 (Eval harness for measurement)
@@ -10,6 +10,12 @@
 **Reviews:** `docs/reviews/F075-spec-arch-review.md`, `F075-spec-python-pro-review.md`, `F075-spec-devil-review.md`
 
 ---
+
+## v2.17 changelog (codex re-review round 17)
+
+Codex flagged 1 P2 on v2.16, validated by tracing the unit math:
+
+- **P2 — BudgetTracker unit mismatch.** v2.15-v2.16 initialized with `BudgetTracker(token_budget // _TOKENS_PER_LLM_CALL)` (CALL count, e.g. 200 calls for a 50K-token budget) but `_process_batch` called `budget.consume(_TOKENS_PER_LLM_CALL)` (TOKEN count, e.g. 250). After the first classification, the counter went `200 - 250 = -50`, `ok()` returned False, the loop exited with ~199 calls unused. At `--token-budget 50000` only ~1 row got processed. Fixed: `consume()` is now no-arg and decrements `remaining_calls` by 1; added explicit class definition to the spec so units are unambiguous.
 
 ## v2.16 changelog (codex re-review round 16)
 
@@ -625,7 +631,7 @@ async def _process_batch(
             row["embedding"],
         )
         classified = await _classify_event_date(row, chunk_context=chunk_ctx)  # date | None
-        budget.consume(_TOKENS_PER_LLM_CALL)
+        budget.consume()  # decrement remaining_calls by 1
 
         # ALWAYS mark classified — even when no date found. This is what
         # prevents re-processing the same stable facts on subsequent batches.
@@ -652,7 +658,25 @@ async def _process_batch(
 
 The work session is short-lived (one batch) and never touches `pg_advisory_lock`. The lock-holding `lock_conn` (in `_run_with_lock`) is the only connection that ever issues lock/unlock calls — never commits data.
 
-`BudgetTracker` is a tiny class mirroring F047's bookkeeping (`actionability_backfill.py:48-65, 162-167`): initialized with `token_budget // _TOKENS_PER_LLM_CALL = max_calls`; `ok()` returns `remaining_calls > 0`; `consume(tokens)` decrements. The outer `_run_batches` loop exits cleanly when `_process_batch` returns `stop_requested=True`.
+`BudgetTracker` is a tiny class mirroring F047's bookkeeping (`actionability_backfill.py:48-65, 162-167`): initialized with `remaining_calls = token_budget // _TOKENS_PER_LLM_CALL`; `ok()` returns `remaining_calls > 0`; `consume()` (no-arg) decrements `remaining_calls` by 1. The outer `_run_batches` loop exits cleanly when `_process_batch` returns `stop_requested=True`.
+
+```python
+# Codex round-17 P2 catch: units must match. v2.15-v2.16 init'd with
+# call-count (token_budget // _TOKENS_PER_LLM_CALL) but consume() took
+# a token count. First classification subtracted _TOKENS_PER_LLM_CALL
+# from a counter sized in calls (e.g. consume(250) on a 200-call cap)
+# → ok() goes false after one call → ~199 calls unused at budget=50000.
+
+class BudgetTracker:
+    def __init__(self, max_calls: int) -> None:
+        self.remaining_calls = max_calls
+
+    def ok(self) -> bool:
+        return self.remaining_calls > 0
+
+    def consume(self) -> None:
+        self.remaining_calls -= 1
+```
 
 This makes the script terminate cleanly (every batch advances the eligibility cursor) and remains idempotent (re-runs only pick up rows still at `event_date_classified_at IS NULL`, which by definition haven't been tried).
 

--- a/docs/features/F075-temporal-fact-extraction.md
+++ b/docs/features/F075-temporal-fact-extraction.md
@@ -1,6 +1,6 @@
 # F075 — Temporal Fact Extraction + Date-Aware Retrieval
 
-**Status:** 📝 Draft **v2.9** (2026-05-28) — incorporates arch / python-pro / devil's-advocate spec review + 9 rounds of codex PR review fixes
+**Status:** 📝 Draft **v2.10** (2026-05-28) — incorporates arch / python-pro / devil's-advocate spec review + 10 rounds of codex PR review fixes
 **Proposed by:** Tim + investigation thread
 **Date:** 2026-05-27
 **Depends on:** F002 (Heart), F022 (Cross-type linking), F040 (Graph Densifier), F047 (Actionability backfill pattern), F051 (Eval harness for measurement)
@@ -10,6 +10,14 @@
 **Reviews:** `docs/reviews/F075-spec-arch-review.md`, `F075-spec-python-pro-review.md`, `F075-spec-devil-review.md`
 
 ---
+
+## v2.10 changelog (codex re-review round 10)
+
+Codex flagged 1 P1 (material) + 2 P2s on v2.9:
+
+- **P1 — Multi-chunk merge truncates dated facts before FactExtractor sees them.** For transcripts exceeding `transcript_max_chars` (16K default), `EpisodeSummarizer._merge_summaries` at `episode_summarizer.py:445-468` summarizes chunks separately and returns `merged_candidate_facts[:5]` in chunk order. Dated events from later chunks are dropped — exactly the BEAM-100K case F075 targets. Fixed: wire path row 13 added — `_merge_summaries` stable-partitions the merged list so `event_date IS not None` candidates sort first BEFORE the [:5] truncation. Python's stable sort with `key=lambda c: c.get("event_date") is None` (False < True) puts dated facts at the front in their original chunk order; truncation then drops stable-fact tail, never dated-fact tail.
+- **P2 — Token budget exhaustion checked only between batches.** v2.9's `_process_batch` had no per-row budget gate, so a small `--token-budget` would be exceeded by up to a full batch (or unbounded if the outer loop kept invoking). F047 mirrors this exact pattern via `classifier._budget_check` at `actionability_backfill.py:57-65`. Fixed: `_process_batch` now takes a `BudgetTracker`, calls `budget.ok()` before every `_classify_event_date(row)`, and returns `(updated, stop_requested)` so the outer loop can halt cleanly.
+- **P2 — Subject-ILIKE chunk lookup too brittle for LLM-generated subjects.** v2.9's `WHERE content ILIKE '%' || subject || '%'` fails when the subject is a descriptor not a verbatim transcript substring — `OpenWeather API key acquisition` doesn't appear in "I got my OpenWeather API key on March 10" because `acquisition` is absent. Fixed: switched to pgvector cosine distance against `fact.embedding` (already SELECTed in the batch query). Matches the rest of the codebase's fact↔chunk semantic-similarity pattern. Falls back gracefully when fact has no embedding (legacy rows).
 
 ## v2.9 changelog (codex re-review round 9)
 
@@ -257,6 +265,7 @@ Per Arch P1-1's enumeration:
 | 10 | `nous/heart/facts.py` `_to_recall_result` path | `RecallResult.metadata["event_date"] = fact.event_date.isoformat() if fact.event_date else None` so Layer 3 boost has the field to read |
 | 11 | `nous/handlers/fact_extractor.py:189-196` (Layer 1b direct path) | The fallback `FactInput(...)` construction must also pass `event_date=fact.get("event_date")` AND `event_date_classified_at=datetime.now(UTC)` (gated on `settings.temporal_extraction_enabled`). This path does NOT go through `_store_candidate_facts`, so step 2 alone doesn't cover it. Without this, eval / direct-ingest traffic that bypasses the summarizer silently discards extracted dates. |
 | 12 | `nous/api/retrieval_pipeline.py:659-669` (`_heart_results_to_pipeline`) | Copy `event_date` from `RecallResult.metadata` into the new `PipelineResult.metadata` dict. Today the conversion drops metadata entirely. Layer 3's `r.metadata.get("event_date")` reads from `PipelineResult`, so the field must survive the conversion. |
+| 13 | `nous/handlers/episode_summarizer.py:445-468` (`_merge_summaries`) | **P1 — multi-chunk merge truncation.** For transcripts exceeding `transcript_max_chars` (16K default), the summarizer summarizes chunks separately and `_merge_summaries` returns `merged_candidate_facts[:5]` in chunk order — dated events from later chunks get dropped before FactExtractor sees them. This is the exact case F075 targets (BEAM-100K conversations routinely exceed 16K). Fix: stable-partition the merged list so candidates with `event_date IS not None` sort first, THEN truncate. Pseudocode: `merged_candidate_facts.sort(key=lambda c: c.get("event_date") is None)` (Python sort is stable — False < True, so dated facts stay in their original chunk order at the front). Truncation then drops stable-fact tail, not dated-fact tail. |
 
 **Plus — marker write site (Codex round-9 fix):** `event_date_classified_at` must be populated by **F075 producers only**, NOT by a generic write inside `FactManager._learn`. Multiple unrelated paths call `Heart.learn(FactInput(...))` directly — `nous/api/tools.py:516` (`learn_fact` tool), `nous/api/rest.py:1722` (REST endpoint), `nous/handlers/knowledge_extractor.py:127` (pre-prune extraction) — none of which run the F075 classifier. If `_learn` blindly stamped `event_date_classified_at = NOW()` for every write when the flag is on, those rows would be falsely marked "F075-classified" and skipped by the backfill forever.
 
@@ -473,10 +482,15 @@ v1's `WHERE id = (SELECT id FROM batch)` was broken for `LIMIT > 1`. v2 copies F
 Fix: the schema adds `event_date_classified_at TIMESTAMPTZ` (see §Schema migration). The backfill writes it on every classification attempt regardless of outcome. Eligibility uses `event_date_classified_at IS NULL` (not `event_date IS NULL`).
 
 ```python
-# Pseudo-code; concrete sites verified against F047
-async def _process_batch(conn, agent_id: str, batch_size: int) -> int:
+# Pseudo-code; concrete sites verified against F047 (actionability_backfill.py:48-65)
+async def _process_batch(
+    conn,
+    agent_id: str,
+    batch_size: int,
+    budget: BudgetTracker,  # injected by _run_batches; F047 pattern
+) -> tuple[int, bool]:    # (updated_rows, stop_requested)
     rows = await conn.fetch("""
-        SELECT id, subject, content, source_episode_id
+        SELECT id, subject, content, embedding, source_episode_id
         FROM heart.facts
         WHERE agent_id = $1
           AND event_date_classified_at IS NULL  -- eligibility = "never tried"
@@ -487,7 +501,21 @@ async def _process_batch(conn, agent_id: str, batch_size: int) -> int:
 
     updated = 0
     for row in rows:
+        # Codex round-10 P2 catch: check budget BEFORE every LLM call, not
+        # just between batches. Mirrors F047's classifier._budget_check
+        # gate at actionability_backfill.py:57-65 — without this, a small
+        # --token-budget gets exceeded by up to a full batch worth of
+        # rows (or unbounded if the outer loop keeps invoking).
+        if not budget.ok():
+            logger.info(
+                "F075 backfill: token budget exhausted, stopping at %d rows",
+                updated,
+            )
+            return (updated, True)  # signal _run_batches to halt
+
         result = await _classify_event_date(row)  # returns date | None
+        budget.consume(_TOKENS_PER_LLM_CALL)
+
         # ALWAYS mark classified — even when no date found. This is what
         # prevents re-processing the same stable facts on subsequent batches.
         await conn.execute("""
@@ -498,8 +526,10 @@ async def _process_batch(conn, agent_id: str, batch_size: int) -> int:
             WHERE id = $2
         """, result, row["id"])  # $1 may be NULL — that's correct
         updated += 1
-    return updated
+    return (updated, False)
 ```
+
+`BudgetTracker` is a tiny class mirroring F047's bookkeeping (`actionability_backfill.py:48-65, 162-167`): initialized with `token_budget // _TOKENS_PER_LLM_CALL = max_calls`; `ok()` returns `remaining_calls > 0`; `consume(tokens)` decrements. The outer `_run_batches` loop exits cleanly when `_process_batch` returns `stop_requested=True`.
 
 This makes the script terminate cleanly (every batch advances the eligibility cursor) and remains idempotent (re-runs only pick up rows still at `event_date_classified_at IS NULL`, which by definition haven't been tried).
 
@@ -511,19 +541,20 @@ Use `call_background_llm_structured` from `nous/handlers/__init__.py:86` (or whe
 
 #### Context source (Arch P2-1 / Python P2 — chunk context, not summary)
 
-v1 fed `episode.summary[:500]` to the classifier. That suffers the same lossy-prose problem as Layer 1. v2 fetches the most-relevant `heart.episode_chunks` row for the fact (best chunk by content similarity OR by simply selecting the chunk whose content contains the candidate entity/action):
+v1 fed `episode.summary[:500]` to the classifier. That suffers the same lossy-prose problem as Layer 1. v2 fetches the most-relevant `heart.episode_chunks` row for the fact. Codex round-10 catch: an ILIKE-on-`fact.subject` lookup is too brittle because LLM-generated subjects are descriptors, not verbatim transcript substrings — the spec's own example subject `OpenWeather API key acquisition` would not match the chunk text "I got my OpenWeather API key on March 10" because `acquisition` is absent. v2 uses **cosine similarity against the fact's existing embedding**, which is the matching strategy the rest of the codebase already uses for fact↔chunk relation:
 
 ```sql
--- Per-row: find chunks containing the fact's subject keywords
+-- Per-row: nearest chunk in the source episode by embedding cosine distance.
+-- pgvector <=> operator returns cosine distance (smaller = closer);
+-- fact.embedding is already SELECTed in the batch query above and passed as $3.
 SELECT content
 FROM heart.episode_chunks
 WHERE agent_id = $1 AND episode_id = $2
-  AND content ILIKE '%' || $3 || '%'  -- subject as keyword
-ORDER BY chunk_index
+ORDER BY embedding <=> $3::vector
 LIMIT 1;
 ```
 
-Feeds raw chunk text (up to ~600 chars) to the classifier instead of the lossy 500-char summary slice.
+Feeds raw chunk text (up to ~600 chars) to the classifier instead of the lossy 500-char summary slice. Works even when the subject is a paraphrase of the underlying transcript event — the embedding already captures semantic similarity. Falls back to no chunk only when the fact has no embedding (legacy rows pre-text-embedding-3-large rollout) or the episode has zero chunks; in either case the classifier still gets `fact.content` as primary signal.
 
 #### CLI shape
 

--- a/docs/features/F075-temporal-fact-extraction.md
+++ b/docs/features/F075-temporal-fact-extraction.md
@@ -1,6 +1,6 @@
 # F075 — Temporal Fact Extraction + Date-Aware Retrieval
 
-**Status:** 📝 Draft **v2.3** (2026-05-27) — incorporates arch / python-pro / devil's-advocate spec review + 3 rounds of codex PR review fixes
+**Status:** 📝 Draft **v2.4** (2026-05-27) — incorporates arch / python-pro / devil's-advocate spec review + 4 rounds of codex PR review fixes
 **Proposed by:** Tim + investigation thread
 **Date:** 2026-05-27
 **Depends on:** F002 (Heart), F022 (Cross-type linking), F040 (Graph Densifier), F047 (Actionability backfill pattern), F051 (Eval harness for measurement)
@@ -10,6 +10,13 @@
 **Reviews:** `docs/reviews/F075-spec-arch-review.md`, `F075-spec-python-pro-review.md`, `F075-spec-devil-review.md`
 
 ---
+
+## v2.4 changelog (codex re-review round 4)
+
+Codex flagged 2 more P2s on v2.3, both wire-path completeness issues. All incorporated:
+
+- **P2 — `_generate_summary` boundary missing from started_at wire path.** v2.2 added `episode_summarizer.py:377, 383, 394` to thread `started_at`, but skipped `summarize_episode → _generate_summary` (lines 135 and 361). `episode.started_at` is in scope at the outer boundary but never reaches `_summarize_single` without threading through the intermediate `_generate_summary` signature. Fixed: wire path now has 5 hops covering every boundary in the chain (135, 361, 377, 383, 394 + prompt template at 50-77).
+- **P2 — FactSummary / FactDetail constructors silently default `event_date=None`.** Adding `event_date` to the schemas isn't enough; each manual `FactSummary(...)` call at 4 sites in `nous/heart/facts.py` (lines 1046, 1160, 1256, 1355) plus `_to_detail` (line 1459) must pass `event_date=fact.event_date`. Without these, the recall surface returns None even when the DB column is populated, making Layer 3 boost and the end-to-end integration test silent failures. Fixed: wire-path table extended with rows 8-10 covering all construction sites + `RecallResult.metadata["event_date"]` serialization.
 
 ## v2.3 changelog (codex re-review round 3)
 
@@ -204,18 +211,23 @@ Per Arch P1-1's enumeration:
 | 5 | `nous/storage/models.py:469-511` | `Fact` ORM adds `event_date: Mapped[date \| None] = mapped_column(Date, nullable=True)` AND `event_date_classified_at: Mapped[datetime \| None] = mapped_column(DateTime(timezone=True), nullable=True)` |
 | 6 | `sql/migrations/053_temporal_fact_extraction.sql` | `ALTER TABLE heart.facts ADD COLUMN event_date DATE + event_date_classified_at TIMESTAMPTZ` + partial indexes + extend `brain.graph_edges` relation CHECK to add `'happened_before'` |
 | 7 | `nous/heart/schemas.py:114-165` | `FactDetail` and `FactSummary` add `event_date: date \| None = None` |
+| 8 | `nous/heart/facts.py:1046, 1160, 1256, 1355` | Each `FactSummary(...)` constructor passes `event_date=fact.event_date` (4 sites). Optional field defaults to None silently otherwise → recall surface returns None even when DB column populated |
+| 9 | `nous/heart/facts.py:1459` (`_to_detail`) | Pass `event_date=fact.event_date` to `FactDetail` construction |
+| 10 | `nous/heart/facts.py` `_to_recall_result` path | `RecallResult.metadata["event_date"] = fact.event_date.isoformat() if fact.event_date else None` so Layer 3 boost has the field to read |
 
 **Plus**: `FactManager._learn` sets `event_date_classified_at = datetime.now(UTC)` on every fact write whose extraction path can produce dates (i.e., the new summarizer/extractor codepath always marks the row classified, even when `event_date` ends up `None`). This keeps newly-ingested facts out of the Layer 4 backfill eligibility set.
 
-**Plus (Codex v2.1 review):** the summarizer's LLM call must receive `Episode.started_at` so it can resolve relative dates ("yesterday", "last Tuesday") deterministically. Current signature `_summarize_single(transcript, decision_context)` at `episode_summarizer.py:394` doesn't take it. Wire path additions for relative-date resolution:
+**Plus (Codex v2.1 review):** the summarizer's LLM call must receive `Episode.started_at` so it can resolve relative dates ("yesterday", "last Tuesday") deterministically. Current chain `summarize_episode → _generate_summary(transcript, decision_context) → _summarize_single(transcript, decision_context)` (lines 135, 361, 394) carries neither the episode object nor `started_at`. Wire path additions for relative-date resolution — every hop must be touched, including the intermediate `_generate_summary` boundary that codex flagged in round 4:
 
 | File:Line | Change |
 |---|---|
-| `episode_summarizer.py:377, 383` | Pass `started_at=episode.started_at` to `_summarize_single` calls |
-| `episode_summarizer.py:394` | `_summarize_single(transcript, decision_context, started_at: datetime)` signature |
-| `episode_summarizer.py:50-77` | Prompt template includes `EPISODE_START_TIMESTAMP: {started_at.isoformat()}` block above the transcript so the LLM has a deterministic anchor for relative-date resolution |
+| `episode_summarizer.py:135` | Pass `started_at=episode.started_at` to `_generate_summary` call from `summarize_episode` |
+| `episode_summarizer.py:361` | `_generate_summary(transcript, decision_context, started_at: datetime \| None = None)` signature |
+| `episode_summarizer.py:377, 383` | Pass `started_at=started_at` through to `_summarize_single` calls |
+| `episode_summarizer.py:394` | `_summarize_single(transcript, decision_context, started_at: datetime \| None = None)` signature |
+| `episode_summarizer.py:50-77` | Prompt template includes `EPISODE_START_TIMESTAMP: {started_at.isoformat()}` block above the transcript when `started_at is not None` |
 
-Without this thread-through, the prompt's "resolve relative phrases against EPISODE_START_TIMESTAMP" instruction has no value to anchor against and dates from transcripts like "deployed yesterday" become guesses.
+Without thread-through at every hop, the prompt's "resolve relative phrases against EPISODE_START_TIMESTAMP" instruction has nothing to anchor against and dates from transcripts like "deployed yesterday" become guesses. Skipping the `_generate_summary` boundary means the value never enters scope at the inner call.
 
 **Plus** Heart.recall surface (Python P1-4): when serializing recall results, `RecallResult.metadata["event_date"]` must be populated with the iso string (or absent if None). Without this, Layer 3 is silent no-op.
 

--- a/docs/features/F075-temporal-fact-extraction.md
+++ b/docs/features/F075-temporal-fact-extraction.md
@@ -1,6 +1,6 @@
 # F075 — Temporal Fact Extraction + Date-Aware Retrieval
 
-**Status:** 📝 Draft **v2.10** (2026-05-28) — incorporates arch / python-pro / devil's-advocate spec review + 10 rounds of codex PR review fixes
+**Status:** 📝 Draft **v2.11** (2026-05-28) — incorporates arch / python-pro / devil's-advocate spec review + 11 rounds of codex PR review fixes
 **Proposed by:** Tim + investigation thread
 **Date:** 2026-05-27
 **Depends on:** F002 (Heart), F022 (Cross-type linking), F040 (Graph Densifier), F047 (Actionability backfill pattern), F051 (Eval harness for measurement)
@@ -10,6 +10,13 @@
 **Reviews:** `docs/reviews/F075-spec-arch-review.md`, `F075-spec-python-pro-review.md`, `F075-spec-devil-review.md`
 
 ---
+
+## v2.11 changelog (codex re-review round 11)
+
+Codex flagged 1 P1 (refinement of round-10) + 1 P2 on v2.10:
+
+- **P1 — Round-10's partition-then-`[:5]` fix is STILL insufficient.** v2.10 sorted dated facts first then truncated at `[:5]`. But if a transcript contains MORE than 5 dated events, the 6th-onward dated facts are still dropped. F075 explicitly targets long multi-day haystacks where 5 dated events is well below typical density. Fixed: split candidates into separate pools — `dated[:candidate_facts_event_limit] + stable[:5]`. Default event-limit = **30** (configurable via new `NOUS_CANDIDATE_FACTS_EVENT_LIMIT`). Stable cap stays at 5.
+- **P2 — Dedup/supersession ignores `event_date`, collapsing distinct-date events.** `Heart._learn` dedup uses embedding cosine ≥ 0.80 and supersession uses subject match — neither considers `event_date`. Two facts like *"Christina obtained API key on March 10"* vs *"Christina rotated API key on March 12"* have high embedding similarity AND collide on subject, so the second silently drops or supersedes the first. **The exact date-pair temporal_reasoning needs is destroyed.** Fixed: added rule — when both candidate and existing have `event_date IS NOT NULL` and the dates differ, dedup/supersession is bypassed. Different dates = different events. Regression test added to `test_temporal_extractor.py`.
 
 ## v2.10 changelog (codex re-review round 10)
 
@@ -265,7 +272,15 @@ Per Arch P1-1's enumeration:
 | 10 | `nous/heart/facts.py` `_to_recall_result` path | `RecallResult.metadata["event_date"] = fact.event_date.isoformat() if fact.event_date else None` so Layer 3 boost has the field to read |
 | 11 | `nous/handlers/fact_extractor.py:189-196` (Layer 1b direct path) | The fallback `FactInput(...)` construction must also pass `event_date=fact.get("event_date")` AND `event_date_classified_at=datetime.now(UTC)` (gated on `settings.temporal_extraction_enabled`). This path does NOT go through `_store_candidate_facts`, so step 2 alone doesn't cover it. Without this, eval / direct-ingest traffic that bypasses the summarizer silently discards extracted dates. |
 | 12 | `nous/api/retrieval_pipeline.py:659-669` (`_heart_results_to_pipeline`) | Copy `event_date` from `RecallResult.metadata` into the new `PipelineResult.metadata` dict. Today the conversion drops metadata entirely. Layer 3's `r.metadata.get("event_date")` reads from `PipelineResult`, so the field must survive the conversion. |
-| 13 | `nous/handlers/episode_summarizer.py:445-468` (`_merge_summaries`) | **P1 — multi-chunk merge truncation.** For transcripts exceeding `transcript_max_chars` (16K default), the summarizer summarizes chunks separately and `_merge_summaries` returns `merged_candidate_facts[:5]` in chunk order — dated events from later chunks get dropped before FactExtractor sees them. This is the exact case F075 targets (BEAM-100K conversations routinely exceed 16K). Fix: stable-partition the merged list so candidates with `event_date IS not None` sort first, THEN truncate. Pseudocode: `merged_candidate_facts.sort(key=lambda c: c.get("event_date") is None)` (Python sort is stable — False < True, so dated facts stay in their original chunk order at the front). Truncation then drops stable-fact tail, not dated-fact tail. |
+| 13 | `nous/handlers/episode_summarizer.py:445-468` (`_merge_summaries`) | **P1 — multi-chunk merge truncation.** For transcripts exceeding `transcript_max_chars` (16K default), the summarizer summarizes chunks separately and `_merge_summaries` returns `merged_candidate_facts[:5]` in chunk order — dated events from later chunks get dropped before FactExtractor sees them. This is the exact case F075 targets (BEAM-100K conversations routinely exceed 16K with many date-anchored events per episode). Fix: split dated and stable candidates into separate pools with independent caps — `dated[:settings.candidate_facts_event_limit] + stable[:5]`. Default event-limit = **30** so multi-day dev projects with daily date-anchored check-ins are preserved. Stable cap stays at 5 (general patterns where 5 covers most episodes). Both pools keep original chunk order so chronological information survives. |
+
+**Plus — dedup/supersession must respect distinct dates (Codex round-11 P2 fix):** Heart.learn currently performs (a) embedding-similarity dedup (cosine ≥ `fact_native_cosine_threshold = 0.80`) and (b) subject-based supersession (same subject → newer deactivates older). Both operate without considering `event_date`. For temporal events with the same entity but different dates — e.g. *"Christina obtained the API key on March 10"* and *"Christina rotated the API key on March 12"* — embedding similarity is high AND subjects collide, so the second fact would either be silently dropped as duplicate or supersede the first. Either outcome destroys the date pair temporal_reasoning needs.
+
+Rule: **when both candidate and existing fact have `event_date IS NOT NULL` and the dates differ, dedup/supersession is bypassed.** Different dates → different events, treated as semantically distinct regardless of embedding/subject similarity. Add the guard in:
+- `Heart._learn` dedup check (before the cosine threshold compare)
+- Whatever subject-based supersession path runs in sleep cycle / extraction (search for `superseded_by` writes)
+
+Regression test: ingest two facts with same subject, same entity, same actor — only `event_date` differs — assert both rows remain active and surface separately in retrieval. Add to `tests/test_temporal_extractor.py`.
 
 **Plus — marker write site (Codex round-9 fix):** `event_date_classified_at` must be populated by **F075 producers only**, NOT by a generic write inside `FactManager._learn`. Multiple unrelated paths call `Heart.learn(FactInput(...))` directly — `nous/api/tools.py:516` (`learn_fact` tool), `nous/api/rest.py:1722` (REST endpoint), `nous/handlers/knowledge_extractor.py:127` (pre-prune extraction) — none of which run the F075 classifier. If `_learn` blindly stamped `event_date_classified_at = NOW()` for every write when the flag is on, those rows would be falsely marked "F075-classified" and skipped by the backfill forever.
 
@@ -695,6 +710,14 @@ temporal_backfill_default_token_budget: int = Field(
     default=50000,
     description="F075: default Haiku token cap for backfill script.",
 )
+candidate_facts_event_limit: int = Field(
+    default=30,
+    ge=0,
+    description="F075: per-episode cap on date-anchored candidate facts "
+                "merged across chunks (before FactExtractor). Stable facts "
+                "stay capped at 5. Default 30 covers BEAM-100K-shaped "
+                "multi-day projects with daily check-ins.",
+)
 ```
 
 `CLAUDE.md` env-var table gets 5 new rows. Update is part of the impl PR, not separate.
@@ -709,6 +732,7 @@ temporal_backfill_default_token_budget: int = Field(
 - Malformed date string fails `date.fromisoformat` → field dropped, fact kept
 - Ambiguous date → field omitted, no false positive
 - Same event, same date → dedup catches duplicate (existing dedup path unchanged)
+- **Distinct event_date for same subject/entity → both facts persist** (Codex round-11 regression test): ingest two facts with same subject ("API key event") + same entity ("Christina") but `event_date` 2024-03-10 vs 2024-03-12, assert both active rows and both surface in retrieval. Dedup/supersession bypassed by the event-date guard.
 - `_store_candidate_facts` reads `event_date` from dict and threads into `FactInput`
 - FactExtractor fallback prompt (Layer 1b) also emits event_date
 

--- a/docs/features/F075-temporal-fact-extraction.md
+++ b/docs/features/F075-temporal-fact-extraction.md
@@ -1,6 +1,6 @@
 # F075 — Temporal Fact Extraction + Date-Aware Retrieval
 
-**Status:** 📝 Draft **v2.14** (2026-05-28) — incorporates arch / python-pro / devil's-advocate spec review + 14 rounds of codex PR review fixes
+**Status:** 📝 Draft **v2.15** (2026-05-28) — incorporates arch / python-pro / devil's-advocate spec review + 15 rounds of codex PR review fixes
 **Proposed by:** Tim + investigation thread
 **Date:** 2026-05-27
 **Depends on:** F002 (Heart), F022 (Cross-type linking), F040 (Graph Densifier), F047 (Actionability backfill pattern), F051 (Eval harness for measurement)
@@ -10,6 +10,12 @@
 **Reviews:** `docs/reviews/F075-spec-arch-review.md`, `F075-spec-python-pro-review.md`, `F075-spec-devil-review.md`
 
 ---
+
+## v2.15 changelog (codex re-review round 15)
+
+Codex flagged 1 P2 on v2.14:
+
+- **P2 — Budget-exhausted early return silently rolls back already-classified rows.** When the token budget runs out mid-batch after some rows have already been classified + UPDATEd, the v2.14 `_process_batch` returned `(updated, True)` before reaching the per-batch `session.commit()` at the bottom of the function. The surrounding `async with session_factory()` then closes the uncommitted work session, rolling back the in-flight UPDATEs. Those rows stay at `event_date_classified_at IS NULL` — the LLM calls already spent on them are wasted because the next run re-classifies the same rows. Only happens when remaining budget < fetched batch size, but at small `--token-budget` values it would burn API spend silently. Fixed: added `await session.commit()` immediately before the early `return (updated, True)` to persist work-so-far.
 
 ## v2.14 changelog (codex re-review round 14)
 
@@ -591,6 +597,13 @@ async def _process_batch(
                 "F075 backfill: token budget exhausted, stopping at %d rows",
                 updated,
             )
+            # Codex round-15 P2 catch: must commit work-so-far BEFORE the
+            # early return. Otherwise the surrounding `async with
+            # session_factory()` exit rolls back the in-flight UPDATEs and
+            # those rows stay event_date_classified_at IS NULL on disk —
+            # the LLM calls already spent against them are wasted because
+            # the next run re-processes the same rows.
+            await session.commit()
             return (updated, True)  # signal _run_batches to halt
 
         classified = await _classify_event_date(row)  # returns date | None

--- a/docs/features/F075-temporal-fact-extraction.md
+++ b/docs/features/F075-temporal-fact-extraction.md
@@ -1,6 +1,6 @@
 # F075 — Temporal Fact Extraction + Date-Aware Retrieval
 
-**Status:** 📝 Draft **v2.15** (2026-05-28) — incorporates arch / python-pro / devil's-advocate spec review + 15 rounds of codex PR review fixes
+**Status:** 📝 Draft **v2.16** (2026-05-28) — incorporates arch / python-pro / devil's-advocate spec review + 16 rounds of codex PR review fixes
 **Proposed by:** Tim + investigation thread
 **Date:** 2026-05-27
 **Depends on:** F002 (Heart), F022 (Cross-type linking), F040 (Graph Densifier), F047 (Actionability backfill pattern), F051 (Eval harness for measurement)
@@ -10,6 +10,14 @@
 **Reviews:** `docs/reviews/F075-spec-arch-review.md`, `F075-spec-python-pro-review.md`, `F075-spec-devil-review.md`
 
 ---
+
+## v2.16 changelog (codex re-review round 16)
+
+Codex flagged 3 P2s on v2.15. Validated each finding against the actual code (`nous/heart/schemas.py`, `nous/brain/graph_linker.py:179`, the v2.15 `_process_batch` loop body) before patching:
+
+- **P2 — `FactInput` schema row missed `event_date_classified_at`.** Wire-path row 3 declared only `event_date` on FactInput, but row 4 says `_learn` copies BOTH `event_date` and `event_date_classified_at` and row 5 declares both on the ORM. Producers (Layer 1a/1b/Layer 4) trying to pass `event_date_classified_at=...` would either fail Pydantic strict mode or have the kwarg silently dropped. Fixed: row 3 now mandates both fields on FactInput.
+- **P2 — `_fetch_chunk_context` defined but never called.** The whole point of fetching chunk context was to give the classifier better signal than `fact.content` paraphrase. v2.15's `_process_batch` body invoked `_classify_event_date(row)` directly — never hitting the helper. Dead code. Fixed: `_process_batch` now calls `_fetch_chunk_context(session, agent_id, row["source_episode_id"], row["embedding"])` BEFORE the classifier call and passes the chunk text as `chunk_context=` kwarg.
+- **P2 — Embedding parameter not serialized for pgvector cast.** v2.15 passed `row["embedding"]` raw into `CAST(:embedding AS vector)`. The repo convention at `nous/brain/graph_linker.py:179, 266` is to serialize to the pgvector text literal `"[" + ",".join(str(float(v)) for v in embedding) + "]"` before binding. Without this, the bind/cast can fail before any chunk is retrieved. Fixed: `_fetch_chunk_context` now builds `embedding_str` first, then binds.
 
 ## v2.15 changelog (codex re-review round 15)
 
@@ -291,7 +299,7 @@ Per Arch P1-1's enumeration:
 |---|---|---|
 | 1 | `episode_summarizer.py:50-77` | Add `event_date` to candidate_facts schema + prompt |
 | 2 | `fact_extractor.py:251-256` | `_store_candidate_facts` reads `event_date = item.get("event_date")` from dict |
-| 3 | `nous/heart/schemas.py:85-98` | `FactInput` adds `event_date: date \| None = None` |
+| 3 | `nous/heart/schemas.py:85-98` | `FactInput` adds BOTH `event_date: date \| None = None` AND `event_date_classified_at: datetime \| None = None`. Both fields must be declared so F075 producer paths (Layer 1a/1b/Layer 4) can pass them as kwargs without Pydantic dropping the value silently. Row 4's `_learn` copy and row 5's ORM column rely on this declaration. |
 | 4 | `nous/heart/facts.py:428-449` | `FactManager._learn` passes `event_date` AND `event_date_classified_at` from `FactInput` to `Fact()` ORM constructor verbatim. NO policy here — `_learn` is a pure sink. Marker policy lives in the F075 producer paths only (Layer 1a, 1b, Layer 4). |
 | 5 | `nous/storage/models.py:469-511` | `Fact` ORM adds `event_date: Mapped[date \| None] = mapped_column(Date, nullable=True)` AND `event_date_classified_at: Mapped[datetime \| None] = mapped_column(DateTime(timezone=True), nullable=True)` |
 | 6 | `sql/migrations/053_temporal_fact_extraction.sql` | `ALTER TABLE heart.facts ADD COLUMN event_date DATE + event_date_classified_at TIMESTAMPTZ` + partial indexes + extend `brain.graph_edges` relation CHECK to add `'happened_before'` |
@@ -606,7 +614,17 @@ async def _process_batch(
             await session.commit()
             return (updated, True)  # signal _run_batches to halt
 
-        classified = await _classify_event_date(row)  # returns date | None
+        # Codex round-16 P2 catch: actually use _fetch_chunk_context
+        # defined below. Without this, the classifier sees only
+        # fact.content (lossy paraphrase) — defeating the whole point
+        # of Layer 4 using chunks instead of episode.summary[:500].
+        chunk_ctx = await _fetch_chunk_context(
+            session,
+            agent_id,
+            row["source_episode_id"],
+            row["embedding"],
+        )
+        classified = await _classify_event_date(row, chunk_context=chunk_ctx)  # date | None
         budget.consume(_TOKENS_PER_LLM_CALL)
 
         # ALWAYS mark classified — even when no date found. This is what
@@ -657,7 +675,7 @@ async def _fetch_chunk_context(
     session: AsyncSession,
     agent_id: str,
     episode_id: UUID | None,
-    embedding,            # fact.embedding from the batch row; may be None
+    embedding,            # fact.embedding from the batch row; may be None or pgvector type
 ) -> str | None:
     """Nearest chunk in the source episode by cosine to fact.embedding.
 
@@ -667,6 +685,12 @@ async def _fetch_chunk_context(
     """
     if episode_id is None or embedding is None:
         return None
+    # Codex round-16 P2 catch: the embedding from SELECT comes back as a
+    # pgvector type (numpy array / list of floats), not a string. Passing
+    # it raw into CAST(:embedding AS vector) can fail binding. The repo
+    # convention at nous/brain/graph_linker.py:179, 266 is to serialize
+    # to the pgvector text literal "[v1,v2,...]" first, then bind as str.
+    embedding_str = "[" + ",".join(str(float(v)) for v in embedding) + "]"
     result = await session.execute(
         text("""
             SELECT content
@@ -685,7 +709,7 @@ async def _fetch_chunk_context(
         {
             "agent_id": agent_id,
             "episode_id": episode_id,
-            "embedding": embedding,
+            "embedding": embedding_str,
         },
     )
     row = result.first()

--- a/docs/features/F075-temporal-fact-extraction.md
+++ b/docs/features/F075-temporal-fact-extraction.md
@@ -1,6 +1,6 @@
 # F075 — Temporal Fact Extraction + Date-Aware Retrieval
 
-**Status:** 📝 Draft **v2.1** (2026-05-27) — incorporates arch / python-pro / devil's-advocate spec review feedback + codex PR review fixes
+**Status:** 📝 Draft **v2.2** (2026-05-27) — incorporates arch / python-pro / devil's-advocate spec review + 2 rounds of codex PR review fixes
 **Proposed by:** Tim + investigation thread
 **Date:** 2026-05-27
 **Depends on:** F002 (Heart), F022 (Cross-type linking), F040 (Graph Densifier), F047 (Actionability backfill pattern), F051 (Eval harness for measurement)
@@ -10,6 +10,15 @@
 **Reviews:** `docs/reviews/F075-spec-arch-review.md`, `F075-spec-python-pro-review.md`, `F075-spec-devil-review.md`
 
 ---
+
+## v2.2 changelog (codex re-review round 2)
+
+After v2.1 push, codex re-reviewed and flagged 5 more findings. All incorporated:
+
+- **P1 — stale eligibility predicate in §Idempotence.** The v2.1 fix updated the per-batch SELECT to `event_date_classified_at IS NULL` but left the §Idempotence one-liner saying `WHERE event_date IS NULL`. Same starvation bug, separate doc location. Fixed: §Idempotence now matches the SELECT predicate.
+- **P2 — quadratic happened_before edges.** The `NOT EXISTS (intermediate-date)` formulation links every fact on date D to every fact on date D+1 because it excludes intermediate *dates*, not intermediate *facts*. 20 facts on Jan 1 + 20 on Jan 2 = 400 edges, not 20. Fixed: §Layer 2 INSERT now uses `LATERAL ... LIMIT 1` to pick exactly one representative successor per source fact.
+- **P2 — `EPISODE_START_TIMESTAMP` not wired through summarizer.** The Layer 1 prompt directs the LLM to resolve relative dates against `EPISODE_START_TIMESTAMP`, but `_summarize_single(transcript, decision_context)` at `episode_summarizer.py:394` doesn't receive it. Fixed: §Layer 1a wire path adds 3 hops to thread `Episode.started_at` from `summarize_episode` → `_summarize_single` → prompt template.
+- **P2 — backfill SELECT missing `subject` column.** The chunk-context lookup in §Layer 4 uses `$3 = subject keywords` but the batch SELECT only returns `(id, content, source_episode_id)`. Fixed: SELECT now includes `subject`.
 
 ## v2.1 changelog (codex PR review)
 
@@ -191,6 +200,16 @@ Per Arch P1-1's enumeration:
 
 **Plus**: `FactManager._learn` sets `event_date_classified_at = datetime.now(UTC)` on every fact write whose extraction path can produce dates (i.e., the new summarizer/extractor codepath always marks the row classified, even when `event_date` ends up `None`). This keeps newly-ingested facts out of the Layer 4 backfill eligibility set.
 
+**Plus (Codex v2.1 review):** the summarizer's LLM call must receive `Episode.started_at` so it can resolve relative dates ("yesterday", "last Tuesday") deterministically. Current signature `_summarize_single(transcript, decision_context)` at `episode_summarizer.py:394` doesn't take it. Wire path additions for relative-date resolution:
+
+| File:Line | Change |
+|---|---|
+| `episode_summarizer.py:377, 383` | Pass `started_at=episode.started_at` to `_summarize_single` calls |
+| `episode_summarizer.py:394` | `_summarize_single(transcript, decision_context, started_at: datetime)` signature |
+| `episode_summarizer.py:50-77` | Prompt template includes `EPISODE_START_TIMESTAMP: {started_at.isoformat()}` block above the transcript so the LLM has a deterministic anchor for relative-date resolution |
+
+Without this thread-through, the prompt's "resolve relative phrases against EPISODE_START_TIMESTAMP" instruction has no value to anchor against and dates from transcripts like "deployed yesterday" become guesses.
+
 **Plus** Heart.recall surface (Python P1-4): when serializing recall results, `RecallResult.metadata["event_date"]` must be populated with the iso string (or absent if None). Without this, Layer 3 is silent no-op.
 
 #### Pydantic v2 validator
@@ -227,29 +246,34 @@ def _parse_event_date(cls, v):
 `brain.graph_edges` requires `agent_id NOT NULL` (`sql/init.sql:197`) and constrains `relation` via a CHECK clause that currently allows only the existing relation set (`sql/init.sql:198-201` + migration `051_f070_chunk_graph_edges.sql:34-45`). The schema migration (§Schema migration) must extend the CHECK to add `'happened_before'`, mirroring the pattern F070 used to add `'part_of'` and `'summarized_by'`.
 
 ```sql
--- For all (fact_a, fact_b) pairs in same episode, chronologically adjacent
--- on event_date — chain through ordered events, not all pairs.
+-- Each dated fact gets at most ONE outgoing happened_before edge,
+-- pointing to a single representative fact on the next-distinct date
+-- in the same episode. LATERAL with LIMIT 1 prevents the quadratic
+-- explosion that would occur when multiple facts share the same
+-- event_date (a NOT EXISTS-on-dates approach would link every fact
+-- on date D to every fact on date D+1, producing O(N²) edges per
+-- adjacent-date pair).
 INSERT INTO brain.graph_edges
     (source_id, source_type, target_id, target_type, agent_id, relation, weight, auto_linked)
-SELECT a.id, 'fact', b.id, 'fact', a.agent_id, 'happened_before', 1.0, TRUE
+SELECT a.id, 'fact', b.id, 'fact',
+       a.agent_id, 'happened_before', 1.0, TRUE
 FROM heart.facts a
-JOIN heart.facts b
-  ON a.agent_id = b.agent_id
- AND a.source_episode_id = b.source_episode_id
- AND a.event_date < b.event_date
+JOIN LATERAL (
+    SELECT b.id
+    FROM heart.facts b
+    WHERE b.agent_id = a.agent_id
+      AND b.source_episode_id = a.source_episode_id
+      AND b.event_date IS NOT NULL
+      AND b.event_date > a.event_date
+    ORDER BY b.event_date ASC, b.id ASC   -- deterministic tiebreaker
+    LIMIT 1
+) b ON TRUE
 WHERE a.agent_id = $1
   AND a.event_date IS NOT NULL
-  AND b.event_date IS NOT NULL
-  AND NOT EXISTS (
-    SELECT 1 FROM heart.facts c
-    WHERE c.source_episode_id = a.source_episode_id
-      AND c.event_date > a.event_date
-      AND c.event_date < b.event_date
-  )
 ON CONFLICT (source_id, target_id, relation) DO NOTHING;
 ```
 
-Result: at most N-1 edges per episode (a chain through ordered events). O(N), not O(N²). `auto_linked=TRUE` mirrors F040's sleep-cycle convention.
+Edge count per episode: at most N (where N = facts with non-NULL `event_date` in the episode). When multiple facts share the same `event_date`, all of them get a single outgoing edge pointing to the *same* representative successor — a 20-on-Jan-1 / 20-on-Jan-2 cluster produces 20 edges (Jan-1 facts → one Jan-2 fact), not 400. `auto_linked=TRUE` mirrors F040's sleep-cycle convention. Same-date facts deliberately get no edges between each other (we don't claim ordering on concurrent events).
 
 **Consumer (already-shipped):**
 
@@ -333,7 +357,7 @@ Fix: the schema adds `event_date_classified_at TIMESTAMPTZ` (see §Schema migrat
 # Pseudo-code; concrete sites verified against F047
 async def _process_batch(conn, agent_id: str, batch_size: int) -> int:
     rows = await conn.fetch("""
-        SELECT id, content, source_episode_id
+        SELECT id, subject, content, source_episode_id
         FROM heart.facts
         WHERE agent_id = $1
           AND event_date_classified_at IS NULL  -- eligibility = "never tried"
@@ -394,7 +418,7 @@ uv run python scripts/backfill_temporal_facts.py \
 
 #### Idempotence
 
-`WHERE event_date IS NULL` predicate makes re-runs safe. NULL rows only.
+`WHERE event_date_classified_at IS NULL` predicate makes re-runs safe — only rows that have NEVER been classified are picked up. Stable facts that were classified and intentionally left with `event_date = NULL` (because the classifier correctly found no date) are NOT eligible for re-processing. This is the same column the per-batch SELECT above uses; the predicate stays consistent everywhere.
 
 #### Edge-build trigger
 

--- a/docs/features/F075-temporal-fact-extraction.md
+++ b/docs/features/F075-temporal-fact-extraction.md
@@ -1,6 +1,6 @@
 # F075 — Temporal Fact Extraction + Date-Aware Retrieval
 
-**Status:** 📝 Draft **v2.6** (2026-05-27) — incorporates arch / python-pro / devil's-advocate spec review + 6 rounds of codex PR review fixes
+**Status:** 📝 Draft **v2.7** (2026-05-27) — incorporates arch / python-pro / devil's-advocate spec review + 7 rounds of codex PR review fixes
 **Proposed by:** Tim + investigation thread
 **Date:** 2026-05-27
 **Depends on:** F002 (Heart), F022 (Cross-type linking), F040 (Graph Densifier), F047 (Actionability backfill pattern), F051 (Eval harness for measurement)
@@ -10,6 +10,13 @@
 **Reviews:** `docs/reviews/F075-spec-arch-review.md`, `F075-spec-python-pro-review.md`, `F075-spec-devil-review.md`
 
 ---
+
+## v2.7 changelog (codex re-review round 7)
+
+Codex flagged 2 stale-cross-reference P2s on v2.6. Both were leftover from rounds 5/6 fixes that didn't propagate to all mentions of the same rule. Incorporated:
+
+- **P2 — Layer 4 §Per-row UPDATE post-script still claimed unconditional `event_date_classified_at = NOW()` write by live path.** v2.6 §Layer 1a §Flag-gating added the rule that the marker is only written when the flag is on, but the matching sentence in §Layer 4 wasn't updated and still says "writes `event_date_classified_at = NOW()` whenever it stores a fact." Two sources of truth contradicting. Fixed: §Layer 4 sentence now defers to §Layer 1a §Flag-gating, restating the conditional rule.
+- **P2 — Acceptance criterion #1 still said "4 unit files".** v2.6 deferred `test_date_aware_boost.py` with Layer 3 but the acceptance count wasn't updated. Fixed: criterion #1 now says "3 unit files + 1 integration file" and lists the file names explicitly so reviewers can verify scope at a glance.
 
 ## v2.6 changelog (codex re-review round 6)
 
@@ -446,7 +453,7 @@ async def _process_batch(conn, agent_id: str, batch_size: int) -> int:
 
 This makes the script terminate cleanly (every batch advances the eligibility cursor) and remains idempotent (re-runs only pick up rows still at `event_date_classified_at IS NULL`, which by definition haven't been tried).
 
-The live-path Layer 1 extractor also writes `event_date_classified_at = NOW()` whenever it stores a fact (whether or not it found a date), so newly-ingested facts never enter the backfill eligibility set.
+The live-path Layer 1 extractor writes `event_date_classified_at = NOW()` only when `settings.temporal_extraction_enabled = True` (i.e., when the new prompt actually ran). When the flag is `False` (dark-launch default), the marker stays NULL so those rows remain eligible for the backfill to pick up once the flag is flipped on. See §Layer 1a "Flag-gating" — same rule, restated here for the backfill reader.
 
 #### Classification LLM call (Python P2 — guaranteed JSON)
 
@@ -660,7 +667,7 @@ pytest-asyncio config in `pyproject.toml:59` is already `asyncio_mode = "auto"` 
 
 ## Acceptance criteria
 
-1. **All new tests pass.** 4 unit files + 1 integration file, ~30 tests.
+1. **All new tests pass.** 3 unit files + 1 integration file, ~25 tests (`test_temporal_extractor.py`, `test_temporal_edges.py`, `test_temporal_backfill.py`, `test_f075_end_to_end.py`). `test_date_aware_boost.py` ships with Layer 3, NOT in this PR.
 2. **Existing tests pass.** No regression in `tests/test_fact_extractor_episode_id.py`, `tests/test_heart.py`, `tests/test_graph_densifier.py`.
 3. **Migration runs cleanly on fresh DB** (`docker compose up` cold start), verified by F074 harness pattern.
 4. **LongMemEval N=20 retrieval pre-check** (cheap, ~$5): hit@10 on temporal-reasoning category questions improves by ≥+5% vs current baseline. If LME pre-check fails, do NOT proceed to BEAM.

--- a/docs/features/F075-temporal-fact-extraction.md
+++ b/docs/features/F075-temporal-fact-extraction.md
@@ -1,6 +1,6 @@
 # F075 — Temporal Fact Extraction + Date-Aware Retrieval
 
-**Status:** 📝 Draft **v2.11** (2026-05-28) — incorporates arch / python-pro / devil's-advocate spec review + 11 rounds of codex PR review fixes
+**Status:** 📝 Draft **v2.12** (2026-05-28) — incorporates arch / python-pro / devil's-advocate spec review + 12 rounds of codex PR review fixes
 **Proposed by:** Tim + investigation thread
 **Date:** 2026-05-27
 **Depends on:** F002 (Heart), F022 (Cross-type linking), F040 (Graph Densifier), F047 (Actionability backfill pattern), F051 (Eval harness for measurement)
@@ -10,6 +10,14 @@
 **Reviews:** `docs/reviews/F075-spec-arch-review.md`, `F075-spec-python-pro-review.md`, `F075-spec-devil-review.md`
 
 ---
+
+## v2.12 changelog (codex re-review round 12)
+
+Codex flagged 1 P1 (continued cap refinement) + 2 P2s on v2.11:
+
+- **P1 — Downstream cap at `_store_candidate_facts` still truncates to 5.** v2.11 fixed `_merge_summaries` to emit `dated[:30] + stable[:5]` = up to 35 candidates. But `fact_extractor.py:249` then iterates `candidates[:5]` — so only the first 5 (dated, by partition order) reach `Heart.learn`. The 6th-onward dated facts that row 13's fix preserved are dropped at the storage gate. Two-site fix required, not one. Fixed: wire-path row 14 added — `_store_candidate_facts` applies the same partition (`dated[:event_limit] + stable[:5]`).
+- **P2 — Pre-learn dedup paths bypass the round-11 `_learn` event_date guard.** Both extractor paths (`fact_extractor.py:176-179`, `263-269`) call `search_facts(content, limit=1)` and skip on `fact_dedup_threshold` BEFORE `Heart.learn` is invoked. The round-11 `_learn` guard never fires for hits caught at this pre-check — distinct-date events still collapse. Fixed: wire-path row 15 added — same `event_date != event_date → bypass` rule applied at both pre-learn dedup sites. (Requires `search_facts` to surface `event_date` on results, already mandated by row 7's FactSummary update.)
+- **P2 — Backfill pseudo-code mixed AsyncSession lock with asyncpg-style SQL.** v2.11's `_run_batches` acquired the lock via `db.session()` (SQLAlchemy AsyncSession), but `_process_batch` used `conn.fetch(...)` with asyncpg `$1` placeholders. AsyncSession has `execute()` not `fetch()` — script would `AttributeError` before classifying any row. F047 uses consistent `session.execute(text(...), {...})` throughout (`actionability_backfill.py:78-205`). Fixed: pseudo-code rewritten to use SQLAlchemy `session.execute(text("..."), {...})` + `result.mappings().all()` + per-row `session.commit()`.
 
 ## v2.11 changelog (codex re-review round 11)
 
@@ -273,6 +281,8 @@ Per Arch P1-1's enumeration:
 | 11 | `nous/handlers/fact_extractor.py:189-196` (Layer 1b direct path) | The fallback `FactInput(...)` construction must also pass `event_date=fact.get("event_date")` AND `event_date_classified_at=datetime.now(UTC)` (gated on `settings.temporal_extraction_enabled`). This path does NOT go through `_store_candidate_facts`, so step 2 alone doesn't cover it. Without this, eval / direct-ingest traffic that bypasses the summarizer silently discards extracted dates. |
 | 12 | `nous/api/retrieval_pipeline.py:659-669` (`_heart_results_to_pipeline`) | Copy `event_date` from `RecallResult.metadata` into the new `PipelineResult.metadata` dict. Today the conversion drops metadata entirely. Layer 3's `r.metadata.get("event_date")` reads from `PipelineResult`, so the field must survive the conversion. |
 | 13 | `nous/handlers/episode_summarizer.py:445-468` (`_merge_summaries`) | **P1 — multi-chunk merge truncation.** For transcripts exceeding `transcript_max_chars` (16K default), the summarizer summarizes chunks separately and `_merge_summaries` returns `merged_candidate_facts[:5]` in chunk order — dated events from later chunks get dropped before FactExtractor sees them. This is the exact case F075 targets (BEAM-100K conversations routinely exceed 16K with many date-anchored events per episode). Fix: split dated and stable candidates into separate pools with independent caps — `dated[:settings.candidate_facts_event_limit] + stable[:5]`. Default event-limit = **30** so multi-day dev projects with daily date-anchored check-ins are preserved. Stable cap stays at 5 (general patterns where 5 covers most episodes). Both pools keep original chunk order so chronological information survives. |
+| 14 | `nous/handlers/fact_extractor.py:249` (`_store_candidate_facts`) | **P1 — downstream cap re-truncates to 5.** `_store_candidate_facts` iterates `candidates[:5]` — even after `_merge_summaries` (row 13) emits 35 candidates, only the first 5 dated facts get stored, defeating row 13's fix. Apply the same partition here: `dated, stable = partition(candidates); dated[:settings.candidate_facts_event_limit] + stable[:5]`. Both caps come from the same settings to keep the merge+store pipeline self-consistent. |
+| 15 | `nous/handlers/fact_extractor.py:176-179, 263-269` (pre-learn dedup paths) | **P2 — event_date dedup-bypass needs to apply BEFORE Heart.learn.** Both extractor paths run `search_facts(content, limit=1)` and skip on `fact_dedup_threshold` BEFORE invoking `Heart.learn` — the round-11 `_learn` event_date guard never fires for these pre-learn dedup hits. Apply the same rule at both pre-learn sites: when both candidate AND `existing[0]` have `event_date IS NOT NULL` and the dates differ, do NOT skip — proceed with the learn. Requires `search_facts` results to surface `event_date` (already covered by wire row 8 if FactSummary carries it, which row 7 mandates). |
 
 **Plus — dedup/supersession must respect distinct dates (Codex round-11 P2 fix):** Heart.learn currently performs (a) embedding-similarity dedup (cosine ≥ `fact_native_cosine_threshold = 0.80`) and (b) subject-based supersession (same subject → newer deactivates older). Both operate without considering `event_date`. For temporal events with the same entity but different dates — e.g. *"Christina obtained the API key on March 10"* and *"Christina rotated the API key on March 12"* — embedding similarity is high AND subjects collide, so the second fact would either be silently dropped as duplicate or supersede the first. Either outcome destroys the date pair temporal_reasoning needs.
 
@@ -497,22 +507,30 @@ v1's `WHERE id = (SELECT id FROM batch)` was broken for `LIMIT > 1`. v2 copies F
 Fix: the schema adds `event_date_classified_at TIMESTAMPTZ` (see §Schema migration). The backfill writes it on every classification attempt regardless of outcome. Eligibility uses `event_date_classified_at IS NULL` (not `event_date IS NULL`).
 
 ```python
-# Pseudo-code; concrete sites verified against F047 (actionability_backfill.py:48-65)
+# Pseudo-code; uses SQLAlchemy AsyncSession to match the locked session
+# context from _run_batches above. F047's actionability_backfill.py:78-205
+# uses the same idiom — session.execute(text(...), {...}).
+from sqlalchemy import text
+
 async def _process_batch(
-    conn,
+    session: AsyncSession,        # the same locked session from _run_batches
     agent_id: str,
     batch_size: int,
-    budget: BudgetTracker,  # injected by _run_batches; F047 pattern
-) -> tuple[int, bool]:    # (updated_rows, stop_requested)
-    rows = await conn.fetch("""
-        SELECT id, subject, content, embedding, source_episode_id
-        FROM heart.facts
-        WHERE agent_id = $1
-          AND event_date_classified_at IS NULL  -- eligibility = "never tried"
-          AND active = TRUE
-        ORDER BY learned_at DESC
-        LIMIT $2
-    """, agent_id, batch_size)
+    budget: BudgetTracker,        # injected by _run_batches; F047 pattern
+) -> tuple[int, bool]:            # (updated_rows, stop_requested)
+    result = await session.execute(
+        text("""
+            SELECT id, subject, content, embedding, source_episode_id
+            FROM heart.facts
+            WHERE agent_id = :agent_id
+              AND event_date_classified_at IS NULL  -- eligibility = "never tried"
+              AND active = TRUE
+            ORDER BY learned_at DESC
+            LIMIT :batch_size
+        """),
+        {"agent_id": agent_id, "batch_size": batch_size},
+    )
+    rows = result.mappings().all()
 
     updated = 0
     for row in rows:
@@ -528,21 +546,27 @@ async def _process_batch(
             )
             return (updated, True)  # signal _run_batches to halt
 
-        result = await _classify_event_date(row)  # returns date | None
+        classified = await _classify_event_date(row)  # returns date | None
         budget.consume(_TOKENS_PER_LLM_CALL)
 
         # ALWAYS mark classified — even when no date found. This is what
         # prevents re-processing the same stable facts on subsequent batches.
-        await conn.execute("""
-            UPDATE heart.facts
-            SET event_date = $1,
-                event_date_classified_at = NOW(),
-                updated_at = NOW()
-            WHERE id = $2
-        """, result, row["id"])  # $1 may be NULL — that's correct
+        await session.execute(
+            text("""
+                UPDATE heart.facts
+                SET event_date = :event_date,
+                    event_date_classified_at = NOW(),
+                    updated_at = NOW()
+                WHERE id = :id
+            """),
+            {"event_date": classified, "id": row["id"]},  # event_date may be NULL
+        )
+        await session.commit()  # per-row commit so a crash mid-loop preserves progress
         updated += 1
     return (updated, False)
 ```
+
+Single SQLAlchemy session is used for the lock acquisition (`_run_batches`), the batch SELECT, the per-row UPDATE, and the lock release — consistent API throughout. F047 follows the exact same pattern at `actionability_backfill.py:78-205`.
 
 `BudgetTracker` is a tiny class mirroring F047's bookkeeping (`actionability_backfill.py:48-65, 162-167`): initialized with `token_budget // _TOKENS_PER_LLM_CALL = max_calls`; `ok()` returns `remaining_calls > 0`; `consume(tokens)` decrements. The outer `_run_batches` loop exits cleanly when `_process_batch` returns `stop_requested=True`.
 

--- a/docs/features/F075-temporal-fact-extraction.md
+++ b/docs/features/F075-temporal-fact-extraction.md
@@ -1,6 +1,6 @@
 # F075 — Temporal Fact Extraction + Date-Aware Retrieval
 
-**Status:** 📝 Draft **v2.4** (2026-05-27) — incorporates arch / python-pro / devil's-advocate spec review + 4 rounds of codex PR review fixes
+**Status:** 📝 Draft **v2.5** (2026-05-27) — incorporates arch / python-pro / devil's-advocate spec review + 5 rounds of codex PR review fixes
 **Proposed by:** Tim + investigation thread
 **Date:** 2026-05-27
 **Depends on:** F002 (Heart), F022 (Cross-type linking), F040 (Graph Densifier), F047 (Actionability backfill pattern), F051 (Eval harness for measurement)
@@ -10,6 +10,16 @@
 **Reviews:** `docs/reviews/F075-spec-arch-review.md`, `F075-spec-python-pro-review.md`, `F075-spec-devil-review.md`
 
 ---
+
+## v2.5 changelog (codex re-review round 5)
+
+Codex flagged 5 more P2s on v2.4. All incorporated:
+
+- **P2 — happened_before edges may target inactive facts.** Original SQL filtered neither side for `active=TRUE`. With superseded facts in the corpus, an active Jan-1 fact could point at an inactive Jan-2 successor while the active Jan-2 siblings get no edge — dead-weight reinforcement because Heart recall only returns active rows. Fixed: both `a` and `b` filter `active=TRUE`.
+- **P2 — Layer 1b direct FactInput path missing.** Wire path covered `_store_candidate_facts` (step 2) but the FactExtractor's direct LLM fallback path at `fact_extractor.py:189-196` builds `FactInput(...)` directly without going through `_store_candidate_facts`. For eval / direct-ingest traffic that bypasses the summarizer, the extracted `event_date` would still be silently discarded. Fixed: wire path adds row 11 covering the direct construction.
+- **P2 — ORM source_type/target_type constraints also stale.** v2.3 brought `ck_edges_relation` current but left `ck_edges_source_type` and `ck_edges_target_type` at their init.sql values — both omit `'chunk'` (added by F070 migration 051). ORM-driven fresh schemas reject every F070 chunk edge today. Fixed: §Schema migration now updates all three ORM constraints in one pass.
+- **P2 — PipelineResult conversion drops metadata.** Layer 3 boost reads `r.metadata.get("event_date")` from `PipelineResult`, but `_heart_results_to_pipeline` at `retrieval_pipeline.py:659-669` doesn't copy `RecallResult.metadata` into the new `PipelineResult.metadata` dict. Even with Layer 1 correctly populating the source-side metadata, the boost reads `None` after conversion and is a silent no-op. Fixed: wire path adds row 12 for the conversion step.
+- **P2 — Layer 1 prompt change unconditional, violating dark-launch.** v2.4 said all flags default OFF but the wire path changes were unconditional — the summarizer prompt and dict-unpacks would emit/consume `event_date` regardless of the flag. Rollback claim was unreliable. Fixed: §Layer 1a now explicitly notes the prompt addition, schema slot, dict-unpacks, and `event_date_classified_at` live-path write are ALL gated on `settings.temporal_extraction_enabled`. Backfill script unaffected (governed by explicit invocation, not the flag).
 
 ## v2.4 changelog (codex re-review round 4)
 
@@ -194,6 +204,8 @@ the date.
 
 **Critical wiring detail (Arch P1-2):** the summarizer already passes the transcript content into the LLM call when constructing the summary. The prompt addition above directs the same LLM to also extract dates from that transcript — no new data is needed; the LLM just needs the instruction. This is why we target the summarizer rather than the downstream extractor.
 
+**Flag-gating (Codex round 5 fix):** the prompt addition, the `event_date` schema field on the candidate_facts dict, and the `_store_candidate_facts` / direct-path `FactInput` dict-unpacks are ALL gated on `settings.temporal_extraction_enabled`. When the flag is `False` (default), the summarizer emits the legacy prompt without the date instruction, the candidate_facts dict carries no `event_date` key, the dict-unpacks ignore the field if present, and `event_date_classified_at` is NOT written by the live path. This makes the dark-launch rollback in §Rollback honest end-to-end: setting the flag false truly stops new ingests from producing event_date facts. The Layer 4 backfill script is unaffected by the flag (it runs explicitly when invoked; the flag governs live ingest only).
+
 #### Layer 1b (defense-in-depth): FactExtractor
 
 `nous/handlers/fact_extractor.py:_EXTRACT_PROMPT` is the fallback path used when `candidate_facts` are absent (eval shortcuts, direct ingest tools). Same instruction block as 1a, adapted for the fact-extractor's output schema. Lower priority because production traffic always has summarizer-emitted candidates.
@@ -214,6 +226,8 @@ Per Arch P1-1's enumeration:
 | 8 | `nous/heart/facts.py:1046, 1160, 1256, 1355` | Each `FactSummary(...)` constructor passes `event_date=fact.event_date` (4 sites). Optional field defaults to None silently otherwise → recall surface returns None even when DB column populated |
 | 9 | `nous/heart/facts.py:1459` (`_to_detail`) | Pass `event_date=fact.event_date` to `FactDetail` construction |
 | 10 | `nous/heart/facts.py` `_to_recall_result` path | `RecallResult.metadata["event_date"] = fact.event_date.isoformat() if fact.event_date else None` so Layer 3 boost has the field to read |
+| 11 | `nous/handlers/fact_extractor.py:189-196` (Layer 1b direct path) | The fallback `FactInput(...)` construction must also pass `event_date=fact.get("event_date")`. This path does NOT go through `_store_candidate_facts`, so step 2 alone doesn't cover it. Without this, eval / direct-ingest traffic that bypasses the summarizer silently discards extracted dates. |
+| 12 | `nous/api/retrieval_pipeline.py:659-669` (`_heart_results_to_pipeline`) | Copy `event_date` from `RecallResult.metadata` into the new `PipelineResult.metadata` dict. Today the conversion drops metadata entirely. Layer 3's `r.metadata.get("event_date")` reads from `PipelineResult`, so the field must survive the conversion. |
 
 **Plus**: `FactManager._learn` sets `event_date_classified_at = datetime.now(UTC)` on every fact write whose extraction path can produce dates (i.e., the new summarizer/extractor codepath always marks the row classified, even when `event_date` ends up `None`). This keeps newly-ingested facts out of the Layer 4 backfill eligibility set.
 
@@ -284,15 +298,17 @@ JOIN LATERAL (
       AND b.source_episode_id = a.source_episode_id
       AND b.event_date IS NOT NULL
       AND b.event_date > a.event_date
+      AND b.active = TRUE                  -- never link to superseded/inactive
     ORDER BY b.event_date ASC, b.id ASC   -- deterministic tiebreaker
     LIMIT 1
 ) b ON TRUE
 WHERE a.agent_id = $1
   AND a.event_date IS NOT NULL
+  AND a.active = TRUE                       -- active sources only (Heart recall default)
 ON CONFLICT (source_id, target_id, relation) DO NOTHING;
 ```
 
-Edge count per episode: at most N (where N = facts with non-NULL `event_date` in the episode). When multiple facts share the same `event_date`, all of them get a single outgoing edge pointing to the *same* representative successor — a 20-on-Jan-1 / 20-on-Jan-2 cluster produces 20 edges (Jan-1 facts → one Jan-2 fact), not 400. `auto_linked=TRUE` mirrors F040's sleep-cycle convention. Same-date facts deliberately get no edges between each other (we don't claim ordering on concurrent events).
+Edge count per episode: at most N (where N = active facts with non-NULL `event_date` in the episode). When multiple facts share the same `event_date`, all of them get a single outgoing edge pointing to the *same* representative successor — a 20-on-Jan-1 / 20-on-Jan-2 cluster produces 20 edges (Jan-1 facts → one Jan-2 fact), not 400. `auto_linked=TRUE` mirrors F040's sleep-cycle convention. Same-date facts deliberately get no edges between each other (we don't claim ordering on concurrent events). Both sides filter `active = TRUE` — otherwise an inactive successor could become the only target while the active siblings get no `happened_before` reinforcement (Heart recall returns only active rows, so the edge would be dead weight).
 
 **Consumer (already-shipped):**
 
@@ -510,7 +526,7 @@ The relation CHECK extension is required by Layer 2's INSERT — without it the 
 
 **ORM CheckConstraint must also be updated** (`nous/storage/models.py:239-244`). The SQLAlchemy `GraphEdge.__table_args__` declares its own `ck_edges_relation` constraint that is currently **stale** — it still lists only the init.sql-era relations and was not updated when F070's migration 051 added `part_of` and `summarized_by`. Any fresh-schema path (tests using `Base.metadata.create_all`, future Alembic autogenerate) would reject all three relations.
 
-F075 brings the ORM fully current:
+F075 brings the ORM fully current for **all three** stale check constraints — `ck_edges_relation`, `ck_edges_source_type`, and `ck_edges_target_type`. `'chunk'` was added to the SQL source/target_type constraints by migration 051 (F070) but the ORM was never updated; fresh ORM-driven schemas reject every F070 chunk edge today. F075 fixes all three in one pass:
 
 ```python
 # nous/storage/models.py — GraphEdge.__table_args__
@@ -520,6 +536,14 @@ CheckConstraint(
     "'part_of', 'summarized_by', "             # F070 catch-up
     "'happened_before')",                       # F075 addition
     name="ck_edges_relation",
+),
+CheckConstraint(
+    "source_type IN ('decision', 'fact', 'episode', 'procedure', 'chunk')",  # F070 catch-up
+    name="ck_edges_source_type",
+),
+CheckConstraint(
+    "target_type IN ('decision', 'fact', 'episode', 'procedure', 'chunk')",  # F070 catch-up
+    name="ck_edges_target_type",
 ),
 ```
 

--- a/docs/reviews/F075-spec-arch-review.md
+++ b/docs/reviews/F075-spec-arch-review.md
@@ -1,0 +1,146 @@
+# F075 Architecture Review — Temporal Fact Extraction + Date-Aware Retrieval
+
+**Reviewer:** Senior Architect (feature-dev:code-architect)
+**Spec:** `docs/features/F075-temporal-fact-extraction.md`
+**Date:** 2026-05-27
+**Verdict:** Two P1 architectural gaps must be fixed before implementation. Schema and phase strategy are sound.
+
+---
+
+## Executive Summary
+
+F075 correctly diagnoses the root cause and the synthetic validation proving the fix works is solid. The schema choice (single `event_date DATE` column on `heart.facts`, partial index, no new table) is correct. Two architectural gaps in Layer 1 will make it a no-op on production-shape ingestion if unaddressed.
+
+**P1-1 (blocking) — Wrong augmentation target.** The spec proposes augmenting `FactExtractor._EXTRACT_PROMPT` at `nous/handlers/fact_extractor.py`. That is the LLM fallback path. In production, every conversation goes through the 008.4 fast-path at `fact_extractor.py:143-148`: if `candidate_facts` are present in the event data (which they always are in the standard episode-summarize pipeline), `_extract_facts` is never called and `_EXTRACT_PROMPT` is never used. The correct augmentation target is the **episode summarizer's `candidate_facts` schema** at `nous/handlers/episode_summarizer.py:50-56`, where adding optional `"event_date": "YYYY-MM-DD"` to the structured output schema fixes the primary path. The `_store_candidate_facts` dict-unpacking loop at `fact_extractor.py:251-256` also needs an explicit `event_date = item.get("event_date")` line, or the field is silently discarded regardless of what the LLM emits.
+
+**P1-2 (blocking) — LLM context is lossy prose, not transcript.** Even at the correct target, the summarizer's LLM receives a 100-150 word prose summary, not the raw transcript. If "March 10" didn't survive summarization (as in the conv 2 Q0 smoke), neither path can recover it. The fix is a two-line prompt addition directing the summarizer to extract dates from the **transcript text** it already holds — the summarizer has the full transcript in scope at `episode_summarizer.py:258`.
+
+**P1-3 (framing, not blocking) — `happened_before` consumer is real but cannot surface retrieval misses.** `graph_adjacency_boost` at `retrieval_pipeline.py:243-247` is a valid consumer and the F065 trap is genuinely avoided. However, the boost requires both endpoints to already be in the retrieved candidate set, and the default for `NOUS_GRAPH_ADJACENCY_BOOST_ENABLED` is `false`. Layer 2 provides modest reranking reinforcement; it cannot surface retrieval-miss failures. The spec should be explicit about this scope.
+
+Fix P1-1 and P1-2 before implementation. Phase strategy (Layers 1+2+4 first) is sound.
+
+---
+
+## P1 Findings (Must Fix Before Implementation)
+
+### P1-1: Layer 1 augments the wrong code path — production bypasses `_EXTRACT_PROMPT` entirely
+
+**Spec claim:** "Prompt change in `FactExtractor._extract_prompt`" will cause date-anchored events to be extracted.
+
+The production fact extraction path is controlled by the 008.4 fast-path at `nous/handlers/fact_extractor.py:143-148`:
+
+```python
+cands = candidate_facts if candidate_facts is not None else summary.get("candidate_facts", [])
+if cands:
+    return await self._store_candidate_facts(cands, episode_id, transcript=transcript)
+# Fallback: LLM extraction  ← _EXTRACT_PROMPT lives here
+candidates = await self._extract_facts(summary)
+```
+
+In every standard production conversation, the episode summarizer emits `candidate_facts` inline in its JSON output (`nous/handlers/episode_summarizer.py:50-56`). When `handle()` receives the `episode_summarized` event, it reads `event.data.get("candidate_facts", [])` and passes them to `_store_candidate_facts`, bypassing `_extract_facts` and its `_EXTRACT_PROMPT` entirely. Augmenting `_EXTRACT_PROMPT` has zero effect on the primary path.
+
+**Required fix:** The correct augmentation target is the episode summarizer's `candidate_facts` schema at `nous/handlers/episode_summarizer.py:50-56`. Add an optional `"event_date": "YYYY-MM-DD"` field to the structured dict the summarizer's LLM is instructed to emit. The `_store_candidate_facts` dict-unpacking loop at `fact_extractor.py:251-256` must also add `event_date = item.get("event_date")` and thread it through `FactInput` construction.
+
+The full wire path that must be enumerated in the impl plan:
+1. Summarizer prompt schema (`episode_summarizer.py:50-56`) — add `event_date`
+2. `_store_candidate_facts` item unpacking (`fact_extractor.py:251-256`) — read `event_date`
+3. `FactInput` (`nous/heart/schemas.py:85-98`) — add `event_date: date | None = None`
+4. `FactManager._learn` ORM construction (`nous/heart/facts.py:428-449`) — pass to `Fact()`
+5. `Fact` ORM model (`nous/storage/models.py:469-511`) — add mapped column
+6. Migration `053` — `ALTER TABLE heart.facts ADD COLUMN IF NOT EXISTS event_date DATE DEFAULT NULL`
+7. `FactDetail` and `FactSummary` (`nous/heart/schemas.py:114-165`) — add field for downstream consumers
+
+`FactExtractor._EXTRACT_PROMPT` should also be augmented as defense-in-depth for direct-ingest and eval paths that bypass the episode summarizer, but it is not the primary lever.
+
+### P1-2: LLM feeding Layer 1 operates on lossy prose, not the transcript
+
+Even targeting the episode summarizer correctly (fixing P1-1), the summarizer's LLM receives a 100-150 word prose summary and `key_points` list — not the raw transcript (`episode_summarizer.py:40-57` shows the output format; the input to the extraction call is the same prose). If the date-bearing sentence was dropped during transcript-to-summary compression (as occurred in conv 2 Q0, where "March 10" appeared in a user message about API rate limits), the LLM has no data to extract it from.
+
+The transcript IS in scope: `episode_summarizer.py:258` passes `transcript=...` to `extract_and_store`, and the summarizer itself has the full transcript text available when generating the summary. The fix is a prompt addition at `episode_summarizer.py:76-77`:
+
+> "Also extract date-anchored events: if the transcript mentions that something happened on a specific date, add it as a candidate_fact with `event_date: YYYY-MM-DD`. Resolve relative dates against the episode start timestamp."
+
+This directs the summarizer's LLM — which **sees the transcript** — to extract dates from raw conversation content before compaction discards them.
+
+### P1-3: `happened_before` consumer is real but materially weak for the retrieval-miss failure class
+
+**Spec claim (Layer 2):** "`graph_adjacency_boost` is the consumer for `happened_before` edges."
+
+**Verification:** `retrieval_pipeline.py:243-247` confirms the consumer exists:
+
+```python
+if getattr(settings, "graph_adjacency_boost_enabled", False):
+    results = await _apply_graph_adjacency_boost(brain, results, alpha=alpha)
+```
+
+`_apply_graph_adjacency_boost` at `retrieval_pipeline.py:699-738` queries edges where BOTH `source_id` AND `target_id` are in the current candidate set (line 714-715: `AND source_id = ANY(...) AND target_id = ANY(...)`). The only excluded relation is `contradicts` (line 712). The spec's F065 claim is technically correct — `happened_before` edges have a real consumer and are not inert in the way F065's inferred-edge penalty was.
+
+However, two constraints limit Layer 2's practical impact:
+
+1. `NOUS_GRAPH_ADJACENCY_BOOST_ENABLED=false` is the default (`nous/config.py:1055-1056`). The spec says it is "gated by `NOUS_GRAPH_ADJACENCY_BOOST_ENABLED=true` in prod" — but the codebase default is `false`. The impl plan must include explicitly flipping this flag to realize any Layer 2 benefit.
+
+2. For the 3/5 retrieval-miss failures (conv 2 Q0, conv 4 Q1, conv 5 Q1), the date-anchored fact is not in the retrieved candidate set at all (conv 2 Q0 smoke: rank >39 of 39). The boost acts on items already retrieved — it cannot surface items below the retrieval cut. Layer 2 reinforces when both temporally-linked facts independently reach retrieval; that condition does not hold for the dominant failure class.
+
+**Verdict:** Not the F065 trap. Layer 2 is a valid reranking reinforcer. The spec should explicitly frame it as: "modest score reinforcement when both endpoints are already retrieved; ineffective for retrieval-miss failures." This is not a reason to omit Layer 2, but overstating its contribution risks misaligned acceptance criteria.
+
+---
+
+## P2 Findings (Should Fix)
+
+### P2-1: Backfill context source inherits the same lossy data gap
+
+The Layer 4 backfill script proposes feeding Haiku `episode.summary[:500]` as context. If the date was lost during summarization (the same root cause as P1-2), the backfill cannot recover it either. A stronger context source: query `heart.episode_chunks` for the source episode and pass the chunk whose content contains the candidate entity/action. The query shape exists at `retrieval_pipeline.py:818-851` (`_search_episode_chunks`). At ~5K facts, one extra DB query per row is feasible.
+
+### P2-2: Migration number is correct; confirm before branching
+
+`053_temporal_fact_extraction.sql` is the next available slot after `052_f069_document_source_kind.sql`. No conflict exists on current `main`. Verify again immediately before cutting the feature branch.
+
+### P2-3: Same-episode `happened_before` constraint inherits F070's inertness risk for cross-session queries
+
+F070's same-episode-only chunk edges were observed to be inert on session-level recall (per `project_f070_shipped` memory note: "all 3 retrieval consumers inert on session-level recall (same-episode-only constraint)"), requiring F070.1 for cross-episode edges. The `happened_before` same-episode constraint avoids O(N²) pairs but means "how long between X and Y" queries where X and Y come from different sessions never get edges built. For BEAM's single long-conversation haystacks, within-episode ordering is the common case — this is acceptable for v1. The spec should document the ceiling explicitly.
+
+### P2-4: Layer 3 requires `event_date` in `PipelineResult.metadata` — wire path missing
+
+Layer 3's boost at `r.metadata.get("event_date")` assumes `event_date` is already present in each `PipelineResult`. Currently `_heart_results_to_pipeline` at `retrieval_pipeline.py:659-671` constructs `PipelineResult` with an empty metadata dict. Surfacing `event_date` requires either modifying the Heart recall SQL to return the column, or a batch post-join. Layer 3 is deferred pending measurement, but the impl plan should budget for this additional wiring.
+
+---
+
+## P3 Findings (Nice to Have)
+
+### P3-1: `content_date_extractor.py` is untracked; move before reuse
+
+`nous/heart/content_date_extractor.py` is git-untracked (confirmed in `git status`). The module is well-structured but should be committed and given test coverage before being imported from `retrieval_pipeline.py` as a production dependency.
+
+### P3-2: Default `temporal_extraction_enabled=True` is inconsistent with dark-launch convention
+
+All prior behavioral augmentations (F042, F047, F067, F071) defaulted off and required an explicit flag flip after measurement. Recommend `default=False` with flip gated on the LME pre-check.
+
+---
+
+## Schema Choice Assessment
+
+`event_date DATE DEFAULT NULL` on `heart.facts` with a partial index is the correct design. The ORM model at `nous/storage/models.py:469-511` needs one `Mapped[date | None]` column using Python's `datetime.date` type (not `datetime`).
+
+## Phase Strategy Assessment
+
+"Layers 1+2+4 first" is sound after incorporating P1 fixes. Reframe as:
+
+- **Layer 1a (primary):** Augment episode summarizer prompt — extract dates from transcript text.
+- **Layer 1b (defense-in-depth):** Augment `FactExtractor._EXTRACT_PROMPT` for direct-ingest/eval paths.
+- **Layer 2:** Ship with Layer 1. Document as reranking reinforcer; flip `NOUS_GRAPH_ADJACENCY_BOOST_ENABLED`.
+- **Layer 4:** Backfill with chunk context source (P2-1).
+- **Layer 3:** Defer; budget metadata surfacing work for when it lands.
+
+## Finding Summary
+
+| Finding | Files | Priority |
+|---------|-------|----------|
+| `_EXTRACT_PROMPT` is the fallback; prod uses `_store_candidate_facts` via 008.4 fast-path | `fact_extractor.py:143-148`, `episode_summarizer.py:50-56` | P1 |
+| Summarizer LLM sees 150-word prose, not transcript; date lost in compression is unrecoverable | `episode_summarizer.py:76-77`, `fact_extractor.py:297-308` | P1 |
+| `happened_before` consumer is real but default-off and cannot surface retrieval-miss failures | `retrieval_pipeline.py:243-247, 699-738`, `config.py:1055-1056` | P1 |
+| `_store_candidate_facts` dict-unpacking silently discards unknown keys including `event_date` | `fact_extractor.py:251-256` | P2 |
+| Backfill Haiku context (`episode.summary[:500]`) suffers same lossy gap as Layer 1 | spec Layer 4, `retrieval_pipeline.py:818-851` | P2 |
+| Same-episode `happened_before` cannot link cross-session date pairs (F070 ceiling pattern) | `brain/graph_densifier.py:1045-1098` | P2 |
+| Layer 3 `metadata.get("event_date")` requires new surfacing logic in `_heart_results_to_pipeline` | `retrieval_pipeline.py:659-671` | P2 |
+| `content_date_extractor.py` is untracked; needs commit + tests before production reuse | `nous/heart/content_date_extractor.py` | P3 |
+| `temporal_extraction_enabled=True` default inconsistent with dark-launch convention | spec §Settings | P3 |

--- a/docs/reviews/F075-spec-devil-review.md
+++ b/docs/reviews/F075-spec-devil-review.md
@@ -1,0 +1,108 @@
+# F075 — Devil's-Advocate Spec Review
+
+**Reviewer role:** Adversarial. Find weaknesses, not blessings.
+**Date:** 2026-05-27
+**Subject:** `docs/features/F075-temporal-fact-extraction.md` (Draft v1)
+**Verdict header:** Spec is **directionally plausible but operationally under-derisked**. The smoking-gun n=1 validation has done less work than the spec implies, and several mechanism claims do not survive code-reading.
+
+---
+
+## Finding 1 — Smoking-gun validation is n=1 (Critical)
+
+**Claim under review:** §Problem says 3 of 5 failures are retrieval-miss, fixable by extractor.
+**The mechanism behind that 3-of-5 number:** only conv 2 Q0 was traced end-to-end (SQL + retrieval pipeline + LLM rerun). Conv 4 Q1 and conv 5 Q1 are presumed to be the same shape "no info about when X happened" purely from the answer text. The spec then projects 3-of-5 cleanly into "≥0.60 temporal_reasoning."
+**Sibling precedent:** the `BEAM_TERSE_LIST` diagnostic (memory `f074-terse-list-shim`) shows the same investigator's surface-shape intuition was wrong — what looked like a vocabulary gap was a topical-choice gap, and the shim moved 0.00 on the actual rubric. The exact same epistemic risk applies here: surface-shape "no info about when" failures may have different mechanisms (LLM hedge, abstention, contradicting context retrieved alongside the date, ambiguous rubric date).
+**What we'd need to verify or change:** Before paying ~$12 to re-run BEAM, run the cheap diagnostic (~$0.20) for conv 4 Q1 and conv 5 Q1 too — read source chat, check if the date(s) the rubric expects appear at all, count how many times, and confirm the rate-limit-style "buried in unrelated context" structure repeats. If only 1 of the 3 retrieval-miss failures repeats the pattern, the expected lift drops from +0.18 to +0.06 and the entire feature shape is over-engineered.
+
+## Finding 2 — `_apply_graph_adjacency_boost` is a footgun for `happened_before` (High)
+
+**Claim under review:** §Layer 2 says "the existing boost summing edges across candidates will naturally include `happened_before` once we write them. **No new consumer code required.**"
+**What the code actually does** (`nous/api/retrieval_pipeline.py:709-716`): the SQL filter is `WHERE agent_id = :a AND relation != 'contradicts' AND source_id = ANY(...) AND target_id = ANY(...)`. So yes, `happened_before` will be summed indiscriminately into the adjacency degree alongside `related_to`, `informed_by`, `summarized_by`, etc.
+**The hidden risk:** the boost rewards "this candidate is connected to OTHER candidates in the same recall batch." For a date-arithmetic query like *"how many days between API key acquisition and wireframe completion"* both endpoint facts will be in the batch, and they will reinforce each other — that part is fine. **But** any unrelated date-anchored fact in the same episode will also be in the `happened_before` chain through that batch, and so it will inherit boost too, surfacing topical-neighbors-that-happen-to-be-time-adjacent. The boost is **multiplicative on existing relevance score**, so the worst case is a moderately-relevant time-neighbor moves above the correct fact.
+**Worse:** there is no current consumer that treats `happened_before` differently from `related_to`. Layer 2 ships a new edge type with semantically-distinct meaning into a sum that treats all relations as equivalent — that *is* the F065 anti-pattern in reverse (edges with semantically-wrong consumer, instead of edges with no consumer).
+**What we'd need to verify or change:** Either (a) gate `_apply_graph_adjacency_boost` to specific relations via a settings allowlist before writing `happened_before` edges, or (b) drop Layer 2 entirely from v1 and rely purely on the `event_date` SQL column (Layer 3) — the spec already admits at line 489 that "synthetic validation showed the fact embedding alone (no boost) ranked #3." If the synthetic fact wins on cosine alone, Layer 2 is unjustified for the validated use case and the marginal risk is unbounded.
+
+## Finding 3 — Extractor sees the SUMMARY, not the transcript (Critical)
+
+**Claim under review:** §Layer 1 augments `FactExtractor` to produce date-anchored facts.
+**What the code actually does** (`nous/handlers/fact_extractor.py:297-308`): `_extract_facts` consumes only `summary["summary"]` and `summary["key_points"]`. Both are produced by `EpisodeSummarizer` (`_SUMMARY_PROMPT`, ~150-word prose summary) which itself summarizes the transcript and does NOT have any instruction to preserve dates faithfully. The "March 10" the diagnostic found in `episode_chunks` is in the **raw transcript**, not the summary.
+**The risk:** Even with a perfect F075 prompt addition, the extractor only sees what the summarizer kept. If the summarizer dropped "March 10" because it lived in a rate-limit code block (and the summarizer rightly compresses code-heavy content), the extractor cannot extract what it cannot see. The "0 rows contain March 10" observation in the diagnostic might be a summarizer-drop rather than an extractor-miss — and F075 fixes the latter, not the former.
+**Spec also references `EPISODE_START_TIMESTAMP`** in the prompt template (line 109 "Resolve relative dates ... against the EPISODE_START_TIMESTAMP provided in the metadata block") — but the existing `_extract_facts` call site does not pass episode start. That's at minimum new plumbing not accounted for in the 80-LOC Layer 1 estimate; at maximum it's a contradiction with where the data actually lives.
+**What we'd need to verify or change:** Before writing any code, instrument **one** failing conv: dump the `summary["summary"]` text for the episode containing "March 10" and grep for the date. If absent, F075 must also modify `EpisodeSummarizer`'s prompt — bringing this to 2 prompt mutations, doubling the regression-risk surface for non-event content (Finding 4). If present, then F075's Layer 1 lever is empirically valid.
+
+## Finding 4 — Two-prompt collateral risk understated (High)
+
+**Claim under review:** §Risks lists "Prompt-engineering risk" with mitigation "integration test with known-date corpus; track precision/recall in eval."
+**Sibling precedent:** Memory `lme-qa-winning-recipe` records V10's timestamp-prompt finding — a small prompt addition produced category-specific regressions, with the win coming from one category and losses in others. Same shape applies here: a date-focused instruction to the FactExtractor (or EpisodeSummarizer if Finding 3 forces it) will plausibly compete for output tokens against the existing instructions ("preferences, person, rule, technical, concept, tool"). On non-event content, the extractor may produce fewer category-correct facts because attention is now split.
+**Spec mitigation is insufficient:** "existing test suite" only checks output schema; "LME hand-label qrels" measures retrieval, not extractor output quality. Neither catches a 5% regression in `knowledge_update` or `information_extraction` BEAM abilities.
+**What we'd need to verify or change:** Add an acceptance criterion: re-run BEAM ability scores for `knowledge_update` and `information_extraction` and require ≤0.05 regression. (The spec already commits to "Other ability scores stay within ±0.05" in §Acceptance #4, but only against prod-v3, and at n=5 the noise floor is ±0.025 — see Finding 6.) Make this a numeric gate, not an inspection step. Better: add a holdout fact-extraction unit test where the input has no date content and assert the output is byte-identical pre/post-prompt.
+
+## Finding 5 — Dedup is silent on same-event-different-date (Medium)
+
+**Claim under review:** §Layer 1 says "Date-anchored events should still go through the dedup check. If the same event was already captured (same entity+action+date), do not duplicate."
+**The unaddressed case:** if the same event is extracted twice on different sessions with slightly different parsed dates (LLM relative-date resolution drift: "yesterday" resolved against episode_start vs against session_start), what happens? Today's dedup is hybrid-search RRF at 0.92 + native cosine at 0.95 on **content** — both score on the text, not on `event_date`. So `"Christina obtained the OpenWeather key on 2024-03-10"` and `"Christina got her OpenWeather key on 2024-03-11"` would both pass dedup and both live in facts with different `event_date`. Retrieval surfaces both. Date-arithmetic LLM picks one. Spec promises this is "category B (wrong-date), not addressable" — but F075 will CREATE category-B failures it does not currently have.
+**What we'd need to verify or change:** Either (a) make `event_date` part of dedup key (composite on subject + event_date) — this is a real schema change and unbudgeted; (b) prefer the older/more-confident date in a tie via post-extract reconciliation; (c) accept the risk explicitly and add a regression check that the `wrong-date` failure count does not rise. Without any of these, F075 may move 3 failures from class-A to class-A-fixed but introduce 1-2 new class-B failures, netting a smaller lift than projected.
+
+## Finding 6 — n=5 noise floor against a 0.18 expected lift (High)
+
+**Claim under review:** §Acceptance #4 says re-run BEAM Phase 1 at n=5 conv with threshold ≥0.55 (ideally ≥0.60), current 0.417.
+**The math:** BEAM Phase 1 noise at n=5 conv is ±0.025 from `f074-beam-results` (your own characterization in the task brief). Six temporal_reasoning Qs per conv × 5 conv = 30 Q. A 0.18 expected lift moves the metric ~7× the noise floor, so the **direction** would be detectable. But the **magnitude** required for the gate (≥0.55 = +0.13) is only ~5× noise, and the "ideal" target (≥0.60 = +0.18) only ~7×. If the real lift is 0.06 (Finding 1 worst case), n=5 cannot distinguish that from noise.
+**What we'd need to verify or change:** Specify the gate more rigorously: (a) require both `temporal_reasoning ≥ 0.55` AND no individual conv-level temporal score regresses by >0.10 (catches lift-on-average-with-one-conv-getting-worse); (b) require non-overlapping confidence interval against prod-v3 baseline; (c) if the n=5 result falls in 0.45-0.55 (i.e., ambiguous), commit to an n=20 re-run BEFORE flipping any defaults. Currently the spec allows a "lucky 5-conv" pass to lock in the change.
+
+## Finding 7 — Synthetic validation phrasing is the best possible case (High)
+
+**Claim under review:** §Smoking-gun finding — synthetic fact `"Christina obtained the OpenWeather API key on March 10, 2024."` ranked #3 with score 0.827.
+**What was actually validated:** the embedding cosine between *that exact sentence* and the date-arithmetic query. The sentence is a clean SVO-on-date construction with the entity name, the action verb, and the ISO-resolved date in the order a curator would write. **Real extractor output won't be this clean.** Possible LLM outputs:
+- `"User got their OpenWeather API key around the 10th of March."` (lower cosine — pronoun drift + relative phrasing)
+- `"OpenWeather API key acquisition: March 10, 2024."` (header-style, low cosine to natural-language question)
+- `"On March 10, 2024, Christina obtained the API key for OpenWeather and configured rate limits."` (mixed-topic, embedding dragged toward "rate limits" — same root failure that caused the chunk to rank low)
+**The synthetic ranked #3.** If real extraction produces a phrasing 0.05 less aligned, that drops to rank 8-12 — possibly outside top-K, restoring the original failure.
+**What we'd need to verify or change:** Before committing to Layer 1's design, run an extractor draft prompt on the 3 retrieval-miss episodes, dump the actual produced fact text, embed it, rank it against the live K=20 result set. If the produced fact ranks worse than #5 in any of the 3 cases, the prompt needs more constraint on output phrasing OR Layer 3 (boost) is mandatory, not optional.
+
+## Finding 8 — Scope creep concealed in "440 LOC" (Medium)
+
+**Claim under review:** Cost section says "~440 LOC + 30 tests. ~2-3 days for one engineer."
+**Hidden scope items not in that count:**
+- **EpisodeSummarizer prompt change** (Finding 3) — at least 1 prompt mutation + 5 tests + a snapshot-update for the existing summarizer tests.
+- **Episode start timestamp threading** — `_extract_facts` and the prompt template need access to `episode.started_at`. Not currently in `_EXTRACT_PROMPT.format()` args. Touches handler + summarizer + tests.
+- **Settings update in `CLAUDE.md` env-var table** — spec mentions 5 new rows but the table is already 250+ rows. New rows need a careful insert location for the row-ordering convention. ~30 min, but real time.
+- **Sleep cycle re-run after backfill** — spec promises §Layer 4 step "triggers `GraphDensifier.run_backfill_cycle` at end" — but `run_backfill_cycle` operates per-cycle, not per-episode. The 5K-fact backfill will produce up to ~N-per-episode chains for ~hundreds of episodes; one `run_backfill_cycle` call may not cover all episodes (depends on `NOUS_GRAPH_BACKFILL_MAX_FACTS=50` per cycle). Either the backfill script must run multiple densifier passes OR document that edges will fill in over multiple sleeps.
+- **Eval re-run is two passes:** LME N=20 pre-check ($5) AND BEAM ($7), per spec line 444. Plus the n=20 re-run if Finding 6 hits.
+**Realistic estimate:** 600-750 LOC, 35-45 tests, 4-5 days. The 2-3 day estimate is for the happy-path subset only.
+**What we'd need to verify or change:** Re-plan with the summarizer prompt change explicit, the episode-start-timestamp wiring explicit, and a written guarantee that the densifier covers all backfilled facts in finite time (or accept the multi-sleep convergence model).
+
+## Finding 9 — Hidden assumption in the diagnostic chain (Medium)
+
+**Claim under review:** §Problem's reasoning chain is unusually clean — five intuitive levers falsified neatly, leaving one survivor: "the gap is at ingest."
+**The hidden assumption:** that the right fix can be reasoned about per-failure-class independently. The diagnostic separates "class A retrieval-miss" from "class B wrong-date" as if F075 only touches A. **But F075 changes extractor output for ALL episodes, including the ones whose class-A and class-B failures share the same underlying property** — that the source has weakly-grounded date references. F075 will produce more dates in the candidate pool overall. For class-B (wrong-date) episodes the candidate pool was already noisy; adding more dated facts to the same noisy pool plausibly worsens those failures (Finding 5 mechanism). The chain treats A and B as independent, but the corpus is shared.
+**Sibling precedent:** the V14→V18 LME finding (`lme-v18-cognitive-overhead`) — adding capabilities targeted at one weakness regressed an unrelated category because attention/scoring is shared.
+**What we'd need to verify or change:** Add an acceptance criterion that the **wrong-date failure count** does not increase. Concretely: count conv 2 Q1 + conv 3 Q1 in the re-run; if either moves from `wrong-date` to `still wrong-date but a different date now`, the feature is at parity or worse on those Qs and the spec's 0.7 ceiling claim must be revised.
+
+---
+
+## Summary table
+
+| # | Finding | Severity |
+|---|---|---|
+| 1 | n=1 smoking-gun extrapolated to 3-of-5 without per-Q diagnostic | Critical |
+| 2 | `_apply_graph_adjacency_boost` will treat `happened_before` like any other edge — semantic mismatch | High |
+| 3 | FactExtractor reads summary, not transcript — Layer 1 may target the wrong stage | Critical |
+| 4 | Two-prompt collateral on non-event content not measured rigorously | High |
+| 5 | Dedup blind to event_date — creates class-B failures it claims not to | Medium |
+| 6 | n=5 BEAM noise (±0.025) too close to gate threshold (≥0.55) for confident accept | High |
+| 7 | Synthetic validation phrasing was a best-case; real extractor output may rank worse | High |
+| 8 | 440-LOC / 2-3-day estimate excludes summarizer change, timestamp threading, multi-pass densifier | Medium |
+| 9 | Per-class reasoning ignores shared-corpus interactions between class A and class B | Medium |
+
+---
+
+## Recommendation
+
+Do NOT proceed to implementation as scoped. Before plan/spec lock:
+
+1. **Spend $0.20 on three diagnostic dumps** (conv 4 Q1, conv 5 Q1, plus a clean reread of conv 2 Q1) and re-verify the 3-of-5 retrieval-miss class distribution.
+2. **Read the episode summaries themselves** for the failing conversations. If "March 10" is absent from the summary text, Layer 1 must be split into a summarizer change + an extractor change, doubling the prompt-collateral risk.
+3. **Resolve the adjacency-boost mechanism** (Finding 2) — either explicitly allowlist relations in `_apply_graph_adjacency_boost` as part of F075, or drop Layer 2 entirely and rely on the SQL column.
+4. **Define the gate numerically and pre-register it** — include knowledge_update and information_extraction floors, wrong-date count ceiling, and an n=20 re-run trigger band.
+
+These are 4 hours of pre-work that derisk a 5-day implementation against the most likely failure modes. Skipping them recreates the F065 trap structurally.

--- a/docs/reviews/F075-spec-python-pro-review.md
+++ b/docs/reviews/F075-spec-python-pro-review.md
@@ -1,0 +1,233 @@
+# F075 — Python-Level Spec Review
+
+**Reviewer:** python-pro (Claude code reviewer)
+**Date:** 2026-05-27
+**Spec:** `docs/features/F075-temporal-fact-extraction.md` (Draft v1)
+**Scope:** Python-level correctness — pydantic v2 idioms, SQLAlchemy migration shape, async retrofit script, retrieval boost step, type safety, test idioms.
+
+---
+
+## TL;DR
+
+Spec is implementable as drafted, but six concrete Python-level corrections are needed before code. The biggest is **P1-1**: the spec invents an `ExtractedFact` pydantic model that does not exist in the codebase — the current `FactExtractor` (`nous/handlers/fact_extractor.py:153-208`) passes raw dicts straight into `FactInput`. Spec must either create `ExtractedFact` (and wire `_extract_facts` through it) or augment `FactInput` directly. The other findings are smaller but blocking: malformed `WHERE id = (SELECT id FROM batch)` SQL (P1-2), missing `r.score or 0.0` defensive coalesce in the boost (P2-2), and unspecified ORM mapping for the new `event_date` column (P1-4).
+
+---
+
+## P1 — Must-fix before implementation
+
+### P1-1. `ExtractedFact` pydantic model does not exist in the codebase
+
+**Spec claim (§Layer 1, lines 119-121):**
+> Add `event_date: str | None` to `ExtractedFact` Pydantic model (`nous/heart/schemas.py`). Validator: must match `^\d{4}-\d{2}-\d{2}$` OR be `None`.
+
+**Reality:** No such class. `nous/heart/schemas.py:85-99` defines `FactInput` (write-path into Heart). `FactExtractor._extract_facts` (`nous/handlers/fact_extractor.py:297-324`) returns `list[dict[str, Any]]` — raw JSON from `parse_llm_json`. The dicts are read by `_store_extracted_facts` (`nous/handlers/fact_extractor.py:154-208`) which builds `FactInput` directly via `fact.get("subject")`, `fact.get("content")`, etc. **There is no intermediate pydantic boundary today.**
+
+**Two clean options — pick one in the impl plan:**
+
+1. **Create `ExtractedFact` as a real boundary** in `nous/heart/schemas.py`:
+
+   ```python
+   class ExtractedFact(BaseModel):
+       subject: str
+       content: str
+       category: str | None = None
+       confidence: float = Field(default=0.7, ge=0.0, le=1.0)
+       event_date: str | None = Field(
+           default=None,
+           pattern=r"^\d{4}-\d{2}-\d{2}$",
+       )
+   ```
+
+   Then refactor `_extract_facts` to return `list[ExtractedFact]` (using `ExtractedFact.model_validate(d)` per dict in a try/except — fail-soft per spec §Layer 1 closing paragraph). This is the cleanest pydantic v2 idiom; `Field(pattern=...)` is the v2-native way for simple regex (matches `nous_eval/handlers/_models.py:25,42,108`).
+
+2. **Skip `ExtractedFact`, add `event_date` directly to `FactInput`** (`nous/heart/schemas.py:85`) and to the SQLAlchemy `Fact` model (`nous/storage/models.py:469`). The fact_extractor's current "dict → FactInput" boundary already does the validation. Add a `@field_validator("event_date", mode="before")` on `FactInput` that:
+   - coerces empty string to None,
+   - rejects malformed ISO strings (raises pydantic `ValueError` → caller catches → drops the field per spec's fail-soft requirement).
+
+   This is the **smaller change** and matches the existing architecture better.
+
+Recommend Option 2 unless arch review wants a public DTO layer.
+
+**Pydantic v2 idiom for the validator (if going stricter than regex):**
+
+```python
+from datetime import date
+from pydantic import field_validator
+
+@field_validator("event_date", mode="before")
+@classmethod
+def _validate_iso_date(cls, v: str | None) -> str | None:
+    if v is None or v == "":
+        return None
+    try:
+        date.fromisoformat(v)  # validates YYYY-MM-DD shape
+    except (ValueError, TypeError):
+        raise ValueError(f"event_date must be ISO YYYY-MM-DD, got {v!r}")
+    return v
+```
+
+Using `date.fromisoformat` is stricter than the regex (rejects `2024-02-30`, `2024-13-01`) and matches what Layer 3 will do at read time. **Strongly prefer this over the bare regex.**
+
+### P1-2. Backfill SQL `WHERE id = (SELECT id FROM batch)` is malformed for batches > 1
+
+**Spec §Layer 4, lines 303-314:**
+
+```sql
+WITH batch AS (
+  SELECT id FROM heart.facts ... LIMIT $2
+)
+UPDATE heart.facts
+SET event_date = $3, updated_at = NOW()
+WHERE id = (SELECT id FROM batch);
+```
+
+`= (SELECT ...)` raises `more than one row returned by a subquery used as an expression` at runtime when `LIMIT > 1`. The spec text immediately below the SQL ("Per-row update, not bulk, because each row gets a different LLM-derived date") makes the intent clear: **drop the CTE entirely** and just do per-row update keyed on `id = :id`, mirroring F047 (`nous/handlers/actionability_backfill.py:198-216`):
+
+```sql
+UPDATE heart.facts
+SET event_date = :event_date, updated_at = NOW()
+WHERE id = :id
+```
+
+The CTE in the spec confuses fetch (batched) with update (per-row). Keep them separate as F047 does (`_fetch_batch` returns N rows; `_update_actionable` runs per-row).
+
+### P1-3. Advisory lock: prefer F049's `hashlib.sha256 % (2**31)` over `hashtext`
+
+**Spec §Layer 4, lines 251-253** mentions `pg_try_advisory_xact_lock` keyed on SHA-256 of agent_id. Two existing precedents in the repo:
+
+- **F047 backfill** (`nous/handlers/actionability_backfill.py:108-115`): `hashlib.sha256(...).digest()[:8]` → `int.from_bytes(..., "big", signed=True)` → full 64-bit signed bigint passed to `pg_try_advisory_lock` (session-scoped, paired with `pg_advisory_unlock`).
+- **F049 WM sweep** (`nous/heart/working_memory.py:343-348`): `hashlib.sha256(...).digest()[:4]` → `int.from_bytes(..., "big") % (2**31)` → 31-bit unsigned key passed to `pg_try_advisory_xact_lock` (transaction-scoped, auto-released).
+
+`hashtext(agent_id)::bigint` would be simpler but **not portable to SQLite tests** (F047's lock gate already has a `try/except` exactly for this — see `nous/handlers/actionability_backfill.py:78-86`). Use Python-side hashing.
+
+**For this backfill: copy F047's pattern** (session-scoped lock + explicit unlock + SQLite-safe try/except). The backfill is a one-shot script, not a hot path; transaction-scoped (F049 style) would lock for the entire script duration which is fine but less explicit on failure. F047 is the closer analog.
+
+### P1-4. ORM mapping for `event_date` not specified
+
+The spec adds a SQL column at migration 053 but never says how `Fact` SQLAlchemy class (`nous/storage/models.py:469-511`) is updated. **Required additions:**
+
+```python
+from datetime import date  # add to imports at top
+from sqlalchemy import Date
+
+# In Fact class, near actionable (line 503-505):
+# F075: Temporal anchor for date-arithmetic queries
+event_date: Mapped[date | None] = mapped_column(Date, nullable=True, default=None)
+```
+
+Without this, ORM reads will silently miss the column. Add to the spec's §Tests under "Acceptance criteria #2 (existing tests pass)" — `tests/test_storage_models.py` if it touches `Fact` will need a corresponding addition.
+
+Also: spec proposes surfacing `event_date` via `r.metadata.get("event_date")` in Layer 3 (line 215). That requires the recall pipeline to **actually populate** `metadata["event_date"]` when constructing `PipelineResult` from `RecallResult`. Currently `RecallResult.metadata` (`nous/heart/schemas.py:340`) is `dict = {}` and gets type-specific fields. Spec must explicitly add: "Heart.recall populates `event_date` in `RecallResult.metadata` for fact rows when the column is non-NULL." Otherwise Layer 3 reads None and silently no-ops forever.
+
+---
+
+## P2 — Should fix
+
+### P2-1. `_apply_date_boost` should defensively coalesce `r.score`
+
+**Spec §Layer 3, line 223:**
+
+```python
+r_boosted = replace(r, score=r.score * settings.date_aware_boost_factor)
+```
+
+`PipelineResult.score` is typed `float` (`retrieval_pipeline.py:62`) but the existing twin `_apply_adjacency_boost` uses `(r.score or 0.0) * boost` (`retrieval_pipeline.py:736`) defensively. Match that idiom — costs nothing, prevents a class of None-multiply crashes if a future caller constructs `PipelineResult(score=None)` somewhere upstream.
+
+Also: the spec's sort key `key=lambda r: r.score` (line 227) should be `key=lambda r: r.score or 0.0` to match `_apply_adjacency_boost:737`.
+
+### P2-2. Migration 053 style: pick BEGIN/COMMIT or not
+
+Existing migrations are inconsistent:
+- `052_f069_document_source_kind.sql:22,34` — wraps in `BEGIN; ... COMMIT;`
+- `034_fact_actionability.sql` — no transaction wrapper
+
+Both work (psycopg/asyncpg DDL is autocommit per statement unless wrapped). **Recommend matching 052** (the most recent migration) and wrapping the `ALTER TABLE` + `CREATE INDEX` + `COMMENT` in `BEGIN; ... COMMIT;` so either all three apply or none do.
+
+The spec's draft 053 omits the transaction wrapper. Minor — should be added when impl PR lands.
+
+### P2-3. `LLMClient` choice for the backfill script
+
+Spec §Layer 4 says "Per-row LLM call (cheap — Haiku)" without specifying client construction. **Correct pattern** (from F047, but `actionability_backfill.py` actually receives a pre-built `classifier` injected with a client — not directly comparable):
+
+```python
+# scripts/backfill_temporal_facts.py
+from nous.config import Settings
+from nous.api.anthropic_client import create_client
+from nous.handlers import call_background_llm_structured
+
+settings = Settings()  # loads from env
+client = create_client(settings)  # AnthropicClient Protocol
+await client.start()
+try:
+    # ... batched extraction loop, calling
+    # call_background_llm_structured(client, model=settings.actionability_model, ...)
+finally:
+    await client.close()
+```
+
+`create_client` is at `nous/api/anthropic_client.py:1182`. The `LLMClient` protocol at `nous/handlers/__init__.py:23-28` is what `call_background_llm` consumes. **Use `call_background_llm_structured`** (`__init__.py:86`) with a `{"event_date": {"type": "string"} | null, "reason": "..."}` tool input_schema — the tool_use trick gives guaranteed JSON, no `parse_llm_json` repair fallback needed. Cleaner than the spec's pseudo-`USER` prompt with prose JSON instructions.
+
+### P2-4. Token budget exhaustion path — F047 model
+
+Spec §Layer 4 ("Token budget exhausted → clean halt with resume marker") matches F047 closely but doesn't name the mechanism. **F047's pattern** (`nous/handlers/actionability_backfill.py:55-65`) injects a `_budget_check` callable into the classifier; classifier returns "default" tier and increments a separate counter. **For F075** the equivalent is:
+
+```python
+# In the per-row loop:
+if not self._budget_ok():
+    logger.info(
+        "F075 backfill: token budget exhausted at %d/%d rows. "
+        "Re-run with same flags; NULL filter makes this idempotent.",
+        processed, total_eligible,
+    )
+    break
+```
+
+The "resume marker" is **implicit** — the `event_date IS NULL` filter on `_fetch_batch` is the resume marker. Don't add an external marker file; spec already correctly notes this in line 318 ("Idempotence: the `event_date IS NULL` predicate makes the script safe to re-run after crash"). Just make sure the impl actually checks `_budget_ok` per row, not per batch.
+
+### P2-5. `dataclasses.replace` import for Layer 3
+
+Spec §Layer 3 shows `replace(r, score=...)` without an import. Existing pattern in `retrieval_pipeline.py:696,754` is `from dataclasses import replace` **inside the function body**, not module-level. Either works; spec should pick one. Module-level is fine since `dataclasses` is stdlib and free. Minor — pick consistent style.
+
+---
+
+## P3 — Nits / observations
+
+### P3-1. pytest-asyncio config
+
+Already in auto-mode (`pyproject.toml:59` — `asyncio_mode = "auto"`). The proposed `tests/test_temporal_*` files don't need `@pytest.mark.asyncio` decorators on individual tests when the function is `async def`. Spec doesn't mention decorators; just confirming no config change is required.
+
+### P3-2. `tests/test_fact_extractor.py` does NOT exist
+
+Spec §Tests "No regression in `tests/test_fact_extractor.py`" — that file isn't in the repo. Only `tests/test_fact_extractor_episode_id.py` exists (single-purpose F022 audit regression). The new `tests/test_temporal_extractor.py` will be the primary FactExtractor test suite. Either rename the spec reference or note that the existing file is the F022 narrow test.
+
+### P3-3. `dateparser` not in dependencies
+
+Spec §Layer 1 closing paragraph and §Deferred F075.4 reference `dateparser` as a v2 fallback. `dateparser` is a heavyweight dep (~3 MB, pulls `pytz`, `tzlocal`, etc.). If it's truly v2-deferred, no action; if anyone wants to land it in v1, it must be added to `pyproject.toml` and **not** as a runtime-optional like `sentence-transformers`. Date parsing is a critical path, not feature-flagged. Just keep it out of v1 as the spec correctly proposes.
+
+### P3-4. `event_date` Python type: `date` not `datetime`, not `str`
+
+Type-safety flow (spec §Layer 1 + §Schema):
+- Pydantic field: `str | None` (LLM emits ISO string)
+- DB column: `DATE` (Postgres native)
+- ORM read: `Mapped[date | None]` (Python `datetime.date`)
+- Layer 3 read: `date.fromisoformat(ed)` already returns `date`, comparison `window[0] <= event_date <= window[1]` requires `window[0]: date` not `datetime`.
+
+**Spec is consistent here.** Just flag for impl: do NOT use `datetime` anywhere; mixing `date` and `datetime` in comparisons raises `TypeError`. `_infer_query_date_window` must return `(date, date) | None`, not `(datetime, datetime) | None`.
+
+### P3-5. `r.metadata.get("event_date")` in Layer 3 → see P1-4
+
+Cross-referenced above. Without RecallResult.metadata propagation from Heart.recall, this `.get()` returns None and the whole boost is a silent no-op. Important enough to surface in arch review too.
+
+---
+
+## Summary of changes the spec needs before impl PR
+
+1. **Decide:** create `ExtractedFact` model OR extend `FactInput` directly (P1-1).
+2. **Fix backfill SQL:** drop the broken CTE; use per-row UPDATE keyed on `:id` (P1-2).
+3. **Specify advisory lock implementation:** copy F047's `hashlib.sha256().digest()[:8]` → signed bigint pattern (P1-3).
+4. **Add ORM mapping for `event_date`** in `nous/storage/models.py:469` Fact class (P1-4).
+5. **Add `RecallResult.metadata["event_date"]` propagation step** in Heart.recall — without this, Layer 3 is dead code (P1-4 corollary).
+6. **Use `date.fromisoformat` in validator**, not bare regex (P1-1 strengthening).
+7. Smaller polish: `r.score or 0.0` coalesce, BEGIN/COMMIT in 053, `call_background_llm_structured` over prose JSON prompt.
+
+None of these are architectural — they're Python-level corrections to make the spec implementable as written. Total spec-edit surface: ~30 lines across §Layer 1, §Layer 4, §Schema migration.


### PR DESCRIPTION
## Summary

Spec proposes extracting date-anchored events as discrete facts during episode summarization. Adds `event_date` column to `heart.facts`, `happened_before` edges (reranking reinforcer), and a retrofit script (F047 pattern). Date-aware retrieval boost (Layer 3) deferred pending Layer 1+2+4 measurement.

## Motivation

BEAM-100K prod-v3 measures temporal_reasoning at **0.417**. Diagnostic chain across 3 falsified easy levers (staleness, K-bump, inline date markers) traced the root cause to `EpisodeSummarizer.candidate_facts` schema lacking a slot for dates — date-anchored events survive in `heart.episode_chunks` but never become discrete facts in `heart.facts`. Chunks containing the dates rank too low on date-arithmetic queries because surrounding content (code, prose) dominates the embedding.

**Empirical validation (~$0.05):** hand-injecting `"Christina obtained the OpenWeather API key on March 10, 2024."` into `heart.facts` for conv 2 caused the synthetic fact to rank #3 of 39 in retrieval, and the LLM produced *"...That's 2 days between the two events."* — moving conv 2 Q0's BEAM score from 0.000 → 1.000.

Failure-mode classification (verified empirically across 4 failed Qs):
- 2 PATTERN_MATCH: date in chunks, missing from facts, chunk not retrieved → extractor directly fixes
- 2 PARTIAL_MATCH: date in chunks, retrieved at rank 3, LLM doesn't compose prose → extractor helps via discrete dated facts
- 1 source ambiguity: unrelated to this feature

## Review history

Three parallel reviews (architecture, python-pro, devil's-advocate). Surfaced 4 P1s + 7 P2s + 2 P3s, all incorporated into v2:

| Finding | v2 fix |
|---|---|
| **Arch P1-1**: v1 augmented `FactExtractor._EXTRACT_PROMPT` — the fallback path | Retargets to `EpisodeSummarizer.candidate_facts` (primary prod path) |
| **Arch P1-2**: Summarizer LLM operates on lossy 150-word prose | Directs summarizer to extract dates from raw transcript it already holds |
| **Arch P1-3 / Devil's #3**: Layer 2 overstated as retrieval-surfacing lever | Reframed as reranking reinforcer; impl plan flips `NOUS_GRAPH_ADJACENCY_BOOST_ENABLED=true` |
| **Python P1-1**: `ExtractedFact` class doesn't exist | Targets `FactInput` + `_store_candidate_facts` dict-unpack |
| **Python P1-2**: Backfill SQL malformed (`WHERE id = SELECT…` crashes LIMIT>1) | Copies F047's per-row UPDATE pattern verbatim |
| **Python P1-3**: Advisory lock keying invented | Copies F047's `hashlib.sha256().digest()[:8]` pattern |
| **Python P1-4**: ORM mapping + `RecallResult.metadata` surfacing missing | 7-hop wire path table in §Layer 1 |
| **Devil's #2**: 3-of-5 retrieval-miss extrapolated from n=1 | Pre-investigation reclassified failures; acceptance criterion #6 adds per-class synthetic verification gate |

## What's in this PR

- `docs/features/F075-temporal-fact-extraction.md` — spec v2 (592 lines)
- `docs/reviews/F075-spec-arch-review.md` — architecture review
- `docs/reviews/F075-spec-python-pro-review.md` — python-pro review
- `docs/reviews/F075-spec-devil-review.md` — devil's-advocate review

Spec-only. No code changes. Implementation is a separate PR.

## What's NOT in this PR

- **BEAM diagnostic-flag wiring** (`NOUS_BEAM_TERSE_LIST`, `NOUS_BEAM_RECALL_TOP_K`) that produced the empirical evidence — these live in the uncommitted `nous_eval/beam/` directory and depend on F074's BEAM harness landing first.
- **Diagnostic scripts** (`diag_temporal_retrieval.py`, `diag_synthetic_temporal_validate.py`, `diag_temporal_failure_classes.py`) at repo root — investigation artifacts; findings captured in spec + reviews.

## Test plan

This PR is spec-only — no automated tests apply. Verification steps for reviewers:

- [ ] Read the spec (`docs/features/F075-temporal-fact-extraction.md`) for design soundness
- [ ] Cross-reference the v2 changelog against the 3 reviews to confirm all findings were addressed
- [ ] Validate the 7-hop wire path in §Layer 1 against current code locations (`fact_extractor.py:143-148`, `episode_summarizer.py:50-77`, `nous/heart/schemas.py:85-98`, `storage/models.py:469-511`)
- [ ] Confirm acceptance criteria #4 (BEAM temporal_reasoning ≥0.55) and #6 (per-class synthetic verification) are sufficient gates for impl

Implementation PR will land tests for all 4 new test files outlined in §Tests.

## Phase plan post-merge

1. Pre-impl synthetic verification (acceptance #6, ~$0.30): inject hand-crafted dated facts for one PATTERN_MATCH + one PARTIAL_MATCH case
2. Implement Layers 1+2+4 (Layer 3 deferred)
3. LME N=20 retrieval pre-check (~$5)
4. BEAM Phase 1 n=5 re-run (~$7); compare temporal_reasoning vs prod-v3 0.417 baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)