### PR TITLE
fix(#462): background turns no longer starve the sleep cycle

### DIFF
--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -354,7 +354,12 @@ class AgentRunner:
         # otherwise be closed mid-stream by a monitor tick. The bus is
         # async-queued so emitting message_received here would leave a
         # residual race; the synchronous touch eliminates it.
-        if self._session_monitor is not None:
+        #
+        # #462: skip the refresh for background turns (heartbeat/subtask).
+        # touch() resets _global_last_activity + _sleep_emitted; a background
+        # turn firing inside the sleep_timeout window would otherwise defer
+        # the sleep cycle forever. Foreground turns still close the race.
+        if self._session_monitor is not None and not is_background:
             try:
                 self._session_monitor.touch(session_id, _agent_id)
             except Exception:
@@ -394,7 +399,10 @@ class AgentRunner:
                 response_text = turn_context.censor_block_reason or "I can't process that request."
                 conversation.messages.append(Message(role="assistant", content=response_text))
                 turn_result = TurnResult(response_text=response_text)
-                await self._cognitive.post_turn(_agent_id, session_id, turn_result, turn_context)
+                await self._cognitive.post_turn(
+                    _agent_id, session_id, turn_result, turn_context,
+                    is_background=is_background,
+                )
                 return response_text, turn_context, usage
 
             # F026: Get/create execution ledger and set turn
@@ -525,7 +533,10 @@ class AgentRunner:
                 error=error,
                 thinking_blocks=thinking_blocks,
             )
-            await self._cognitive.post_turn(_agent_id, session_id, turn_result, turn_context)
+            await self._cognitive.post_turn(
+                _agent_id, session_id, turn_result, turn_context,
+                is_background=is_background,
+            )
 
             # 8. Safety net: warn if decision frame but record_decision not called
             self._check_safety_net(turn_context, tool_results)

--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -355,13 +355,15 @@ class AgentRunner:
         # async-queued so emitting message_received here would leave a
         # residual race; the synchronous touch eliminates it.
         #
-        # #462: skip the refresh for background turns (heartbeat/subtask).
-        # touch() resets _global_last_activity + _sleep_emitted; a background
-        # turn firing inside the sleep_timeout window would otherwise defer
-        # the sleep cycle forever. Foreground turns still close the race.
-        if self._session_monitor is not None and not is_background:
+        # #462: a background turn (heartbeat/subtask) still touches its own
+        # session entry — so the monitor won't close it mid-turn and will
+        # later reclaim its runner state — but touch(is_background=True) does
+        # not reset the global sleep timer and flags the session for exclusion
+        # from the sleep gate. Foreground turns still close the race and re-arm
+        # the timer.
+        if self._session_monitor is not None:
             try:
-                self._session_monitor.touch(session_id, _agent_id)
+                self._session_monitor.touch(session_id, _agent_id, is_background=is_background)
             except Exception:
                 logger.debug("session_monitor.touch failed (suppressed)", exc_info=True)
 

--- a/nous/cognitive/layer.py
+++ b/nous/cognitive/layer.py
@@ -888,6 +888,7 @@ class CognitiveLayer:
         turn_result: TurnResult,
         turn_context: TurnContext,
         session: AsyncSession | None = None,
+        is_background: bool = False,
     ) -> Assessment:
         """ACT (done) -> MONITOR -> LEARN — process LLM output.
 
@@ -1128,6 +1129,9 @@ class CognitiveLayer:
             "surprise_level": assessment.surprise_level,
             "decision_id": decision_id,
             "has_errors": turn_result.error is not None,
+            # #462: background turns (heartbeat/subtask) must not reset the
+            # session monitor's idle timer, or the sleep cycle never fires.
+            "is_background": is_background,
         }
         try:
             if self._bus:

--- a/nous/handlers/session_monitor.py
+++ b/nous/handlers/session_monitor.py
@@ -72,6 +72,13 @@ class SessionTimeoutMonitor:
         self._runner = runner
         self._last_activity: dict[str, float] = {}  # session_id -> monotonic time
         self._last_agent: dict[str, str] = {}  # session_id -> agent_id
+        # #462: sessions whose activity came from a background turn
+        # (heartbeat/subtask). They are still tracked in _last_activity so the
+        # idle-close path can clean them up (their runner state would otherwise
+        # leak — inline await_result subtasks don't call end_conversation), but
+        # they are excluded from the global sleep-timer gate so they cannot
+        # starve the sleep cycle.
+        self._background_sessions: set[str] = set()
         self._global_last_activity: float = time.monotonic()
         self._sleep_emitted: bool = False
         self._last_wm_sweep: float = 0.0  # F049: monotonic time of last WM sweep
@@ -85,23 +92,27 @@ class SessionTimeoutMonitor:
         """Track session activity.
 
         #462: background turns (heartbeat/subtask) carry ``is_background=True``
-        in the ``turn_completed`` event. They must NOT reset
-        ``_global_last_activity`` or clear ``_sleep_emitted`` — a background
-        turn firing within the sleep_timeout window would otherwise starve the
-        sleep cycle indefinitely. This is the bus-side guard; runner.py also
-        skips the synchronous ``touch()`` for background turns.
+        in the ``turn_completed`` event. Their session is still tracked in
+        ``_last_activity`` (so the idle-close path eventually reclaims its
+        runner state), but they must NOT reset ``_global_last_activity`` or
+        clear ``_sleep_emitted`` and must be excluded from the sleep gate — a
+        background turn firing within the sleep_timeout window would otherwise
+        starve the sleep cycle indefinitely.
         """
-        if event.data and event.data.get("is_background") is True:
-            return
+        is_background = bool(event.data and event.data.get("is_background") is True)
         now = time.monotonic()
         if event.session_id:
             self._last_activity[event.session_id] = now
             if event.agent_id:
                 self._last_agent[event.session_id] = event.agent_id
+            if is_background:
+                self._background_sessions.add(event.session_id)
+        if is_background:
+            return  # don't reset the global timer / sleep flag
         self._global_last_activity = now
-        self._sleep_emitted = False  # Reset sleep flag on any activity
+        self._sleep_emitted = False  # Reset sleep flag on any foreground activity
 
-    def touch(self, session_id: str, agent_id: str) -> None:
+    def touch(self, session_id: str, agent_id: str, is_background: bool = False) -> None:
         """Synchronously refresh activity for a session.
 
         Called by AgentRunner at the START of run_turn so a long in-flight
@@ -111,10 +122,17 @@ class SessionTimeoutMonitor:
         wide race window where the monitor would close a session whose
         request was received but whose turn hadn't completed. This direct
         call closes the window.
+
+        #462: a background turn still refreshes its own session entry (so the
+        monitor won't close it mid-turn), but does not reset the global sleep
+        timer and marks the session background so it's excluded from the gate.
         """
         now = time.monotonic()
         self._last_activity[session_id] = now
         self._last_agent[session_id] = agent_id
+        if is_background:
+            self._background_sessions.add(session_id)
+            return
         self._global_last_activity = now
         self._sleep_emitted = False
 
@@ -123,6 +141,7 @@ class SessionTimeoutMonitor:
         if event.session_id:
             self._last_activity.pop(event.session_id, None)
             self._last_agent.pop(event.session_id, None)
+            self._background_sessions.discard(event.session_id)
 
     async def start(self) -> None:
         """Start the periodic timeout checker."""
@@ -287,6 +306,7 @@ class SessionTimeoutMonitor:
         for sid in closed:
             self._last_activity.pop(sid, None)
             self._last_agent.pop(sid, None)
+            self._background_sessions.discard(sid)
 
         # 2. Check global inactivity -> sleep_started
         #
@@ -302,11 +322,20 @@ class SessionTimeoutMonitor:
         # sleep_timeout, rather than requiring the dict to be empty. This
         # handles both the normal case (dict already empty after session
         # timeouts) and the edge case where sleep_timeout <= session_idle_timeout.
+        # #462: exclude background sessions (heartbeat/subtask) from the gate —
+        # they're tracked for idle cleanup but a recurring background session
+        # would otherwise keep at least one entry perpetually "recent" and
+        # block sleep forever, the same starvation in a second guise.
         global_idle = now - self._global_last_activity
+        foreground_activity = [
+            last
+            for sid, last in self._last_activity.items()
+            if sid not in self._background_sessions
+        ]
         all_sessions_sleeping = all(
             (now - last) > self._settings.sleep_timeout
-            for last in self._last_activity.values()
-        ) if self._last_activity else True
+            for last in foreground_activity
+        ) if foreground_activity else True
         if (
             global_idle > self._settings.sleep_timeout
             and not self._sleep_emitted

--- a/nous/handlers/session_monitor.py
+++ b/nous/handlers/session_monitor.py
@@ -82,7 +82,17 @@ class SessionTimeoutMonitor:
         bus.on("session_ended", self._on_session_ended)  # P1-4 fix: cleanup
 
     async def on_activity(self, event: Event) -> None:
-        """Track session activity."""
+        """Track session activity.
+
+        #462: background turns (heartbeat/subtask) carry ``is_background=True``
+        in the ``turn_completed`` event. They must NOT reset
+        ``_global_last_activity`` or clear ``_sleep_emitted`` — a background
+        turn firing within the sleep_timeout window would otherwise starve the
+        sleep cycle indefinitely. This is the bus-side guard; runner.py also
+        skips the synchronous ``touch()`` for background turns.
+        """
+        if event.data and event.data.get("is_background") is True:
+            return
         now = time.monotonic()
         if event.session_id:
             self._last_activity[event.session_id] = now

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -1455,8 +1455,10 @@ class TestSessionTimeoutMonitor:
         assert monitor._sleep_emitted is False
 
     @pytest.mark.asyncio
-    async def test_background_turn_does_not_reset_activity(self):
-        """#462: a background turn must not refresh the global idle timer."""
+    async def test_background_turn_does_not_reset_global_timer(self):
+        """#462: a background turn must not reset the global idle timer or sleep
+        flag, but its session IS still tracked (so idle-close can reclaim it)
+        and is flagged background (so it's excluded from the sleep gate)."""
         monitor, bus, cognitive = self._make_monitor()
         idle_marker = time.monotonic() - 500
         monitor._global_last_activity = idle_marker
@@ -1473,12 +1475,15 @@ class TestSessionTimeoutMonitor:
         # Global timer untouched and sleep flag NOT cleared by the background turn.
         assert monitor._global_last_activity == idle_marker
         assert monitor._sleep_emitted is True
-        # Per-session tracking also skipped — the background session is invisible.
-        assert "bg-sess" not in monitor._last_activity
+        # But the session IS tracked + flagged background (cleanup preserved,
+        # excluded from the sleep gate).
+        assert "bg-sess" in monitor._last_activity
+        assert "bg-sess" in monitor._background_sessions
 
     @pytest.mark.asyncio
     async def test_sleep_fires_despite_repeated_background_turns(self):
-        """#462: background turns spaced over > sleep_timeout still let sleep fire."""
+        """#462: a recurring background session, even refreshed right now, must
+        not block sleep — it's excluded from the all-sessions-sleeping gate."""
         monitor, bus, cognitive = self._make_monitor(
             settings=_mock_settings(
                 session_idle_timeout=9999, sleep_timeout=0, sleep_check_interval=1
@@ -1495,8 +1500,9 @@ class TestSessionTimeoutMonitor:
         bus.on("sleep_started", capture)
         await bus.start()
         try:
-            # 5 consecutive background turns — each would reset the idle timer
-            # under the old behavior and starve sleep forever.
+            # 5 consecutive background turns — each would reset the global timer
+            # under the old behavior, and each leaves a "recent" entry in
+            # _last_activity that would block the gate without the exclusion.
             for _ in range(5):
                 await monitor.on_activity(
                     _make_event(
@@ -1505,10 +1511,39 @@ class TestSessionTimeoutMonitor:
                         data={"is_background": True},
                     )
                 )
+            # Background session is tracked and freshly active...
+            assert "bg-sess" in monitor._last_activity
             await monitor._check_timeouts()
             await asyncio.sleep(0.1)
+            # ...yet sleep still fires because it's excluded from the gate.
             assert len(received) == 1
             assert received[0].type == "sleep_started"
+        finally:
+            await bus.stop()
+
+    @pytest.mark.asyncio
+    async def test_foreground_session_still_blocks_sleep(self):
+        """#462 guard: a recent FOREGROUND session must still block sleep — the
+        background exclusion must not leak to normal sessions."""
+        monitor, bus, cognitive = self._make_monitor(
+            settings=_mock_settings(
+                session_idle_timeout=9999, sleep_timeout=9999, sleep_check_interval=1
+            )
+        )
+        monitor._global_last_activity = time.monotonic() - 100000
+        monitor._last_activity["fg-sess"] = time.monotonic()  # recent, foreground
+
+        received: list[Event] = []
+
+        async def capture(event: Event) -> None:
+            received.append(event)
+
+        bus.on("sleep_started", capture)
+        await bus.start()
+        try:
+            await monitor._check_timeouts()
+            await asyncio.sleep(0.1)
+            assert len(received) == 0
         finally:
             await bus.stop()
 

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -1455,6 +1455,64 @@ class TestSessionTimeoutMonitor:
         assert monitor._sleep_emitted is False
 
     @pytest.mark.asyncio
+    async def test_background_turn_does_not_reset_activity(self):
+        """#462: a background turn must not refresh the global idle timer."""
+        monitor, bus, cognitive = self._make_monitor()
+        idle_marker = time.monotonic() - 500
+        monitor._global_last_activity = idle_marker
+        monitor._sleep_emitted = True
+
+        await monitor.on_activity(
+            _make_event(
+                "turn_completed",
+                session_id="bg-sess",
+                data={"is_background": True},
+            )
+        )
+
+        # Global timer untouched and sleep flag NOT cleared by the background turn.
+        assert monitor._global_last_activity == idle_marker
+        assert monitor._sleep_emitted is True
+        # Per-session tracking also skipped — the background session is invisible.
+        assert "bg-sess" not in monitor._last_activity
+
+    @pytest.mark.asyncio
+    async def test_sleep_fires_despite_repeated_background_turns(self):
+        """#462: background turns spaced over > sleep_timeout still let sleep fire."""
+        monitor, bus, cognitive = self._make_monitor(
+            settings=_mock_settings(
+                session_idle_timeout=9999, sleep_timeout=0, sleep_check_interval=1
+            )
+        )
+        monitor._global_last_activity = time.monotonic() - 10
+        monitor._last_activity.clear()
+
+        received: list[Event] = []
+
+        async def capture(event: Event) -> None:
+            received.append(event)
+
+        bus.on("sleep_started", capture)
+        await bus.start()
+        try:
+            # 5 consecutive background turns — each would reset the idle timer
+            # under the old behavior and starve sleep forever.
+            for _ in range(5):
+                await monitor.on_activity(
+                    _make_event(
+                        "turn_completed",
+                        session_id="bg-sess",
+                        data={"is_background": True},
+                    )
+                )
+            await monitor._check_timeouts()
+            await asyncio.sleep(0.1)
+            assert len(received) == 1
+            assert received[0].type == "sleep_started"
+        finally:
+            await bus.stop()
+
+    @pytest.mark.asyncio
     async def test_expired_sessions_cleaned_from_tracking(self):
         """33. Expired sessions cleaned from tracking dict."""
         monitor, bus, cognitive = self._make_monitor(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -443,7 +443,9 @@ async def test_run_turn_touches_session_monitor(runner, mock_cognitive):
     session_id = f"test-{uuid.uuid4().hex[:8]}"
     await runner.run_turn(session_id, "Hello!")
 
-    monitor.touch.assert_called_once_with(session_id, runner._settings.agent_id)
+    monitor.touch.assert_called_once_with(
+        session_id, runner._settings.agent_id, is_background=False
+    )
 
 
 async def test_run_turn_touch_failure_does_not_break_turn(runner, mock_cognitive):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -49,7 +49,7 @@ class MockCognitiveLayer:
         self.pre_turn_calls.append((agent_id, session_id, user_input))
         return self.preset_context
 
-    async def post_turn(self, agent_id, session_id, turn_result, turn_context, session=None):
+    async def post_turn(self, agent_id, session_id, turn_result, turn_context, session=None, is_background=False):
         self.post_turn_calls.append((agent_id, session_id, turn_result, turn_context))
         from nous.cognitive.schemas import Assessment
 

--- a/tests/test_runner_background.py
+++ b/tests/test_runner_background.py
@@ -47,7 +47,7 @@ class _MockCognitive:
     async def pre_turn(self, agent_id, session_id, user_input, session=None, **_):
         return self.preset
 
-    async def post_turn(self, agent_id, session_id, turn_result, turn_context, session=None):
+    async def post_turn(self, agent_id, session_id, turn_result, turn_context, session=None, is_background=False):
         from nous.cognitive.schemas import Assessment
         return Assessment(actual=turn_result.response_text[:200])
 


### PR DESCRIPTION
## Problem

Heartbeat and subtask turns emit `turn_completed` exactly like foreground turns. `SessionTimeoutMonitor.on_activity` unconditionally reset `_global_last_activity` and cleared `_sleep_emitted` on every such event. So any background turn firing inside the `sleep_timeout` window deferred the sleep cycle **indefinitely** — under a normal heartbeat tick interval (30s) vs sleep_timeout (default 7200s), sleep never fired at all once heartbeat was active.

Closes #462.

Knock-on effect this also unblocks: the F075 `happened_before` edge build runs during the sleep cycle. No sleep → no temporal edge densification in prod.

## Fix

Thread `is_background` through the existing F048 wire (the same flag heartbeat/subtask callers already pass into `run_turn`):

- **`CognitiveLayer.post_turn`** gains `is_background: bool = False`; included in the `turn_completed` `event_data`.
- **`runner.run_turn`** passes `is_background` to both `post_turn` calls and to `monitor.touch(is_background=...)`.
- **`SessionTimeoutMonitor`** keeps a background session **tracked** in `_last_activity` (recorded in a new `_background_sessions` set), but for background turns it does **not** reset `_global_last_activity` / `_sleep_emitted`, and the `all_sessions_sleeping` gate **excludes** `_background_sessions`.

`stream_chat` (foreground) has no `is_background` param; its `post_turn` calls correctly default to `False`.

### Why tracked-but-excluded (not invisible)

The first cut made background sessions fully invisible to the monitor. Codex correctly flagged that inline `await_result` subtasks (`tools.py`) run `run_turn(is_background=True)` with their own `session_id` and never call `end_conversation` — the monitor's idle-close was their **only** cleanup, so invisibility leaks runner `_conversations`/ledger/persisted state after each inline subtask. Keeping them tracked preserves that cleanup. The exclusion-set is independently necessary: a recurring background session (heartbeat reusing one `session_id`) keeps a "recent" `_last_activity` entry forever, which would block the gate — the same starvation in a second guise. `_background_sessions` is discarded on session end and on idle-close, so it can't grow unbounded.

## Verification

- **Producer stamps it** — every background `run_turn` caller already passes `is_background=True`: heartbeat triage + on_complete, subtask_worker, DynamicCheck, subtask_executor, inline spawn_task. Foreground emitters (rest/mcp) omit it.
- **Sole emitter** — `turn_completed` is emitted only inside `post_turn` (`layer.py`).
- **Re-arm semantics** — `_sleep_emitted` re-arms on foreground activity, matching the global-timer gating. Sleep fires once per genuine-idle period.

## Tests

`TestSessionTimeoutMonitor`:
- `test_background_turn_does_not_reset_global_timer` — background turn leaves `_global_last_activity` + `_sleep_emitted` untouched, but the session **is** tracked and flagged background.
- `test_sleep_fires_despite_repeated_background_turns` — 5 background turns leave a fresh `_last_activity` entry, yet sleep still fires (gate exclusion).
- `test_foreground_session_still_blocks_sleep` — guard: a recent foreground session still blocks sleep (exclusion must not leak).

Existing monitor + runner + `test_runner_background` suites green (the `touch()` call-signature assertion was updated). Pre-existing `test_cognitive_layer` DB-dependent failures are unrelated — identical on the clean baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
