### PR TITLE
fix(F071): streaming contextvar crash — Token reset across async-gen contexts

### DIFF
--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -1053,9 +1053,19 @@ class AgentRunner:
             # loop — recall_deep can be dispatched inside the for-turn
             # iteration. Reset lives in the existing `finally:` below so
             # we don't add new nesting (single source of cleanup).
-            _f071_token = CURRENT_TURN_EXCLUDE_IDS.set(
-                _build_exclude_ids(self._settings, turn_context)
-            )
+            #
+            # stream_chat is an async GENERATOR. rest.py pumps it via
+            # asyncio.ensure_future(gen.__anext__()) once per SSE chunk (the
+            # keepalive race), so each resume runs in a FRESH copied context.
+            # A Token from set() in one __anext__ cannot be reset() in a later
+            # one — CPython raises "Token was created in a different Context".
+            # So: only engage the contextvar when the feature is actually on
+            # (None = flag off, the prod default → no churn, no crash), and
+            # restore by value (set) rather than by token (reset) so the
+            # finally can never raise across the generator's context boundaries.
+            _f071_exclude = _build_exclude_ids(self._settings, turn_context)
+            if _f071_exclude is not None:
+                CURRENT_TURN_EXCLUDE_IDS.set(_f071_exclude)
             try:
                 for turn in range(self._settings.max_turns):
                     # Unified block accumulator: keyed by block_index, preserves
@@ -1343,9 +1353,12 @@ class AgentRunner:
                 # F026: Post-response claim verification (streaming: warn+inject only)
                 self._verify_claims(session_id, response_text, all_tool_results, ledger)
             finally:
-                # F071: reset the per-turn exclusion set first — restoring the
-                # contextvar must not depend on post_turn's success.
-                CURRENT_TURN_EXCLUDE_IDS.reset(_f071_token)
+                # F071: clear the per-turn exclusion set first — restoring the
+                # contextvar must not depend on post_turn's success. Value-based
+                # (set(None), not reset(token)) so it can't raise across the
+                # async-generator's per-chunk context boundaries (see set above).
+                if _f071_exclude is not None:
+                    CURRENT_TURN_EXCLUDE_IDS.set(None)
                 # ALWAYS call post_turn (review P1: guaranteed cleanup).
                 # Shield from cancellation to prevent DB connection pool leaks —
                 # CancelledError during post_turn's DB ops leaves sessions checked

--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -1063,6 +1063,17 @@ class AgentRunner:
             # (None = flag off, the prod default → no churn, no crash), and
             # restore by value (set) rather than by token (reset) so the
             # finally can never raise across the generator's context boundaries.
+            #
+            # KNOWN LIMITATION (deferred): for the same fresh-context-per-chunk
+            # reason, a value set here is only visible within THIS __anext__.
+            # Once stream_chat yields, the next __anext__ runs in the parent
+            # context, so a recall_deep dispatched after the first yielded event
+            # reads None — i.e. F071 exclusions do NOT apply on the streaming
+            # path. recall_exclude_context_ids is off-by-default/dark and was
+            # only ever validated on the non-streaming run_turn path; making it
+            # work under SSE needs the contextvar set in rest.py's parent
+            # context (or exclude-ids threaded explicitly), tracked separately.
+            # This block's job is solely to not CRASH the streaming turn.
             _f071_exclude = _build_exclude_ids(self._settings, turn_context)
             if _f071_exclude is not None:
                 CURRENT_TURN_EXCLUDE_IDS.set(_f071_exclude)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -453,7 +453,13 @@ class TestStreamChat:
     ):
         """F071 regression with the feature ON: the contextvar is engaged, but
         value-based restore (set(None), not reset(token)) must still not raise
-        when the generator is pumped across contexts."""
+        when the generator is pumped across contexts.
+
+        Scope: this asserts no crash + post_turn runs. It does NOT assert that
+        exclusions are *applied* mid-stream — they aren't on the SSE path (the
+        set() is invisible after the first yield; documented limitation in
+        stream_chat). This is a crash regression, not a feature-correctness test.
+        """
         cognitive, _ = mock_cognitive
         settings = _make_mock_settings()
         settings.recall_exclude_context_ids = True  # F071 ON

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -8,6 +8,7 @@ Tests cover:
 - Telegram StreamingMessage progressive editing with debounce
 """
 
+import asyncio
 import json
 import time
 from typing import Any, AsyncGenerator
@@ -408,6 +409,66 @@ class TestStreamChat:
         assert text_events[0].text == "Hello "
         assert text_events[1].text == "world"
         assert len(done_events) >= 1
+
+    @staticmethod
+    async def _drain_via_tasks(agen):
+        """Pump an async generator the way rest.py's SSE keepalive race does:
+        each __anext__ wrapped in its own asyncio Task, so every resume runs
+        in a FRESH copied context. This is what fragments contextvar context
+        and exposed the F071 'Token was created in a different Context' crash.
+        """
+        events = []
+        while True:
+            try:
+                events.append(await asyncio.ensure_future(agen.__anext__()))
+            except StopAsyncIteration:
+                break
+        return events
+
+    @pytest.mark.asyncio
+    async def test_streaming_contextvar_survives_cross_context_pump_flag_off(
+        self, runner, mock_cognitive
+    ):
+        """F071 regression (prod default, flag OFF): pumping stream_chat across
+        per-chunk contexts must NOT raise the contextvar Token error, and the
+        finally's post_turn must still run. Pre-fix, reset(token) raised in the
+        finally (token born in a different __anext__ context) and skipped
+        post_turn on every Telegram turn."""
+        cognitive, _ = mock_cognitive
+
+        async def fake_stream(*args, **kwargs):
+            yield StreamEvent(type="text_delta", text="hi")
+            yield StreamEvent(type="done", stop_reason="end_turn")
+
+        runner._call_api_stream = MagicMock(side_effect=fake_stream)
+
+        events = await self._drain_via_tasks(runner.stream_chat("s-ctx-off", "Hi"))
+
+        assert any(e.type == "done" for e in events)  # clean completion, finally didn't raise
+        cognitive.post_turn.assert_awaited()  # finally ran to completion
+
+    @pytest.mark.asyncio
+    async def test_streaming_contextvar_survives_cross_context_pump_flag_on(
+        self, mock_cognitive
+    ):
+        """F071 regression with the feature ON: the contextvar is engaged, but
+        value-based restore (set(None), not reset(token)) must still not raise
+        when the generator is pumped across contexts."""
+        cognitive, _ = mock_cognitive
+        settings = _make_mock_settings()
+        settings.recall_exclude_context_ids = True  # F071 ON
+        runner = _make_runner(cognitive, settings)
+
+        async def fake_stream(*args, **kwargs):
+            yield StreamEvent(type="text_delta", text="hi")
+            yield StreamEvent(type="done", stop_reason="end_turn")
+
+        runner._call_api_stream = MagicMock(side_effect=fake_stream)
+
+        events = await self._drain_via_tasks(runner.stream_chat("s-ctx-on", "Hi"))
+
+        assert any(e.type == "done" for e in events)
+        cognitive.post_turn.assert_awaited()
 
     @pytest.mark.asyncio
     async def test_tool_call_mid_stream(self, runner, mock_cognitive):


### PR DESCRIPTION
## Symptom

After **every Telegram (streaming) response**, the bot appends:

> ❌ `<Token var=<ContextVar name='CURRENT_TURN_EXCLUDE_IDS' …> …> was created in a different Context`

## Root cause

`stream_chat` is an async **generator**. `rest.py` pumps it via `asyncio.ensure_future(gen.__anext__())` once per SSE chunk (the keepalive race from the `/chat/stream` robustness work), so **each resume runs in a fresh copied context**. The F071 `CURRENT_TURN_EXCLUDE_IDS.set()` runs in one `__anext__` context; the `finally`'s `CURRENT_TURN_EXCLUDE_IDS.reset(token)` runs in a later one → CPython raises *"Token was created in a different Context"*.

Two aggravating facts:
1. That `reset()` was the **first statement** in the `finally`, so its raise **skipped the rest of the finally** — `post_turn`, the safety-net check, and `turn_context` bookkeeping — on every streaming turn.
2. The set/reset ran **unconditionally even with the flag off** (`_build_exclude_ids` returns `None` → `set(None)` still mints a token), so it crashed regardless of `NOUS_RECALL_EXCLUDE_CONTEXT_IDS` (prod default = off).

## Blast radius (what actually broke)

On every Telegram turn, `post_turn` was skipped → lost **per-turn monitoring/assessment, working-memory thread resolution, and the `turn_completed` event**.

Not broken: the user still gets the reply (streamed before the `finally`); the conversation transcript is intact (assistant message persisted before the `finally`), so **session-level memory still forms** (episode summary + fact extraction run on `session_ended`); sleep/idle timing is fine (start-of-turn `touch()` runs before the `finally`); and **non-streaming paths (`/chat`, subtasks, heartbeat) are unaffected** — they use a coroutine with a stable context, so `reset(token)` works there.

## Fix

Streaming path only (the coroutine `run_turn` path is correct by construction):
- **Engage the contextvar only when the feature is on** (`None` = flag off → no churn, no crash).
- **Restore by value (`set(None)`) instead of by token (`reset`)**, so the `finally` can never raise across the generator's per-chunk context boundaries.

## Tests

2 regression tests pump `stream_chat` via `ensure_future(__anext__())` per chunk (reproducing rest.py's context fragmentation), flag **off** and **on**; both assert no Token error and that `post_turn` still runs. **Verified they fail pre-fix** (`ValueError` at the `reset` line) **and pass post-fix**. Full `test_streaming` + dedup + runner suites green (103 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
