### PR TITLE
fix(#381): orphan_trend SQL counts each node once at first-connected-at

### DIFF
--- a/nous/api/dashboard_queries.py
+++ b/nous/api/dashboard_queries.py
@@ -809,15 +809,23 @@ async def get_health_data(session: AsyncSession, agent_id: str) -> dict:
                 GROUP BY CAST(created_at AS date)
             ),
             daily_new_connected AS (
-                SELECT day, COUNT(DISTINCT node_id) AS cnt
+                -- #381: count each node ONCE, on the date its FIRST edge appeared.
+                -- The prior form counted a node on every day it had any edge, so a
+                -- node edged on multiple days inflated the running connected sum past
+                -- the running total and GREATEST(...,0) clamped orphan_count to 0.
+                SELECT first_connected_day AS day, COUNT(*) AS cnt
                 FROM (
-                    SELECT CAST(created_at AS date) AS day, source_id AS node_id
-                    FROM brain.graph_edges WHERE agent_id = :agent_id
-                    UNION
-                    SELECT CAST(created_at AS date) AS day, target_id AS node_id
-                    FROM brain.graph_edges WHERE agent_id = :agent_id
+                    SELECT node_id, CAST(MIN(created_at) AS date) AS first_connected_day
+                    FROM (
+                        SELECT source_id AS node_id, created_at
+                        FROM brain.graph_edges WHERE agent_id = :agent_id
+                        UNION ALL
+                        SELECT target_id AS node_id, created_at
+                        FROM brain.graph_edges WHERE agent_id = :agent_id
+                    ) all_endpoints
+                    GROUP BY node_id
                 ) first_seen
-                GROUP BY day
+                GROUP BY first_connected_day
             ),
             pre_period AS (
                 SELECT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ asyncio_default_test_loop_scope = "session"
 markers = [
     "integration: requires live PostgreSQL (run with --integration)",
     "eval: F051 retrieval-eval-harness unit tests (no DB required)",
+    "postgres_only: requires real PostgreSQL (skipped unless NOUS_TEST_DB=postgres)",
 ]
 
 [tool.ruff]

--- a/tests/test_density_dashboard.py
+++ b/tests/test_density_dashboard.py
@@ -101,3 +101,59 @@ async def test_get_density_data_with_data(db):
     # Backfill progress should have today's entry
     assert len(data["backfill_progress"]) >= 1
     assert data["backfill_progress"][0]["edges"] == 1
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_orphan_trend_counts_each_node_once_across_multiple_days(db):
+    """Regression for #381: orphan_trend must not undercount when a node gains
+    edges on multiple days. The old daily_new_connected CTE counted a node once
+    per day it had ANY edge, inflating cumulative connected past cumulative total
+    so GREATEST(...,0) clamped the orphan count to 0. The final-day orphan_trend
+    value must equal the ground-truth total_orphans."""
+    from nous.api.dashboard_queries import get_health_data
+
+    agent_id = f"test-orphan-trend-{uuid.uuid4().hex[:8]}"
+    fact_a = uuid.uuid4()
+    fact_b = uuid.uuid4()  # stays orphan
+    dec_id = uuid.uuid4()
+
+    async with db.session() as session:
+        await session.execute(
+            text("""
+                INSERT INTO heart.facts (id, agent_id, content, category, active, created_at)
+                VALUES (:a, :aid, 'fact a', 'general', true, now() - interval '6 days'),
+                       (:b, :aid, 'fact b', 'general', true, now() - interval '6 days')
+            """),
+            {"a": fact_a, "b": fact_b, "aid": agent_id},
+        )
+        await session.execute(
+            text("""
+                INSERT INTO brain.decisions (id, agent_id, description, confidence, stakes, category, created_at)
+                VALUES (:id, :aid, 'decision d', 0.8, 'low', 'tooling', now() - interval '6 days')
+            """),
+            {"id": dec_id, "aid": agent_id},
+        )
+        # fact_a <-> decision connected by TWO edges created on different days.
+        # The buggy CTE counts {fact_a, decision} on each day => 4 connected,
+        # exceeding the 3 total nodes => clamp to 0 orphans.
+        await session.execute(
+            text("""
+                INSERT INTO brain.graph_edges
+                    (id, agent_id, source_id, source_type, target_id, target_type, relation, auto_linked, created_at)
+                VALUES (:e1, :aid, :src, 'fact', :tgt, 'decision', 'evidence_for', true, now() - interval '5 days'),
+                       (:e2, :aid, :src, 'fact', :tgt, 'decision', 'related_to',  true, now() - interval '3 days')
+            """),
+            {"e1": uuid.uuid4(), "e2": uuid.uuid4(), "aid": agent_id, "src": fact_a, "tgt": dec_id},
+        )
+        await session.commit()
+
+    async with db.session() as session:
+        data = await get_health_data(session, agent_id)
+
+    # Ground truth: only fact_b is an orphan.
+    assert data["total_orphans"] == 1
+    # The final-day orphan trend must match the ground-truth count, not the
+    # clamped-to-0 value the multi-day double-count used to produce.
+    assert data["orphan_trend"][-1]["count"] == data["total_orphans"]
+    assert data["orphan_trend"][-1]["count"] == 1


### PR DESCRIPTION
## Problem
`get_health_data`'s `daily_new_connected` CTE counted a node once **per day it had any edge**, so a node that gained edges across multiple days inflated the cumulative connected-node sum past the cumulative total. `GREATEST(..., 0)` then clamped `orphan_count` to 0 — the `/dashboard/health` card showed **0 orphans** while `/dashboard/density` reported the real ~40% orphan rate (#381).

## Fix
Replace the CTE with a `MIN(created_at)`-per-node **first-connected-day** calc so each node is counted exactly once, on the date its first edge appeared. `pre_period.connected_base` already counts distinct nodes connected before the window, so the two compose without double-counting. Single-CTE change.

## Test
Adds `postgres_only` regression `test_orphan_trend_counts_each_node_once_across_multiple_days` asserting `orphan_trend[-1].count == total_orphans`. Verified RED (`assert 0 == 1`) on the old CTE → GREEN after the fix. All 22 dashboard/density tests pass against Postgres. Registers the `postgres_only` pytest marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)