### PR TITLE
feat(#377): Leg-1 dedup tiebreaker to fix RRF over-dedup of opposites

### DIFF
--- a/nous/config.py
+++ b/nous/config.py
@@ -238,6 +238,15 @@ class Settings(BaseSettings):
     # Default kept 0.95 for backwards-compat.
     fact_native_cosine_threshold: float = 0.95
 
+    # F377: Leg-1 dedup tiebreaker. When a fact's hybrid-search (RRF) pre-check
+    # flags it as a duplicate, a same-vs-distinct Haiku classifier confirms the
+    # verdict before skipping the write. Fixes RRF over-dedup on high-lexical-
+    # overlap semantic opposites ("MRR -5%" vs "MRR +5%") that threshold tuning
+    # cannot separate (sweep 0.92/0.95/0.97 = byte-identical). Fires only on the
+    # RRF-dup path, fails open (None/error -> dedup as before). Reuses
+    # contradiction_model. Default OFF (land dark; flip after the dedup eval).
+    fact_dedup_tiebreaker_enabled: bool = False
+
     # Runtime
     host: str = "0.0.0.0"
     port: int = 8000

--- a/nous/handlers/fact_extractor.py
+++ b/nous/handlers/fact_extractor.py
@@ -122,9 +122,11 @@ class FactExtractor:
         and should be stored. Fails open to dedup (flag off, or None verdict) so a
         tiebreaker outage never changes legacy behaviour. Shared by both dedup
         sites so they cannot drift (cf. #354)."""
-        # getattr default-off: duck-typed / stub settings without the attr must
-        # not accidentally enable the tiebreaker (codex P2).
-        if not getattr(self._settings, "fact_dedup_tiebreaker_enabled", False):
+        # `is True` (not truthiness): real Settings stores a bool, so this only
+        # activates on an explicit True and stays off for duck-typed/Mock
+        # settings whose auto-attr is truthy but not the literal True (codex P2;
+        # bare-MagicMock truthiness is a known test footgun).
+        if getattr(self._settings, "fact_dedup_tiebreaker_enabled", False) is not True:
             return True
         if await self._heart.facts.is_distinct_fact(existing_content, candidate_content) is True:
             logger.debug(
@@ -147,7 +149,9 @@ class FactExtractor:
         dates = distinct events). Shared by both producer paths (cf. #354)."""
         if not self._dedup_via_search:
             return None
-        tiebreaker = getattr(self._settings, "fact_dedup_tiebreaker_enabled", False)
+        # `is True` so a truthy Mock/duck-typed setting can't widen the search
+        # or trip the await-a-mock path (codex P2 / MagicMock footgun).
+        tiebreaker = getattr(self._settings, "fact_dedup_tiebreaker_enabled", False) is True
         # Only widen the search when the tiebreaker can re-judge lower hits;
         # flag-off keeps the historical single-top-hit behaviour exactly.
         limit = 5 if tiebreaker else 1

--- a/nous/handlers/fact_extractor.py
+++ b/nous/handlers/fact_extractor.py
@@ -138,17 +138,27 @@ class FactExtractor:
 
     async def _resolve_dedup(
         self, content: str, candidate_event_date: "date | None"
-    ) -> UUID | None:
-        """Return the canonical fact UUID to dedup against, or None to store new.
+    ) -> "tuple[UUID | None, list[UUID]]":
+        """Resolve the RRF dedup decision for a candidate.
+
+        Returns ``(canonical_id, exclude_ids)``:
+        - ``canonical_id`` is the existing fact to dedup against, or ``None`` to
+          store the candidate as new.
+        - ``exclude_ids`` are above-threshold hits the tiebreaker judged DISTINCT;
+          the caller must pass them to ``Heart.learn(exclude_ids=...)`` so the
+          native-cosine (Leg-2) dedup cannot silently re-merge them and undo the
+          DISTINCT verdict (codex P2).
 
         Examines every above-threshold RRF hit (not just the top one) when the
         tiebreaker is enabled, so a high-overlap opposite ranked first cannot
         hide a real duplicate ranked lower (codex P2). With the flag off, only
-        the top hit is examined — byte-identical to the pre-F377 path. Hits whose
-        ``event_date`` differs from the candidate are skipped (F075: distinct
-        dates = distinct events). Shared by both producer paths (cf. #354)."""
+        the top hit is examined and ``exclude_ids`` is empty — byte-identical to
+        the pre-F377 path. Hits whose ``event_date`` differs from the candidate
+        are skipped (F075: distinct dates = distinct events). Shared by both
+        producer paths (cf. #354)."""
+        distinct_ids: list[UUID] = []
         if not self._dedup_via_search:
-            return None
+            return None, distinct_ids
         # `is True` so a truthy Mock/duck-typed setting can't widen the search
         # or trip the await-a-mock path (codex P2 / MagicMock footgun).
         tiebreaker = getattr(self._settings, "fact_dedup_tiebreaker_enabled", False) is True
@@ -168,8 +178,11 @@ class FactExtractor:
             ):
                 continue
             if await self._confirm_dedup(cand.content, content):
-                return cand.id
-        return None
+                return cand.id, distinct_ids
+            # Tiebreaker judged DISTINCT: keep examining lower hits, and exclude
+            # this id from the downstream native dedup so it isn't re-merged.
+            distinct_ids.append(cand.id)
+        return None, distinct_ids
 
     async def extract_and_store(
         self,
@@ -256,7 +269,7 @@ class FactExtractor:
             # _resolve_dedup examines all above-threshold RRF hits (F377) and
             # applies the F075 distinct-event_date bypass; None = store as new.
             content = fact.get("content", "")
-            canonical = await self._resolve_dedup(content, candidate_event_date)
+            canonical, exclude_ids = await self._resolve_dedup(content, candidate_event_date)
             if canonical is not None:
                 stored_ids.append(canonical)
                 logger.debug(
@@ -293,7 +306,12 @@ class FactExtractor:
                 event_date=candidate_event_date,
                 event_date_classified_at=classified_at,
             )
-            result = await self._heart.learn(fact_input)
+            # F377: exclude tiebreaker-DISTINCT hits from native (Leg-2) dedup so
+            # learn can't re-merge what the tiebreaker already cleared.
+            if exclude_ids:
+                result = await self._heart.learn(fact_input, exclude_ids=exclude_ids)
+            else:
+                result = await self._heart.learn(fact_input)
             if isinstance(result, FactRejected):
                 logger.debug("Admission rejected extracted fact: %s", content[:50])
                 continue
@@ -379,7 +397,7 @@ class FactExtractor:
             # Dedup: check if similar fact exists. _resolve_dedup examines all
             # above-threshold RRF hits (F377) + the F075 distinct-date bypass;
             # None = store as new.
-            canonical = await self._resolve_dedup(content, candidate_event_date)
+            canonical, exclude_ids = await self._resolve_dedup(content, candidate_event_date)
             if canonical is not None:
                 stored_ids.append(canonical)
                 logger.debug("Dedup skip (candidate) — adding canonical UUID %s for: %s", canonical, content[:50])
@@ -412,7 +430,11 @@ class FactExtractor:
                 event_date=candidate_event_date,
                 event_date_classified_at=classified_at,
             )
-            result = await self._heart.learn(fact_input)
+            # F377: exclude tiebreaker-DISTINCT hits from native (Leg-2) dedup.
+            if exclude_ids:
+                result = await self._heart.learn(fact_input, exclude_ids=exclude_ids)
+            else:
+                result = await self._heart.learn(fact_input)
             if isinstance(result, FactRejected):
                 logger.debug("Admission rejected candidate fact: %s", content[:50])
                 continue

--- a/nous/handlers/fact_extractor.py
+++ b/nous/handlers/fact_extractor.py
@@ -122,7 +122,9 @@ class FactExtractor:
         and should be stored. Fails open to dedup (flag off, or None verdict) so a
         tiebreaker outage never changes legacy behaviour. Shared by both dedup
         sites so they cannot drift (cf. #354)."""
-        if not self._settings.fact_dedup_tiebreaker_enabled:
+        # getattr default-off: duck-typed / stub settings without the attr must
+        # not accidentally enable the tiebreaker (codex P2).
+        if not getattr(self._settings, "fact_dedup_tiebreaker_enabled", False):
             return True
         if await self._heart.facts.is_distinct_fact(existing_content, candidate_content) is True:
             logger.debug(
@@ -131,6 +133,39 @@ class FactExtractor:
             )
             return False
         return True
+
+    async def _resolve_dedup(
+        self, content: str, candidate_event_date: "date | None"
+    ) -> UUID | None:
+        """Return the canonical fact UUID to dedup against, or None to store new.
+
+        Examines every above-threshold RRF hit (not just the top one) when the
+        tiebreaker is enabled, so a high-overlap opposite ranked first cannot
+        hide a real duplicate ranked lower (codex P2). With the flag off, only
+        the top hit is examined — byte-identical to the pre-F377 path. Hits whose
+        ``event_date`` differs from the candidate are skipped (F075: distinct
+        dates = distinct events). Shared by both producer paths (cf. #354)."""
+        if not self._dedup_via_search:
+            return None
+        tiebreaker = getattr(self._settings, "fact_dedup_tiebreaker_enabled", False)
+        # Only widen the search when the tiebreaker can re-judge lower hits;
+        # flag-off keeps the historical single-top-hit behaviour exactly.
+        limit = 5 if tiebreaker else 1
+        existing = await self._heart.search_facts(content, limit=limit)
+        for cand in existing:
+            # search_facts is score-desc; stop at the first sub-threshold hit.
+            if cand.score is None or cand.score <= self._settings.fact_dedup_threshold:
+                break
+            # F075: distinct event_dates = distinct events, never a duplicate.
+            if (
+                candidate_event_date is not None
+                and cand.event_date is not None
+                and candidate_event_date != cand.event_date
+            ):
+                continue
+            if await self._confirm_dedup(cand.content, content):
+                return cand.id
+        return None
 
     async def extract_and_store(
         self,
@@ -213,29 +248,18 @@ class FactExtractor:
                 else None
             )
 
-            # Dedup: check if similar fact exists (production paraphrase guard)
+            # Dedup: check if similar fact exists (production paraphrase guard).
+            # _resolve_dedup examines all above-threshold RRF hits (F377) and
+            # applies the F075 distinct-event_date bypass; None = store as new.
             content = fact.get("content", "")
-            if self._dedup_via_search:
-                existing = await self._heart.search_facts(content, limit=1)
-                if existing and existing[0].score is not None and existing[0].score > self._settings.fact_dedup_threshold:
-                    # F075 dedup bypass: distinct event_dates = distinct events.
-                    # Both sides are post-validator date|None objects after the
-                    # round-trip above — type-safe equality, no string coercion.
-                    existing_event_date = existing[0].event_date
-                    if not (
-                        candidate_event_date is not None
-                        and existing_event_date is not None
-                        and candidate_event_date != existing_event_date
-                    ):
-                        # F377: confirm the RRF dup before skipping the write.
-                        if await self._confirm_dedup(existing[0].content, content):
-                            stored_ids.append(existing[0].id)
-                            logger.debug(
-                                "Dedup skip — adding canonical UUID %s for content: %s",
-                                existing[0].id, content[:50],
-                            )
-                            continue
-                    # else: dates differ (or tiebreaker says distinct) — fall through to store
+            canonical = await self._resolve_dedup(content, candidate_event_date)
+            if canonical is not None:
+                stored_ids.append(canonical)
+                logger.debug(
+                    "Dedup skip — adding canonical UUID %s for content: %s",
+                    canonical, content[:50],
+                )
+                continue
 
             # F075 (arch P2-1): the fallback _EXTRACT_PROMPT has no event_date
             # field, so any dated candidate here is best-effort and we should
@@ -348,24 +372,14 @@ class FactExtractor:
             if not content or not str(content).strip():
                 continue
 
-            # Dedup: check if similar fact exists
-            if self._dedup_via_search:
-                existing = await self._heart.search_facts(content, limit=1)
-                if existing and existing[0].score is not None and existing[0].score > self._settings.fact_dedup_threshold:
-                    # F075 dedup bypass: distinct event_dates = distinct events.
-                    # Both sides are post-validator date|None — type-safe equality.
-                    existing_event_date = existing[0].event_date
-                    if not (
-                        candidate_event_date is not None
-                        and existing_event_date is not None
-                        and candidate_event_date != existing_event_date
-                    ):
-                        # F377: confirm the RRF dup before skipping the write.
-                        if await self._confirm_dedup(existing[0].content, content):
-                            stored_ids.append(existing[0].id)
-                            logger.debug("Dedup skip (candidate) — adding canonical UUID %s for: %s", existing[0].id, content[:50])
-                            continue
-                    # else: dates differ (or tiebreaker says distinct) — fall through to store
+            # Dedup: check if similar fact exists. _resolve_dedup examines all
+            # above-threshold RRF hits (F377) + the F075 distinct-date bypass;
+            # None = store as new.
+            canonical = await self._resolve_dedup(content, candidate_event_date)
+            if canonical is not None:
+                stored_ids.append(canonical)
+                logger.debug("Dedup skip (candidate) — adding canonical UUID %s for: %s", canonical, content[:50])
+                continue
 
             # F075: producer-path classification marker — gated on flag.
             # The summarizer's prompt DOES include event_date (Layer 1a in spec)

--- a/nous/handlers/fact_extractor.py
+++ b/nous/handlers/fact_extractor.py
@@ -112,6 +112,26 @@ class FactExtractor:
         if bus is not None:
             bus.on("episode_summarized", self.handle)
 
+    async def _confirm_dedup(self, existing_content: str, candidate_content: str) -> bool:
+        """F377: confirm an RRF-flagged duplicate before skipping the write.
+
+        The hybrid-search (RRF) pre-check over-dedups high-lexical-overlap
+        semantic opposites ("MRR -5%" vs "+5%"). When the tiebreaker flag is on,
+        a same-vs-distinct Haiku classifier confirms the verdict. Returns True if
+        the candidate should be deduped (skipped), False if it was judged DISTINCT
+        and should be stored. Fails open to dedup (flag off, or None verdict) so a
+        tiebreaker outage never changes legacy behaviour. Shared by both dedup
+        sites so they cannot drift (cf. #354)."""
+        if not self._settings.fact_dedup_tiebreaker_enabled:
+            return True
+        if await self._heart.facts.is_distinct_fact(existing_content, candidate_content) is True:
+            logger.debug(
+                "F377 tiebreaker: DISTINCT — storing despite RRF dup: %s",
+                candidate_content[:50],
+            )
+            return False
+        return True
+
     async def extract_and_store(
         self,
         summary: dict,
@@ -207,13 +227,15 @@ class FactExtractor:
                         and existing_event_date is not None
                         and candidate_event_date != existing_event_date
                     ):
-                        stored_ids.append(existing[0].id)
-                        logger.debug(
-                            "Dedup skip — adding canonical UUID %s for content: %s",
-                            existing[0].id, content[:50],
-                        )
-                        continue
-                    # else: dates differ, fall through to store as new fact
+                        # F377: confirm the RRF dup before skipping the write.
+                        if await self._confirm_dedup(existing[0].content, content):
+                            stored_ids.append(existing[0].id)
+                            logger.debug(
+                                "Dedup skip — adding canonical UUID %s for content: %s",
+                                existing[0].id, content[:50],
+                            )
+                            continue
+                    # else: dates differ (or tiebreaker says distinct) — fall through to store
 
             # F075 (arch P2-1): the fallback _EXTRACT_PROMPT has no event_date
             # field, so any dated candidate here is best-effort and we should
@@ -338,10 +360,12 @@ class FactExtractor:
                         and existing_event_date is not None
                         and candidate_event_date != existing_event_date
                     ):
-                        stored_ids.append(existing[0].id)
-                        logger.debug("Dedup skip (candidate) — adding canonical UUID %s for: %s", existing[0].id, content[:50])
-                        continue
-                    # else: dates differ, fall through to store
+                        # F377: confirm the RRF dup before skipping the write.
+                        if await self._confirm_dedup(existing[0].content, content):
+                            stored_ids.append(existing[0].id)
+                            logger.debug("Dedup skip (candidate) — adding canonical UUID %s for: %s", existing[0].id, content[:50])
+                            continue
+                    # else: dates differ (or tiebreaker says distinct) — fall through to store
 
             # F075: producer-path classification marker — gated on flag.
             # The summarizer's prompt DOES include event_date (Layer 1a in spec)

--- a/nous/heart/facts.py
+++ b/nous/heart/facts.py
@@ -100,6 +100,35 @@ _SUPERSESSION_CLASSIFIER_SCHEMA: dict[str, Any] = {
 }
 
 
+# F377: Leg-1 dedup tiebreaker prompt. Purpose-built binary same-vs-distinct
+# classifier (the supersession classifier above has no SAME/DUPLICATE label, so
+# paraphrases map ambiguously). Used only when the RRF pre-check flagged a dup.
+_DEDUP_TIEBREAKER_PROMPT_TEMPLATE = (
+    "Two short facts were flagged as possible duplicates by keyword search. "
+    "Decide whether they state the SAME fact or DIFFERENT facts.\n\n"
+    "EXISTING fact: {existing}\n\n"
+    "CANDIDATE fact: {candidate}\n\n"
+    "Return DUPLICATE only if the candidate is a restatement or paraphrase of "
+    "the existing fact with no materially different claim. Return DISTINCT if "
+    "they differ in any value, sign, polarity, quantity, direction, entity, or "
+    "time, or if one negates or contradicts the other — even when the wording "
+    "is very similar (e.g. 'metric down 5%' vs 'metric up 5%' are DISTINCT)."
+)
+
+_DEDUP_TIEBREAKER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "verdict": {
+            "type": "string",
+            "enum": ["DUPLICATE", "DISTINCT"],
+            "description": "DUPLICATE if the candidate restates the existing fact; "
+            "DISTINCT if it makes any materially different or contradictory claim.",
+        },
+    },
+    "required": ["verdict"],
+}
+
+
 class FactManager:
     """Manages semantic memory — what we know."""
 
@@ -260,6 +289,46 @@ class FactManager:
             output_schema=_SUPERSESSION_CLASSIFIER_SCHEMA,
             max_tokens=300,
         )
+
+    async def is_distinct_fact(
+        self, existing_content: str, candidate_content: str
+    ) -> bool | None:
+        """F377 dedup tiebreaker for the Leg-1 (RRF pre-check) path.
+
+        Returns ``True`` if the candidate is a DISTINCT fact (store it, do not
+        dedup), ``False`` if it is a DUPLICATE/paraphrase (dedup), or ``None``
+        if the LLM is unavailable or the call fails. Callers MUST fail open on
+        ``None`` — i.e. preserve the pre-tiebreaker behaviour (dedup) so the
+        learn path is never blocked by a tiebreaker outage.
+        """
+        if self._llm is None:
+            return None
+
+        from nous.handlers import call_background_llm_structured
+
+        prompt = _DEDUP_TIEBREAKER_PROMPT_TEMPLATE.format(
+            existing=existing_content[:500],
+            candidate=candidate_content[:500],
+        )
+        try:
+            result = await call_background_llm_structured(
+                client=self._llm,
+                model=self._llm_model,
+                system_prompt="You are a memory deduplication classifier. "
+                "Decide whether two facts are the same or distinct.",
+                user_message=prompt,
+                tool_name="classify_dedup",
+                tool_description="Decide whether two facts are duplicates or distinct.",
+                output_schema=_DEDUP_TIEBREAKER_SCHEMA,
+                max_tokens=100,
+            )
+        except Exception:
+            logger.debug("F377 dedup tiebreaker call failed; failing open", exc_info=True)
+            return None
+
+        if not result or "verdict" not in result:
+            return None
+        return result["verdict"] == "DISTINCT"
 
     # ------------------------------------------------------------------
     # F027: Retrieval soft suppression

--- a/nous/heart/heart.py
+++ b/nous/heart/heart.py
@@ -282,6 +282,7 @@ class Heart:
         session: AsyncSession | None = None,
         encoded_frame: str | None = None,
         encoded_censors: list[str] | None = None,
+        exclude_ids: list[UUID] | None = None,
     ) -> FactDetail | FactRejected:
         """Store a new fact with deduplication.
 
@@ -290,12 +291,17 @@ class Heart:
             session: Optional DB session.
             encoded_frame: Active frame when fact was learned (003.2).
             encoded_censors: Active censors when fact was learned (003.2).
+            exclude_ids: Fact IDs to skip in the native-cosine dedup check.
+                F377: lets the fact extractor exclude RRF hits its tiebreaker
+                already judged DISTINCT, so Heart.learn's Leg-2 dedup can't
+                silently re-merge them.
         """
         result = await self.facts.learn(
             input,
             session=session,
             encoded_frame=encoded_frame,
             encoded_censors=encoded_censors,
+            exclude_ids=exclude_ids,
         )
 
         # F023: Skip event emission for rejected facts (FactRejected has no .id)

--- a/nous_eval/retrieval_runner.py
+++ b/nous_eval/retrieval_runner.py
@@ -390,6 +390,26 @@ async def _build_heart_for_eval(
                 exc_info=True,
             )
 
+    # F377: wire the dedup-tiebreaker LLM client onto heart.facts when enabled.
+    # Mirrors nous/main.py:192. Without this the fact_dedup_tiebreaker_enabled
+    # flag is a no-op in the harness (is_distinct_fact returns None -> fail-open
+    # dedup) and the dedup eval can't measure the tiebreaker. Reuse the F050
+    # api_client if one was already created.
+    if getattr(settings, "fact_dedup_tiebreaker_enabled", False):
+        try:
+            if api_client is None:
+                from nous.api.anthropic_client import create_client
+                api_client = create_client(settings)
+                await api_client.start()
+            heart.facts.set_llm_client(api_client, model=settings.contradiction_model)
+            logger.info("F377: harness dedup tiebreaker LLM client wired for eval")
+        except Exception:
+            logger.warning(
+                "F377: harness dedup tiebreaker wiring failed; tiebreaker collapses "
+                "to fail-open dedup",
+                exc_info=True,
+            )
+
     try:
         async with heart:
             yield heart

--- a/tests/test_f377_dedup_tiebreaker.py
+++ b/tests/test_f377_dedup_tiebreaker.py
@@ -1,0 +1,74 @@
+"""Tests for F377 Leg-1 dedup tiebreaker (FactManager.is_distinct_fact).
+
+The tiebreaker resolves the RRF over-dedup of high-lexical-overlap semantic
+opposites. It must:
+- return None when no LLM client is wired (caller fails open -> dedup),
+- map a DISTINCT verdict to True (store, don't dedup),
+- map a DUPLICATE verdict to False (dedup),
+- return None on malformed output or LLM error (fail open).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nous.heart.facts import FactManager
+
+
+def _mock_llm_response(result_dict: dict) -> AsyncMock:
+    """Mock LLM client returning a single tool_use block (matches the shape
+    call_background_llm_structured extracts: first type=='tool_use' -> input)."""
+    response = MagicMock()
+    response.content = [
+        {"type": "tool_use", "id": "call_1", "name": "classify_dedup", "input": result_dict}
+    ]
+    client = AsyncMock()
+    client.call = AsyncMock(return_value=response)
+    return client
+
+
+def _fm() -> FactManager:
+    return FactManager(db=MagicMock(), embeddings=None, agent_id="test")
+
+
+@pytest.mark.asyncio
+async def test_returns_none_without_llm():
+    """No LLM wired -> None so the caller fails open to current dedup behavior."""
+    fm = _fm()
+    assert await fm.is_distinct_fact("MRR is down 5%", "MRR fell by 5 percent") is None
+
+
+@pytest.mark.asyncio
+async def test_distinct_verdict_returns_true():
+    fm = _fm()
+    fm.set_llm_client(_mock_llm_response({"verdict": "DISTINCT"}))
+    # semantic opposite -> store, don't dedup
+    assert await fm.is_distinct_fact("MRR is down 5%", "MRR is up 5%") is True
+
+
+@pytest.mark.asyncio
+async def test_duplicate_verdict_returns_false():
+    fm = _fm()
+    fm.set_llm_client(_mock_llm_response({"verdict": "DUPLICATE"}))
+    # paraphrase -> dedup
+    assert await fm.is_distinct_fact("MRR is down 5%", "MRR fell by 5 percent") is False
+
+
+@pytest.mark.asyncio
+async def test_malformed_output_returns_none():
+    """Missing verdict key -> None (fail open)."""
+    fm = _fm()
+    fm.set_llm_client(_mock_llm_response({"unexpected": "shape"}))
+    assert await fm.is_distinct_fact("a", "b") is None
+
+
+@pytest.mark.asyncio
+async def test_llm_error_returns_none():
+    """LLM call raising -> None (fail open, never block the learn path)."""
+    fm = _fm()
+    client = AsyncMock()
+    client.call = AsyncMock(side_effect=Exception("LLM error"))
+    fm.set_llm_client(client)
+    assert await fm.is_distinct_fact("a", "b") is None

--- a/tests/test_f377_dedup_tiebreaker.py
+++ b/tests/test_f377_dedup_tiebreaker.py
@@ -72,3 +72,80 @@ async def test_llm_error_returns_none():
     client.call = AsyncMock(side_effect=Exception("LLM error"))
     fm.set_llm_client(client)
     assert await fm.is_distinct_fact("a", "b") is None
+
+
+# ---------------------------------------------------------------------------
+# FactExtractor._resolve_dedup — multi-hit checking (codex P2-1)
+# ---------------------------------------------------------------------------
+
+from types import SimpleNamespace  # noqa: E402
+from uuid import uuid4  # noqa: E402
+
+from nous.handlers.fact_extractor import FactExtractor  # noqa: E402
+
+
+def _hit(content: str, score: float, *, id=None, event_date=None) -> SimpleNamespace:
+    return SimpleNamespace(id=id or uuid4(), content=content, score=score, event_date=event_date)
+
+
+def _extractor(heart, *, tiebreaker: bool) -> FactExtractor:
+    settings = SimpleNamespace(
+        fact_dedup_tiebreaker_enabled=tiebreaker,
+        fact_dedup_threshold=0.92,
+    )
+    return FactExtractor(
+        heart=heart, settings=settings, bus=None, llm_client=None, dedup_via_search=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_dedup_checks_lower_hits_when_top_is_distinct():
+    """P2-1: a high-overlap opposite ranked #1 must not hide a true duplicate
+    ranked #2. With the tiebreaker on, dedup against the lower paraphrase."""
+    opp, para = _hit("MRR is up 5%", 0.97), _hit("MRR fell by 5 percent", 0.95)
+    heart = MagicMock()
+    heart.search_facts = AsyncMock(return_value=[opp, para])
+    # top opposite -> DISTINCT (skip), lower paraphrase -> DUPLICATE (dedup)
+    heart.facts.is_distinct_fact = AsyncMock(side_effect=[True, False])
+    ext = _extractor(heart, tiebreaker=True)
+
+    result = await ext._resolve_dedup("MRR dropped five percent", None)
+    assert result == para.id
+
+
+@pytest.mark.asyncio
+async def test_resolve_dedup_stores_when_all_hits_distinct():
+    """All above-threshold hits judged DISTINCT -> None (store as new)."""
+    heart = MagicMock()
+    heart.search_facts = AsyncMock(return_value=[_hit("x up", 0.97), _hit("y down", 0.95)])
+    heart.facts.is_distinct_fact = AsyncMock(return_value=True)
+    ext = _extractor(heart, tiebreaker=True)
+    assert await ext._resolve_dedup("z", None) is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_dedup_flag_off_dedups_top_hit_without_llm():
+    """Flag off -> legacy single-top-hit dedup; the tiebreaker is never called."""
+    top = _hit("anchor", 0.97)
+    heart = MagicMock()
+    heart.search_facts = AsyncMock(return_value=[top])
+    heart.facts.is_distinct_fact = AsyncMock()
+    ext = _extractor(heart, tiebreaker=False)
+
+    assert await ext._resolve_dedup("paraphrase", None) == top.id
+    heart.facts.is_distinct_fact.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_dedup_skips_distinct_event_date():
+    """F075 bypass: an above-threshold hit with a different event_date is not a
+    duplicate, so it is skipped even before the tiebreaker."""
+    from datetime import date
+    hit = _hit("same text", 0.97, event_date=date(2024, 1, 1))
+    heart = MagicMock()
+    heart.search_facts = AsyncMock(return_value=[hit])
+    heart.facts.is_distinct_fact = AsyncMock()
+    ext = _extractor(heart, tiebreaker=True)
+
+    assert await ext._resolve_dedup("same text", date(2024, 6, 1)) is None
+    heart.facts.is_distinct_fact.assert_not_called()

--- a/tests/test_f377_dedup_tiebreaker.py
+++ b/tests/test_f377_dedup_tiebreaker.py
@@ -109,37 +109,46 @@ async def test_resolve_dedup_checks_lower_hits_when_top_is_distinct():
     heart.facts.is_distinct_fact = AsyncMock(side_effect=[True, False])
     ext = _extractor(heart, tiebreaker=True)
 
-    result = await ext._resolve_dedup("MRR dropped five percent", None)
-    assert result == para.id
+    canonical, exclude_ids = await ext._resolve_dedup("MRR dropped five percent", None)
+    assert canonical == para.id
+    # the DISTINCT-judged opposite is recorded for native-dedup exclusion
+    assert opp.id in exclude_ids
 
 
 @pytest.mark.asyncio
 async def test_resolve_dedup_stores_when_all_hits_distinct():
-    """All above-threshold hits judged DISTINCT -> None (store as new)."""
+    """All above-threshold hits judged DISTINCT -> store as new, and every hit
+    id is returned for native-dedup exclusion (codex P2)."""
+    a, b = _hit("x up", 0.97), _hit("y down", 0.95)
     heart = MagicMock()
-    heart.search_facts = AsyncMock(return_value=[_hit("x up", 0.97), _hit("y down", 0.95)])
+    heart.search_facts = AsyncMock(return_value=[a, b])
     heart.facts.is_distinct_fact = AsyncMock(return_value=True)
     ext = _extractor(heart, tiebreaker=True)
-    assert await ext._resolve_dedup("z", None) is None
+    canonical, exclude_ids = await ext._resolve_dedup("z", None)
+    assert canonical is None
+    assert set(exclude_ids) == {a.id, b.id}
 
 
 @pytest.mark.asyncio
 async def test_resolve_dedup_flag_off_dedups_top_hit_without_llm():
-    """Flag off -> legacy single-top-hit dedup; the tiebreaker is never called."""
+    """Flag off -> legacy single-top-hit dedup; tiebreaker never called and no
+    exclusion ids (native dedup behaves exactly as pre-F377)."""
     top = _hit("anchor", 0.97)
     heart = MagicMock()
     heart.search_facts = AsyncMock(return_value=[top])
     heart.facts.is_distinct_fact = AsyncMock()
     ext = _extractor(heart, tiebreaker=False)
 
-    assert await ext._resolve_dedup("paraphrase", None) == top.id
+    canonical, exclude_ids = await ext._resolve_dedup("paraphrase", None)
+    assert canonical == top.id
+    assert exclude_ids == []
     heart.facts.is_distinct_fact.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_resolve_dedup_skips_distinct_event_date():
     """F075 bypass: an above-threshold hit with a different event_date is not a
-    duplicate, so it is skipped even before the tiebreaker."""
+    duplicate, so it is skipped even before the tiebreaker (and not excluded)."""
     from datetime import date
     hit = _hit("same text", 0.97, event_date=date(2024, 1, 1))
     heart = MagicMock()
@@ -147,5 +156,7 @@ async def test_resolve_dedup_skips_distinct_event_date():
     heart.facts.is_distinct_fact = AsyncMock()
     ext = _extractor(heart, tiebreaker=True)
 
-    assert await ext._resolve_dedup("same text", date(2024, 6, 1)) is None
+    canonical, exclude_ids = await ext._resolve_dedup("same text", date(2024, 6, 1))
+    assert canonical is None
+    assert exclude_ids == []
     heart.facts.is_distinct_fact.assert_not_called()


### PR DESCRIPTION
## Problem
The hybrid-search (RRF) pre-check in `FactExtractor` over-dedups high-lexical-overlap semantic **opposites** ("MRR -5%" vs "+5%"). The dedup eval showed Leg 1 at precision 0.667 / **10 FP**, and a threshold sweep (0.92/0.95/0.97) was **byte-identical** — RRF can't separate opposites from true paraphrases, and a cosine gate just collapses Leg 1 into Leg 2 (combined F1 0.782 → 0.765). The only separating signal is semantic.

## Fix
Flag-gated tiebreaker — `NOUS_FACT_DEDUP_TIEBREAKER_ENABLED` (**default off**, land dark):
- `FactManager.is_distinct_fact()` — purpose-built same-vs-distinct Haiku classifier (reuses `contradiction_model` + `call_background_llm_structured`), runs **only** when the RRF pre-check already flagged a dup. Fails open (None/error/flag-off → prior dedup behaviour) so a tiebreaker outage never blocks a learn.
- Both `FactExtractor` dedup sites (LLM-extraction **and** `candidate_facts` — the path the prod summarizer uses) route through a shared `_confirm_dedup` helper so they can't drift (cf. #354).
- Eval-harness wires the LLM client onto `heart.facts` so the dedup eval can measure it.

> Not the supersession classifier (`_classify_fact_pair`): it outputs UPDATE/CONTRADICTION/REFINEMENT/UNRELATED with no SAME label, so paraphrases map ambiguously.

## Result (nous_eval.handlers.dedup)
| | precision | recall | F1 | FP |
|---|---|---|---|---|
| Leg 1 baseline | 0.667 | 1.000 | 0.800 | 10 |
| **Leg 1 + tiebreaker** | **0.950** | **0.950** | **0.950** | **1** |

Combined 0.782 → **0.857**. Prod runs `dedup_via_search=True` = Leg 1, so the production path is fixed.

## Tests
5 unit tests (`tests/test_f377_dedup_tiebreaker.py`) covering verdict mapping + both fail-open paths; fact tests pass on Postgres.

## Rollout
Land dark; flip `NOUS_FACT_DEDUP_TIEBREAKER_ENABLED=true` in prod `.env` after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)