### PR TITLE
fix(api): drop obsolete Claude-4 beta headers breaking opus-4.8 streaming tool calls

### DIFF
--- a/nous/api/anthropic_client.py
+++ b/nous/api/anthropic_client.py
@@ -386,10 +386,14 @@ class HttpxAnthropicClient:
                 "API calls will fail"
             )
 
+        # interleaved-thinking-2025-05-14 and fine-grained-tool-streaming-2025-05-14
+        # were REMOVED — Anthropic's Claude 4 migration guide marks both obsolete.
+        # Adaptive thinking (Opus 4.6+/Sonnet 4.6+) enables interleaved thinking
+        # natively, and sending the legacy interleaved header alongside it broke
+        # opus-4.8 streaming tool round-trips ("tool_use ids without tool_result").
+        # Nous targets Claude 4.6+ only, so they are dropped unconditionally.
         beta_features: list[str] = [
             "claude-code-20250219",
-            "fine-grained-tool-streaming-2025-05-14",
-            "interleaved-thinking-2025-05-14",
         ]
         if is_oat:
             beta_features.append("oauth-2025-04-20")
@@ -816,10 +820,14 @@ class SdkAnthropicClient:
             kwargs["api_key"] = "missing"
 
         # Beta headers + OAT browser access header
+        # interleaved-thinking-2025-05-14 and fine-grained-tool-streaming-2025-05-14
+        # were REMOVED — Anthropic's Claude 4 migration guide marks both obsolete.
+        # Adaptive thinking (Opus 4.6+/Sonnet 4.6+) enables interleaved thinking
+        # natively, and sending the legacy interleaved header alongside it broke
+        # opus-4.8 streaming tool round-trips ("tool_use ids without tool_result").
+        # Nous targets Claude 4.6+ only, so they are dropped unconditionally.
         beta_features: list[str] = [
             "claude-code-20250219",
-            "fine-grained-tool-streaming-2025-05-14",
-            "interleaved-thinking-2025-05-14",
         ]
         if is_oat:
             beta_features.append("oauth-2025-04-20")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -987,35 +987,41 @@ def test_parse_signature_delta():
 
 
 async def test_start_thinking_beta_header(mock_cognitive):
-    """start() adds interleaved-thinking beta header when thinking enabled."""
+    """start() pins the claude-code beta and drops obsolete Claude-4 betas."""
     s = Settings(ANTHROPIC_API_KEY="test-api-key", thinking_mode="adaptive", api_backend="httpx")
     r = AgentRunner(mock_cognitive, MockBrain(), MockHeart(), s)
     await r.start()
     try:
         http = r._api._http
         assert "anthropic-beta" in http.headers
-        assert "interleaved-thinking-2025-05-14" in http.headers["anthropic-beta"]
+        beta = http.headers["anthropic-beta"]
+        assert "claude-code-20250219" in beta
+        # Removed for Claude 4.6+: adaptive thinking enables interleaved thinking
+        # natively, and the legacy header broke opus-4.8 streaming tool round-trips.
+        assert "interleaved-thinking-2025-05-14" not in beta
+        assert "fine-grained-tool-streaming-2025-05-14" not in beta
     finally:
         await r.close()
 
 
 async def test_start_no_thinking_no_beta(mock_cognitive):
-    """start() still has beta headers (claude-code, fine-grained-tool-streaming, etc.)."""
+    """start() always pins the claude-code beta; legacy Claude-4 betas are absent."""
     s = Settings(ANTHROPIC_API_KEY="test-api-key", thinking_mode="off", api_backend="httpx")
     r = AgentRunner(mock_cognitive, MockBrain(), MockHeart(), s)
     await r.start()
     try:
         http = r._api._http
-        # Beta headers are always present (claude-code, fine-grained-tool-streaming, etc.)
         assert "anthropic-beta" in http.headers
-        # But interleaved-thinking is always included for forward compat
-        assert "interleaved-thinking-2025-05-14" in http.headers["anthropic-beta"]
+        beta = http.headers["anthropic-beta"]
+        assert "claude-code-20250219" in beta
+        assert "interleaved-thinking-2025-05-14" not in beta
+        assert "fine-grained-tool-streaming-2025-05-14" not in beta
     finally:
         await r.close()
 
 
 async def test_start_oat_plus_thinking_headers(mock_cognitive):
-    """start() combines OAT + thinking beta headers."""
+    """start() combines the OAT beta with the pinned claude-code beta."""
     s = Settings(
         ANTHROPIC_API_KEY="sk-ant-oat-test-token",
         thinking_mode="manual",
@@ -1028,7 +1034,8 @@ async def test_start_oat_plus_thinking_headers(mock_cognitive):
     try:
         beta = r._api._http.headers["anthropic-beta"]
         assert "oauth-2025-04-20" in beta
-        assert "interleaved-thinking-2025-05-14" in beta
+        assert "claude-code-20250219" in beta
+        assert "interleaved-thinking-2025-05-14" not in beta
     finally:
         await r.close()
 


### PR DESCRIPTION
## Problem
On `claude-opus-4-8`, interactive Telegram/web streaming turns (`/chat/stream` → `stream_chat`) produced "💭 Thinking… (redacted) / 🔧 Ran N tools" with **no answer body**. `claude-opus-4-7` worked, and background tasks (`run_turn` → `_tool_loop`) were unaffected.

## Root cause
Both `HttpxAnthropicClient` and `SdkAnthropicClient` `start()` pinned two beta headers that Anthropic's Claude 4 migration guide marks **obsolete**:
- `interleaved-thinking-2025-05-14`
- `fine-grained-tool-streaming-2025-05-14`

Adaptive thinking (Opus 4.6+/Sonnet 4.6+, which prod uses) enables interleaved thinking **natively**. Sending the legacy `interleaved-thinking-2025-05-14` header on top of it is a documented cause of *"`tool_use` ids ... without `tool_result` blocks immediately after"* (vercel/ai#6472) — a broken tool round-trip, which is exactly the "tools ran, no answer" symptom on the streaming path. Background uses `_tool_loop` (non-streaming) so it was unaffected.

## Fix
- Remove both obsolete betas from both clients; keep `claude-code-20250219` (OAT rate limits) + `oauth-2025-04-20`.
- Nous targets Claude 4.6+ only, so they're dropped unconditionally.
- Updated 3 beta-header unit tests.

## Testing
- `pytest tests/test_runner.py -k "beta or header"` → **3 passed**.
- ⚠️ Real verification is a live opus-4.8 streaming turn — unit tests only assert header presence/absence, and minimal API repros did not reproduce the break (it needs the real multi-tool round-trip).

## Refs
- [Adaptive thinking — Claude docs](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking)
- [Migrating to Claude 4](https://platform.claude.com/docs/en/docs/about-claude/models/migrating-to-claude-4)
- vercel/ai#6472

🤖 Generated with [Claude Code](https://claude.com/claude-code)
