### PR TITLE
fix(runner): dispatch opus-4.8 tool calls returned with stop_reason='end_turn'

### DIFF
--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -1202,7 +1202,11 @@ class AgentRunner:
                             if thinking_text:
                                 all_thinking_blocks.append(thinking_text)
 
-                    if stop_reason == "end_turn" or not tool_calls:
+                    # Dispatch whenever there are tool calls, even with stop_reason='end_turn'
+                    # (opus-4.8 interleaved thinking can end the message with a thinking block
+                    # after the tool_use, flipping the stop_reason). Terminal only when there
+                    # are no tool calls to dispatch.
+                    if not tool_calls:
                         response_text = "".join(text_parts)
                         break
 
@@ -1591,9 +1595,20 @@ class AgentRunner:
                     if thinking_text:
                         all_thinking_blocks.append(thinking_text)
 
-            # If not a tool use, we're done
-            if api_response.stop_reason != "tool_use":
+            # Terminate only when there are genuinely no tool_use blocks to dispatch.
+            # opus-4.8 with adaptive/interleaved thinking can return tool_use blocks while
+            # reporting stop_reason='end_turn' (the message ends with a thinking block AFTER
+            # the tool_use). Gating on stop_reason=='tool_use' silently dropped those tool
+            # calls -> turns=0, empty answer. Dispatch whenever tool_use blocks are present.
+            has_tool_use = any(b.get("type") == "tool_use" for b in api_response.content)
+            if not has_tool_use:
                 response_text = self._extract_text(api_response.content)
+                logger.debug(
+                    "tool-loop terminal: stop=%s blocks=%s text_len=%d thinking=%d turns=%d toolcalls=%d",
+                    api_response.stop_reason,
+                    [b.get("type") for b in api_response.content],
+                    len(response_text), len(all_thinking_blocks), turns, total_tool_calls,
+                )
                 return response_text, all_tool_results, total_usage, all_thinking_blocks
 
             # P0-3: Append FULL assistant response (all content blocks)
@@ -1809,7 +1824,14 @@ class AgentRunner:
             if final_response.usage:
                 total_usage["input_tokens"] += final_response.usage.get("input_tokens", 0)
                 total_usage["output_tokens"] += final_response.usage.get("output_tokens", 0)
-            return self._extract_text(final_response.content), all_tool_results, total_usage, all_thinking_blocks
+            _rt = self._extract_text(final_response.content)
+            logger.debug(
+                "tool-loop max_turns: stop=%s blocks=%s text_len=%d thinking=%d",
+                final_response.stop_reason,
+                [b.get("type") for b in final_response.content],
+                len(_rt), len(all_thinking_blocks),
+            )
+            return _rt, all_tool_results, total_usage, all_thinking_blocks
         except Exception:
             return "I reached the maximum number of tool iterations. Please try again.", all_tool_results, total_usage, all_thinking_blocks
 

--- a/tests/test_tool_loop.py
+++ b/tests/test_tool_loop.py
@@ -197,6 +197,29 @@ class TestToolLoop:
         assert loop_runner._call_api.call_count == 2
 
     @pytest.mark.asyncio
+    async def test_tool_use_dispatched_despite_end_turn_stop_reason(self, loop_runner):
+        """opus-4.8 with adaptive/interleaved thinking returns tool_use blocks while
+        reporting stop_reason='end_turn' (the message ends with a thinking block AFTER the
+        tool_use). The loop MUST dispatch those tools, not terminate on the stop_reason —
+        gating on stop_reason=='tool_use' silently dropped them, producing empty answers.
+        Regression for the opus-4.8 non-streaming dropped-tool bug."""
+        tool_response = _make_api_response(
+            stop_reason="end_turn",   # the bug trigger: end_turn WITH a tool_use block
+            tool_uses=[{"name": "echo", "input": {"message": "bridge"}, "id": "toolu_et"}],
+        )
+        final_response = _make_api_response(text="Answered after the tool", stop_reason="end_turn")
+        loop_runner._call_api = AsyncMock(side_effect=[tool_response, final_response])
+
+        conv = _make_conversation([("user", "needs a tool")])
+        response_text, tool_results, _usage, _ = await loop_runner._tool_loop(
+            system_prompt="Test prompt", conversation=conv, frame_id="task",
+        )
+        assert len(tool_results) == 1, "tool_use must dispatch even when stop_reason='end_turn'"
+        assert tool_results[0].tool_name == "echo"
+        assert response_text == "Answered after the tool"
+        assert loop_runner._call_api.call_count == 2
+
+    @pytest.mark.asyncio
     async def test_tool_loop_max_turns(self, loop_runner):
         """API always returns tool_use -> stops at max_turns (3) and makes final call."""
         # Always return tool_use (will hit max_turns=3)


### PR DESCRIPTION
## Problem

opus-4.8 turns that want a tool silently do nothing on the **non-streaming** path (subtasks, heartbeat, `/chat`) — the agent appears to "not call tools / 0 tools this turn", returning an empty answer.

Root cause: the tool loop terminates on `stop_reason`. But opus-4.8 with adaptive/interleaved thinking returns `tool_use` blocks while reporting **`stop_reason='end_turn'`** (the message ends with a `thinking` block *after* the tool_use). The loop sees `end_turn`, declares "done", and returns **without dispatching the tool calls**.

```
RTDIAG terminal: stop=end_turn blocks=['thinking','tool_use','tool_use','tool_use','thinking'] text_len=0 turns=0 toolcalls=0
```

This is the deeper cause behind the original symptom; the obsolete-beta-header fix (#473) only covered the **streaming** manifestation. This one is backend-independent (reproduced on both the SDK and httpx clients).

## Fix

Dispatch whenever `tool_use` blocks are present; terminate only when there are genuinely none.
- `_tool_loop` (non-streaming): `has_tool_use = any(b.type=='tool_use'); if not has_tool_use:` (was `if stop_reason != 'tool_use':`)
- streaming loop: `if not tool_calls:` (dropped the `stop_reason == 'end_turn' or`)
- regression test: `stop_reason='end_turn'` + a `tool_use` block must dispatch the tool
- downgraded the RTDIAG `warning` diagnostics to `debug`

## Verification

- 9 tool-loop + 107 runner tests green.
- End-to-end on the **SDK / prod** backend with opus-4.8: pre-fix `turns=0 toolcalls=0` (dropped) → post-fix `turns=1 toolcalls=3` (dispatched, real answers).

Found by the associative-memory faculty eval (`scripts/diag/faculty/`), whose agentic lens was returning empty answers until this was fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
