### PR TITLE
F078: Correct-side censor enforcement (steer/refuse/abort + UI severity)

### DIFF
--- a/docs/features/F078-correct-side-censor-enforcement.md
+++ b/docs/features/F078-correct-side-censor-enforcement.md
@@ -1,0 +1,181 @@
+# F078 — Correct-Side Censor Enforcement
+
+**Status:** 📝 Draft v3 — **operator backward-compatibility constraint (2026-06-05)**; see "## v3" at the end (supersedes R2/R4). Then "## v2" (supersedes §1–§8).
+**Author:** Tim + Claude
+**Absorbs:** F068 (Censor Action Tiers — `steer | refuse | abort`; was draft, never shipped) — its tier vocabulary is folded in here.
+**Depends on:** F031 (Censor Middleware with Action Payloads — shipped, PR #209)
+**Decision:** forge `4c72c61f`. **Migration input:** `docs/reviews/censor-triage-2026-06-05.md`.
+
+---
+
+## Problem
+
+A prod audit of `nous-default` (48 active censors, `scripts/diag/censor_audit.json`) shows the censor system **fires on the wrong side** and **halts the agentic loop on false positives**:
+
+1. **Anti-hallucination censors match the wrong input.** ~10 of the 28 `block` censors were written to constrain the **model's output** (e.g. `delivered|was sent`, `can't do`, `psql|SELECT.*FROM`, `my skills`), but the only enforcing check is `pre_turn` against **user input** (`cognitive/layer.py:767`). So when *the user* says "did that email get sent?", the censor matches and the turn is replaced by a canned `"Blocked by censor: …"` — the agent can't even answer. This is the dominant false-halt.
+2. **`block` halts instead of refusing.** When `block` fires, the LLM never runs (`layer.py:810-822`, `runner.py:400/958`); Tim gets a generic refusal with no path forward and re-prompts 2–3× to get around it. (F068's original motivation.)
+3. **Silent auto-escalation.** A `warn` censor auto-escalates to `block` at `activation_count ≥ 3` (`censors.py:182`) with no human in the loop — a loose auto-created rule promotes itself into a turn-killer.
+4. **The auto-learn loop produces dead clutter.** 19 of 20 `warn` censors have **never once matched** — they're English-prose triggers fed to `re.search` (from `monitor.py` tool-error learning + F039 correction extraction). Plus 2 test rows and a duplicate `rm -rf /`.
+5. **`false_positive_count = 0` on all 48** — `record_false_positive` is unwired, so there is no signal to self-correct bad censors.
+
+### Hard constraint (operator)
+**F026 ActionGate is DISABLED in prod** (`NOUS_ACTION_GATING_ENABLED=false`) — it "blocked almost everything." F078 **must not depend on ActionGate**, and must **bias to advisory (steer) over blocking**, or it repeats the over-gating that got ActionGate turned off.
+
+---
+
+## Goals
+1. **Fire on the correct side.** Output-shaping rules (anti-hallucination, preferences) become **non-blocking pre-turn directives**; input-gating rules (prohibitive actions, destructive) gate the inbound intent.
+2. **Never halt the loop on a false positive.** A false match must degrade to a harmless extra directive, not a dead turn.
+3. **Refusals stay in the LLM's hands** for non-catastrophic cases (F068).
+4. **Auto-learned censors can never become turn-killers.** Provenance-capped to `steer`.
+5. **Self-correcting.** Repeated false positives demote a censor; promotion to a harder tier is human-gated.
+6. **No ActionGate dependency.** Self-contained enforcement.
+
+## Non-goals (deferred)
+- **F078.1 — per-tool-call action-scope.** Gate a *specific* tool call by argument (e.g. "decline `send_file` when recipient ∉ verified") rather than turn-level tool-strip. v1 uses F068's turn-level strip for `refuse`. (This is where ActionGate-style precision returns — done right this time, per-censor-scoped, not a global LLM gate.)
+- **F078.2 — enforcing output-side check.** Actually intercept the model's *output* if it still violates a rule (regenerate/append). v1 relies on the pre-turn steer directive; output enforcement risks loops (see F068.4) and is deferred.
+- **F078.3 — Haiku intent-confirm** before `refuse`/`abort` fires (cheap "does this input really violate `<reason>`?"). Schema leaves room; default off.
+
+---
+
+## Design
+
+### 1. Tier × side model
+Two tiers shape output (non-blocking); one gates input. The **tier implies the side**, so no separate `side` column is needed:
+
+| Tier | Side | Behavior | Use for | False-match cost |
+|---|---|---|---|---|
+| **steer** | output-shaping | LLM runs. The censor's **directive** (`action_instruction`) + any `trigger_action` results are injected into the system prompt as guidance. **Never blocks.** | anti-hallucination ("verify before asserting"), verify-before-acting ("check recipient before send"), preferences, positive directives ("always answer Maya") | **benign** — one extra directive line |
+| **refuse** | input-gate | LLM runs with a refusal directive; the **state-modifying tool denylist** (F068 §3, sourced from `execution_ledger` `WRITE_TOOLS ∪ EXTERNAL_TOOLS ∪ IRREVERSIBLE_TOOLS ∪ {bash}`) is stripped for the turn unless `refuse_keep_tools`. Model declines gracefully + may offer `suggested_alternative`. | genuinely prohibitive actions (never sell underwater, never lower exit_threshold to flush, decline autopilot-noise `record_decision`) | turn loses write tools (recoverable; LLM still answers) |
+| **abort** | input-gate, pre-LLM | Hard cut before the LLM — canned refusal. | destructive only (`rm -rf /`) | turn dead (reserved for cases where that's correct) |
+
+**Why this is the fix:** the false-halt came from output-intent rules matched on input as `block`. Moving them to `steer` makes a false match cost one harmless directive line instead of a dead turn. `refuse`/`abort` (which *can* block) are reserved for the few precise, prohibitive/destructive rules — biasing the whole system to advisory, as the ActionGate lesson demands.
+
+### 2. `steer` mechanics (the workhorse)
+On a `steer` match against user input:
+1. Inject the censor's **directive** into the system prompt under a `## Active Guidance` block: `action_instruction` (preferred) or fall back to `reason`.
+2. If `trigger_action` is set, execute it (F031 read-only executor, unchanged) and inject results too.
+3. The LLM runs normally. The directive shapes the response (e.g. "you have previously falsely claimed delivery — verify before asserting").
+
+Because a false `steer` match is benign, **steer matching may stay loose** (keyword/semantic). This is the robustness inversion: the common tier's failure mode is harmless.
+
+### 3. Creation hardening
+- **Provenance + max-tier cap.** New `provenance` field: `auto` (monitor tool-errors + F039), `agent` (`create_censor` tool), `human` (REST/operator). Enforce a cap at create *and* escalation time: `auto → max steer`, `agent → max refuse`, `human → abort`. An auto-learned censor **can never reach a halting tier.** (`monitor.py:172/378`, `correction_extractor.py:131` set `provenance="auto"`, force `tier="steer"`.)
+- **Kill silent auto-escalation.** Remove the `activation_count ≥ threshold → promote` logic (`censors.py:182-193`). Promotion to a harder tier is a deliberate human action only. Replace the upward ratchet with **FP-driven demotion** (§4).
+- **Validate at create, both paths.** `create_censor` tool (`tools.py:798`) and `_add` (`censors.py:84`) must validate: `trigger_pattern` compiles (`re.compile` in try/except), `unblock_pattern` compiles, `trigger_action.tool ∈ ALLOWED_TOOLS` (today only REST `PUT` validates — `rest.py:607`). Invalid → reject at the boundary, not silently dead at check time.
+
+### 4. Self-correction (wire `false_positive_count`)
+- Wire `record_false_positive` (exists, unused). Signal sources: user override/re-prompt immediately after a `refuse`/`abort` (heuristic), or explicit operator dismissal.
+- **Auto-demote** on repeated FPs: `refuse → steer → inactive` past per-tier thresholds. Demotion is safe (less blocking); promotion is human-only.
+
+### 5. Persisted audit (parity with CEL guardrails / F026)
+Emit `nous_system.events` for actual enforcement outcomes — `censor_steered`, `censor_refused`, `censor_aborted`, `censor_demoted` — not just the existing match-level `censor_triggered`. So "what actually blocked / what self-demoted" is queryable. (CEL guardrails already do this; censors are `logger`-only today — G5.)
+
+### 6. Schema migration
+```python
+# nous/heart/schemas.py
+CensorAction = Literal["steer", "refuse", "abort"]   # was warn|block|absolute
+```
+```sql
+-- migration NNN_censor_correct_side.sql  (constraint is ck_censors_action, models.py:618)
+ALTER TABLE heart.censors ADD COLUMN provenance TEXT NOT NULL DEFAULT 'human'
+  CHECK (provenance IN ('auto','agent','human'));
+ALTER TABLE heart.censors ADD COLUMN refuse_keep_tools BOOLEAN NOT NULL DEFAULT false;  -- F068
+-- action enum migrated by the data-migration script (§7), NOT a blind rename,
+-- then the CHECK constraint is swapped to ('steer','refuse','abort').
+```
+The action remap is **not** a blind `warn→steer / block→refuse`; it is the per-censor triage (§7).
+
+### 7. Data migration = the triage, dry-run first (NOT a rename)
+Per `docs/reviews/censor-triage-2026-06-05.md`:
+- **RETIRE 19** (dead prose, 2 tests, dup `rm -rf /`, broken trigger/reason) → `active=false`.
+- **CONSOLIDATE 11→5** (Celsius, runner.sh, capability-claims, workspace-path; deliverables stay 3 distinct).
+- **RE-TIER 16:** 10 → `steer`, 3 → `refuse`, 1 → `abort`, +2 deliverable steers.
+- Script `scripts/migrate_censors_f078.py`: **`--dry-run` prints the full before/after table**; `--commit` applies under a transaction; reversible (retired rows kept, not deleted). **Run against prod ONLY after Tim reviews the dry-run** (hard-to-reverse prod write — gated).
+- Provenance backfill: F039/`Auto-created` reason → `provenance='auto'`; `learned_from_decision IS NOT NULL` → `'agent'`; else `'human'`.
+
+### 8. Code touch points
+- `nous/heart/schemas.py` — `CensorAction` literal; add `provenance`; (directive reuses `action_instruction`).
+- `nous/storage/models.py:618` — CHECK constraint via migration + `provenance`, `refuse_keep_tools` columns.
+- `nous/cognitive/layer.py:767-846,1072-1110` — rewrite the censor block: `steer` → inject `## Active Guidance` (non-block); `refuse` → refusal directive + tool-strip (import denylist from `execution_ledger`, NOT ActionGate); `abort` → pre-LLM cut. Remove the output-side side-effecting `check()` call (G8) — output path becomes read-only/log or removed.
+- `nous/heart/censors.py:84-121` (validate), `:182-193` (delete auto-escalation; add demotion), `_check` side-effects audited.
+- `nous/cognitive/monitor.py:172,378` + `nous/handlers/correction_extractor.py:131` — set `provenance='auto'`, force `action='steer'`.
+- `nous/api/tools.py:798` — `create_censor` validates + provenance='agent' + cap at refuse; expose `action_instruction`.
+- `nous/api/rest.py:586` — provenance='human'; keep validation.
+- `nous/cognitive/schemas.py` — `suggested_alternative` on `TurnResult` (F068).
+- System-prompt rendering — surface new vocabulary where censors are listed.
+
+---
+
+## Rollout
+1. **Phase 1 — schema + enforcement rewrite (one PR).** Migration (columns + constraint), tier behaviors (steer/refuse/abort), provenance cap, kill auto-escalation, validation, audit events. Snapshot test: a no-directive `steer` is a no-op; `refuse` invokes the LLM with directive+strip; `abort` unchanged from `absolute`.
+2. **Phase 2 — data migration (gated).** Dry-run the triage on prod → Tim reviews → `--commit`. Sample-audit the first wave of `steer`/`refuse` activations.
+3. **Phase 3 — self-correction + FP wiring** (can trail Phase 1/2).
+
+### Risk
+- Medium: `block→refuse/steer` changes behavior for the 28 real block censors — but that's the point; the triage makes each call explicit and the dry-run is reviewable.
+- Low: `steer` false matches are benign; auto-cap prevents new turn-killers.
+
+## Open questions (for review)
+1. Is turn-level tool-strip for `refuse` (F068) acceptable for v1, or do the trading `refuse` censors need per-tool action-scope (F078.1) now to avoid stripping unrelated writes?
+2. Should `steer` directives be deduped/budgeted in the system prompt (many steers matching one turn → prompt bloat)?
+3. FP-demotion heuristic: is "user re-prompt after refuse" a reliable enough false-positive signal, or operator-only to start?
+4. The SOL `record_decision` noise-filter (`4e697cb1`) — keep as `refuse`, or move to decision-admission (out of censor scope)?
+
+---
+
+## v2 — Post-review revisions (2026-06-05, 3-agent review)
+
+Reviews: architecture (REWORK), devil's-advocate (P1 security), implementation (APPROVE-WITH-CHANGES). These resolutions supersede conflicting parts of §1–§8.
+
+**R1 (P1) — `steer` must inject into `sections_by_tier`, not the flat `system_prompt`.** F036 cache-split (`NOUS_CACHE_SPLIT_SYSTEM_PROMPT=true`, default) makes `runner._build_system_prompt` (runner.py:1884-1918) build from `sections_by_tier` and **ignore** `turn_context.system_prompt`. So the existing F031 `## Censor-Injected Context` AND F078 steer would be silently dropped under default config. **PRE-EXISTING PROD BUG: F031 censor injection has been a no-op since F036 shipped** — worth fixing regardless of F078. Fix: inject a dynamic section into `sections_by_tier`; add a test asserting injected guidance reaches the API payload. [layer.py:636,849-854,896]
+
+**R2 (P1) — migration is atomic + self-valid auto-SQL; the gated script does only judgment.** `056_censor_correct_side.sql` (idempotent, fresh-DB-safe): `DROP CONSTRAINT IF EXISTS ck_censors_action` → mechanical `UPDATE` (`block→refuse`, `warn→steer`, `absolute→abort`) → `ALTER COLUMN action SET DEFAULT 'steer'` → `ADD CONSTRAINT … CHECK (action IN ('steer','refuse','abort'))` → `ADD COLUMN IF NOT EXISTS provenance, refuse_keep_tools`. Update `models.py` CHECK (it's at **models.py:674**, not :618) + server_default + `schemas.py` `CensorAction` literal **in the same PR** (the ORM CHECK is enforced in SQLite test mode). `block→refuse` (not `→steer`) preserves enforcement through the window with no halts (refuse runs the LLM); the gated `scripts/migrate_censors_f078.py` then runs UNDER the new constraint and does only the triage judgment (retire 19 / consolidate / demote anti-hallucination to steer / set the 1 abort).
+
+**R3 (P1) — retier the subtask-spawn gate (`tools.py:1922`) — REQUIRED touch-point (was missing).** Today it rejects on `"block"`; after the swap both branches are dead → zero censor enforcement on the background/subtask path (the exfil-incident path, `cc5e6284`). Fix: spawn gate **rejects on `abort` AND `refuse`**; `steer` injects its directive into the subtask task context (or logs). The `if not is_subtask` guard (layer.py:767) is benign for steer but the spawn gate is the only censor enforcement subtasks get — it must honor the new tiers.
+
+**R4 (P1, security) — exfil censors are `refuse`, NOT `steer`.** Demoting `send.*email`/`sending email with sensitive data` to advisory steer re-enables the documented incident. Revised tiering: `cc5e6284`, `27dc4c8a` → **refuse**, so the retiered spawn gate (R3) **rejects** them on the autonomous path (restoring protection) and interactive declines + strips bash/send. Cost: interactive legit email is over-blocked when matched; the precise fix (allow verified recipient, block others) is **F078.1 per-tool recipient-scope = fast-follow** (not indefinitely deferred). *Operator note: elevate to `abort` if email-send should be hard-blocked.* Triage doc updated accordingly.
+
+**R5 (P1, security) — `refuse`/`abort` demotion is OPERATOR-ONLY.** The re-prompt FP heuristic applies to `steer` only. An insistent user re-prompting a trading safety rule (`95c945d8`, `c58c6cf3`) must not auto-walk it down. Add an operator digest of "censors that keep matching" as the human-gated **promotion** signal (counters demotion-only erosion). Resolves open-Q3.
+
+**R6 (P2) — the `refuse` tool-strip is the only net-new mechanism; spec it.** `absolute` is a no-op today (only block/warn are branched in layer.py), so `abort`=rename of block-halt and `steer`=rename of warn-inject (low risk); `refuse` (LLM-runs-but-strip-writes) is new. Wire: `TurnContext.refuse_active: bool` + denylist; `run_turn`/`_tool_loop` filter the tool schema before `_call_api` using `WRITE_TOOLS ∪ EXTERNAL_TOOLS ∪ IRREVERSIBLE_TOOLS ∪ {bash}` imported from `execution_ledger` (NOT ActionGate, NOT the existing whitelist `tool_filter`). Build last.
+
+**R7 (P2) — `steer` directive budget + dedup (required).** ~13 steers + loose matching → prompt bloat that dilutes the security steers. Cap N directives/turn, dedup by censor-id/reason-hash, prioritize security-domain. [layer.py:848 has no cap today]
+
+**R8 (P2) — mis-tiered irreversible rules flagged.** `git push.*main` and the runtime-path rules (`write to /root/nous/`, `cd /app/`) are left `steer` only because turn-level strip is too blunt; they're genuinely under-guarded until **F078.1** per-tool scope. Documented, not silently accepted.
+
+**R9 (P2) — ReDoS is NOT closed by `re.compile`** (catastrophic backtracking compiles fine; the 10K bound limits length not time). Accept as pre-existing residual risk + recommend a per-match timeout (or `re2`) as hardening; don't claim compile-check closes it.
+
+**R10 (P2) — provenance cap + validation live in ONE place: `CensorManager._add` (censors.py:84).** All create paths funnel through `add_censor→_add`. Callers only SET provenance (`monitor.py`×2 + `correction_extractor.py` → `auto`; `create_censor` tool → `agent`). `_add` enforces cap (`auto→steer`, `agent→refuse`, `human→abort`) + regex-compile validation + `trigger_action.tool ∈ ALLOWED_TOOLS`. **No POST /censors endpoint exists** (`rest.py:586` is PUT/update) — `human` provenance = migration default + direct DB only; a POST endpoint is out-of-scope.
+
+**R11 (P3 corrections):** constraint at `models.py:674` (citations of `:618` were wrong); `abort` is NEW behavior not a rename (today `absolute` is a silent input no-op) — fix snapshot-test premise; keep legacy `created_by` for audit, `provenance` for the cap (retiring auto-escalation orphans the `auto_escalation` value — stop writing it, leave it); rework `_ESCALATION_ORDER`/`escalate()` (censors.py:26,491) to new vocab + human-gated + their tests; provenance backfill — **F039/`Auto-created` reason wins → `auto` even when `learned_from_decision` is set**.
+
+### Implementation order (adopted from impl review)
+1. Schema + ORM lockstep migration `056` (R2, R11).
+2. Cap + validation + demotion in `_add`; set provenance at 3 callers; delete auto-escalation (R10, R11).
+3. Enforcement rewrite — `steer` (→`sections_by_tier`, R1) + `abort` renames first; output-side check read-only; retier spawn gate (R3); **then** the `refuse` tool-strip wire last (R6).
+4. Audit events + `record_false_positive` wiring (§4/§5, R5).
+5. Tests — `postgres_only` migration test; convert ~10 `block` cases; steer-no-op, refuse-strips-tools, abort-halts, provenance-cap, regex-reject, injection-reaches-payload (R1).
+6. Gated triage script with idempotent re-run guard.
+
+### Verdict after revisions
+Design holds; resolutions clear the P1s. **Genuine operator fork:** R4 (exfil = refuse + spawn-reject + F078.1 fast-follow — or elevate to `abort`). **Separately surfaced:** R1 is a pre-existing prod bug (F031 injection dropped since F036), fixable independently.
+
+---
+
+## v3 — Backward-compatibility constraint (2026-06-05)
+
+**Operator hard rule: F078 must not break any currently-working path** — in particular the **daily scheduled tasks that send email**. Email is sent by agent-authored code (run_python/bash + `smtplib` using `NOUS_EMAIL_*` creds) — there is **no email-tool chokepoint** in `nous/` (verified: no `smtplib`/`send_email` in the package). This supersedes R2 and R4.
+
+**BC-1 — email censors are `steer`, never `refuse`/`abort` (revises R4).** `refuse` strips bash/write tools; `abort` and the spawn-reject would kill the daily email subtasks on the autonomous path. The only non-breaking tier is `steer` (advisory, non-blocking). So `cc5e6284` / `27dc4c8a` → **steer**.
+
+**BC-2 — the mechanical migration is functionally INERT: `block→steer`, `warn→steer`, `absolute→abort` (revises R2's `block→refuse`).** Mapping `block→steer` changes **no working path's behavior except to stop the false-halts** (blocks become advisory; wrongly-halted turns now run). **The migration creates NO new hard tier.** The few genuinely-prohibitive censors (trading → `refuse`; `rm -rf` → `abort`) are PROMOTED **only by the gated triage script after Tim reviews the dry-run** — human-gated, explicit, reversible. Net automatic behavior change = "blocks stop halting." Nothing new blocks. (`absolute→abort` is safe: `absolute` is a no-op on input today and the only case is `rm -rf /`.)
+
+**BC-3 — exfil re-hardening is ADDITIVE (F078.1), not a block on the existing path.** The real fix = a guarded `send_email` tool (or SMTP wrapper) with a **recipient allowlist** (seeded from the daily tasks' recipients + Tim + Maya), added ALONGSIDE the working ad-hoc path; the steer directive points the agent to it; daily tasks migrate over time. Until then exfil protection is advisory (steer) — an explicit, accepted v1 gap, the price of the no-break rule. (Allowlist seed: audit prod `schedules` for daily email recipients.)
+
+**BC invariant (whole feature):** every change is either (a) non-blocking (steer / directive / the F036 injection fix), (b) a human-gated promotion via the reviewed triage, or (c) additive (new guarded tool). **No automatic step removes or blocks a currently-working capability.** This is the acceptance test for every PR in F078.
+
+### Net effect on the migration + triage
+- Mechanical migration (auto-SQL `056`): `block→steer`, `warn→steer`, `absolute→abort`. Inert except halts→advisory.
+- Gated triage script (post dry-run review): retire 19 dead, consolidate 11→5, and **promote** the explicit short-list to hard tiers — `refuse`: `95c945d8` (exit_threshold), `c58c6cf3` (sell-underwater), `4e697cb1` (record_decision noise); `abort`: `0b7dd037` (`rm -rf /`). **Email stays steer.** Everything else stays steer.
+- Spawn-gate retier (R3) still rejects `refuse`/`abort` — but post-triage those are only the trading rules + `rm -rf`, which SHOULD reject on the autonomous path; **email (steer) passes**, so daily email subtasks are unaffected.

--- a/docs/reviews/censor-triage-2026-06-05.md
+++ b/docs/reviews/censor-triage-2026-06-05.md
@@ -1,0 +1,97 @@
+# Censor Triage — prod `nous-default`, 48 active (2026-06-05)
+
+Migration input for **F078** (correct-side censor enforcement). Source: `scripts/diag/censor_audit.json` (pulled from prod `heart.censors`).
+Decision author: Claude (per Tim's "decide yourself first"). Tiers are F068's `steer | refuse | abort`; **SIDE** = where the rule should fire.
+
+> **v2 (post-review, 2026-06-05):** the exfil censors **`cc5e6284` (`send.*email…`) and `27dc4c8a` (`sending email with sensitive data`) move steer → REFUSE** (F078 R4) — advisory steer was a security downgrade re-enabling the stranger-email incident; refuse makes the retiered subtask-spawn gate reject them on the autonomous path. Precise "allow verified recipient" is F078.1 fast-follow. (Operator may elevate to `abort`.)
+
+## Disposition summary
+| Disposition | Count | Meaning |
+|---|---|---|
+| **RETIRE** | 19 | dead prose-regex (never matched), test rows, exact dups, broken trigger/reason |
+| **CONSOLIDATE** | 11 → 5 | overlapping rules merged into one clean censor each |
+| **KEEP → steer** | 10 | output-shaping directive injected pre-turn (non-blocking) |
+| **KEEP → refuse** | 3 | genuinely prohibitive action → LLM runs, declines, action stripped |
+| **KEEP → abort** | 1 | destructive → hard cut before LLM |
+
+Net: **48 → ~16 clean censors.** The dominant false-halt source — anti-hallucination block censors matched on *user input* — all become **steer** directives (fire on the output side, never block the turn).
+
+---
+
+## KEEP → abort (1) — destructive, command-scoped, pre-LLM hard cut
+| id | trigger | rationale |
+|---|---|---|
+| 0b7dd037 | `rm -rf /` | genuine destructive floor. (Dup `6542fead` retired.) Scope: bash command. |
+
+## KEEP → refuse (3) — prohibitive action; LLM runs + declines + relevant action stripped
+| id | trigger | rationale |
+|---|---|---|
+| 95c945d8 | `exit_threshold.*(lower\|reduce…)` | Tim's hard rule: never lower exit_threshold to flush an underwater position. Decline the proposal. |
+| c58c6cf3 | `sell.*underwater\|liquidate.*underwater…` | hard policy: never propose selling underwater. Decline; HOLD + notify. |
+| 4e697cb1 | `SOL.*HOLD\|autopilot.*tick.*triage…` | record_decision noise-filter (369×): autopilot HOLD logs are not decisions. Decline the `record_decision` call. *(Better long-term home: decision admission — noted in F078 §deferred.)* |
+
+## KEEP → steer (10) — output-intent directive injected pre-turn; **non-blocking**
+| id | trigger | becomes directive |
+|---|---|---|
+| cc5e6284 | `send.*email\|smtp\|send_message` | "Before sending email, verify recipient against stored facts = Tim's verified address (Tfatykhov@gmail.com); never infer/generate a recipient." *(was block — would wrongly block legit sends)* |
+| e81eab2d | `delivered\|was sent\|email (went\|was)…` | "Before claiming any deliverable was sent, verify subtask result non-empty + episode recorded + send tool_call event. Never equate status='completed' with delivered." |
+| 7e49ca32 | `my skills\|registered skills\|my procedures…` | "Call a retrieval tool before enumerating system facts (skills/procedures/memory/tools/tasks)." |
+| 0fb5c685 | `citing.*source\|according to.*study…` | "When generating citations, fetch + verify; do not assert sourced claims unverified." |
+| 28fb60e8 | `can't do\|cannot do\|not able to…` | "Before claiming inability, check whether bash/a tool accomplishes it." (consolidation anchor — see C3) |
+| 2c4da9f1 | `placeholder…\|successfully (delivered\|sent)…` | "Validate actual subtask output content, not completion status." |
+| b0f01858 | `psql\|SELECT.*FROM\|INSERT INTO…` | "Before writing SQL, verify schema (`\dt`,`\d`); never assume table/column names." |
+| 5532eeaa | `Goal.{0,5}Project Registry\|workstream.registry` | "Nous is not a dev tool — no project/workstream tracking constructs." |
+| 1e166c30 | `maechkina@gmail\|email from Maya` | **positive directive** "Always respond to Maya's (maechkina@gmail.com) emails." *(was block — a positive rule must never block)* |
+| f062c16e | `one-pager\|infographic\|slide…` | "Before finalizing a visual deliverable, verify no overlap/clipping, adequate padding." (consolidation anchor for deliverable-format — see C5) |
+
+## CONSOLIDATE (11 → 5)
+- **C1 Celsius:** `68c44c0f` (`\d+°F|Fahrenheit`, keep as anchor) ⊕ `4f1d5b03` (`°F`) → one steer "Output temperatures in °C; °F only as requested parenthetical." → **retire `4f1d5b03`**.
+- **C2 runner.sh launch:** `d4850ecb` (`runner\.sh launch|launch.*claude.*job`, anchor → refuse/steer) ⊕ `d7b3bfe6` (`runner\.sh launch`) → one rule "Launch Claude Code jobs only via a DAG first node; verify no stale job; cancel old first." Tier **steer** (advisory; over-blocking launches is high-friction). → **retire `d7b3bfe6`**.
+- **C3 capability-claims:** `28fb60e8` (anchor, steer) ⊕ `e738cd97` (`not implemented`) ⊕ `4e6c08df` (`feature is implemented`) ⊕ `c55db37f` (`claiming inability…`) ⊕ `c0993982` (`nous doctor`) → one steer "Before asserting a capability/feature is missing/unimplemented, verify against current code/tools." → **retire the 4 non-anchors.**
+- **C4 workspace-path:** `7a90f414` (`/tmp/(?!nous-workspace)`, anchor → steer) ⊕ `525edc71` (`clone…`) ⊕ `e0b3535c` (`write to /root/nous/`) ⊕ `ebf97209` (`cd /app/…`) → one steer "Write/clone only under /tmp/nous-workspace/; never runtime paths (/app, /root/nous)." → **retire the 3 non-anchors.**
+- **C5 deliverable-format:** `f062c16e` (anchor, steer) ⊕ `b18be236` (long-form→.docx) ⊕ `ebbb16d8` (speaking-notes ask-first) → keep `f062c16e` + **keep `b18be236` and `ebbb16d8` as distinct steers** (different intents: format-quality / channel / pre-questions). *No retire — these three stay as 3 steers; listed here only to note adjacency.*
+
+## KEEP → steer (deliverables, from C5) (2 more)
+| id | trigger | directive |
+|---|---|---|
+| b18be236 | `deliver(ing)?.*article\|long-form…` | "Long-form (1000+ words) → .md→.docx→send_file, then offer email; never paste into Telegram." |
+| ebbb16d8 | `speaking notes\|one-pager…` | "Before speaking-notes/one-pager, ask target time + audience/venue." |
+
+## KEEP → steer (operational, low-activation but legitimate) (3 more)
+| id | trigger | directive / tier note |
+|---|---|---|
+| 657e6e8e | `git commit.*main\|git push.*main` | steer "Never commit/push to main; branch + PR." *(refuse candidate, but steer avoids stripping all git for a turn; revisit with per-tool scope in v2)* |
+| 6b729aa8 | `F047.*Goal.*Registry\|F047.*Phase 2` | steer "F047 = Actionability Classification (shipped); 'Goal Registry/Phase 2/3' is stale — verify from docs." |
+| 27dc4c8a | `sending email with sensitive data` | steer "Never include keys/passwords/tokens/private data in emails; clear subject; ≤5 emails/hr." *(prose trigger weak — re-author as a send-scoped directive)* |
+
+## RETIRE (19) — dead/junk/dup/broken
+| id | trigger | why |
+|---|---|---|
+| 6542fead | `rm -rf /` | exact dup of `0b7dd037` |
+| 26eb60d3 | `Delivered. ✅` | trigger/reason mismatch (reason is about acknowledging arguments) — broken |
+| 1e397355 / 119fa890 | `test pattern` ("Test") | test rows |
+| 22f199a1 | `8b — SNN densification` | niche; covered by general "verify before listing pipeline phases" if ever needed |
+| 1e56d7fc | `phase 8b` | dup of above; niche |
+| 753a7746 | `notifying Tim unnecessarily` | never matched; notification discipline belongs in heartbeat config, not a text censor |
+| 8b56e01a | `depending on which side of the Atlantic` | dead prose |
+| 8d75c405 | `hallucinated venue attribution…` | dead prose; intent covered by C3/citations steer |
+| 593711fd | `fabricating execution results…` | dead prose; covered by delivery/placeholder steers |
+| a3ec99c0 | `emoji or symbols in academic…` | dead prose; re-author as a writing-skill steer later if wanted |
+| b860c5d7 | `single flat table` | dead prose; vague |
+| 2d336fde | `implies user defended…` | dead prose; voice-fidelity, vague |
+| ec6335d7 | `everything I know about you` | dead prose; "don't fabricate user facts" — re-author as steer later if wanted |
+| efa6f810 | `Nous doesn't have / Nous lacks…` | dead prose; meta |
+| 6f1978db | `not host` | dead prose; hyper-niche |
+| 91aebe98 | `heartbeat_check.*instead of dag` | never matched; orchestration preference — low value as a censor |
+| e0b3535c, ebf97209, 525edc71 | (workspace dups) | retired via C4 |
+| 4f1d5b03, d7b3bfe6, e738cd97, 4e6c08df, c55db37f, c0993982 | (consolidation non-anchors) | retired via C1/C2/C3 |
+
+*(Retire count includes the consolidation non-anchors; net active after migration ≈ 16.)*
+
+---
+
+## Cross-cutting notes for F078
+1. **The 10 steer conversions are the fix.** Every one was a `block` matched on user input; as a pre-turn directive it shapes output without halting. This single reclassification removes the dominant false-halt.
+2. **`false_positive_count = 0` on all 48** — the FP signal is unwired; triage here is judgment-based. F078 must wire `record_false_positive`.
+3. **Regex hygiene:** several triggers carry unicode (`→`), heavy alternations, lookaheads. Validate-on-write + ReDoS bound (10K input cap already exists, `censors.py:29`) carry forward.
+4. **No new auto-junk:** F078's provenance cap (auto-created censors max `steer`) + retiring the dead F039 prose prevents the warn-table from refilling.

--- a/nous/api/rest.py
+++ b/nous/api/rest.py
@@ -584,7 +584,11 @@ def create_app(
             return JSONResponse({"error": str(e)}, status_code=500)
 
     async def update_censor(request: Request) -> JSONResponse:
-        """PUT /censors/{id} - Update censor fields (F031)."""
+        """PUT /censors/{id} - Update censor fields (F031).
+
+        F078: ``action`` (steer|refuse|abort) and ``active`` (bool) are the UI
+        severity-control path — operator=human, so any valid tier is allowed.
+        """
         censor_id = request.path_params["id"]
         try:
             body = await request.json()
@@ -592,12 +596,25 @@ def create_app(
             return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
 
         update_fields = {}
-        for field in ("trigger_action", "action_instruction", "unblock_pattern", "reason", "domain"):
+        for field in (
+            "trigger_action", "action_instruction", "unblock_pattern",
+            "reason", "domain", "action", "active",
+        ):
             if field in body:
                 update_fields[field] = body[field]
 
         if not update_fields:
             return JSONResponse({"error": "No fields to update"}, status_code=400)
+
+        # F078: validate action vocabulary (UI severity control).
+        if "action" in update_fields and update_fields["action"] not in ("steer", "refuse", "abort"):
+            return JSONResponse(
+                {"error": "action must be one of: steer, refuse, abort"},
+                status_code=400,
+            )
+        # F078: validate active is a bool.
+        if "active" in update_fields and not isinstance(update_fields["active"], bool):
+            return JSONResponse({"error": "active must be a boolean"}, status_code=400)
 
         # F031: Validate trigger_action structure if provided
         ta = update_fields.get("trigger_action")

--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -515,7 +515,7 @@ class AgentRunner:
                         extra_tools=extra_tools,
                         force_tool_on_penultimate=force_tool_on_penultimate,
                         dag_node_id=dag_node_id,
-                        refuse_active=turn_context.refuse_active,  # F078 R6
+                        refuse_active=getattr(turn_context, "refuse_active", False),  # F078 R6
                     )
                 finally:
                     CURRENT_TURN_EXCLUDE_IDS.reset(_f071_token)
@@ -1001,7 +1001,7 @@ class AgentRunner:
             # path (used by Telegram) built tools directly and would otherwise leak write/
             # external/irreversible/bash to a refused turn. refuse_active already accounts for
             # refuse_keep_tools (set in cognitive/layer.py).
-            if turn_context.refuse_active and tools:
+            if getattr(turn_context, "refuse_active", False) and tools:
                 _refuse_denylist = WRITE_TOOLS | EXTERNAL_TOOLS | IRREVERSIBLE_TOOLS | {"bash"}
                 _before = len(tools)
                 tools = [t for t in tools if t["name"] not in _refuse_denylist]

--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -996,6 +996,16 @@ class AgentRunner:
                 else:
                     system_prompt = system_prompt_prefix + "\n\n" + system_prompt
             tools = self._dispatcher.available_tools(turn_context.frame.frame_id)
+            # F078 (codex P1): a refuse-tier censor must strip state-modifying tools on the
+            # STREAMING path too — the non-streaming _tool_loop already does this, but the SSE
+            # path (used by Telegram) built tools directly and would otherwise leak write/
+            # external/irreversible/bash to a refused turn. refuse_active already accounts for
+            # refuse_keep_tools (set in cognitive/layer.py).
+            if turn_context.refuse_active and tools:
+                _refuse_denylist = WRITE_TOOLS | EXTERNAL_TOOLS | IRREVERSIBLE_TOOLS | {"bash"}
+                _before = len(tools)
+                tools = [t for t in tools if t["name"] not in _refuse_denylist]
+                logger.info("F078 refuse: stripped %d state-modifying tool(s) (streaming)", _before - len(tools))
             messages = self._format_messages(conversation)
 
             # F036: Compactor needs flat string for token estimation

--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -30,7 +30,12 @@ from nous.api.models import ApiResponse, Conversation, Message  # noqa: F401 —
 from nous.brain.brain import Brain
 from nous.cognitive.action_gate import ActionGate
 from nous.cognitive.claim_verifier import ClaimVerifier, IntentTracker
-from nous.cognitive.execution_ledger import ExecutionLedger
+from nous.cognitive.execution_ledger import (
+    EXTERNAL_TOOLS,
+    IRREVERSIBLE_TOOLS,
+    WRITE_TOOLS,
+    ExecutionLedger,
+)
 from nous.cognitive.layer import CognitiveLayer
 from nous.cognitive.schemas import ToolResult, TurnContext, TurnResult
 from nous.config import Settings
@@ -510,6 +515,7 @@ class AgentRunner:
                         extra_tools=extra_tools,
                         force_tool_on_penultimate=force_tool_on_penultimate,
                         dag_node_id=dag_node_id,
+                        refuse_active=turn_context.refuse_active,  # F078 R6
                     )
                 finally:
                     CURRENT_TURN_EXCLUDE_IDS.reset(_f071_token)
@@ -1425,6 +1431,7 @@ class AgentRunner:
         extra_tools: dict[str, tuple[dict, Any]] | None = None,
         force_tool_on_penultimate: str | None = None,
         dag_node_id: UUID | None = None,  # F064.1: activity-ping target
+        refuse_active: bool = False,  # F078: strip state-modifying tools for the turn
     ) -> tuple[str, list[ToolResult], dict[str, int], list[str]]:
         """Run the tool use loop until completion or max_turns.
 
@@ -1456,6 +1463,20 @@ class AgentRunner:
         # F034.5: Dynamic check tool restriction
         if tool_filter is not None:
             base_tools = [t for t in base_tools if t["name"] in tool_filter]
+
+        # F078 (R6): a `refuse`-tier censor matched. The LLM still runs, but its
+        # state-modifying tools are stripped for the turn so it can only decline
+        # gracefully (or answer read-only). This is a DENYLIST removal, distinct
+        # from the whitelist `tool_filter` above. Denylist sourced from
+        # execution_ledger (NOT ActionGate, which is disabled in prod).
+        if refuse_active:
+            _refuse_denylist = WRITE_TOOLS | EXTERNAL_TOOLS | IRREVERSIBLE_TOOLS | {"bash"}
+            before = len(base_tools)
+            base_tools = [t for t in base_tools if t["name"] not in _refuse_denylist]
+            logger.warning(
+                "F078 refuse: stripped %d state-modifying tools for the turn",
+                before - len(base_tools),
+            )
 
         # Build initial messages from conversation history
         # The latest user message is already in conversation.messages

--- a/nous/api/tools.py
+++ b/nous/api/tools.py
@@ -798,7 +798,7 @@ def create_nous_tools(brain: Brain, heart: Heart, settings: Settings | None = No
     async def create_censor(
         trigger_pattern: str,
         reason: str,
-        action: str = "warn",
+        action: str = "steer",
         domain: str | None = None,
         learned_from_decision: str | None = None,
         learned_from_episode: str | None = None,
@@ -808,7 +808,8 @@ def create_nous_tools(brain: Brain, heart: Heart, settings: Settings | None = No
         Args:
             trigger_pattern: Pattern to match (substring or regex)
             reason: Why this censor exists
-            action: warn, block, or absolute
+            action: steer (advisory, default), refuse, or abort. Agent-created
+                censors are capped at refuse (provenance="agent").
             domain: Domain this censor applies to (architecture, debugging, etc.)
             learned_from_decision: Decision UUID that triggered this censor
             learned_from_episode: Episode UUID that triggered this censor
@@ -817,6 +818,20 @@ def create_nous_tools(brain: Brain, heart: Heart, settings: Settings | None = No
             MCP-compliant response with censor ID or error message
         """
         try:
+            # F078: validate action vocabulary before constructing the input.
+            if action not in ("steer", "refuse", "abort"):
+                return {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                f"Invalid action {action!r}; must be one of "
+                                "steer, refuse, abort."
+                            ),
+                        }
+                    ]
+                }
+
             # Parse UUIDs if provided
             decision_uuid = UUID(learned_from_decision) if learned_from_decision else None
             episode_uuid = UUID(learned_from_episode) if learned_from_episode else None
@@ -828,6 +843,8 @@ def create_nous_tools(brain: Brain, heart: Heart, settings: Settings | None = No
                 domain=domain,
                 learned_from_decision=decision_uuid,
                 learned_from_episode=episode_uuid,
+                # F078: agent provenance -> _add caps tier at refuse.
+                provenance="agent",
             )
 
             # Create censor
@@ -1423,9 +1440,13 @@ _CREATE_CENSOR_SCHEMA: dict[str, Any] = {
         "reason": {"type": "string", "description": "Why this censor exists"},
         "action": {
             "type": "string",
-            "description": "Censor action",
-            "enum": ["warn", "block", "absolute"],
-            "default": "warn",
+            "description": (
+                "Censor tier: steer (advisory directive, non-blocking), "
+                "refuse (LLM declines + write tools stripped), or abort (hard cut). "
+                "Agent-created censors are capped at refuse."
+            ),
+            "enum": ["steer", "refuse", "abort"],
+            "default": "steer",
         },
         "domain": {"type": "string", "description": "Domain this censor applies to"},
         "learned_from_decision": {"type": "string", "description": "Decision UUID"},
@@ -1913,15 +1934,20 @@ def create_subtask_tools(
                     settings.subtask_max_timeout,
                 )
 
-            # F031: Check censors on subtask task text at creation time.
+            # F078 (R3): Check censors on subtask task text at creation time.
             # Subtasks are non-interactive so censor checks are skipped during
-            # execution (pre_turn). We check here instead for immediate feedback.
+            # execution (pre_turn) — the spawn gate is the ONLY censor enforcement
+            # the background path gets, so it must honor the new tiers:
+            #   abort / refuse -> REJECT the subtask (the autonomous-exfil path).
+            #   steer          -> do NOT reject; inject the directive into the task.
+            # Email censors are `steer`, so daily email subtasks pass unaffected.
             try:
                 from nous.heart.censor_actions import CensorActionExecutor
+                _steer_directives: list[str] = []
                 matches = await heart.check_censors(task)
                 for match in matches:
-                    if match.action == "block":
-                        # F031: Check unblock condition before rejecting
+                    if match.action in ("abort", "refuse"):
+                        # F031: refuse may downgrade to steer via unblock_pattern.
                         unblocked = False
                         if match.trigger_action and match.unblock_pattern:
                             executor = CensorActionExecutor(heart)
@@ -1939,10 +1965,24 @@ def create_subtask_tools(
                             if match.action_instruction:
                                 msg += f"\n{match.action_instruction}"
                             return {"content": [{"type": "text", "text": msg}]}
-                    elif match.action == "warn":
-                        logger.info("Censor WARN on subtask creation: %s", match.trigger_pattern)
+                        # downgraded refuse -> treat as steer directive below
+                        directive = match.action_instruction or match.reason
+                        if directive:
+                            _steer_directives.append(directive)
+                    elif match.action == "steer":
+                        logger.info("Censor STEER on subtask creation: %s", match.trigger_pattern)
+                        directive = match.action_instruction or match.reason
+                        if directive:
+                            _steer_directives.append(directive)
+                # Inject steer directives into the task text so the subtask honors them.
+                if _steer_directives:
+                    task = task + "\n\n## Active Guidance\n" + "\n".join(
+                        f"- {d}" for d in _steer_directives
+                    )
             except Exception:
-                logger.debug("Censor check failed during spawn_task, proceeding")
+                # The spawn gate is the ONLY censor enforcement a subtask gets (the exfil
+                # path) — a swallowed failure here is a silent enforcement gap, so WARN.
+                logger.warning("Censor check failed during spawn_task, proceeding", exc_info=True)
 
             # F062: persist payload_schema only when BOTH flags are on
             # (Codex round-9 P2). Without F061 hardening the legacy executor

--- a/nous/cognitive/context.py
+++ b/nous/cognitive/context.py
@@ -127,7 +127,7 @@ class ContextEngine:
 
         Assembly order (by priority):
         1. Identity prompt (always included, static)
-        2. Active censors (always, action=block first)
+        2. Active censors (always, action=abort first)
         3. Frame description + questions_to_ask
         4. Working memory (current task + open threads)
         5. Similar decisions from Brain.query()
@@ -1066,24 +1066,25 @@ class ContextEngine:
     def _format_censors(self, censors: list) -> str:
         """Format active censors.
 
-        P1-4: Use action (not severity).
+        F078: Use the steer | refuse | abort vocabulary (was warn | block | absolute).
         Format: - **{ACTION}:** {trigger_pattern} -- {reason}
-        F031: Append action_instruction for warn censors if present.
+        Append action_instruction for steer/refuse censors (the directive-bearing tiers).
         """
-        action_order = {"absolute": 0, "block": 1, "warn": 2}
+        # Hardest tier first so the LLM sees blocking rules at the top.
+        action_order = {"abort": 0, "refuse": 1, "steer": 2}
         sorted_censors = sorted(
             censors,
-            key=lambda c: action_order.get(getattr(c, "action", "warn"), 3),
+            key=lambda c: action_order.get(getattr(c, "action", "steer"), 3),
         )
         lines = []
         for c in sorted_censors:
-            action = getattr(c, "action", "warn").upper()
+            action = getattr(c, "action", "steer").upper()
             pattern = getattr(c, "trigger_pattern", "")
             reason = getattr(c, "reason", "")
             line = f"- **{action}:** {pattern} -- {reason}"
-            # F031: Append action_instruction for warn censors
+            # F078: surface the directive for the advisory/refusal tiers.
             instruction = getattr(c, "action_instruction", None)
-            if instruction and action == "WARN":
+            if instruction and action in ("STEER", "REFUSE"):
                 line += f"\n  *Instruction:* {instruction}"
             lines.append(line)
         return "\n".join(lines)

--- a/nous/cognitive/layer.py
+++ b/nous/cognitive/layer.py
@@ -761,19 +761,39 @@ class CognitiveLayer:
         # Programmatic censor check on user input (#160 follow-up).
         # Subtasks skip censor checks here — they are checked at creation
         # time in spawn_task instead (non-interactive, no user to see blocks).
-        censor_injected: dict[str, str] = {}
+        # F078: censor enforcement on user input. Tier implies side:
+        #   abort  -> hard cut before the LLM (input-gate; reserved for destructive).
+        #   refuse -> LLM runs, refusal directive injected, write tools stripped (runner).
+        #   steer  -> directive (action_instruction|reason) + any trigger_action results
+        #             injected as Active Guidance. NEVER blocks.
+        # The injected guidance is the directive itself for EVERY steer/refuse match,
+        # not only the F031 trigger_action results.
+        censor_injected: dict[str, str] = {}  # censor_id -> guidance text
         censor_blocked = False
         censor_block_reason: str | None = None
+        refuse_active = False
         if not is_subtask:
           try:
             matches = await self._heart.check_censors(user_input, session=session)
             for match in matches:
-                if match.action == "block":
-                    # F031: Conditional unblock — if trigger_action + unblock_pattern,
-                    # execute action and check if results match unblock_pattern.
-                    # Match → downgrade to warn (skip block). No match → block as normal.
-                    unblocked = False
+                if match.action == "abort":
+                    # Hard cut before the LLM (was the old block-halt behavior).
+                    censor_blocked = True
+                    censor_block_reason = (
+                        f"Blocked by censor: {match.reason or match.trigger_pattern}"
+                    )
+                    logger.warning(
+                        "Censor ABORT on user input (session=%s, censor=%s): %s",
+                        session_id, match.id, match.trigger_pattern,
+                    )
+                    if match.action_instruction:
+                        censor_block_reason += f"\n\n{match.action_instruction}"
+                    break  # One abort is enough
+                elif match.action == "refuse":
+                    # F031: Conditional unblock — if trigger_action + unblock_pattern
+                    # match, downgrade refuse -> steer (run normally, no tool strip).
                     action_result: str | None = None
+                    downgraded = False
                     if match.trigger_action:
                         try:
                             action_result = await self._censor_executor.execute(
@@ -781,58 +801,62 @@ class CognitiveLayer:
                             )
                         except Exception:
                             logger.warning(
-                                "Censor block action failed (session=%s, censor=%s)",
+                                "Censor refuse action failed (session=%s, censor=%s)",
                                 session_id, match.id, exc_info=True,
                             )
-
-                        # Check unblock condition
                         if action_result and match.unblock_pattern:
                             try:
                                 if re.search(match.unblock_pattern, action_result, re.IGNORECASE):
-                                    unblocked = True
+                                    downgraded = True
                                     logger.info(
-                                        "Censor UNBLOCK: pattern matched (session=%s, censor=%s)",
+                                        "Censor REFUSE→STEER downgrade (session=%s, censor=%s)",
                                         session_id, match.id,
                                     )
                             except re.error:
                                 logger.warning("Invalid unblock_pattern regex: %s", match.unblock_pattern)
 
-                    if unblocked:
-                        # Downgrade to warn — inject context like a warn censor
-                        logger.info(
-                            "Censor BLOCK→WARN downgrade (session=%s, censor=%s): %s",
-                            session_id, match.id, match.trigger_pattern,
-                        )
+                    directive = match.action_instruction or match.reason
+                    if downgraded:
+                        # Treat as steer: guidance only, no tool strip.
+                        guidance = directive
                         if action_result:
-                            censor_injected[str(match.id)] = action_result
+                            guidance = f"{guidance}\n\n{action_result}" if guidance else action_result
+                        if guidance:
+                            censor_injected[str(match.id)] = guidance
                     else:
-                        # Block as normal
-                        censor_blocked = True
-                        censor_block_reason = (
-                            f"Blocked by censor: {match.reason or match.trigger_pattern}"
-                        )
+                        # F078 R6: strip write tools unless the censor opted out
+                        # via refuse_keep_tools. The refusal directive is still
+                        # injected either way.
+                        if not match.refuse_keep_tools:
+                            refuse_active = True
                         logger.warning(
-                            "Censor BLOCK on user input (session=%s, censor=%s): %s",
-                            session_id, match.id, match.trigger_pattern,
+                            "Censor REFUSE on user input (session=%s, censor=%s, keep_tools=%s): %s",
+                            session_id, match.id, match.refuse_keep_tools, match.trigger_pattern,
+                        )
+                        guidance = (
+                            "You must DECLINE this request. "
+                            f"{directive}" if directive else "You must DECLINE this request."
                         )
                         if action_result:
-                            censor_block_reason += f"\n\nRelated context:\n{action_result}"
-                        if match.action_instruction:
-                            censor_block_reason += f"\n\n{match.action_instruction}"
-                        break  # One block is enough
-                elif match.action == "warn":
+                            guidance += f"\n\n{action_result}"
+                        censor_injected[str(match.id)] = guidance
+                elif match.action == "steer":
                     logger.info(
-                        "Censor WARN on user input (session=%s, censor=%s): %s",
+                        "Censor STEER on user input (session=%s, censor=%s): %s",
                         session_id, match.id, match.trigger_pattern,
                     )
-                    # F031: Execute trigger_action if present
+                    directive = match.action_instruction or match.reason
+                    guidance = directive or ""
+                    # F031: Execute trigger_action if present and append its results.
                     if match.trigger_action:
                         try:
                             action_result = await self._censor_executor.execute(
                                 match.trigger_action, session=session,
                             )
                             if action_result:
-                                censor_injected[str(match.id)] = action_result
+                                guidance = (
+                                    f"{guidance}\n\n{action_result}" if guidance else action_result
+                                )
                                 logger.info(
                                     "Censor action executed (session=%s, censor=%s, tool=%s)",
                                     session_id, match.id, match.trigger_action.get("tool"),
@@ -842,16 +866,35 @@ class CognitiveLayer:
                                 "Censor action failed (session=%s, censor=%s)",
                                 session_id, match.id, exc_info=True,
                             )
+                    if guidance:
+                        censor_injected[str(match.id)] = guidance
           except Exception:
             logger.debug("Censor check failed during pre_turn")
 
-        # F031: Append censor-injected context to system prompt
+        # F078 R1: route censor-injected guidance into BOTH the flat system_prompt
+        # (legacy path) AND sections_by_tier["dynamic"] (F036 cache-split path,
+        # default). runner._build_system_prompt ignores the flat string when
+        # cache_split_system_prompt is true, so steer/refuse would be a silent
+        # no-op unless we also write the dynamic tier here.
         if censor_injected:
-            injected_section = "\n\n## Censor-Injected Context\n"
-            injected_section += "The following information was automatically retrieved by active censors. Use it to inform your response:\n\n"
-            for censor_id, result_text in censor_injected.items():
-                injected_section += f"{result_text}\n\n"
-            system_prompt += injected_section
+            injected_section = "## Active Guidance\n"
+            injected_section += (
+                "Active censors flagged this turn. Follow the directives below:\n\n"
+            )
+            for _censor_id, result_text in censor_injected.items():
+                injected_section += f"- {result_text}\n\n"
+            system_prompt += "\n\n" + injected_section
+            # Only touch sections_by_tier when it's already populated (build
+            # succeeded). If build failed it stays {} and runner uses the flat
+            # path — writing a lone "dynamic" key would wrongly trigger the
+            # split path and drop the identity prompt.
+            if sections_by_tier:
+                existing_dynamic = sections_by_tier.get("dynamic", "")
+                sections_by_tier["dynamic"] = (
+                    existing_dynamic + "\n\n" + injected_section
+                    if existing_dynamic
+                    else injected_section
+                )
 
         # F065 Phase 2: Hub-shift autosurface (gated dormant by default).
         # Synchronous by design — the manager swallows DB errors internally
@@ -884,6 +927,7 @@ class CognitiveLayer:
             active_censors=active_censors,
             censor_blocked=censor_blocked,
             censor_block_reason=censor_block_reason,
+            refuse_active=refuse_active,
             context_token_estimate=context_token_estimate,
             recalled_decision_ids=recalled_decision_ids,
             recalled_fact_ids=recalled_fact_ids,
@@ -1071,23 +1115,17 @@ class CognitiveLayer:
 
         # Post-turn censor check on model output (#160 follow-up).
         # Catches credential leaks, blocked content in model responses.
-        # Only logs — doesn't block (response already sent in streaming).
-        # Increments activation_count for monitoring/escalation.
+        # F078: READ-ONLY — uses search() (no side effects): no activation_count
+        # increment, no escalation. Log-only (response already sent in streaming).
         try:
-            output_matches = await self._heart.check_censors(
+            output_matches = await self._heart.censors.search(
                 turn_result.response_text, session=session,
             )
             for match in output_matches:
-                if match.action == "block":
-                    logger.warning(
-                        "Censor BLOCK on model output (session=%s, censor=%s): %s",
-                        session_id, match.id, match.trigger_pattern,
-                    )
-                elif match.action == "warn":
-                    logger.info(
-                        "Censor WARN on model output (session=%s, censor=%s): %s",
-                        session_id, match.id, match.trigger_pattern,
-                    )
+                logger.info(
+                    "Censor match on model output (session=%s, censor=%s, action=%s): %s",
+                    session_id, match.id, match.action, match.trigger_pattern,
+                )
         except Exception:
             logger.debug("Censor check failed during post_turn")
 

--- a/nous/cognitive/monitor.py
+++ b/nous/cognitive/monitor.py
@@ -168,11 +168,12 @@ class MonitorEngine:
 
                 try:
                     # P1-5: Construct CensorInput pydantic model
-                    # P1-4: Use action, not severity
+                    # F078: auto-learned censors are provenance="auto" -> capped to steer.
                     censor_input = CensorInput(
                         trigger_pattern=candidate_text,
                         reason="Auto-created from tool error",
-                        action="warn",
+                        action="steer",
+                        provenance="auto",
                     )
                     await self._heart.add_censor(censor_input, session=session)
                     existing_patterns.add(candidate_text)
@@ -375,10 +376,12 @@ class MonitorEngine:
 
             # Optionally create censor
             if extraction.get("is_censor") and extraction.get("censor_pattern"):
+                # F078: auto-learned (F039) censors are provenance="auto" -> capped to steer.
                 censor_input = CensorInput(
                     trigger_pattern=extraction["censor_pattern"],
                     reason=f"F039: Inline correction — {principle[:100]}",
-                    action="warn",
+                    action="steer",
+                    provenance="auto",
                 )
                 await self._heart.add_censor(censor_input, session=session)
 

--- a/nous/cognitive/schemas.py
+++ b/nous/cognitive/schemas.py
@@ -172,8 +172,11 @@ class TurnContext(BaseModel):
     frame: FrameSelection
     decision_id: str | None = None  # Set if frame is 'decision' or 'task'
     active_censors: list[str] = Field(default_factory=list)
-    censor_blocked: bool = False  # Set if a block censor matched user input
-    censor_block_reason: str | None = None  # Reason for the block
+    censor_blocked: bool = False  # F078: set if an `abort` censor matched user input (hard cut)
+    censor_block_reason: str | None = None  # Reason for the abort
+    # F078: set when a `refuse`-tier censor matched. The LLM still runs, but
+    # runner strips the state-modifying tool denylist for the turn (R6).
+    refuse_active: bool = False
     context_token_estimate: int = 0
     recalled_decision_ids: list[str] = Field(default_factory=list)
     recalled_fact_ids: list[str] = Field(default_factory=list)

--- a/nous/handlers/correction_extractor.py
+++ b/nous/handlers/correction_extractor.py
@@ -128,10 +128,12 @@ class CorrectionExtractor:
 
                 # Optionally create censor for "never do" patterns
                 if extraction.get("is_censor") and extraction.get("censor_pattern"):
+                    # F078: auto-learned (F039) censors are provenance="auto" -> capped to steer.
                     censor_input = CensorInput(
                         trigger_pattern=extraction["censor_pattern"],
                         reason=f"F039: Learned from correction — {principle[:100]}",
-                        action="warn",
+                        action="steer",
+                        provenance="auto",
                     )
                     await self._heart.add_censor(censor_input)
                     logger.info("F039: Created censor for correction: %s", extraction["censor_pattern"])

--- a/nous/heart/censors.py
+++ b/nous/heart/censors.py
@@ -22,8 +22,16 @@ from nous.storage.models import Censor, Event
 
 logger = logging.getLogger(__name__)
 
-# Escalation path: warn -> block -> absolute. No downgrade.
-_ESCALATION_ORDER = {"warn": "block", "block": "absolute", "absolute": "absolute"}
+# F078: manual escalation path: steer -> refuse -> abort. No downgrade.
+# Used ONLY by escalate() (a deliberate operator action). Auto-escalation removed.
+_ESCALATION_ORDER = {"steer": "refuse", "refuse": "abort", "abort": "abort"}
+
+# F078: provenance -> max tier a censor may be created/updated at.
+# auto (monitor/F039) can never reach a halting tier; agent (create_censor tool)
+# caps at refuse; human (operator/migration) may reach abort.
+_TIER_RANK = {"steer": 0, "refuse": 1, "abort": 2}
+_PROVENANCE_MAX_TIER = {"auto": "steer", "agent": "refuse", "human": "abort"}
+_VALID_ACTIONS = ("steer", "refuse", "abort")
 
 # Maximum length of text input to evaluate against regex patterns (ReDoS guard)
 _MAX_REGEX_INPUT_LEN = 10_000
@@ -82,6 +90,38 @@ class CensorManager:
         return await self._add(input, session)
 
     async def _add(self, input: CensorInput, session: AsyncSession) -> CensorDetail:
+        # F078: validate trigger_pattern compiles (reject at the boundary, not
+        # silently dead at check time). Same for unblock_pattern if present.
+        try:
+            re.compile(input.trigger_pattern)
+        except re.error as exc:
+            raise ValueError(f"Invalid trigger_pattern regex: {exc}") from exc
+        if input.unblock_pattern is not None:
+            try:
+                re.compile(input.unblock_pattern)
+            except re.error as exc:
+                raise ValueError(f"Invalid unblock_pattern regex: {exc}") from exc
+
+        # F078: validate trigger_action.tool against the read-only allowlist.
+        # Local import avoids a circular import (censor_actions imports Heart).
+        if input.trigger_action is not None:
+            from nous.heart.censor_actions import ALLOWED_TOOLS
+
+            tool = input.trigger_action.get("tool") if isinstance(input.trigger_action, dict) else None
+            if tool is not None and tool not in ALLOWED_TOOLS:
+                raise ValueError(f"Censor trigger_action.tool not allowed: {tool}")
+
+        # F078: provenance -> max-tier cap. Clamp DOWN to the cap (do not raise)
+        # so an over-eager auto/agent caller can never create a turn-killer.
+        action = input.action
+        cap = _PROVENANCE_MAX_TIER.get(input.provenance, "steer")
+        if _TIER_RANK.get(action, 0) > _TIER_RANK[cap]:
+            logger.warning(
+                "Censor provenance=%s caps tier at %s; clamping requested action %s down",
+                input.provenance, cap, action,
+            )
+            action = cap
+
         # Generate embedding from trigger_pattern + reason
         embedding = None
         if self.embeddings:
@@ -94,7 +134,7 @@ class CensorManager:
         censor = Censor(
             agent_id=self.agent_id,
             trigger_pattern=input.trigger_pattern,
-            action=input.action,
+            action=action,
             reason=input.reason,
             domain=input.domain,
             learned_from_decision=input.learned_from_decision,
@@ -102,6 +142,8 @@ class CensorManager:
             trigger_action=input.trigger_action,
             action_instruction=input.action_instruction,
             unblock_pattern=input.unblock_pattern,
+            provenance=input.provenance,
+            refuse_keep_tools=input.refuse_keep_tools,
             created_by="manual",
             embedding=embedding,
         )
@@ -114,7 +156,8 @@ class CensorManager:
             {
                 "censor_id": str(censor.id),
                 "trigger": input.trigger_pattern,
-                "action": input.action,
+                "action": action,
+                "provenance": input.provenance,
             },
         )
 
@@ -132,8 +175,9 @@ class CensorManager:
     ) -> list[CensorMatch]:
         """Check text against all active censors (with side effects).
 
-        Increments activation_count, updates last_activated, and
-        auto-escalates when threshold is reached.
+        Increments activation_count and updates last_activated. F078 removed
+        the silent auto-escalation — promotion to a harder tier is now a
+        deliberate operator action only (see escalate()).
         """
         if session is None:
             async with self.db.session() as session:
@@ -174,23 +218,10 @@ class CensorManager:
 
         for censor, _similarity in matches:
             # Increment activation_count (P2-9: NULL-safe)
+            # F078: auto-escalation removed — a loose auto-created rule can no
+            # longer promote itself into a turn-killer. Promotion is human-only.
             censor.activation_count = (censor.activation_count or 0) + 1
             censor.last_activated = now
-
-            # Auto-escalation check
-            threshold = censor.escalation_threshold or 3
-            if censor.activation_count >= threshold and censor.action == "warn":
-                old_action = censor.action
-                censor.action = "block"
-                await self._emit_event(
-                    session,
-                    "censor_escalated",
-                    {
-                        "censor_id": str(censor.id),
-                        "old_action": old_action,
-                        "new_action": "block",
-                    },
-                )
 
             await self._emit_event(
                 session,
@@ -211,6 +242,7 @@ class CensorManager:
                     trigger_action=censor.trigger_action,
                     action_instruction=censor.action_instruction,
                     unblock_pattern=censor.unblock_pattern,
+                    refuse_keep_tools=bool(censor.refuse_keep_tools),
                 )
             )
 
@@ -393,6 +425,7 @@ class CensorManager:
                 trigger_action=c.trigger_action,
                 action_instruction=c.action_instruction,
                 unblock_pattern=c.unblock_pattern,
+                refuse_keep_tools=bool(c.refuse_keep_tools),
             )
             for cid in ids
             if (c := censors.get(cid)) is not None
@@ -438,6 +471,7 @@ class CensorManager:
                             trigger_action=censor.trigger_action,
                             action_instruction=censor.action_instruction,
                             unblock_pattern=censor.unblock_pattern,
+                            refuse_keep_tools=bool(censor.refuse_keep_tools),
                         )
                     )
             except re.error:
@@ -489,7 +523,10 @@ class CensorManager:
     # ------------------------------------------------------------------
 
     async def escalate(self, censor_id: UUID, session: AsyncSession | None = None) -> CensorDetail:
-        """Manually escalate censor severity. warn -> block -> absolute. No downgrade."""
+        """Manually escalate censor severity. steer -> refuse -> abort. No downgrade.
+
+        F078: deliberate operator action only — there is no automatic caller.
+        """
         if session is None:
             async with self.db.session() as session:
                 result = await self._escalate(censor_id, session)
@@ -619,12 +656,18 @@ class CensorManager:
         unblock_pattern: str | None | object = _SENTINEL,
         reason: str | None | object = _SENTINEL,
         domain: str | None | object = _SENTINEL,
+        action: str | object = _SENTINEL,
+        active: bool | object = _SENTINEL,
         session: AsyncSession | None = None,
     ) -> CensorDetail:
         """Update specific fields on an existing censor.
 
         Only fields explicitly passed are updated. Pass None to clear a field.
         Fields not passed are left unchanged.
+
+        F078: ``action`` and ``active`` are the UI severity-control path. The
+        operator is provenance=human, so ANY valid tier (incl. abort) is allowed
+        on update — no cap. ``action`` must be one of steer/refuse/abort.
         """
         if session is None:
             async with self.db.session() as session:
@@ -632,7 +675,8 @@ class CensorManager:
                     censor_id, trigger_action=trigger_action,
                     action_instruction=action_instruction,
                     unblock_pattern=unblock_pattern,
-                    reason=reason, domain=domain, session=session,
+                    reason=reason, domain=domain,
+                    action=action, active=active, session=session,
                 )
                 await session.commit()
                 return result
@@ -640,7 +684,8 @@ class CensorManager:
             censor_id, trigger_action=trigger_action,
             action_instruction=action_instruction,
             unblock_pattern=unblock_pattern,
-            reason=reason, domain=domain, session=session,
+            reason=reason, domain=domain,
+            action=action, active=active, session=session,
         )
 
     async def _update(
@@ -652,6 +697,8 @@ class CensorManager:
         unblock_pattern,
         reason,
         domain,
+        action=_SENTINEL,
+        active=_SENTINEL,
         session: AsyncSession,
     ) -> CensorDetail:
         censor = await self._get_censor_orm(censor_id, session)
@@ -669,6 +716,28 @@ class CensorManager:
             censor.reason = reason
         if domain is not SENTINEL:
             censor.domain = domain
+
+        # F078: UI severity-control path. Operator may set any valid tier.
+        if action is not SENTINEL and action is not None:
+            if action not in _VALID_ACTIONS:
+                raise ValueError(f"Invalid censor action: {action!r}")
+            old_action = censor.action
+            if action != old_action:
+                censor.action = action
+                await self._emit_event(
+                    session,
+                    "censor_updated",
+                    {
+                        "censor_id": str(censor_id),
+                        "old_action": old_action,
+                        "new_action": action,
+                    },
+                )
+
+        if active is not SENTINEL and active is not None:
+            if not isinstance(active, bool):
+                raise ValueError(f"Invalid censor active flag: {active!r}")
+            censor.active = active
 
         censor.updated_at = datetime.now(UTC)
         await session.flush()
@@ -706,4 +775,6 @@ class CensorManager:
             trigger_action=censor.trigger_action,
             action_instruction=censor.action_instruction,
             unblock_pattern=censor.unblock_pattern,
+            provenance=censor.provenance or "human",
+            refuse_keep_tools=bool(censor.refuse_keep_tools),
         )

--- a/nous/heart/schemas.py
+++ b/nous/heart/schemas.py
@@ -22,7 +22,8 @@ _DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 # Type aliases using Literal for compile-time validation (P3-2)
 MemoryType = Literal["fact", "procedure", "decision", "censor", "episode", "chunk"]
-CensorAction = Literal["warn", "block", "absolute"]
+CensorAction = Literal["steer", "refuse", "abort"]  # F078 (was warn|block|absolute)
+CensorProvenance = Literal["auto", "agent", "human"]  # F078: caps max tier at create
 EpisodeOutcome = Literal["success", "partial", "failure", "ongoing", "abandoned"]
 ProcedureOutcome = Literal["success", "failure", "neutral"]
 
@@ -297,13 +298,17 @@ class CensorInput(BaseModel):
 
     trigger_pattern: str
     reason: str
-    action: CensorAction = "warn"  # P3-2: Literal type
+    action: CensorAction = "steer"  # F078: steer | refuse | abort (was warn)
     domain: str | None = None
     learned_from_decision: UUID | None = None
     learned_from_episode: UUID | None = None
     trigger_action: dict | None = None  # F031: e.g. {"tool": "recall", "args": {...}}
     action_instruction: str | None = None  # F031: human-readable instruction
-    unblock_pattern: str | None = None  # F031: regex — if action results match, downgrade block→warn
+    unblock_pattern: str | None = None  # F031: regex — if action results match, downgrade refuse→steer
+    # F078: creation provenance — caps the max tier (auto<=steer, agent<=refuse, human<=abort).
+    provenance: CensorProvenance = "human"
+    # F078: when true, a refuse-tier censor does NOT strip tools for the turn.
+    refuse_keep_tools: bool = False
 
 
 class CensorDetail(BaseModel):
@@ -327,6 +332,9 @@ class CensorDetail(BaseModel):
     trigger_action: dict | None = None  # F031
     action_instruction: str | None = None  # F031
     unblock_pattern: str | None = None  # F031
+    # F078: creation provenance + refuse opt-out.
+    provenance: CensorProvenance = "human"
+    refuse_keep_tools: bool = False
 
 
 class CensorMatch(BaseModel):
@@ -341,6 +349,8 @@ class CensorMatch(BaseModel):
     trigger_action: dict | None = None  # F031
     action_instruction: str | None = None  # F031
     unblock_pattern: str | None = None  # F031
+    # F078: surfaced so the turn-enforcer can honor the refuse tool-strip opt-out.
+    refuse_keep_tools: bool = False
 
 
 # --- Working Memory ---

--- a/nous/storage/models.py
+++ b/nous/storage/models.py
@@ -669,10 +669,21 @@ class OutcomeSignal(Base):
 class Censor(Base):
     __tablename__ = "censors"
     __table_args__ = (
+        # F078: steer | refuse | abort (was warn | block | absolute). Migration 056
+        # remaps existing rows; this CHECK is also enforced in SQLite test mode, so it
+        # must move in lockstep with the migration.
         CheckConstraint(
-            "action IN ('warn', 'block', 'absolute')",
+            "action IN ('steer', 'refuse', 'abort')",
             name="ck_censors_action",
         ),
+        # F078: provenance drives the max-tier creation cap (auto<=steer, agent<=refuse,
+        # human<=abort). Distinct from the legacy created_by audit field below.
+        CheckConstraint(
+            "provenance IN ('auto', 'agent', 'human')",
+            name="ck_censors_provenance",
+        ),
+        # Legacy audit field (kept for history). 'auto_escalation' is no longer written
+        # once F078 removes auto-escalation, but the value stays valid.
         CheckConstraint(
             "created_by IN ('manual', 'auto_failure', 'auto_escalation')",
             name="ck_censors_created_by",
@@ -683,8 +694,12 @@ class Censor(Base):
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
     agent_id: Mapped[str] = mapped_column(String(100), nullable=False)
     trigger_pattern: Mapped[str] = mapped_column(Text, nullable=False)
-    action: Mapped[str] = mapped_column(String(20), nullable=False, server_default="warn")
+    action: Mapped[str] = mapped_column(String(20), nullable=False, server_default="steer")
     reason: Mapped[str] = mapped_column(Text, nullable=False)
+    # F078: creation provenance — caps the max tier a censor may reach.
+    provenance: Mapped[str] = mapped_column(String(20), nullable=False, server_default="human")
+    # F078: when true, a refuse-tier censor does not strip tools for the turn.
+    refuse_keep_tools: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
     domain: Mapped[str | None] = mapped_column(String(100))
     learned_from_decision: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("brain.decisions.id")

--- a/scripts/migrate_censors_f078.py
+++ b/scripts/migrate_censors_f078.py
@@ -1,0 +1,125 @@
+"""F078 gated triage — restore the few hard-tier censors after migration 056.
+
+Migration 056 maps every existing censor to advisory `steer` (functionally INERT,
+so a deploy never auto-blocks). This operator-run script restores the genuinely
+prohibitive tiers and retires obvious dead/junk censors. It is the "gated triage
+mechanism" referenced by F078 / docs/reviews/censor-triage-2026-06-05.md.
+
+  PROMOTE -> abort   : destructive (rm -rf)
+  PROMOTE -> refuse  : trading safety (never lower exit_threshold to flush an
+                       underwater position, never sell/liquidate underwater) +
+                       the autopilot record_decision noise filter
+  RETIRE  (active=false): never-activated auto-prose censors + test rows
+
+DRY-RUN BY DEFAULT. Reversible: retire sets active=false (never deletes); tier
+changes are plain UPDATEs. Idempotent: only rows not already at target change.
+
+Run against prod by pointing DB_* env at the prod DB, then:
+  uv run python scripts/migrate_censors_f078.py --agent nous-default            # dry-run
+  uv run python scripts/migrate_censors_f078.py --agent nous-default --commit   # apply
+
+Email censors are intentionally LEFT as steer (BC invariant — daily email
+senders must keep working; recipient-allowlist hardening is F078.1).
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sqlalchemy import text  # noqa: E402
+
+from nous.config import Settings  # noqa: E402
+from nous.storage.database import Database  # noqa: E402
+
+# Operator-reviewed promotions, matched case-insensitively against trigger_pattern.
+# abort wins over refuse if both match (more restrictive).
+PROMOTE_ABORT = [r"rm\s+-rf"]
+PROMOTE_REFUSE = [
+    r"exit_threshold",
+    r"sell.*underwater",
+    r"liquidate.*underwater",
+    r"SOL.*HOLD",          # autopilot record_decision noise filter
+    r"autopilot.*tick.*triage",
+]
+
+
+def _matches(patterns: list[str], trigger: str) -> bool:
+    return any(re.search(p, trigger or "", re.IGNORECASE) for p in patterns)
+
+
+def _target(action: str, trigger: str, reason: str, activation_count: int,
+            provenance: str) -> tuple[str | None, bool, str]:
+    """Return (new_action_or_None, retire, why). new_action None = keep current."""
+    # Retire obvious junk first.
+    if (reason or "").strip().lower() == "test" or (trigger or "").strip() == "test pattern":
+        return None, True, "test row"
+    if activation_count == 0 and provenance == "auto":
+        return None, True, "never-activated auto-prose"
+    # Promotions.
+    if _matches(PROMOTE_ABORT, trigger):
+        return ("abort" if action != "abort" else None), False, "destructive -> abort"
+    if _matches(PROMOTE_REFUSE, trigger):
+        return ("refuse" if action != "refuse" else None), False, "prohibitive -> refuse"
+    return None, False, "keep steer (advisory)"
+
+
+async def main() -> None:
+    ap = argparse.ArgumentParser(description="F078 gated censor triage")
+    ap.add_argument("--agent", default="nous-default")
+    ap.add_argument("--commit", action="store_true", help="apply changes (default: dry-run)")
+    args = ap.parse_args()
+
+    db = Database(Settings())
+    await db.connect()
+    try:
+        async with db.session() as s:
+            rows = (await s.execute(text(
+                "SELECT id::text, action, trigger_pattern, coalesce(reason,'') AS reason, "
+                "coalesce(activation_count,0) AS ac, coalesce(provenance,'human') AS prov "
+                "FROM heart.censors WHERE agent_id=:a AND active ORDER BY ac DESC"
+            ), {"a": args.agent})).mappings().all()
+
+            promote, retire, keep = [], [], 0
+            for r in rows:
+                new_action, do_retire, why = _target(
+                    r["action"], r["trigger_pattern"], r["reason"], r["ac"], r["prov"])
+                if do_retire:
+                    retire.append((r, why))
+                elif new_action:
+                    promote.append((r, new_action, why))
+                else:
+                    keep += 1
+
+            mode = "COMMIT" if args.commit else "DRY-RUN"
+            print(f"\n=== F078 triage [{mode}] agent={args.agent}  active={len(rows)} ===")
+            print(f"\nPROMOTE ({len(promote)}):")
+            for r, na, why in promote:
+                print(f"  {r['action']:6} -> {na:6}  [{why}]  {r['trigger_pattern'][:46]}")
+            print(f"\nRETIRE ({len(retire)}):")
+            for r, why in retire:
+                print(f"  active=false  [{why}]  {r['trigger_pattern'][:46]}")
+            print(f"\nKEEP as steer (advisory): {keep}")
+
+            if not args.commit:
+                print("\n(dry-run — re-run with --commit to apply; reversible)")
+                return
+
+            for r, na, _why in promote:
+                await s.execute(text("UPDATE heart.censors SET action=:na, updated_at=now() WHERE id=:id"),
+                                {"na": na, "id": r["id"]})
+            for r, _why in retire:
+                await s.execute(text("UPDATE heart.censors SET active=false, updated_at=now() WHERE id=:id"),
+                                {"id": r["id"]})
+            await s.commit()
+            print(f"\nAPPLIED: promoted {len(promote)}, retired {len(retire)}.")
+    finally:
+        await db.disconnect()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/sql/migrations/056_censor_correct_side.sql
+++ b/sql/migrations/056_censor_correct_side.sql
@@ -1,0 +1,40 @@
+-- 056_censor_correct_side.sql — F078 Correct-Side Censor Enforcement (v3)
+-- Backward-compatible by design (BC invariant). This migration is functionally INERT.
+-- It renames the action vocabulary and adds two columns. It creates NO new hard tier.
+--   block    -> steer   (halts become advisory, wrongly-halted turns now run)
+--   warn     -> steer   (already non-blocking, just the rename)
+--   absolute -> abort   (absolute was a no-op on input, only rm -rf-class lives here)
+-- The few genuinely-prohibitive censors (trading -> refuse, rm -rf -> abort) are
+-- PROMOTED later by the gated triage script (scripts/migrate_censors_f078.py),
+-- only after operator review of its --dry-run. Nothing here blocks anything new.
+-- Idempotent: safe on fresh DB (no rows) and re-runnable via DROP/ADD ... IF EXISTS.
+-- NOTE: no semicolon may appear inside these comment lines (the splitter breaks on it).
+
+-- 1. Drop the old action CHECK so values can be remapped.
+--    init.sql declares it inline, so Postgres auto-names it `censors_action_check`.
+--    Later ORM/migration paths may name it `ck_censors_action`. Drop BOTH so this
+--    migration is correct on a fresh DB (auto-named) and on any partially-migrated DB.
+ALTER TABLE heart.censors DROP CONSTRAINT IF EXISTS ck_censors_action;
+ALTER TABLE heart.censors DROP CONSTRAINT IF EXISTS censors_action_check;
+
+-- 2. Mechanical, UNIVERSALLY-inert remap: every old tier -> steer (advisory).
+--    Even 'absolute' (historically rm -rf-class, and a no-op on input today) maps to
+--    steer so NO row can auto-become a hard tier. The one real 'rm -rf' censor is
+--    promoted to 'abort' by the gated triage / operator UI, never automatically.
+UPDATE heart.censors SET action = 'steer' WHERE action IN ('warn', 'block', 'absolute');
+
+-- 3. New default plus new CHECK.
+ALTER TABLE heart.censors ALTER COLUMN action SET DEFAULT 'steer';
+ALTER TABLE heart.censors ADD CONSTRAINT ck_censors_action
+    CHECK (action IN ('steer', 'refuse', 'abort'));
+
+-- 4. Provenance drives the max-tier creation cap (auto<=steer, agent<=refuse, human<=abort).
+--    Backfill is conservative here (existing rows default to 'human'). The gated triage
+--    script reclassifies auto/agent precisely (an F039/Auto-created reason wins).
+ALTER TABLE heart.censors ADD COLUMN IF NOT EXISTS provenance VARCHAR(20) NOT NULL DEFAULT 'human';
+ALTER TABLE heart.censors DROP CONSTRAINT IF EXISTS ck_censors_provenance;
+ALTER TABLE heart.censors ADD CONSTRAINT ck_censors_provenance
+    CHECK (provenance IN ('auto', 'agent', 'human'));
+
+-- 5. F068 refuse opt-out. When true, a refuse-tier censor does NOT strip tools.
+ALTER TABLE heart.censors ADD COLUMN IF NOT EXISTS refuse_keep_tools BOOLEAN NOT NULL DEFAULT false;

--- a/static/dashboard/js/app.js
+++ b/static/dashboard/js/app.js
@@ -159,6 +159,25 @@ const Dashboard = {
     },
 
     /**
+     * Send a JSON body to the API (PUT by default). F078: used by the censor
+     * severity-control UI to call PUT /censors/{id}.
+     */
+    async apiSend(path, body, method) {
+        var res = await fetch(path, {
+            method: method || 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+        var data = null;
+        try { data = await res.json(); } catch (e) { /* no body */ }
+        if (!res.ok) {
+            var msg = (data && data.error) ? data.error : (res.status + ' ' + res.statusText);
+            throw new Error(msg);
+        }
+        return data;
+    },
+
+    /**
      * Show loading skeleton in a container.
      */
     showLoading(container) {

--- a/static/dashboard/js/browser.js
+++ b/static/dashboard/js/browser.js
@@ -76,7 +76,7 @@ Dashboard.registerView('browser', async function(container) {
             html += buildSelect('filter-stakes', 'Stakes', ['', 'low', 'medium', 'high'], state.filters.stakes);
             html += buildSelect('filter-outcome', 'Outcome', ['', 'success', 'partial', 'failure', 'pending'], state.filters.outcome);
         } else if (tab === 'censors') {
-            html += buildSelect('filter-action', 'Action', ['', 'warn', 'block', 'absolute'], state.filters.action);
+            html += buildSelect('filter-action', 'Action', ['', 'steer', 'refuse', 'abort'], state.filters.action);
         }
 
         html += '<button class="btn" id="tab-search-btn">Search</button>';
@@ -186,6 +186,9 @@ Dashboard.registerView('browser', async function(container) {
             });
         });
 
+        // F078: wire censor severity controls (tier dropdown + active toggle + save).
+        if (tab === 'censors') wireCensorControls(tableArea);
+
         // Pagination
         var totalPages = Math.ceil(state.total / state.limit);
         var currentPage = Math.floor(state.offset / state.limit) + 1;
@@ -283,7 +286,8 @@ Dashboard.registerView('browser', async function(container) {
             return '<span class="badge ' + cls + '">' + escapeHtml(val) + '</span>';
         }
         if (col.format === 'action') {
-            var actionCls = val === 'block' || val === 'absolute' ? 'badge-censor' : 'badge-partial';
+            // F078: abort/refuse are halting/blocking tiers; steer is advisory.
+            var actionCls = (val === 'abort' || val === 'refuse') ? 'badge-censor' : 'badge-partial';
             return '<span class="badge ' + actionCls + '">' + escapeHtml(val) + '</span>';
         }
         if (col.badge) return '<span class="badge ' + col.badge + '">' + escapeHtml(String(val)) + '</span>';
@@ -341,11 +345,14 @@ Dashboard.registerView('browser', async function(container) {
             case 'censors':
                 html += detailRow('Trigger', item.trigger_pattern);
                 html += detailRow('Action', item.action);
+                html += detailRow('Provenance', item.provenance);
                 html += detailRow('Reason', item.reason);
                 html += detailRow('Domain', item.domain);
                 html += detailRow('Activations', item.activation_count);
                 html += detailRow('False Positives', item.false_positive_count);
                 html += detailRow('ID', null, '<span class="mono">' + escapeHtml(item.id || '') + '</span>');
+                // F078: per-censor severity control — tier dropdown + active toggle + save.
+                html += detailRow('Severity (tier)', null, buildCensorTierControl(item));
                 break;
             case 'chunks':
                 html += detailRow('Content', item.content);
@@ -358,6 +365,50 @@ Dashboard.registerView('browser', async function(container) {
 
         html += '</div>';
         return html;
+    }
+
+    // F078: per-censor tier dropdown + active toggle + save button.
+    // Calls PUT /censors/{id} with {action} / {active}.
+    function buildCensorTierControl(item) {
+        var id = escapeHtml(item.id || '');
+        var tiers = ['steer', 'refuse', 'abort'];
+        var sel = '<select class="filter-select censor-tier-select" data-censor-id="' + id + '">';
+        tiers.forEach(function(t) {
+            sel += '<option value="' + t + '"' + (item.action === t ? ' selected' : '') + '>' + t + '</option>';
+        });
+        sel += '</select>';
+        var activeChecked = item.active === false ? '' : ' checked';
+        var toggle = '<label class="censor-active-toggle" style="margin-left:8px">' +
+            '<input type="checkbox" class="censor-active-check" data-censor-id="' + id + '"' + activeChecked + '> Active</label>';
+        var btn = '<button class="btn censor-save-btn" data-censor-id="' + id + '" style="margin-left:8px">Save</button>';
+        var status = '<span class="censor-save-status" data-censor-id="' + id + '" style="margin-left:8px"></span>';
+        return sel + toggle + btn + status;
+    }
+
+    function wireCensorControls(tableArea) {
+        // Stop row collapse when interacting with the controls.
+        tableArea.querySelectorAll('.censor-tier-select, .censor-active-check, .censor-save-btn').forEach(function(el) {
+            el.addEventListener('click', function(e) { e.stopPropagation(); });
+        });
+        tableArea.querySelectorAll('.censor-save-btn').forEach(function(btn) {
+            btn.addEventListener('click', async function(e) {
+                e.stopPropagation();
+                var id = btn.dataset.censorId;
+                var sel = tableArea.querySelector('.censor-tier-select[data-censor-id="' + id + '"]');
+                var chk = tableArea.querySelector('.censor-active-check[data-censor-id="' + id + '"]');
+                var status = tableArea.querySelector('.censor-save-status[data-censor-id="' + id + '"]');
+                var body = {};
+                if (sel) body.action = sel.value;
+                if (chk) body.active = chk.checked;
+                if (status) status.textContent = 'Saving...';
+                try {
+                    await Dashboard.apiSend('/censors/' + id, body, 'PUT');
+                    if (status) { status.textContent = 'Saved'; status.className = 'censor-save-status text-green'; }
+                } catch (err) {
+                    if (status) { status.textContent = 'Error: ' + err.message; status.className = 'censor-save-status text-muted'; }
+                }
+            });
+        });
     }
 
     function detailRow(label, value, rawHtml) {

--- a/tests/test_censors.py
+++ b/tests/test_censors.py
@@ -3,6 +3,11 @@
 All tests use real Postgres via the SAVEPOINT fixture from conftest.py.
 Heart methods receive the test session via the session parameter (P1-1).
 
+F078: action vocabulary is now steer | refuse | abort (was warn | block | absolute).
+  - steer  = output-shaping directive, non-blocking (was warn)
+  - refuse = LLM runs but write tools stripped (new behavior; was a kind of block)
+  - abort  = hard cut before the LLM (was block-halt / absolute)
+
 Key MockEmbeddingProvider behavior:
 - Identical text = cosine 1.0 (matches > 0.7 threshold)
 - Different text = cosine ~0.0 (no match)
@@ -27,7 +32,7 @@ def _censor_input(**overrides) -> CensorInput:
     defaults = dict(
         trigger_pattern="never deploy on Friday",
         reason="Deployments on Friday risk weekend outages",
-        action="warn",
+        action="steer",
         domain="operations",
     )
     defaults.update(overrides)
@@ -47,12 +52,15 @@ async def test_add_censor(heart, session):
     assert isinstance(detail, CensorDetail)
     assert detail.trigger_pattern == "never deploy on Friday"
     assert detail.reason == "Deployments on Friday risk weekend outages"
-    assert detail.action == "warn"
+    assert detail.action == "steer"
     assert detail.domain == "operations"
     assert detail.activation_count == 0
     assert detail.false_positive_count == 0
     assert detail.active is True
     assert detail.escalation_threshold == 3
+    # F078: defaults
+    assert detail.provenance == "human"
+    assert detail.refuse_keep_tools is False
 
 
 # ---------------------------------------------------------------------------
@@ -131,12 +139,12 @@ async def test_activation_count_incremented(heart, session):
 
 
 # ---------------------------------------------------------------------------
-# 5. test_auto_escalation
+# 5. test_no_auto_escalation (F078: auto-escalation REMOVED)
 # ---------------------------------------------------------------------------
 
 
-async def test_auto_escalation(heart, session):
-    """After threshold triggers, warn -> block."""
+async def test_no_auto_escalation(heart, session):
+    """F078: a steer censor never auto-escalates, no matter how many times it fires."""
     censor = await heart.add_censor(
         _censor_input(
             trigger_pattern="escalation test censor trigger",
@@ -144,18 +152,23 @@ async def test_auto_escalation(heart, session):
         ),
         session=session,
     )
-    assert censor.action == "warn"
+    assert censor.action == "steer"
 
-    # Trigger enough times to cross threshold (default=3)
-    for _ in range(3):
+    # Trigger well past the old threshold (default=3).
+    for _ in range(5):
         matches = await heart.check_censors(
             "escalation test censor trigger escalation test reason",
             session=session,
         )
 
-    # After 3 triggers, should auto-escalate from warn to block
+    # Stays steer — no silent promotion to a halting tier.
     assert len(matches) >= 1
-    assert matches[0].action == "block"
+    assert all(m.action == "steer" for m in matches)
+
+    updated = await session.execute(select(Censor).where(Censor.id == censor.id))
+    c = updated.scalar_one()
+    assert c.action == "steer"
+    assert (c.activation_count or 0) >= 5
 
 
 # ---------------------------------------------------------------------------
@@ -181,53 +194,53 @@ async def test_false_positive_tracking(heart, session):
 
 
 # ---------------------------------------------------------------------------
-# 7. test_manual_escalation
+# 7. test_manual_escalation (F078: steer -> refuse -> abort)
 # ---------------------------------------------------------------------------
 
 
 async def test_manual_escalation(heart, session):
-    """warn -> block -> absolute."""
+    """steer -> refuse -> abort (manual operator action only)."""
     censor = await heart.add_censor(
         _censor_input(
             trigger_pattern="manual escalation test",
             reason="test reason",
-            action="warn",
+            action="steer",
         ),
         session=session,
     )
-    assert censor.action == "warn"
+    assert censor.action == "steer"
 
     escalated1 = await heart.escalate_censor(censor.id, session=session)
-    assert escalated1.action == "block"
+    assert escalated1.action == "refuse"
 
     escalated2 = await heart.escalate_censor(censor.id, session=session)
-    assert escalated2.action == "absolute"
+    assert escalated2.action == "abort"
 
 
 # ---------------------------------------------------------------------------
-# 8. test_escalation_no_downgrade
+# 8. test_escalation_no_downgrade (F078)
 # ---------------------------------------------------------------------------
 
 
 async def test_escalation_no_downgrade(heart, session):
-    """block cannot go back to warn."""
+    """refuse cannot go back to steer; abort stays abort."""
     censor = await heart.add_censor(
         _censor_input(
             trigger_pattern="no downgrade test",
             reason="test reason",
-            action="block",
+            action="refuse",
         ),
         session=session,
     )
-    assert censor.action == "block"
+    assert censor.action == "refuse"
 
-    # Escalate — should go to absolute, never back to warn
+    # Escalate — should go to abort, never back to steer
     escalated = await heart.escalate_censor(censor.id, session=session)
-    assert escalated.action == "absolute"
+    assert escalated.action == "abort"
 
-    # Escalate again — should stay absolute
+    # Escalate again — should stay abort
     escalated2 = await heart.escalate_censor(censor.id, session=session)
-    assert escalated2.action == "absolute"
+    assert escalated2.action == "abort"
 
 
 # ---------------------------------------------------------------------------
@@ -337,9 +350,6 @@ async def test_keyword_fallback_for_null_embeddings(heart, session):
     )
 
     # Null out the embedding to simulate a censor created without embeddings
-    await session.execute(
-        select(Censor).where(Censor.id == censor.id)
-    )
     from sqlalchemy import update
     await session.execute(
         update(Censor).where(Censor.id == censor.id).values(embedding=None)
@@ -369,7 +379,7 @@ async def test_keyword_match_pipe_separated_pattern(heart, session):
         _censor_input(
             trigger_pattern="api_key|token|secret|password",
             reason="Block credential exposure",
-            action="block",
+            action="abort",
         ),
         session=session,
     )
@@ -402,7 +412,7 @@ async def test_keyword_match_regex_wildcard_pattern(heart, session):
         _censor_input(
             trigger_pattern="send.*email|smtp|mail.*to",
             reason="Email protection",
-            action="warn",
+            action="steer",
         ),
         session=session,
     )
@@ -426,25 +436,30 @@ async def test_keyword_match_regex_wildcard_pattern(heart, session):
 
 
 async def test_keyword_match_invalid_regex_skipped(heart, session):
-    """Invalid regex patterns are skipped without breaking other censors."""
+    """Invalid regex patterns are skipped without breaking other censors.
+
+    F078 validates patterns at create time, so we insert the bad-pattern row
+    directly via the ORM (bypassing _add) to exercise the check-time guard.
+    """
     from sqlalchemy import update
 
-    # Create a censor with invalid regex
-    bad_censor = await heart.add_censor(
-        _censor_input(
-            trigger_pattern="[invalid(regex",
-            reason="Bad pattern",
-            action="warn",
-        ),
-        session=session,
+    # Insert a censor with invalid regex directly (bypass create-time validation).
+    bad_censor = Censor(
+        agent_id=heart.agent_id,
+        trigger_pattern="[invalid(regex",
+        action="steer",
+        reason="Bad pattern",
+        provenance="human",
     )
+    session.add(bad_censor)
+    await session.flush()
 
     # Create a valid censor that should still match
     good_censor = await heart.add_censor(
         _censor_input(
             trigger_pattern="password|secret",
             reason="Credential protection",
-            action="block",
+            action="abort",
         ),
         session=session,
     )
@@ -478,7 +493,7 @@ async def test_keyword_match_no_false_positive(heart, session):
         _censor_input(
             trigger_pattern="api_key|token|secret|password",
             reason="Block credential exposure",
-            action="block",
+            action="abort",
         ),
         session=session,
     )
@@ -505,7 +520,7 @@ async def test_censor_input_with_trigger_action(heart, session):
     inp = CensorInput(
         trigger_pattern="citing.*source",
         reason="Verify citations",
-        action="warn",
+        action="steer",
         trigger_action={"tool": "recall", "args": {"query": "citations", "limit": 5}},
         action_instruction="Verify all citations against recalled sources.",
     )
@@ -545,7 +560,7 @@ def test_censor_match_includes_action_fields():
     match = CensorMatch(
         id=uuid4(),
         trigger_pattern="test",
-        action="warn",
+        action="steer",
         reason="test reason",
         domain=None,
         trigger_action={"tool": "recall", "args": {"query": "test"}},
@@ -638,6 +653,16 @@ def test_turn_context_censor_injected_context_default_empty():
     assert ctx.censor_injected_context == {}
 
 
+def test_turn_context_refuse_active_default_false():
+    """F078: refuse_active defaults to False."""
+    from nous.cognitive.schemas import TurnContext, FrameSelection
+    ctx = TurnContext(
+        system_prompt="test",
+        frame=FrameSelection(frame_id="conversation", frame_name="Conversation", description="test", confidence=1.0, match_method="pattern"),
+    )
+    assert ctx.refuse_active is False
+
+
 # ---------------------------------------------------------------------------
 # F031 Task 5: Post-turn compliance check tests
 # ---------------------------------------------------------------------------
@@ -684,7 +709,7 @@ async def test_censor_action_end_to_end(heart, session):
     inp = CensorInput(
         trigger_pattern="capital.*country|what.*capital",
         reason="Verify geographic claims",
-        action="warn",
+        action="steer",
         trigger_action={"tool": "recall", "args": {"query": "capital country geography", "limit": 3}},
         action_instruction="Verify geographic claims against recalled facts.",
     )
@@ -693,19 +718,19 @@ async def test_censor_action_end_to_end(heart, session):
 
     matches = await heart.check_censors("What is the capital of France?", session=session)
     assert len(matches) >= 1
-    warn_match = [m for m in matches if m.action == "warn"]
-    assert len(warn_match) >= 1
-    assert warn_match[0].trigger_action is not None
+    steer_match = [m for m in matches if m.action == "steer"]
+    assert len(steer_match) >= 1
+    assert steer_match[0].trigger_action is not None
 
     from nous.heart.censor_actions import CensorActionExecutor
     executor = CensorActionExecutor(heart)
-    result = await executor.execute(warn_match[0].trigger_action, session=session)
+    result = await executor.execute(steer_match[0].trigger_action, session=session)
     assert result is not None
     assert "capital" in result.lower() or "france" in result.lower() or "paris" in result.lower()
 
 
-async def test_block_censor_with_action_enriches_reason(heart, session):
-    """Block censor with trigger_action enriches the block reason with evidence."""
+async def test_abort_censor_with_action_enriches_reason(heart, session):
+    """Abort censor with trigger_action carries evidence/instruction through the match."""
     from nous.heart.schemas import FactInput
     await heart.learn(
         FactInput(content="Production database was accidentally deleted on 2025-12-01", category="incident", subject="production"),
@@ -715,29 +740,29 @@ async def test_block_censor_with_action_enriches_reason(heart, session):
     inp = CensorInput(
         trigger_pattern="delete.*production|drop.*production",
         reason="Destructive production operations are prohibited",
-        action="block",
+        action="abort",
         trigger_action={"tool": "recall", "args": {"query": "production deletion incident", "limit": 3}},
         action_instruction="Contact the infrastructure team for production changes.",
     )
     detail = await heart.add_censor(inp, session=session)
-    assert detail.action == "block"
+    assert detail.action == "abort"
     assert detail.trigger_action is not None
 
     matches = await heart.check_censors("Let's delete the production database", session=session)
-    block_matches = [m for m in matches if m.action == "block"]
-    assert len(block_matches) >= 1
-    assert block_matches[0].trigger_action is not None
-    assert block_matches[0].action_instruction == "Contact the infrastructure team for production changes."
+    abort_matches = [m for m in matches if m.action == "abort"]
+    assert len(abort_matches) >= 1
+    assert abort_matches[0].trigger_action is not None
+    assert abort_matches[0].action_instruction == "Contact the infrastructure team for production changes."
 
     from nous.heart.censor_actions import CensorActionExecutor
     executor = CensorActionExecutor(heart)
-    result = await executor.execute(block_matches[0].trigger_action, session=session)
+    result = await executor.execute(abort_matches[0].trigger_action, session=session)
     assert result is not None
 
 
 @pytest.mark.postgres_only
-async def test_block_censor_conditional_unblock(heart, session):
-    """Block censor with unblock_pattern downgrades to warn when pattern matches action results."""
+async def test_refuse_censor_conditional_unblock(heart, session):
+    """Refuse censor with unblock_pattern can downgrade when pattern matches results."""
     from nous.heart.schemas import FactInput
     await heart.learn(
         FactInput(content="Allowed admin admin@company.com ops@company.com access list", category="access", subject="admin-list"),
@@ -747,7 +772,7 @@ async def test_block_censor_conditional_unblock(heart, session):
     inp = CensorInput(
         trigger_pattern="delete.*production",
         reason="Production deletion requires admin access",
-        action="block",
+        action="refuse",
         trigger_action={"tool": "recall", "args": {"query": "Allowed admin admin@company.com ops@company.com access list", "limit": 5}},
         unblock_pattern=r"admin@company\.com",
         action_instruction="Contact infrastructure team if you need access.",
@@ -759,32 +784,32 @@ async def test_block_censor_conditional_unblock(heart, session):
     import re
     executor = CensorActionExecutor(heart)
     matches = await heart.check_censors("delete production database", session=session)
-    block_match = [m for m in matches if m.trigger_pattern == "delete.*production"][0]
+    refuse_match = [m for m in matches if m.trigger_pattern == "delete.*production"][0]
 
-    result = await executor.execute(block_match.trigger_action, session=session)
+    result = await executor.execute(refuse_match.trigger_action, session=session)
     assert result is not None
-    assert re.search(block_match.unblock_pattern, result, re.IGNORECASE)
+    assert re.search(refuse_match.unblock_pattern, result, re.IGNORECASE)
 
 
-async def test_block_censor_no_unblock_when_pattern_missing(heart, session):
-    """Block censor without unblock_pattern always blocks (no downgrade)."""
+async def test_refuse_censor_no_unblock_when_pattern_missing(heart, session):
+    """Refuse censor without unblock_pattern carries no downgrade hint."""
     inp = CensorInput(
         trigger_pattern="drop.*table",
         reason="No dropping tables",
-        action="block",
+        action="refuse",
         trigger_action={"tool": "recall", "args": {"query": "table drops", "limit": 3}},
     )
     detail = await heart.add_censor(inp, session=session)
     assert detail.unblock_pattern is None
 
     matches = await heart.check_censors("drop table users", session=session)
-    block_matches = [m for m in matches if m.action == "block"]
-    assert len(block_matches) >= 1
-    assert block_matches[0].unblock_pattern is None
+    refuse_matches = [m for m in matches if m.action == "refuse"]
+    assert len(refuse_matches) >= 1
+    assert refuse_matches[0].unblock_pattern is None
 
 
 async def test_multiple_censor_actions_all_injected(heart, session):
-    """When multiple warn censors with trigger_action fire, all results are collected."""
+    """When multiple steer censors with trigger_action fire, all results are collected."""
     from nous.heart.schemas import FactInput
     await heart.learn(
         FactInput(content="Python is a programming language", category="tech", subject="Python"),
@@ -798,26 +823,26 @@ async def test_multiple_censor_actions_all_injected(heart, session):
     inp1 = CensorInput(
         trigger_pattern="python.*code",
         reason="Check coding standards",
-        action="warn",
+        action="steer",
         trigger_action={"tool": "recall", "args": {"query": "python programming", "limit": 3}},
     )
     inp2 = CensorInput(
         trigger_pattern="python.*code",
         reason="Check security",
-        action="warn",
+        action="steer",
         trigger_action={"tool": "search_facts", "args": {"query": "security", "limit": 3}},
     )
     await heart.add_censor(inp1, session=session)
     await heart.add_censor(inp2, session=session)
 
     matches = await heart.check_censors("Write python code for login", session=session)
-    warn_matches = [m for m in matches if m.action == "warn" and m.trigger_action]
-    assert len(warn_matches) >= 2
+    steer_matches = [m for m in matches if m.action == "steer" and m.trigger_action]
+    assert len(steer_matches) >= 2
 
     from nous.heart.censor_actions import CensorActionExecutor
     executor = CensorActionExecutor(heart)
     results = {}
-    for m in warn_matches:
+    for m in steer_matches:
         result = await executor.execute(m.trigger_action, session=session)
         if result:
             results[str(m.id)] = result
@@ -829,7 +854,7 @@ async def test_backward_compat_censor_no_action(heart, session):
     inp = CensorInput(
         trigger_pattern="deploy.*friday",
         reason="No Friday deploys",
-        action="warn",
+        action="steer",
     )
     detail = await heart.add_censor(inp, session=session)
     assert detail.trigger_action is None
@@ -853,7 +878,7 @@ async def test_update_censor_add_action_fields(heart, session):
     inp = CensorInput(
         trigger_pattern="deploy.*friday",
         reason="No Friday deploys",
-        action="warn",
+        action="steer",
     )
     detail = await heart.add_censor(inp, session=session)
     assert detail.trigger_action is None
@@ -868,15 +893,15 @@ async def test_update_censor_add_action_fields(heart, session):
     assert updated.action_instruction == "Check past deploy incidents before proceeding."
     assert updated.trigger_pattern == "deploy.*friday"
     assert updated.reason == "No Friday deploys"
-    assert updated.action == "warn"
+    assert updated.action == "steer"
 
 
 async def test_update_censor_add_unblock_pattern(heart, session):
-    """Upgrade a block censor with unblock_pattern."""
+    """Upgrade a refuse censor with unblock_pattern."""
     inp = CensorInput(
         trigger_pattern="delete.*production",
         reason="No production deletes",
-        action="block",
+        action="refuse",
     )
     detail = await heart.add_censor(inp, session=session)
 
@@ -889,7 +914,7 @@ async def test_update_censor_add_unblock_pattern(heart, session):
     )
     assert updated.unblock_pattern == r"admin@company\.com"
     assert updated.trigger_action is not None
-    assert updated.action == "block"
+    assert updated.action == "refuse"
 
 
 # ---------------------------------------------------------------------------
@@ -907,69 +932,210 @@ def test_pre_turn_accepts_is_subtask_param():
     assert param.default is False
 
 
-async def test_spawn_task_rejects_blocked_subtask(heart, session):
-    """spawn_task censor check rejects subtasks that match a block censor."""
-    # Create a block censor
+async def test_spawn_task_rejects_aborted_subtask(heart, session):
+    """spawn_task censor check rejects subtasks that match an abort censor."""
     inp = CensorInput(
         trigger_pattern="delete.*production",
         reason="No production deletes from subtasks",
-        action="block",
+        action="abort",
     )
     await heart.add_censor(inp, session=session)
 
     # Simulate what spawn_task does: check censors on task text
     matches = await heart.check_censors("delete production logs", session=session)
-    block_matches = [m for m in matches if m.action == "block"]
-    assert len(block_matches) >= 1, "Block censor should fire on subtask text"
+    # F078: spawn gate rejects on abort OR refuse
+    reject_matches = [m for m in matches if m.action in ("abort", "refuse")]
+    assert len(reject_matches) >= 1, "Abort censor should fire on subtask text"
 
 
-async def test_spawn_task_allows_unblocked_subtask(heart, session):
-    """spawn_task censor check allows subtask when unblock_pattern matches."""
-    from nous.heart.schemas import FactInput
-    await heart.learn(
-        FactInput(content="Subtask-authorized operations: log-analysis, report-generation", category="access", subject="subtask-perms"),
-        session=session,
-    )
-
+async def test_steer_censor_does_not_reject_subtask(heart, session):
+    """F078: steer censors on subtask creation do NOT reject the task (email path)."""
     inp = CensorInput(
-        trigger_pattern="production.*logs",
-        reason="Production access restricted",
-        action="block",
-        trigger_action={"tool": "search_facts", "args": {"query": "subtask authorized operations"}},
-        unblock_pattern=r"log-analysis",
+        trigger_pattern="send.*email",
+        reason="Verify recipient before sending email",
+        action="steer",
     )
     await heart.add_censor(inp, session=session)
 
-    matches = await heart.check_censors("analyze production logs", session=session)
-    block_matches = [m for m in matches if m.action == "block"]
-    assert len(block_matches) >= 1
-
-    # Verify unblock would work
-    from nous.heart.censor_actions import CensorActionExecutor
-    import re
-    executor = CensorActionExecutor(heart)
-    for match in block_matches:
-        if match.trigger_action and match.unblock_pattern:
-            result = await executor.execute(match.trigger_action, session=session)
-            if result and re.search(match.unblock_pattern, result, re.IGNORECASE):
-                # Would be unblocked — subtask should proceed
-                assert True
-                return
-    # If we get here, unblock didn't work
-    assert False, "Unblock pattern should have matched"
+    matches = await heart.check_censors("send an email to the team with the report", session=session)
+    reject_matches = [m for m in matches if m.action in ("abort", "refuse")]
+    steer_matches = [m for m in matches if m.action == "steer"]
+    assert len(reject_matches) == 0, "Steer censors must not reject (email subtasks must pass)"
+    assert len(steer_matches) >= 1, "Steer censor should fire but only advise"
 
 
-async def test_warn_censor_does_not_block_subtask(heart, session):
-    """Warn censors on subtask creation should not block the task."""
+# ---------------------------------------------------------------------------
+# F078: provenance cap
+# ---------------------------------------------------------------------------
+
+
+async def test_provenance_cap_auto_clamped_to_steer(heart, session):
+    """F078: an auto-provenance censor requesting refuse/abort is clamped to steer."""
     inp = CensorInput(
-        trigger_pattern="sensitive.*data",
-        reason="Handle with care",
-        action="warn",
+        trigger_pattern="auto cap test",
+        reason="auto provenance must never reach a halting tier",
+        action="abort",  # requested
+        provenance="auto",
     )
-    await heart.add_censor(inp, session=session)
+    detail = await heart.add_censor(inp, session=session)
+    assert detail.action == "steer"  # clamped down
+    assert detail.provenance == "auto"
 
-    matches = await heart.check_censors("process sensitive data export", session=session)
-    block_matches = [m for m in matches if m.action == "block"]
-    warn_matches = [m for m in matches if m.action == "warn"]
-    assert len(block_matches) == 0, "Warn censors should not block"
-    assert len(warn_matches) >= 1, "Warn censor should fire but not block"
+
+async def test_provenance_cap_agent_clamped_to_refuse(heart, session):
+    """F078: an agent-provenance censor requesting abort is clamped to refuse."""
+    inp = CensorInput(
+        trigger_pattern="agent cap test",
+        reason="agent provenance caps at refuse",
+        action="abort",  # requested
+        provenance="agent",
+    )
+    detail = await heart.add_censor(inp, session=session)
+    assert detail.action == "refuse"  # clamped to the agent cap
+    assert detail.provenance == "agent"
+
+
+async def test_provenance_human_allows_abort(heart, session):
+    """F078: human provenance may create an abort censor."""
+    inp = CensorInput(
+        trigger_pattern="rm -rf /",
+        reason="destructive",
+        action="abort",
+        provenance="human",
+    )
+    detail = await heart.add_censor(inp, session=session)
+    assert detail.action == "abort"
+
+
+# ---------------------------------------------------------------------------
+# F078: create-time regex validation
+# ---------------------------------------------------------------------------
+
+
+async def test_add_censor_rejects_invalid_trigger_pattern(heart, session):
+    """F078: a non-compiling trigger_pattern is rejected at create time."""
+    inp = CensorInput(
+        trigger_pattern="[invalid(regex",
+        reason="bad pattern",
+        action="steer",
+    )
+    with pytest.raises(ValueError):
+        await heart.add_censor(inp, session=session)
+
+
+async def test_add_censor_rejects_invalid_unblock_pattern(heart, session):
+    """F078: a non-compiling unblock_pattern is rejected at create time."""
+    inp = CensorInput(
+        trigger_pattern="delete.*production",
+        reason="ok",
+        action="refuse",
+        unblock_pattern="[bad(unblock",
+    )
+    with pytest.raises(ValueError):
+        await heart.add_censor(inp, session=session)
+
+
+async def test_add_censor_rejects_disallowed_trigger_action_tool(heart, session):
+    """F078: trigger_action.tool not in ALLOWED_TOOLS is rejected at create time."""
+    inp = CensorInput(
+        trigger_pattern="something",
+        reason="ok",
+        action="steer",
+        trigger_action={"tool": "write_file", "args": {"path": "/etc/passwd"}},
+    )
+    with pytest.raises(ValueError):
+        await heart.add_censor(inp, session=session)
+
+
+# ---------------------------------------------------------------------------
+# F078: update_censor severity path (UI)
+# ---------------------------------------------------------------------------
+
+
+async def test_update_censor_sets_action(heart, session):
+    """F078: operator can set ANY valid tier via update (no provenance cap on update)."""
+    inp = CensorInput(
+        trigger_pattern="ui severity test",
+        reason="start as steer",
+        action="steer",
+    )
+    detail = await heart.add_censor(inp, session=session)
+    assert detail.action == "steer"
+
+    updated = await heart.update_censor(detail.id, action="abort", session=session)
+    assert updated.action == "abort"
+
+
+async def test_update_censor_sets_active(heart, session):
+    """F078: update can toggle active."""
+    inp = CensorInput(
+        trigger_pattern="active toggle test",
+        reason="x",
+        action="steer",
+    )
+    detail = await heart.add_censor(inp, session=session)
+    assert detail.active is True
+
+    updated = await heart.update_censor(detail.id, active=False, session=session)
+    assert updated.active is False
+
+
+async def test_update_censor_rejects_invalid_action(heart, session):
+    """F078: update_censor rejects an out-of-vocab action."""
+    inp = CensorInput(
+        trigger_pattern="bad action update test",
+        reason="x",
+        action="steer",
+    )
+    detail = await heart.add_censor(inp, session=session)
+    with pytest.raises(ValueError):
+        await heart.update_censor(detail.id, action="block", session=session)
+
+
+# ---------------------------------------------------------------------------
+# F078 R1 (runner half): the runner's cache-split build preserves the dynamic
+# tier that the layer writes steer/refuse guidance into. The LAYER half (layer
+# writes guidance into sections_by_tier['dynamic'], not only the flat prompt) is
+# covered by test_cognitive_layer.py::test_pre_turn_steer_directive_reaches_sections_by_tier.
+# ---------------------------------------------------------------------------
+
+
+def _build_prompt_with_injected(injected_guidance: str):
+    """Simulate the runner's cache-split build with a TurnContext that carries
+    steer guidance in sections_by_tier["dynamic"]. Asserts the guidance survives.
+    """
+    from unittest.mock import MagicMock
+    from nous.api.runner import AgentRunner
+    from nous.cognitive.schemas import TurnContext, FrameSelection
+
+    settings = MagicMock()
+    settings.cache_split_system_prompt = True
+    settings.execution_ledger_enabled = False
+
+    runner = AgentRunner.__new__(AgentRunner)
+    runner._settings = settings
+    # _get_frame_instructions reads a frames map; stub it to return "".
+    runner._get_frame_instructions = lambda tc: ""
+
+    tc = TurnContext(
+        system_prompt="flat-prompt-ignored-under-split",
+        frame=FrameSelection(
+            frame_id="conversation", frame_name="Conversation",
+            description="t", confidence=1.0, match_method="pattern",
+        ),
+        sections_by_tier={
+            "static": "STATIC",
+            "dynamic": injected_guidance,
+        },
+    )
+    return runner._build_system_prompt(tc)
+
+
+def test_r1_injected_guidance_reaches_payload_under_cache_split():
+    """F078 R1: steer/refuse guidance routed into sections_by_tier['dynamic']
+    actually appears in the system prompt built under default (cache-split-on)."""
+    guidance = "## Active Guidance\n- Verify recipient before sending email.\n"
+    built = _build_prompt_with_injected(guidance)
+    # Cache-split path returns a dict of tiers.
+    assert isinstance(built, dict)
+    assert "Verify recipient before sending email" in built.get("dynamic", "")

--- a/tests/test_cognitive_layer.py
+++ b/tests/test_cognitive_layer.py
@@ -106,7 +106,7 @@ async def _seed_data(brain, heart, session):
         CensorInput(
             trigger_pattern="seed censor trigger",
             reason="Seed censor reason",
-            action="warn",
+            action="steer",
         ),
         session=session,
     )
@@ -124,6 +124,51 @@ async def test_pre_turn_selects_frame(cognitive, session):
 
     assert isinstance(ctx, TurnContext)
     assert ctx.frame.frame_id == "decision"
+
+
+async def test_pre_turn_steer_directive_reaches_sections_by_tier(cognitive, heart, settings, session, monkeypatch):
+    """F078 R1: a directive-only steer match (no trigger_action) must land in
+    TurnContext.sections_by_tier['dynamic'] so it survives the F036 cache-split
+    in runner._build_system_prompt. This is the half that was the prod no-op:
+    the layer used to append only to the flat system_prompt, which the runner
+    ignores under cache_split_system_prompt=True (default).
+    """
+    from uuid import uuid4
+    from nous.heart.schemas import CensorMatch
+
+    # Ensure the cache-split path is the one under test.
+    settings.cache_split_system_prompt = True
+
+    directive = "VERIFY-RECIPIENT-BEFORE-SENDING-EMAIL-marker"
+
+    async def _fake_check_censors(text, domain=None, session=None):
+        return [
+            CensorMatch(
+                id=uuid4(),
+                trigger_pattern="send.*email",
+                action="steer",
+                reason="fallback reason should be ignored when instruction present",
+                domain=None,
+                trigger_action=None,  # directive-only — the prod-shape steer case
+                action_instruction=directive,
+            )
+        ]
+
+    monkeypatch.setattr(heart, "check_censors", _fake_check_censors)
+
+    sid = f"test-steer-tier-{uuid.uuid4().hex[:8]}"
+    ctx = await cognitive.pre_turn(
+        "nous-default", sid, "please send an email to the team", session=session,
+    )
+
+    # The directive must reach the dynamic tier (the cache-split read path),
+    # NOT only the flat system_prompt. Reverting the layer's sections_by_tier
+    # write turns this assertion red.
+    assert ctx.sections_by_tier, "build should have populated sections_by_tier"
+    assert directive in ctx.sections_by_tier.get("dynamic", "")
+    # And it should NOT have set a blocking flag (steer never blocks).
+    assert ctx.censor_blocked is False
+    assert ctx.refuse_active is False
 
 
 async def test_pre_turn_builds_context(cognitive, brain, heart, session):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -130,7 +130,7 @@ async def _seed_censor(heart, session):
         CensorInput(
             trigger_pattern="dangerous operation",
             reason="Avoid risky operations without review",
-            action="warn",
+            action="steer",
         ),
         session=session,
     )

--- a/tests/test_correction_extractor.py
+++ b/tests/test_correction_extractor.py
@@ -226,7 +226,9 @@ class TestCorrectionExtractor:
             heart.add_censor.assert_called_once()
             censor_input = heart.add_censor.call_args[0][0]
             assert censor_input.trigger_pattern == "assume user preference"
-            assert censor_input.action == "warn"
+            # F078: auto-learned censors are steer + provenance=auto.
+            assert censor_input.action == "steer"
+            assert censor_input.provenance == "auto"
 
     @pytest.mark.asyncio
     async def test_skip_short_principle(self):

--- a/tests/test_dashboard_queries.py
+++ b/tests/test_dashboard_queries.py
@@ -270,7 +270,7 @@ async def _insert_censor(session, *, trigger_pattern="test pattern",
             INSERT INTO heart.censors
                 (id, agent_id, trigger_pattern, action, reason, created_by,
                  activation_count, active)
-            VALUES (:id, :agent_id, :pattern, 'warn', 'test', :created_by,
+            VALUES (:id, :agent_id, :pattern, 'steer', 'test', :created_by,
                     :act_count, :active)
         """),
         {

--- a/tests/test_heart.py
+++ b/tests/test_heart.py
@@ -65,7 +65,7 @@ def _censor_input(**overrides) -> CensorInput:
     defaults = dict(
         trigger_pattern="integration test censor trigger",
         reason="integration test censor reason",
-        action="warn",
+        action="steer",
     )
     defaults.update(overrides)
     return CensorInput(**defaults)
@@ -246,7 +246,7 @@ async def test_procedure_lifecycle(heart, session):
 
 
 async def test_censor_lifecycle(heart, session):
-    """add -> check triggers -> escalate after threshold."""
+    """add -> check triggers (F078: no auto-escalation — stays steer)."""
     censor = await heart.add_censor(
         _censor_input(
             trigger_pattern="lifecycle censor test trigger",
@@ -254,18 +254,18 @@ async def test_censor_lifecycle(heart, session):
         ),
         session=session,
     )
-    assert censor.action == "warn"
+    assert censor.action == "steer"
 
-    # Trigger 3 times (threshold) with identical text
+    # Trigger 3 times with identical text
     for _ in range(3):
         matches = await heart.check_censors(
             "lifecycle censor test trigger lifecycle censor test reason",
             session=session,
         )
 
-    # After threshold, should have auto-escalated to block
+    # F078: auto-escalation removed — the censor stays steer no matter the count.
     assert len(matches) >= 1
-    assert matches[0].action == "block"
+    assert matches[0].action == "steer"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -152,7 +152,7 @@ async def _seed_censor(heart, session):
         CensorInput(
             trigger_pattern="test censor pattern",
             reason="Test censor reason",
-            action="warn",
+            action="steer",
         ),
         session=session,
     )

--- a/tests/test_rest_dashboard.py
+++ b/tests/test_rest_dashboard.py
@@ -186,7 +186,7 @@ async def test_censors_with_pagination(client, heart, db):
     """GET /censors returns total and supports limit/offset."""
     async with db.session() as session:
         await heart.add_censor(
-            CensorInput(trigger_pattern="test pattern", reason="Test", action="warn"),
+            CensorInput(trigger_pattern="test pattern", reason="Test", action="steer"),
             session=session,
         )
         await session.commit()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -351,7 +351,7 @@ class TestCreateCensor:
         result = await tools["create_censor"](
             trigger_pattern="rm -rf /",
             reason="Dangerous command that could delete everything",
-            action="block",
+            action="refuse",
             domain="debugging",
         )
 
@@ -359,7 +359,8 @@ class TestCreateCensor:
         text = result["content"][0]["text"]
         assert "Censor created successfully" in text
         assert "ID:" in text
-        assert "Action: block" in text
+        # F078: agent provenance caps at refuse (would clamp abort -> refuse).
+        assert "Action: refuse" in text
         assert "Domain: debugging" in text
         assert "Pattern: rm -rf /" in text
 


### PR DESCRIPTION
## What & why

Censors fired on the **wrong side** and halted the agentic loop on false positives. Anti-hallucination censors written to constrain the model's *output* (`delivered|was sent`, `can't do`, `psql|SELECT…`) were matched against **user input** (the only enforcing check) and replaced the turn with a canned `"Blocked by censor"`. A prod audit of 48 censors confirmed this is the dominant false-halt; the legacy `block` tier also halts (LLM never runs) and `warn` silently auto-escalated to `block`.

F078 replaces `warn|block|absolute` with **`steer | refuse | abort`**, routed by side.

## Design

| Tier | Behavior | For |
|---|---|---|
| **steer** | directive injected pre-turn, **never blocks** | anti-hallucination, preferences, verify-before-acting |
| **refuse** | LLM runs, declines, write-tools stripped (`execution_ledger` denylist) | prohibitive actions |
| **abort** | hard cut before the LLM | destructive only (`rm -rf /`) |

- **R1 cache-split fix** — steer/refuse guidance is routed into `sections_by_tier` so it survives F036's prompt cache-split. This also repairs a **pre-existing prod bug**: F031 censor injection has been silently dropped since F036 shipped.
- **Creation hardening** — `provenance` caps the max tier (`auto≤steer`, `agent≤refuse`, `human≤abort`) so an auto-learned censor can never become a turn-killer; silent auto-escalation removed; regex validated at create.
- **Spawn-gate retiered** — background/subtask path rejects `abort`/`refuse`; `steer` passes (daily email subtasks unaffected).
- **UI severity control** — per-censor tier dropdown + active toggle → `PUT /censors/{id}`; the operator sets severity directly (human-gated promotion).
- No ActionGate dependency (disabled in prod).

## Backward-compatibility (hard invariant)
Nothing automatic blocks a currently-working path. Email censors stay `steer` (daily email senders keep working). Migration `056` is **functionally inert** — `block/warn/absolute → steer`; hard tiers are promoted only by the operator.

## Validation
- **Review:** APPROVE-WITH-FIXES, no P1s; BC invariant + R1 wiring verified end-to-end.
- **Tests:** 103 green on local Postgres (incl. a discriminating false-halt-fix test).
- **Live instance eval** (real app on isolated eval DB, migration applied): steer input → real answer applying the injected directive ("…always give you forecasts in Celsius…"), **no halt** + R1 confirmed live; `rm -rf /` → **hard-cut**.

## Deploy / follow-ups (gated on operator)
1. Apply migration `056` to prod (inert), then promote the few hard tiers (trading → refuse, `rm -rf` → abort) via the new UI.
2. **F078.1** — recipient-allowlist for email exfil hardening (additive) as fast-follow.

Spec: `docs/features/F078-correct-side-censor-enforcement.md` · Triage: `docs/reviews/censor-triage-2026-06-05.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
