### PR TITLE
F078.1.1: hot-reloadable email allowlist file (no restart)

### DIFF
--- a/docs/features/F078.1-email-recipient-allowlist.md
+++ b/docs/features/F078.1-email-recipient-allowlist.md
@@ -33,6 +33,7 @@ A `send_email` tool closure + `_SEND_EMAIL_SCHEMA` + `register_email_tools(dispa
 - `email_tool_enabled: bool = True` (`NOUS_EMAIL_TOOL_ENABLED`).
 - `email_max_per_hour: int = 5` (`NOUS_EMAIL_MAX_PER_HOUR`).
 - `email_smtp_host: str = "smtp.gmail.com"`, `email_smtp_port: int = 587`.
+- **`email_allowlist_file: str = ""` (`NOUS_EMAIL_ALLOWLIST_FILE`) — F078.1.1, hot-reloadable.** A file (one address per line or CSV, `#` comments) read **at send-time**, mtime-cached, **fail-closed** on error (never widens on read failure). **Effective allowlist = `email_allowlist` (env, static base) ∪ file contents.** Appending an address takes effect on the **next send with no restart** — this is the managed list (the env CSV is just an optional static base). Operator manages additions by editing the file (or the agent appends via `bash`).
 (Reuses existing `email`, `email_user`, `email_password`.)
 
 ### Wiring

--- a/nous/api/email_tools.py
+++ b/nous/api/email_tools.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import re
 import smtplib
 import time
@@ -66,6 +67,37 @@ def _parse_allowlist(raw: str) -> set[str]:
     return {a.strip().lower() for a in (raw or "").split(",") if a.strip()}
 
 
+def _read_allowlist_file(path: str, cache: dict[str, Any]) -> set[str]:
+    """Read the hot-reloadable allowlist file, mtime-cached.
+
+    One address per line or CSV; '#' starts a comment. Re-reads only when the
+    file's mtime changes, so a live edit takes effect on the NEXT send with no
+    restart. On any read error, returns the last-known set (fail-closed — an
+    error never widens the allowlist).
+    """
+    try:
+        mtime = os.path.getmtime(path)
+    except OSError:
+        return cache.get("addrs", set())
+    if cache.get("mtime") == mtime:
+        return cache["addrs"]
+    try:
+        with open(path, encoding="utf-8") as f:
+            raw = f.read()
+    except OSError:
+        return cache.get("addrs", set())
+    addrs: set[str] = set()
+    for line in raw.splitlines():
+        line = line.split("#", 1)[0]
+        for a in line.split(","):
+            a = a.strip().lower()
+            if a:
+                addrs.add(a)
+    cache["mtime"] = mtime
+    cache["addrs"] = addrs
+    return addrs
+
+
 def _scan_secrets(text: str) -> bool:
     """Return True if the text matches any known secret pattern."""
     return any(p.search(text) for p in _SECRET_PATTERNS)
@@ -97,6 +129,8 @@ def create_send_email_tool(settings: Settings):
     """
     # Monotonic timestamps of successful sends, within the current hour window.
     _send_times: list[float] = []
+    # F078.1.1: mtime-cache for the hot-reloadable allowlist file.
+    _file_cache: dict[str, Any] = {"mtime": None, "addrs": set()}
 
     async def send_email(
         to: Any,
@@ -130,7 +164,11 @@ def create_send_email_tool(settings: Settings):
             return _error("No recipient provided in 'to'.")
 
         # 2. Recipient allowlist (the core guard). Empty allowlist => reject all.
+        # Effective = env CSV (static base) UNION the hot-reloadable file (read at
+        # send-time, mtime-cached) — adding an address to the file needs no restart.
         allowlist = _parse_allowlist(settings.email_allowlist)
+        if settings.email_allowlist_file:
+            allowlist |= _read_allowlist_file(settings.email_allowlist_file, _file_cache)
         for addr in to_list + cc_list:
             if addr.lower() not in allowlist:
                 return _error(

--- a/nous/config.py
+++ b/nous/config.py
@@ -727,6 +727,10 @@ class Settings(BaseSettings):
     email_password: str = ""  # IMAP login password
     # F078.1: Guarded send_email tool (recipient allowlist + secret scan + rate limit)
     email_allowlist: str = ""  # CSV of allowed recipients (case-insensitive exact). Empty = reject all.
+    # F078.1.1: hot-reloadable allowlist file (one address per line, or CSV; '#' comments OK).
+    # Read at send-time (mtime-cached), so adding an address takes effect WITHOUT a restart.
+    # Effective allowlist = email_allowlist (env, static base) UNION this file's contents.
+    email_allowlist_file: str = ""
     email_tool_enabled: bool = True  # Master switch for the guarded send_email tool
     email_max_per_hour: int = 5  # In-process sliding-window rate limit
     email_smtp_host: str = "smtp.gmail.com"  # SMTP host for the send_email tool

--- a/tests/test_email_tools.py
+++ b/tests/test_email_tools.py
@@ -180,3 +180,55 @@ def test_exception_sanitized_generic_message(monkeypatch):
     assert "app-password" not in text
     assert "nous@example.com" not in text
     assert secret_leak not in text
+
+
+# --- F078.1.1: hot-reloadable allowlist file (no restart) ---
+
+def test_allowlist_file_hot_reload(no_real_send, tmp_path):
+    """Appending an address to the allowlist FILE takes effect on the next send
+    using the SAME tool instance — no recreation, no restart."""
+    import os
+    import time as _t
+
+    f = tmp_path / "allowlist.txt"
+    f.write_text("bob@example.com\n# a comment line\n", encoding="utf-8")
+    # Empty env base so the file is the only source.
+    tool = create_send_email_tool(
+        _make_settings(email_allowlist="", email_allowlist_file=str(f))
+    )
+
+    # In the file -> allowed.
+    assert "Email sent" in _text(asyncio.run(tool(to="bob@example.com", subject="s", body="b")))
+    # Not yet in the file -> rejected.
+    assert "not on the email allowlist" in _text(
+        asyncio.run(tool(to="carol@example.com", subject="s", body="b"))
+    )
+
+    # Live edit: append carol, force a distinct mtime so the cache re-reads.
+    f.write_text("bob@example.com\ncarol@example.com\n", encoding="utf-8")
+    os.utime(f, (_t.time() + 5, _t.time() + 5))
+
+    # Same tool instance (no restart) now allows carol.
+    assert "Email sent" in _text(asyncio.run(tool(to="carol@example.com", subject="s", body="b")))
+
+
+def test_allowlist_file_union_with_env(no_real_send, tmp_path):
+    """Effective allowlist = env CSV UNION file contents."""
+    f = tmp_path / "al.txt"
+    f.write_text("filey@example.com\n", encoding="utf-8")
+    tool = create_send_email_tool(
+        _make_settings(email_allowlist="envy@example.com", email_allowlist_file=str(f))
+    )
+    assert "Email sent" in _text(asyncio.run(tool(to="envy@example.com", subject="s", body="b")))   # env base
+    assert "Email sent" in _text(asyncio.run(tool(to="filey@example.com", subject="s", body="b")))  # file
+
+
+def test_allowlist_file_missing_falls_back_to_env(no_real_send, tmp_path):
+    """A missing/unreadable file does not widen the allowlist (fail-closed)."""
+    tool = create_send_email_tool(
+        _make_settings(email_allowlist="tim@example.com", email_allowlist_file=str(tmp_path / "nope.txt"))
+    )
+    assert "Email sent" in _text(asyncio.run(tool(to="tim@example.com", subject="s", body="b")))     # env still works
+    assert "not on the email allowlist" in _text(
+        asyncio.run(tool(to="stranger@evil.com", subject="s", body="b"))
+    )


### PR DESCRIPTION
Follow-up to F078.1 (#480). The email recipient allowlist no longer requires a restart to add an address.

## Change
- New `NOUS_EMAIL_ALLOWLIST_FILE` — a file (one address per line or CSV, `#` comments) read **at send-time**, **mtime-cached** (re-read only when the file changes), **fail-closed** on read error (a failure never widens the allowlist).
- **Effective allowlist = `NOUS_EMAIL_ALLOWLIST` (env, static base) ∪ file contents.** The file is the live-managed list; appending an address takes effect on the **next send — no restart**.

## Why
The operator (or the agent via `bash`) adds an allowed recipient by editing the file; the running process picks it up immediately. The env CSV stays as an optional static base.

## Tests
3 new (14 total): hot-reload (append to file → same tool instance allows the new address, no recreation), env∪file union, and missing-file fail-closed. smtplib still fully monkeypatched — nothing sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
