### PR TITLE
F078.1.2: attachments for the guarded send_email tool

### DIFF
--- a/docs/features/F078.1-email-recipient-allowlist.md
+++ b/docs/features/F078.1-email-recipient-allowlist.md
@@ -56,3 +56,14 @@ Ship safe-by-default: tool registered, **empty allowlist = reject-all**, so it c
 - Auto-migrating the daily tasks (operational).
 - Removing/blocking the bash+smtplib path (would break BC).
 - Per-recipient policy / attachments (later if needed; `send_file` already handles Telegram files).
+
+---
+
+## F078.1.2 — attachments (2026-06-06)
+`send_email` gained an optional `attachments` param (file path or list) so report-style emails (a generated `.docx`/`.pdf`) can move onto the guarded tool — a prerequisite for migrating the daily email tasks off bash+smtplib.
+
+- With attachments → `MIMEMultipart` (`MIMEText` body + one `MIMEApplication` part per file); without → plain `MIMEText` (v1 behavior unchanged).
+- Each path validated **before any send**: must be a readable regular file; **total size ≤ `NOUS_EMAIL_MAX_ATTACHMENT_MB`** (default 25, Gmail's limit). Invalid path / oversize → reject, no send.
+- All v1 guards run first (allowlist → secret-scan → rate-limit), so an off-allowlist send is rejected before files are even read.
+- **Attachment *contents* are not secret-scanned** (binary; unreliable). The recipient allowlist (trusted recipients only) is the guard, and the tool is still strictly safer than the unguarded bash+smtplib path it replaces.
+- Config: `email_max_attachment_mb: int = 25` (`NOUS_EMAIL_MAX_ATTACHMENT_MB`).

--- a/nous/api/email_tools.py
+++ b/nous/api/email_tools.py
@@ -21,6 +21,8 @@ import os
 import re
 import smtplib
 import time
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from typing import Any
 
@@ -103,10 +105,65 @@ def _scan_secrets(text: str) -> bool:
     return any(p.search(text) for p in _SECRET_PATTERNS)
 
 
+def _normalize_paths(value: Any) -> list[str]:
+    """Coerce an attachments field (str or list) into a list of stripped paths."""
+    if value is None:
+        return []
+    items = [value] if isinstance(value, str) else list(value)
+    return [str(p).strip() for p in items if p and str(p).strip()]
+
+
+def _build_message(
+    settings: Settings,
+    subject: str,
+    body: str,
+    from_addr: str,
+    to_list: list[str],
+    cc_list: list[str],
+    attachments: list[str],
+) -> tuple[Any | None, str | None]:
+    """Build the MIME message. Returns (msg, None) on success or (None, error).
+
+    With no attachments → plain MIMEText (unchanged from v1). With attachments →
+    MIMEMultipart; each path is validated (regular file, readable, within the
+    total size cap) before any send. NOTE: attachment *contents* are not
+    secret-scanned — the recipient allowlist (trusted recipients only) is the
+    guard, and this is strictly safer than the unguarded bash+smtplib path.
+    """
+    if not attachments:
+        msg: Any = MIMEText(body)
+    else:
+        msg = MIMEMultipart("mixed")
+        msg.attach(MIMEText(body))
+        cap = settings.email_max_attachment_mb * 1024 * 1024
+        total = 0
+        for path in attachments:
+            if not os.path.isfile(path):
+                return None, f"attachment not found or not a regular file: {path}"
+            try:
+                total += os.path.getsize(path)
+                if total > cap:
+                    return None, f"attachments exceed the {settings.email_max_attachment_mb}MB total limit"
+                with open(path, "rb") as fh:
+                    data = fh.read()
+            except OSError:
+                return None, f"attachment unreadable: {path}"
+            name = os.path.basename(path)
+            part = MIMEApplication(data, Name=name)
+            part["Content-Disposition"] = f'attachment; filename="{name}"'
+            msg.attach(part)
+    msg["Subject"] = subject
+    msg["From"] = from_addr
+    msg["To"] = ", ".join(to_list)
+    if cc_list:
+        msg["Cc"] = ", ".join(cc_list)
+    return msg, None
+
+
 def _send_email_sync(
     settings: Settings,
     recipients: list[str],
-    msg: MIMEText,
+    msg: Any,  # MIMEText or MIMEMultipart (with attachments)
 ) -> None:
     """Blocking SMTP send. Runs in a worker thread via asyncio.to_thread."""
     server = smtplib.SMTP(settings.email_smtp_host, settings.email_smtp_port)
@@ -137,6 +194,7 @@ def create_send_email_tool(settings: Settings):
         subject: str,
         body: str,
         cc: Any = None,
+        attachments: Any = None,
     ) -> dict[str, Any]:
         """Send an email to allowlisted recipient(s).
 
@@ -145,6 +203,9 @@ def create_send_email_tool(settings: Settings):
             subject: Email subject line.
             body: Plain-text email body.
             cc: Optional CC address(es) — string or list. Each must be allowlisted.
+            attachments: Optional file path(s) — string or list — to attach (e.g. a
+                generated .docx/.pdf report). Each must be a readable file; the total
+                size must be within NOUS_EMAIL_MAX_ATTACHMENT_MB.
 
         Returns:
             MCP-compliant response confirming the send or naming the rejection reason.
@@ -194,13 +255,14 @@ def create_send_email_tool(settings: Settings):
                 "try again later."
             )
 
-        # 5. Send (smtplib is blocking → run in a worker thread).
-        msg = MIMEText(body)
-        msg["Subject"] = subject
-        msg["From"] = settings.email or settings.email_user
-        msg["To"] = ", ".join(to_list)
-        if cc_list:
-            msg["Cc"] = ", ".join(cc_list)
+        # 5. Build the message (validates attachments) + send (smtplib blocks → worker thread).
+        attach_list = _normalize_paths(attachments)
+        msg, build_err = _build_message(
+            settings, subject, body, settings.email or settings.email_user,
+            to_list, cc_list, attach_list,
+        )
+        if build_err:
+            return _error(build_err)
         all_recipients = to_list + cc_list
 
         try:
@@ -218,7 +280,8 @@ def create_send_email_tool(settings: Settings):
         # 7. Record success for rate limiting and return confirmation.
         _send_times.append(now)
         cc_note = f" (cc: {', '.join(cc_list)})" if cc_list else ""
-        return _ok(f"Email sent to {', '.join(to_list)}{cc_note}.")
+        att_note = f" with {len(attach_list)} attachment(s)" if attach_list else ""
+        return _ok(f"Email sent to {', '.join(to_list)}{cc_note}{att_note}.")
 
     return send_email
 
@@ -229,10 +292,10 @@ def create_send_email_tool(settings: Settings):
 
 _SEND_EMAIL_SCHEMA = {
     "description": (
-        "Send a plain-text email to an allowlisted recipient. The recipient must be "
-        "on the configured allowlist (NOUS_EMAIL_ALLOWLIST) or the send is refused. "
+        "Send an email (optionally with file attachments) to an allowlisted recipient. "
+        "The recipient must be on the configured allowlist or the send is refused. "
         "Prefer this tool over ad-hoc bash+smtplib for sending email — it is the safe, "
-        "guarded path. The message is also scanned for secrets and rate-limited."
+        "guarded path. The message is scanned for secrets and rate-limited."
     ),
     "type": "object",
     "properties": {
@@ -253,6 +316,14 @@ _SEND_EMAIL_SCHEMA = {
             "type": ["string", "array"],
             "items": {"type": "string"},
             "description": "Optional CC address(es). String or list. Must be allowlisted.",
+        },
+        "attachments": {
+            "type": ["string", "array"],
+            "items": {"type": "string"},
+            "description": (
+                "Optional file path(s) to attach (e.g. a generated .docx/.pdf report). "
+                "String or list. Each must be a readable file; total size within the cap."
+            ),
         },
     },
     "required": ["to", "subject", "body"],

--- a/nous/config.py
+++ b/nous/config.py
@@ -735,6 +735,7 @@ class Settings(BaseSettings):
     email_max_per_hour: int = 5  # In-process sliding-window rate limit
     email_smtp_host: str = "smtp.gmail.com"  # SMTP host for the send_email tool
     email_smtp_port: int = 587  # SMTP STARTTLS port
+    email_max_attachment_mb: int = 25  # F078.1.2: total attachment size cap for send_email (Gmail ~25MB)
     tim_chat_id: str = ""  # Tim's Telegram chat ID
     emerson_hook_url: str = ""  # Emerson presence hook URL
     emerson_hook_token: str = ""  # Emerson presence hook token

--- a/tests/test_email_tools.py
+++ b/tests/test_email_tools.py
@@ -232,3 +232,51 @@ def test_allowlist_file_missing_falls_back_to_env(no_real_send, tmp_path):
     assert "not on the email allowlist" in _text(
         asyncio.run(tool(to="stranger@evil.com", subject="s", body="b"))
     )
+
+
+# --- F078.1.2: attachments ---
+
+def test_attachment_sends_multipart(no_real_send, tmp_path):
+    f = tmp_path / "report.docx"
+    f.write_bytes(b"PK\x03\x04 fake docx bytes")
+    tool = create_send_email_tool(_make_settings())
+    resp = asyncio.run(tool(to="tim@example.com", subject="report", body="see attached", attachments=str(f)))
+    assert "Email sent" in _text(resp)
+    assert "1 attachment" in _text(resp)
+    assert len(no_real_send) == 1
+    msg = no_real_send[0][1][2]   # (settings, recipients, msg)
+    assert msg.is_multipart()
+    names = [p.get_filename() for p in msg.walk() if p.get_filename()]
+    assert "report.docx" in names
+
+
+def test_attachment_list(no_real_send, tmp_path):
+    f1 = tmp_path / "a.pdf"; f1.write_bytes(b"%PDF-1.4 x")
+    f2 = tmp_path / "b.csv"; f2.write_text("a,b\n1,2\n")
+    tool = create_send_email_tool(_make_settings())
+    resp = asyncio.run(tool(to="tim@example.com", subject="s", body="b", attachments=[str(f1), str(f2)]))
+    assert "2 attachment" in _text(resp)
+    assert len(no_real_send) == 1
+
+
+def test_attachment_missing_rejects_no_send(no_real_send, tmp_path):
+    tool = create_send_email_tool(_make_settings())
+    resp = asyncio.run(tool(to="tim@example.com", subject="s", body="b", attachments=str(tmp_path / "nope.docx")))
+    assert "not found" in _text(resp).lower()
+    assert len(no_real_send) == 0
+
+
+def test_attachment_oversize_rejects_no_send(no_real_send, tmp_path):
+    f = tmp_path / "big.bin"; f.write_bytes(b"x" * 10)
+    tool = create_send_email_tool(_make_settings(email_max_attachment_mb=0))  # cap 0 => any file too big
+    resp = asyncio.run(tool(to="tim@example.com", subject="s", body="b", attachments=str(f)))
+    assert "exceed" in _text(resp).lower()
+    assert len(no_real_send) == 0
+
+
+def test_attachment_off_allowlist_rejected_before_read(no_real_send, tmp_path):
+    f = tmp_path / "r.docx"; f.write_bytes(b"x")
+    tool = create_send_email_tool(_make_settings())
+    resp = asyncio.run(tool(to="stranger@evil.com", subject="s", body="b", attachments=str(f)))
+    assert "not on the email allowlist" in _text(resp)
+    assert len(no_real_send) == 0


### PR DESCRIPTION
Follow-up to F078.1. The `send_email` tool was plain-text only (`MIMEText`), so report-style emails (.docx/.pdf) couldn't move onto it — blocking the daily-task cutover. This adds attachments.

## Change
- New optional `attachments` param (file path or list). With attachments → `MIMEMultipart` (body + one part per file); without → plain `MIMEText` (v1 behavior unchanged).
- Each path validated **before any send**: readable regular file, **total size ≤ `NOUS_EMAIL_MAX_ATTACHMENT_MB`** (default 25). Invalid/oversize → reject, no send.
- All v1 guards run first (allowlist → secret-scan → rate-limit) — an off-allowlist send is rejected before files are read.
- Attachment *contents* are not secret-scanned (binary, unreliable); the **recipient allowlist** is the guard, and the tool stays strictly safer than the unguarded bash+smtplib path.

## Tests
5 new (19 total): multipart send + part present, list of attachments, missing-file reject, oversize reject, off-allowlist-with-attachment rejected before read. smtplib monkeypatched — nothing sent.

## Deploy note
Needs a redeploy to take effect on prod (then the daily email tasks can migrate to `send_email(..., attachments=[...])`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
