### PR TITLE
F078.1.3: optional html_body for guarded send_email tool

### DIFF
--- a/nous/api/email_tools.py
+++ b/nous/api/email_tools.py
@@ -203,9 +203,9 @@ def create_send_email_tool(settings: Settings):
         to: Any,
         subject: str,
         body: str,
-        html_body: Any = None,
         cc: Any = None,
         attachments: Any = None,
+        html_body: Any = None,
     ) -> dict[str, Any]:
         """Send an email to allowlisted recipient(s).
 
@@ -213,13 +213,13 @@ def create_send_email_tool(settings: Settings):
             to: Recipient address(es) — string or list. Each must be allowlisted.
             subject: Email subject line.
             body: Plain-text email body.
-            html_body: Optional HTML body. When provided, the email is sent as
-                multipart/alternative with the plain ``body`` as the fallback part.
-                Use this for styled newsletter-format emails.
             cc: Optional CC address(es) — string or list. Each must be allowlisted.
             attachments: Optional file path(s) — string or list — to attach (e.g. a
                 generated .docx/.pdf report). Each must be a readable file; the total
                 size must be within NOUS_EMAIL_MAX_ATTACHMENT_MB.
+            html_body: Optional HTML body. When provided, the email is sent as
+                multipart/alternative with the plain ``body`` as the fallback part.
+                Use this for styled newsletter-format emails.
 
         Returns:
             MCP-compliant response confirming the send or naming the rejection reason.

--- a/nous/api/email_tools.py
+++ b/nous/api/email_tools.py
@@ -121,20 +121,30 @@ def _build_message(
     to_list: list[str],
     cc_list: list[str],
     attachments: list[str],
+    html_body: str | None = None,
 ) -> tuple[Any | None, str | None]:
     """Build the MIME message. Returns (msg, None) on success or (None, error).
 
-    With no attachments → plain MIMEText (unchanged from v1). With attachments →
-    MIMEMultipart; each path is validated (regular file, readable, within the
-    total size cap) before any send. NOTE: attachment *contents* are not
-    secret-scanned — the recipient allowlist (trusted recipients only) is the
-    guard, and this is strictly safer than the unguarded bash+smtplib path.
+    With no attachments and no html_body → plain MIMEText (unchanged from v1).
+    With html_body → multipart/alternative with plain text first, HTML second.
+    With attachments → MIMEMultipart("mixed") wrapping the body part plus file
+    parts; each path is validated (regular file, readable, within the total size
+    cap) before any send. NOTE: attachment *contents* are not secret-scanned —
+    the recipient allowlist (trusted recipients only) is the guard, and this is
+    strictly safer than the unguarded bash+smtplib path.
     """
+    if html_body:
+        body_part: Any = MIMEMultipart("alternative")
+        body_part.attach(MIMEText(body))
+        body_part.attach(MIMEText(html_body, "html"))
+    else:
+        body_part = MIMEText(body)
+
     if not attachments:
-        msg: Any = MIMEText(body)
+        msg: Any = body_part
     else:
         msg = MIMEMultipart("mixed")
-        msg.attach(MIMEText(body))
+        msg.attach(body_part)
         cap = settings.email_max_attachment_mb * 1024 * 1024
         total = 0
         for path in attachments:
@@ -193,6 +203,7 @@ def create_send_email_tool(settings: Settings):
         to: Any,
         subject: str,
         body: str,
+        html_body: Any = None,
         cc: Any = None,
         attachments: Any = None,
     ) -> dict[str, Any]:
@@ -202,6 +213,9 @@ def create_send_email_tool(settings: Settings):
             to: Recipient address(es) — string or list. Each must be allowlisted.
             subject: Email subject line.
             body: Plain-text email body.
+            html_body: Optional HTML body. When provided, the email is sent as
+                multipart/alternative with the plain ``body`` as the fallback part.
+                Use this for styled newsletter-format emails.
             cc: Optional CC address(es) — string or list. Each must be allowlisted.
             attachments: Optional file path(s) — string or list — to attach (e.g. a
                 generated .docx/.pdf report). Each must be a readable file; the total
@@ -239,7 +253,7 @@ def create_send_email_tool(settings: Settings):
                 )
 
         # 3. Secret scan (secondary guard).
-        if _scan_secrets(f"{subject}\n{body}"):
+        if _scan_secrets(f"{subject}\n{body}\n{html_body or ''}"):
             return _error(
                 "email appears to contain a secret (API key, password, or token); "
                 "refusing to send."
@@ -259,7 +273,7 @@ def create_send_email_tool(settings: Settings):
         attach_list = _normalize_paths(attachments)
         msg, build_err = _build_message(
             settings, subject, body, settings.email or settings.email_user,
-            to_list, cc_list, attach_list,
+            to_list, cc_list, attach_list, html_body=html_body or None,
         )
         if build_err:
             return _error(build_err)
@@ -311,6 +325,14 @@ _SEND_EMAIL_SCHEMA = {
         "body": {
             "type": "string",
             "description": "Plain-text email body.",
+        },
+        "html_body": {
+            "type": "string",
+            "description": (
+                "Optional rich-HTML email body. When provided, the email is sent as "
+                "multipart/alternative with the plain-text `body` as the fallback part "
+                "— use this for styled newsletter-format emails."
+            ),
         },
         "cc": {
             "type": ["string", "array"],

--- a/tests/test_email_tools.py
+++ b/tests/test_email_tools.py
@@ -280,3 +280,79 @@ def test_attachment_off_allowlist_rejected_before_read(no_real_send, tmp_path):
     resp = asyncio.run(tool(to="stranger@evil.com", subject="s", body="b", attachments=str(f)))
     assert "not on the email allowlist" in _text(resp)
     assert len(no_real_send) == 0
+
+
+# --- F078.1.3: html_body ---
+
+def test_html_body_none_plain_text(no_real_send):
+    """html_body=None → message is plain MIMEText (BC preserved)."""
+    from email.mime.text import MIMEText as _MIMEText
+
+    tool = create_send_email_tool(_make_settings())
+    asyncio.run(tool(to="tim@example.com", subject="hi", body="hello"))
+    assert len(no_real_send) == 1
+    msg = no_real_send[0][1][2]  # (settings, recipients, msg)
+    assert isinstance(msg, _MIMEText)
+    assert msg.get_content_type() == "text/plain"
+
+
+def test_html_body_set_no_attachments(no_real_send):
+    """html_body set, no attachments → top-level multipart/alternative with two
+    parts: text/plain first, text/html second."""
+    tool = create_send_email_tool(_make_settings())
+    asyncio.run(
+        tool(
+            to="tim@example.com",
+            subject="newsletter",
+            body="plain fallback",
+            html_body="<h1>Rich content</h1>",
+        )
+    )
+    assert len(no_real_send) == 1
+    msg = no_real_send[0][1][2]
+    assert msg.get_content_type() == "multipart/alternative"
+    parts = msg.get_payload()
+    assert len(parts) == 2
+    assert parts[0].get_content_type() == "text/plain"
+    assert parts[1].get_content_type() == "text/html"
+
+
+def test_html_body_set_with_attachment(no_real_send, tmp_path):
+    """html_body + attachment → top-level multipart/mixed whose first part is
+    multipart/alternative, plus the attachment part."""
+    f = tmp_path / "report.pdf"
+    f.write_bytes(b"%PDF-1.4 fake")
+    tool = create_send_email_tool(_make_settings())
+    asyncio.run(
+        tool(
+            to="tim@example.com",
+            subject="report",
+            body="see attached",
+            html_body="<p>See attached</p>",
+            attachments=str(f),
+        )
+    )
+    assert len(no_real_send) == 1
+    msg = no_real_send[0][1][2]
+    assert msg.get_content_type() == "multipart/mixed"
+    parts = msg.get_payload()
+    assert parts[0].get_content_type() == "multipart/alternative"
+    alt_parts = parts[0].get_payload()
+    assert alt_parts[0].get_content_type() == "text/plain"
+    assert alt_parts[1].get_content_type() == "text/html"
+    assert parts[1].get_filename() == "report.pdf"
+
+
+def test_html_body_secret_scan_rejected(no_real_send):
+    """html_body containing a secret pattern is rejected."""
+    tool = create_send_email_tool(_make_settings())
+    resp = asyncio.run(
+        tool(
+            to="tim@example.com",
+            subject="newsletter",
+            body="plain text is clean",
+            html_body="<p>key: sk-abcdEFGH1234567890zz</p>",
+        )
+    )
+    assert "secret" in _text(resp).lower()
+    assert len(no_real_send) == 0


### PR DESCRIPTION
## Summary

- Adds an optional `html_body: str | None = None` parameter to `_build_message` and `html_body: Any = None` to the `send_email` closure, plus the corresponding `html_body` property in `_SEND_EMAIL_SCHEMA`.
- When `html_body` is provided, the body part is constructed as `multipart/alternative` (plain text first, HTML second per RFC 2046 — clients render the last supported part). With attachments, this alternative part is nested inside a `multipart/mixed` envelope exactly as before.
- **BC guarantee**: when `html_body` is `None`/absent the MIME structure is byte-for-byte identical to today — plain `MIMEText` with no attachments, `MIMEMultipart("mixed")` with attachments. All 19 pre-existing tests pass unchanged.
- The secret scan now also covers `html_body` content (`_scan_secrets(f"{subject}\n{body}\n{html_body or ''}")`).

## Unblocks

Scheduled jobs (e.g. `premarket-daily`) that generate styled HTML newsletters currently bypass the guarded `send_email` tool and use raw `bash+smtplib` (no allowlist protection). This change lets those jobs migrate onto the protected path while keeping their rich HTML output.

## Test plan

- [x] `test_html_body_none_plain_text` — BC: no html_body → plain `MIMEText`, `content_type=text/plain`
- [x] `test_html_body_set_no_attachments` — top-level `multipart/alternative`, two parts in correct order (plain → html)
- [x] `test_html_body_set_with_attachment` — top-level `multipart/mixed`, first part is `multipart/alternative`, second is the attachment
- [x] `test_html_body_secret_scan_rejected` — secret in html_body triggers the scan and refuses send
- [x] All 19 existing tests pass (allowlist, secret scan, rate limit, attachments, exception sanitization, hot-reload)

```
23 passed in 2.03s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)