### PR TITLE
feat(observability): F079 Phase 0 — populate procedure/episode delivery counters

### DIFF
--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -88,23 +88,6 @@ def _build_exclude_ids(
         "procedure": set(turn_context.recalled_procedure_ids or []),
     }
 
-
-def _recalled_counts(turn_context) -> dict[str, int]:
-    """F079 Phase 0: exact per-section item counts from the turn's selected objects.
-
-    Authoritative source for the context-log delivery counters — derived from the
-    `recalled_*_ids` that `ContextEngine.build` populated at injection time, so the
-    telemetry never relies on parsing the rendered prompt (codex PR #485).
-    """
-    if turn_context is None:
-        return {}
-    return {
-        "facts":      len(turn_context.recalled_fact_ids or []),
-        "decisions":  len(turn_context.recalled_decision_ids or []),
-        "episodes":   len(turn_context.recalled_episode_ids or []),
-        "procedures": len(turn_context.recalled_procedure_ids or []),
-    }
-
 # Frame-gated tool access (D5)
 FRAME_TOOLS: dict[str, list[str]] = {
     "conversation": ["record_decision", "learn_fact", "learn_skill", "recall_deep", "recall_recent", "recall_hubs", "get_procedure", "create_censor", "bash", "read_file", "write_file", "web_search", "web_fetch", "cache_retrieve", "spawn_task", "spawn_sync", "schedule_task", "list_tasks", "cancel_task", "run_python", "send_file", "send_email", "heartbeat_check_create", "heartbeat_check_manage", "dag_create", "dag_manage", "ingest_document"],
@@ -438,7 +421,6 @@ class AgentRunner:
             self._current_turn_number = (len(conversation.messages) + 1) // 2
             self._current_frame_id = turn_context.frame.frame_id if turn_context.frame else "unknown"
             self._current_call_type = "subtask" if is_subtask else "chat"
-            self._current_recalled_counts = _recalled_counts(turn_context)
 
             # 4-6. Build system prompt and run tool loop
             response_text = ""
@@ -856,9 +838,6 @@ class AgentRunner:
                     frame_id=self._current_frame_id,
                     context_window=self._get_context_window_size(),
                     payload=payload if self._settings.context_log_full_payload else None,
-                    # F079 Phase 0: exact per-section counts from the turn's selected
-                    # objects, so telemetry doesn't rely on parsing the rendered prompt.
-                    loaded_counts=getattr(self, "_current_recalled_counts", None),
                 )
                 self._last_context_entry_id = _entry.id
                 # F036: Attach cache break info to context log entry
@@ -1000,7 +979,6 @@ class AgentRunner:
             self._current_turn_number = (len(conversation.messages) + 1) // 2
             self._current_frame_id = turn_context.frame.frame_id if turn_context.frame else "unknown"
             self._current_call_type = "chat"
-            self._current_recalled_counts = _recalled_counts(turn_context)
 
             corrections = self._pending_corrections.pop(session_id, None)
             system_prompt = self._build_system_prompt(

--- a/nous/api/runner.py
+++ b/nous/api/runner.py
@@ -88,6 +88,23 @@ def _build_exclude_ids(
         "procedure": set(turn_context.recalled_procedure_ids or []),
     }
 
+
+def _recalled_counts(turn_context) -> dict[str, int]:
+    """F079 Phase 0: exact per-section item counts from the turn's selected objects.
+
+    Authoritative source for the context-log delivery counters — derived from the
+    `recalled_*_ids` that `ContextEngine.build` populated at injection time, so the
+    telemetry never relies on parsing the rendered prompt (codex PR #485).
+    """
+    if turn_context is None:
+        return {}
+    return {
+        "facts":      len(turn_context.recalled_fact_ids or []),
+        "decisions":  len(turn_context.recalled_decision_ids or []),
+        "episodes":   len(turn_context.recalled_episode_ids or []),
+        "procedures": len(turn_context.recalled_procedure_ids or []),
+    }
+
 # Frame-gated tool access (D5)
 FRAME_TOOLS: dict[str, list[str]] = {
     "conversation": ["record_decision", "learn_fact", "learn_skill", "recall_deep", "recall_recent", "recall_hubs", "get_procedure", "create_censor", "bash", "read_file", "write_file", "web_search", "web_fetch", "cache_retrieve", "spawn_task", "spawn_sync", "schedule_task", "list_tasks", "cancel_task", "run_python", "send_file", "send_email", "heartbeat_check_create", "heartbeat_check_manage", "dag_create", "dag_manage", "ingest_document"],
@@ -421,6 +438,7 @@ class AgentRunner:
             self._current_turn_number = (len(conversation.messages) + 1) // 2
             self._current_frame_id = turn_context.frame.frame_id if turn_context.frame else "unknown"
             self._current_call_type = "subtask" if is_subtask else "chat"
+            self._current_recalled_counts = _recalled_counts(turn_context)
 
             # 4-6. Build system prompt and run tool loop
             response_text = ""
@@ -838,6 +856,9 @@ class AgentRunner:
                     frame_id=self._current_frame_id,
                     context_window=self._get_context_window_size(),
                     payload=payload if self._settings.context_log_full_payload else None,
+                    # F079 Phase 0: exact per-section counts from the turn's selected
+                    # objects, so telemetry doesn't rely on parsing the rendered prompt.
+                    loaded_counts=getattr(self, "_current_recalled_counts", None),
                 )
                 self._last_context_entry_id = _entry.id
                 # F036: Attach cache break info to context log entry
@@ -979,6 +1000,7 @@ class AgentRunner:
             self._current_turn_number = (len(conversation.messages) + 1) // 2
             self._current_frame_id = turn_context.frame.frame_id if turn_context.frame else "unknown"
             self._current_call_type = "chat"
+            self._current_recalled_counts = _recalled_counts(turn_context)
 
             corrections = self._pending_corrections.pop(session_id, None)
             system_prompt = self._build_system_prompt(

--- a/nous/observability/context_logger.py
+++ b/nous/observability/context_logger.py
@@ -143,7 +143,6 @@ class ContextLogEntry:
         frame_id: str,
         context_window: int,
         trace_id: str | None = None,
-        loaded_counts: dict[str, int] | None = None,
     ) -> ContextLogEntry:
         entry_id = uuid4().hex[:16]
         sections = parse_system_sections(system_prompt)
@@ -176,29 +175,19 @@ class ContextLogEntry:
         # F079 Phase 0: previously-unpopulated counters (the columns + INSERT already
         # existed; only the population was missing, so procedure/episode delivery was
         # invisible on the dashboard).
-        # PREFER exact per-section counts derived from the turn's selected objects
-        # (`recalled_*_ids`, passed as `loaded_counts`) — text-parsing the rendered
-        # prompt cannot distinguish a real item from a marker-shaped line embedded in
-        # a verbatim field (codex PR #485). Fall back to the line heuristic only when
-        # counts aren't supplied (e.g. utility calls with no TurnContext).
-        lc = loaded_counts or {}
-
-        def _resolve(key: str, lc_key: str, marker: str | None) -> int:
-            parsed = _count_items(key, marker)
-            # Section absent/empty in THIS prompt -> 0 (also guards against a stale
-            # per-turn loaded_counts leaking into a utility call whose prompt has no
-            # such section). Section present -> prefer the exact count derived from
-            # the selected objects; fall back to the line heuristic if not supplied.
-            if parsed == 0:
-                return 0
-            return lc.get(lc_key, parsed)
-
-        facts_count = _resolve("relevant_facts", "facts", None)
-        decisions_count = _resolve("related_decisions", "decisions", None)
-        procedures_count = _resolve("known_procedures", "procedures", "- **")
-        episodes_count = _resolve("past_episodes", "episodes", "- [")
-        # Not a recalled type (temporal titles tier); single-line `- [time] title`.
-        recent_conversations_count = _count_items("recent_conversations", "- [")
+        # Count items in the RENDERED (post-truncation) section — that is what the
+        # model actually received. NOTE: deliberately NOT the pre-truncation
+        # `recalled_*_ids` counts, which over-state delivery (they're collected before
+        # `_truncate_to_budget` and include episodes that `_format_episodes` skips,
+        # e.g. abandoned ones) — codex PR #485 P1. Top-level item marker keeps the
+        # common embedded-bullet case from inflating the count; a field that embeds a
+        # literal marker-shaped line ("\n- **x**") is a known, rare telemetry
+        # approximation (same limitation the facts/decisions counters have always had).
+        facts_count = _count_items("relevant_facts")
+        decisions_count = _count_items("related_decisions")
+        procedures_count = _count_items("known_procedures", "- **")  # context.py:1047
+        episodes_count = _count_items("past_episodes", "- [")        # context.py:1063
+        recent_conversations_count = _count_items("recent_conversations", "- [")  # context.py:609
 
         tool_names = [t.get("name", "") for t in tools_list]
 
@@ -355,7 +344,6 @@ class ContextLogger:
         context_window: int,
         payload: dict | None = None,
         trace_id: str | None = None,
-        loaded_counts: dict[str, int] | None = None,
     ) -> ContextLogEntry:
         entry = ContextLogEntry.from_payload(
             session_id=session_id,
@@ -368,7 +356,6 @@ class ContextLogger:
             frame_id=frame_id,
             context_window=context_window,
             trace_id=trace_id,
-            loaded_counts=loaded_counts,
         )
         self._entries.append(entry)
         self._entries_by_id[entry.id] = entry

--- a/nous/observability/context_logger.py
+++ b/nous/observability/context_logger.py
@@ -143,6 +143,7 @@ class ContextLogEntry:
         frame_id: str,
         context_window: int,
         trace_id: str | None = None,
+        loaded_counts: dict[str, int] | None = None,
     ) -> ContextLogEntry:
         entry_id = uuid4().hex[:16]
         sections = parse_system_sections(system_prompt)
@@ -172,16 +173,32 @@ class ContextLogEntry:
             # Legacy heuristic for facts/decisions (mixed "- [subj]"/bare "- " bullets).
             return text.count("\n-") + 1
 
-        facts_count = _count_items("relevant_facts")
-        decisions_count = _count_items("related_decisions")
         # F079 Phase 0: previously-unpopulated counters (the columns + INSERT already
         # existed; only the population was missing, so procedure/episode delivery was
-        # invisible on the dashboard). Markers added to SECTION_MARKERS above. Use the
-        # type-specific top-level marker so embedded bullets in unconstrained text
-        # (descriptions/summaries) don't inflate the count.
-        procedures_count = _count_items("known_procedures", "- **")  # context.py:1047
-        episodes_count = _count_items("past_episodes", "- [")        # context.py:1063
-        recent_conversations_count = _count_items("recent_conversations", "- [")  # context.py:609
+        # invisible on the dashboard).
+        # PREFER exact per-section counts derived from the turn's selected objects
+        # (`recalled_*_ids`, passed as `loaded_counts`) — text-parsing the rendered
+        # prompt cannot distinguish a real item from a marker-shaped line embedded in
+        # a verbatim field (codex PR #485). Fall back to the line heuristic only when
+        # counts aren't supplied (e.g. utility calls with no TurnContext).
+        lc = loaded_counts or {}
+
+        def _resolve(key: str, lc_key: str, marker: str | None) -> int:
+            parsed = _count_items(key, marker)
+            # Section absent/empty in THIS prompt -> 0 (also guards against a stale
+            # per-turn loaded_counts leaking into a utility call whose prompt has no
+            # such section). Section present -> prefer the exact count derived from
+            # the selected objects; fall back to the line heuristic if not supplied.
+            if parsed == 0:
+                return 0
+            return lc.get(lc_key, parsed)
+
+        facts_count = _resolve("relevant_facts", "facts", None)
+        decisions_count = _resolve("related_decisions", "decisions", None)
+        procedures_count = _resolve("known_procedures", "procedures", "- **")
+        episodes_count = _resolve("past_episodes", "episodes", "- [")
+        # Not a recalled type (temporal titles tier); single-line `- [time] title`.
+        recent_conversations_count = _count_items("recent_conversations", "- [")
 
         tool_names = [t.get("name", "") for t in tools_list]
 
@@ -338,6 +355,7 @@ class ContextLogger:
         context_window: int,
         payload: dict | None = None,
         trace_id: str | None = None,
+        loaded_counts: dict[str, int] | None = None,
     ) -> ContextLogEntry:
         entry = ContextLogEntry.from_payload(
             session_id=session_id,
@@ -350,6 +368,7 @@ class ContextLogger:
             frame_id=frame_id,
             context_window=context_window,
             trace_id=trace_id,
+            loaded_counts=loaded_counts,
         )
         self._entries.append(entry)
         self._entries_by_id[entry.id] = entry

--- a/nous/observability/context_logger.py
+++ b/nous/observability/context_logger.py
@@ -23,6 +23,8 @@ SECTION_MARKERS: dict[str, str] = {
     "## Working Memory": "working_memory",
     "## Related Decisions": "related_decisions",
     "## Relevant Facts": "relevant_facts",
+    "## Known Procedures": "known_procedures",
+    "## Past Episodes": "past_episodes",
     "## Recent Conversations": "recent_conversations",
     "## Tool Instructions": "frame_instructions",
     "[Execution Ledger]": "execution_ledger",
@@ -156,11 +158,19 @@ class ContextLogEntry:
             role = msg.get("role", "unknown")
             role_counts[role] = role_counts.get(role, 0) + 1
 
-        # Heuristic memory item counts from section content
-        facts_text = sections.get("relevant_facts", "")
-        facts_count = facts_text.count("\n-") + (1 if facts_text.strip() else 0)
-        decisions_text = sections.get("related_decisions", "")
-        decisions_count = decisions_text.count("\n-") + (1 if decisions_text.strip() else 0)
+        # Heuristic memory item counts from section content (one "- " bullet per item).
+        def _count_items(key: str) -> int:
+            text = sections.get(key, "")
+            return text.count("\n-") + (1 if text.strip() else 0)
+
+        facts_count = _count_items("relevant_facts")
+        decisions_count = _count_items("related_decisions")
+        # F079 Phase 0: previously-unpopulated counters (the columns + INSERT already
+        # existed; only the population was missing, so procedure/episode delivery was
+        # invisible on the dashboard). Markers added to SECTION_MARKERS above.
+        procedures_count = _count_items("known_procedures")
+        episodes_count = _count_items("past_episodes")
+        recent_conversations_count = _count_items("recent_conversations")
 
         tool_names = [t.get("name", "") for t in tools_list]
 
@@ -184,6 +194,9 @@ class ContextLogEntry:
             message_roles=role_counts,
             loaded_facts=facts_count,
             loaded_decisions=decisions_count,
+            loaded_procedures=procedures_count,
+            loaded_episodes=episodes_count,
+            recent_conversations=recent_conversations_count,
             sections_text=sections,
         )
 

--- a/nous/observability/context_logger.py
+++ b/nous/observability/context_logger.py
@@ -158,19 +158,30 @@ class ContextLogEntry:
             role = msg.get("role", "unknown")
             role_counts[role] = role_counts.get(role, 0) + 1
 
-        # Heuristic memory item counts from section content (one "- " bullet per item).
-        def _count_items(key: str) -> int:
+        # Heuristic memory item counts from section content (one bullet per item).
+        def _count_items(key: str, marker: str | None = None) -> int:
             text = sections.get(key, "")
-            return text.count("\n-") + (1 if text.strip() else 0)
+            if not text.strip():
+                return 0
+            if marker is not None:
+                # Count only TOP-LEVEL item lines. The formatter emits exactly one
+                # item per line starting with `marker`; an embedded "\n- " inside a
+                # verbatim-interpolated field (e.g. a multiline episode summary or
+                # procedure description) is NOT a delivered item. (codex PR #485)
+                return sum(1 for ln in text.split("\n") if ln.startswith(marker))
+            # Legacy heuristic for facts/decisions (mixed "- [subj]"/bare "- " bullets).
+            return text.count("\n-") + 1
 
         facts_count = _count_items("relevant_facts")
         decisions_count = _count_items("related_decisions")
         # F079 Phase 0: previously-unpopulated counters (the columns + INSERT already
         # existed; only the population was missing, so procedure/episode delivery was
-        # invisible on the dashboard). Markers added to SECTION_MARKERS above.
-        procedures_count = _count_items("known_procedures")
-        episodes_count = _count_items("past_episodes")
-        recent_conversations_count = _count_items("recent_conversations")
+        # invisible on the dashboard). Markers added to SECTION_MARKERS above. Use the
+        # type-specific top-level marker so embedded bullets in unconstrained text
+        # (descriptions/summaries) don't inflate the count.
+        procedures_count = _count_items("known_procedures", "- **")  # context.py:1047
+        episodes_count = _count_items("past_episodes", "- [")        # context.py:1063
+        recent_conversations_count = _count_items("recent_conversations", "- [")  # context.py:609
 
         tool_names = [t.get("name", "") for t in tools_list]
 

--- a/tests/test_context_logger.py
+++ b/tests/test_context_logger.py
@@ -173,12 +173,13 @@ class TestF079DeliveryCounters:
         "- [Jun 03 12:00] chat C\n- [Jun 04 13:00] chat D"
     )
 
-    def _entry(self, prompt: str) -> ContextLogEntry:
+    def _entry(self, prompt: str, loaded_counts=None) -> ContextLogEntry:
         return ContextLogEntry.from_payload(
             session_id="s1", turn_number=1, call_type="chat",
             model="test", system_prompt=prompt,
             messages=[{"role": "user", "content": "hi"}],
             tools=None, frame_id="task", context_window=200000,
+            loaded_counts=loaded_counts,
         )
 
     def test_known_procedures_marker_parsed(self):
@@ -227,6 +228,28 @@ class TestF079DeliveryCounters:
         assert e.loaded_episodes == 0
         assert e.recent_conversations == 0
         assert e.loaded_facts == 1
+
+    def test_loaded_counts_exact_over_marker_shaped_embedded(self):
+        # codex PR #485 (2nd pass): even the marker can appear inside a verbatim
+        # field (e.g. a description containing "\n- **important**"). The exact count
+        # threaded from the selected objects (recalled_*_ids) must win over any text
+        # parse. Here one procedure whose description embeds a "- **"-shaped line.
+        prompt = (
+            "## Known Procedures\n"
+            "- **proc-a** (general): note:\n- **important** caveat in the body\n"
+            "## Past Episodes\n- [success] result:\n- [detail] embedded marker-shaped line\n"
+        )
+        # Text parse would over-count (2 / 2); exact counts say 1 / 1.
+        e = self._entry(prompt, loaded_counts={"procedures": 1, "episodes": 1})
+        assert e.loaded_procedures == 1
+        assert e.loaded_episodes == 1
+
+    def test_stale_loaded_counts_ignored_when_section_absent(self):
+        # A utility call (no procedure section in THIS prompt) must report 0 even if
+        # a stale per-turn loaded_counts is passed.
+        e = self._entry("## Identity\nsafety gate prompt", loaded_counts={"procedures": 4, "episodes": 3})
+        assert e.loaded_procedures == 0
+        assert e.loaded_episodes == 0
 
 
 # ------------------------------------------------------------------

--- a/tests/test_context_logger.py
+++ b/tests/test_context_logger.py
@@ -205,6 +205,21 @@ class TestF079DeliveryCounters:
         assert d["loaded_episodes"] == 2
         assert d["recent_conversations"] == 4
 
+    def test_embedded_bullets_not_overcounted(self):
+        # codex PR #485 P2: a verbatim multiline description/summary containing
+        # "\n- ..." must NOT inflate the count — only top-level items count.
+        prompt = (
+            "## Known Procedures\n"
+            "- **proc-a** (general): result follows:\n- embedded detail one\n- embedded detail two\n"
+            "- **proc-b** (general): clean one\n"
+            "## Past Episodes\n"
+            "- [success] did a thing\n  - sub bullet\n- detail line\n"
+            "- [partial] second episode\n"
+        )
+        e = self._entry(prompt)
+        assert e.loaded_procedures == 2  # proc-a + proc-b, not the 2 embedded bullets
+        assert e.loaded_episodes == 2    # two "- [" episodes, not the embedded "- detail"
+
     def test_absent_sections_count_zero(self):
         # No procedure/episode/recent sections -> counters are 0 (no false positives).
         e = self._entry("## Identity\nI am Nous\n## Relevant Facts\n- only a fact")

--- a/tests/test_context_logger.py
+++ b/tests/test_context_logger.py
@@ -150,6 +150,71 @@ class TestContextLogEntry:
 
 
 # ------------------------------------------------------------------
+# F079 Phase 0: procedure/episode/recent-conversation delivery counters
+# (previously unpopulated -> dashboard was blind to procedure/episode injection)
+# ------------------------------------------------------------------
+
+
+class TestF079DeliveryCounters:
+    # Section bodies in the exact formats build() emits:
+    #   procedures: "- **name** (domain): desc | ..." (context.py:1047)
+    #   episodes:   "- [outcome] summary (date)"       (context.py:1063)
+    #   recent:     "- [time] title"                   (context.py:609)
+    _PROMPT = (
+        "## Identity\nI am Nous\n"
+        "## Related Decisions\n- decision one\n- decision two\n"
+        "## Relevant Facts\n- fact one\n- fact two\n- fact three\n"
+        "## Known Procedures\n"
+        "- **send-email** (comms): send mail | activated 5x\n"
+        "- **dag-debug** (general): debug DAGs | activated 9x\n"
+        "- **deep-research** (general): research | activated 3x\n"
+        "## Past Episodes\n- [success] did a thing (2026-06-01)\n- [partial] tried another (2026-06-02)\n"
+        "## Recent Conversations\n- [Jun 01 10:00] chat A\n- [Jun 02 11:00] chat B\n"
+        "- [Jun 03 12:00] chat C\n- [Jun 04 13:00] chat D"
+    )
+
+    def _entry(self, prompt: str) -> ContextLogEntry:
+        return ContextLogEntry.from_payload(
+            session_id="s1", turn_number=1, call_type="chat",
+            model="test", system_prompt=prompt,
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None, frame_id="task", context_window=200000,
+        )
+
+    def test_known_procedures_marker_parsed(self):
+        sections = parse_system_sections(self._PROMPT)
+        assert "known_procedures" in sections
+        assert "past_episodes" in sections
+        assert "recent_conversations" in sections
+
+    def test_exact_counts(self):
+        e = self._entry(self._PROMPT)
+        # Exact counts, not just >0 (an off-by-N would pass a >0 assertion).
+        assert e.loaded_procedures == 3
+        assert e.loaded_episodes == 2
+        assert e.recent_conversations == 4
+        # Controls — existing counters still correct.
+        assert e.loaded_facts == 3
+        assert e.loaded_decisions == 2
+        assert "known_procedures" in e.sections_present
+        assert "past_episodes" in e.sections_present
+
+    def test_to_dict_carries_counters(self):
+        d = self._entry(self._PROMPT).to_dict()
+        assert d["loaded_procedures"] == 3
+        assert d["loaded_episodes"] == 2
+        assert d["recent_conversations"] == 4
+
+    def test_absent_sections_count_zero(self):
+        # No procedure/episode/recent sections -> counters are 0 (no false positives).
+        e = self._entry("## Identity\nI am Nous\n## Relevant Facts\n- only a fact")
+        assert e.loaded_procedures == 0
+        assert e.loaded_episodes == 0
+        assert e.recent_conversations == 0
+        assert e.loaded_facts == 1
+
+
+# ------------------------------------------------------------------
 # FullPayloadStore
 # ------------------------------------------------------------------
 

--- a/tests/test_context_logger.py
+++ b/tests/test_context_logger.py
@@ -173,13 +173,12 @@ class TestF079DeliveryCounters:
         "- [Jun 03 12:00] chat C\n- [Jun 04 13:00] chat D"
     )
 
-    def _entry(self, prompt: str, loaded_counts=None) -> ContextLogEntry:
+    def _entry(self, prompt: str) -> ContextLogEntry:
         return ContextLogEntry.from_payload(
             session_id="s1", turn_number=1, call_type="chat",
             model="test", system_prompt=prompt,
             messages=[{"role": "user", "content": "hi"}],
             tools=None, frame_id="task", context_window=200000,
-            loaded_counts=loaded_counts,
         )
 
     def test_known_procedures_marker_parsed(self):
@@ -228,28 +227,6 @@ class TestF079DeliveryCounters:
         assert e.loaded_episodes == 0
         assert e.recent_conversations == 0
         assert e.loaded_facts == 1
-
-    def test_loaded_counts_exact_over_marker_shaped_embedded(self):
-        # codex PR #485 (2nd pass): even the marker can appear inside a verbatim
-        # field (e.g. a description containing "\n- **important**"). The exact count
-        # threaded from the selected objects (recalled_*_ids) must win over any text
-        # parse. Here one procedure whose description embeds a "- **"-shaped line.
-        prompt = (
-            "## Known Procedures\n"
-            "- **proc-a** (general): note:\n- **important** caveat in the body\n"
-            "## Past Episodes\n- [success] result:\n- [detail] embedded marker-shaped line\n"
-        )
-        # Text parse would over-count (2 / 2); exact counts say 1 / 1.
-        e = self._entry(prompt, loaded_counts={"procedures": 1, "episodes": 1})
-        assert e.loaded_procedures == 1
-        assert e.loaded_episodes == 1
-
-    def test_stale_loaded_counts_ignored_when_section_absent(self):
-        # A utility call (no procedure section in THIS prompt) must report 0 even if
-        # a stale per-turn loaded_counts is passed.
-        e = self._entry("## Identity\nsafety gate prompt", loaded_counts={"procedures": 4, "episodes": 3})
-        assert e.loaded_procedures == 0
-        assert e.loaded_episodes == 0
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## What
First phase of **F079 — Memory Delivery Overhaul** (`docs/features/F079-memory-delivery-overhaul.md`): fix the context-log telemetry that was **structurally blind to procedure/episode delivery**.

Two defects (both code-verified):
- `loaded_procedures` / `loaded_episodes` / `recent_conversations` were **never assigned** in `ContextLogEntry.from_payload` (only facts + decisions were) → the columns (which already exist in `to_dict` + the INSERT) were always `0`.
- `parse_system_sections` matched a hardcoded `SECTION_MARKERS` with **no `## Known Procedures` / `## Past Episodes` entry** → those keys could never appear in `sections_present`, even when injected.

Together these hid that procedures/episodes are gated out of the prompt, and caused two wrong measurements during the F079 investigation.

## Change (pure observability — no schema / flag / migration; reversible)
- add the two missing markers to `SECTION_MARKERS`;
- populate the three counters in `from_payload` via the existing `count("\n-")` per-item heuristic.

The system prompt sent to the LLM is unchanged; this is a telemetry parse-bucket correction.

## Validation
- **Unit:** exact-count tests (3 procedures / 2 episodes / 4 recent) + absent-section zero case + `to_dict` round-trip — `tests/test_context_logger.py`, 37 pass.
- **Live (real eval instance):** a `task`-frame turn now logs `loaded_procedures=4` with `known_procedures` present in `sections_present` (previously always `0` / absent).

## Why first
This is the measurement substrate the later F079 phases depend on — you can't tell whether any delivery fix works while these signals read 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)