### PR TITLE
feat(retrieval): F079 P1 — pull-path procedure delivery (richer recall_deep bodies + static awareness cue)

### DIFF
--- a/docs/features/F079-memory-delivery-overhaul.md
+++ b/docs/features/F079-memory-delivery-overhaul.md
@@ -1,0 +1,214 @@
+# F079 — Memory Delivery Overhaul (procedures + episodes + pull path)
+
+**Status:** SPEC v2 (rewrite). Supersedes the original `F079-effective-procedure-injection.md` (kept for
+history; its §12 Step-0 result + §11 review carry forward). **Every claim here is code-verified this
+session** (`docs/reviews/memory-injection-validation-2026-06-06.md`); do not trust the earlier
+injection-only framing or any `context_log`-derived numbers.
+**Date:** 2026-06-06.
+
+---
+
+## 1. The architecture is sound — fix the leaks, don't fight it
+
+Nous delivers memory two ways (both read in code):
+- **Passive pre-turn injection** (`ContextEngine.build`, `context.py:114-710`): auto-loads the cheap,
+  always-useful types — **facts + decisions** (~reliably), user-profile, censors, frame, working-memory,
+  and recent-episode **titles**.
+- **Active pull** (`recall_deep` → `run_recall_pipeline`; `get_procedure`): the agent searches and loads
+  on demand. `recall_deep` defaults `memory_types=["all"]` (`tools.py:648`) → reaches **all** types
+  including procedures, episodes, chunks.
+
+This split (auto-inject light types; pull the heavy/situational ones) is **defensible**. Step 0 proved
+the agent **follows a procedure body precisely when it obtains it** (6/6, naming the procedure) and that
+the working channel is **pull, triggered by a cue**. So the overhaul **strengthens pull + fixes the
+specific leaks**, and does NOT force full procedure bodies into the system prompt (the demoted old
+Phase A).
+
+## 2. The defensible, code-verified bugs (what we're fixing)
+
+| ID | Bug | Code | Severity |
+|---|---|---|---|
+| **B-telemetry** | Procedure/episode delivery has **no working telemetry**: `loaded_procedures`/`loaded_episodes`/`recent_conversations` counters never assigned (`context_logger.py:167-188`); `parse_system_sections` `SECTION_MARKERS` has **no "## Known Procedures"/"## Past Episodes"** marker (`context_logger.py:16-31`) so those keys never appear. Hid the bugs; caused two wrong measurements. | `context_logger.py:16-31,167-188` | **HIGH (prereq)** |
+| **B-conv** | The **conversation/default frame** (the fallback for all unmatched + unseeded-agent traffic, `frames.py:199`) **hard-zeros procedures + episode-summaries** via TWO sources: frame budget 0 (`schemas.py:124`) AND the intent override `{procedures:0, episodes:0}` applied last (`intent.py:220-226` via `context.py:159`). Runtime-proven: forced budget=2000+floor=0 was still re-zeroed. | `schemas.py:124`, `intent.py:224-225`, `context.py:159` | **HIGH** |
+| **B-floor** | Procedures alone carry a **0.40 score floor** (`context.py:535`, `config.py:132`) that runs **before** the min-k relevance rescue that protects facts/decisions/episodes (`context.py:777`). Prod cosine probe (6 real task queries × 62 prod procedures): top procedure scores `0.317/0.412/0.626/0.334/0.264/0.482` → **3 of 6 had nothing ≥0.40**; facts scored 0.45–0.69. So procedures are throttled to empty far more often than facts. | `context.py:535-542`, `config.py:132` | **MEDIUM** |
+| **B-pull-thin** | `recall_deep` returns a procedure as **`name: description` only — no `implementation_notes`/body** (`heart.py:1122`); decisions drop `pattern` + never load `context` (`tools.py:389`); episodes are lossy summaries. (`get_procedure` does return the full body — `tools.py:1024` — but it's a 2nd round-trip the agent rarely makes.) | `heart.py:1122`, `tools.py:389` | **HIGH** |
+| **B-pull-reinforce** | Pulled memories (recall_deep/get_procedure) **never enter `recalled_*`** → invisible to post-turn reinforcement (`tools.py:693-793`, `layer.py:1096-1114`). The stronger relevance signal (agent chose to pull) teaches the system nothing; passive injection does. | `layer.py:1096-1114` | **HIGH** |
+| **B-aware** | The agent doesn't pull procedures unless cued (Step 0: cued→6/6, uncued→0; prod `get_procedure` 1 vs `recall_deep` 88). Nothing tells it which procedures exist/apply. | (design gap) | **MEDIUM** |
+
+Out of scope / not bugs (code-verified): chunks-absent-from-passive-injection is **by-design deferral**
+to `recall_deep` (only a gap if we decide passive chunk awareness is wanted); the prod budget override
+does NOT zero procedures (`.env.prod-snapshot`); `critic_mode=advised`+`critic_skill_injection=enabled`
+in prod (the critic path is live — the earlier "shadow/disabled" reading was the *code default*, not prod).
+
+## 3. Design — strengthen pull, repair the injection leaks, restore telemetry
+
+### Phase 0 — Telemetry first (HARD PREREQUISITE; no behavior change)
+You cannot tell if any fix works while the signals are blind. Pure-win, ship first.
+- Add `"## Known Procedures": "known_procedures"` and `"## Past Episodes": "past_episodes"` to
+  `SECTION_MARKERS` (`context_logger.py:16-31`).
+- Populate `loaded_procedures`/`loaded_episodes`/`recent_conversations` in the entry constructor
+  (`context_logger.py:159-188`) by counting their parsed section content (mirror the facts/decisions
+  `count("\n-")` heuristic).
+- **Acceptance:** a turn that injects a procedure section shows `loaded_procedures>0` AND
+  `'known_procedures' ∈ sections_present`. (PG-required test — see §5.)
+- Flag: none (observability fix). This is also the **measurement substrate** for every later phase.
+
+### Phase 1 — Strengthen the PULL path (Step 0's proven channel; highest leverage)
+- **P1.1 recall_deep returns usable bodies.** `heart._to_recall_result` (`heart.py:1122`): procedures
+  return `name` + `description` + a truncated slice of `implementation_notes`/`core_patterns` (enough to
+  act on or judge relevance). Decisions: include `pattern` (`tools.py:389`). Episodes: when
+  `episode_chunks_enabled`, prefer chunk content (already wired) else summary. Truncate on `\n`
+  boundaries with a `[truncated]` marker (never mid-step). Flag: `NOUS_RECALL_FULL_BODIES` (default off,
+  dark-launch).
+- **P1.2 Reinforce pulls.** Thread `recall_deep`/`get_procedure` result IDs into a reinforcement hook so
+  `usage_tracker` + procedure activation/outcome see them (parallel to the injection path at
+  `layer.py:1096-1114`; keep `activation_count` semantics per the audit's decouple-rule —
+  [[project_procedure_subsystem_audit]] R4). Flag: `NOUS_REINFORCE_PULLS` (default off).
+
+### Phase 2 — Repair the injection leaks (passive backstop on the common path)
+- **P2.1 Un-zero the conversation/default frame** for procedures + episodes. Fix **both** sources
+  (two-sources-of-truth): give `conversation` a small non-zero procedure + episode budget
+  (`schemas.py:124`) AND remove/raise the `intent.py:224-225` override (else the override re-zeros —
+  `context.py:159`). Budget kept modest (awareness-sized, not full-menu). Flag: `NOUS_CONV_FRAME_PROC_EPISODE` (default off).
+- **P2.2 Procedure score-floor parity.** Either route procedures through the same min-k relevance rescue
+  the other types get (`context.py:777`) instead of the pre-filter floor, or lower
+  `NOUS_PROCEDURE_SCORE_FLOOR`. Measure the procedure-cosine distribution (probe showed ~0.40) before
+  picking the value — do not guess. Flag: tune `NOUS_PROCEDURE_SCORE_FLOOR` (exists) + a parity toggle.
+- **P2.3 (optional) Frame-seeding hardening** — make the empty-`brain.frames` fallback log loudly / not
+  silently degrade every unseeded agent to procedure-blind `conversation` (`frames.py:199`; `seed.sql`
+  only seeds `nous-default`).
+
+### Phase 3 — Awareness layer (cue the pull)
+- **P3.1** A lightweight, cached **awareness cue** — a short "procedures available: {names + one-line
+  when-to-use}" hint so the agent knows what to pull (Step 0: cue→pull→follow). This is the *only*
+  surviving piece of the old "catalog," and it's awareness-sized, not the full body. Reuse `description`
+  as the when-to-use text (not a new field — [[project_procedure_subsystem_audit]] R8); recompute from DB
+  per build (no memoization). Flag: `NOUS_PROC_AWARENESS_CUE` (default off). Cache-tier decision deferred
+  to review (the old R3 dedicated-cache-block concern applies if it grows).
+
+### Gate (carries over, advisor #3 / R1)
+A positive Step 0 validated the **ceiling** (the agent follows a delivered body). Before any prod flip,
+add a **selection-accuracy** check: does the production ranker actually surface/pull the procedure a human
+judges correct, often enough? Measure on the eval instance (with Phase 0 telemetry live) per phase.
+
+## 4. Sequencing & flags
+**Phase 0 (telemetry) → Phase 1 (pull: P1.1+P1.2) → Phase 2 (injection leaks) → Phase 3 (awareness) →
+selection-accuracy gate before prod.** Each phase independently shippable, behind its own flag, default
+OFF, dark-launch per Nous convention. Phase 1 is highest leverage (pull is the proven channel); Phase 0
+is the prerequisite that makes all the rest measurable.
+
+| flag | default | gates |
+|---|---|---|
+| (none) | — | Phase 0 telemetry (markers + counters) — pure observability |
+| `NOUS_RECALL_FULL_BODIES` | false | P1.1 richer recall_deep bodies |
+| `NOUS_REINFORCE_PULLS` | false | P1.2 reinforce pulled memories |
+| `NOUS_CONV_FRAME_PROC_EPISODE` | false | P2.1 un-zero conversation frame procedures/episodes |
+| `NOUS_PROCEDURE_SCORE_FLOOR` (exists) + parity toggle | 0.40 | P2.2 floor parity |
+| `NOUS_PROC_AWARENESS_CUE` | false | P3.1 awareness cue |
+
+## 5. Acceptance & test discipline (code-only, PG-required)
+- **Phase 0:** PG-required test that INSERTs a turn with a `## Known Procedures` section and asserts
+  `loaded_procedures>0` + key present — the kind of test whose absence let the dead-FTS bug ship green.
+  **CI must run `NOUS_TEST_DB=postgres`** (SQLite default skips PG-only behavior — the recurring trap).
+- **P1.1:** recall_deep result for a procedure contains body text (verbatim, `\n`-truncated), not just
+  name+desc; OFF flag → byte-identical legacy output.
+- **P1.2:** a pulled procedure increments its activation/outcome via the reinforcement hook; ban mocking
+  `recall_deep`/`get_procedure`/`search_procedures` data sources in these tests.
+- **P2.1:** in `conversation` frame with the flag on, a relevant procedure's section builds
+  (`'known_procedures' ∈ sections_present` — now reliable post-Phase-0); OFF → unchanged.
+- **P2.2:** a procedure scoring 0.42 survives to injection (floor) / a relevant procedure survives even
+  at 0.35 under parity (min-k), per the chosen approach.
+- **Gate:** selection-accuracy measured on the eval instance with real frames seeded (the eval gap that
+  blocked the task-frame probe — fix it as part of the harness).
+
+## 6. Risks / notes
+- **Don't quote a procedure/episode injection rate until Phase 0 ships** — current telemetry is blind.
+- Keep **F037 utility boost in the ranker** (`procedures.py:367-381`, shipped win) — drop effectiveness
+  only from any *printed* line, never from ranking ([[project_procedure_subsystem_audit]] R5).
+- Reuse the existing `last_activated` (`models.py:544`); only add `last_fired_at` if Phase 1.2's decouple
+  needs a distinct "actually-fired" timestamp (R4).
+- Eval-instance limitation: it has no seeded frames → everything defaults to `conversation`, which masks
+  task/debug behavior. Seed frames in the harness before measuring Phases 2/3 / the gate.
+- This rewrite is **coupled to the dedup audit** (`docs/reviews/procedure-subsystem-audit-2026-06-06.md`)
+  only for the awareness cue (P3) — a cue listing duplicates is the old problem in a new shape; dedup
+  should precede P3, not P0–P2.
+
+## 7. References (all code-verified this session)
+`docs/reviews/memory-injection-validation-2026-06-06.md` (the validated map),
+`docs/reviews/procedure-delivery-sweep-2026-06-06.md` (the sweep, with retractions),
+F079 v1 §12 (Step-0 result). Code: `context.py:114-710`, `intent.py:108-240`, `schemas.py:124`,
+`heart.py:1091-1144`, `tools.py:609-1046`, `context_logger.py:16-188`, `layer.py:1096-1114`,
+`config.py:132`, `frames.py:199`, `.env.prod-snapshot`.
+
+---
+
+## 8. DECISION — pull-only delivery + static awareness (caching-driven, AUTHORITATIVE)
+
+Supersedes the earlier phased plan (§2-§6) and the prior review-synthesis. Decided 2026-06-07: rather
+than measure-first, commit to the **pull path** for procedures and **drop per-turn passive injection**.
+Phase 0 (telemetry) already shipped (PR #485). The remaining decision is *which delivery channel to
+invest in*, and prompt caching makes it clear-cut.
+
+### Why pull, not passive injection (the caching argument is decisive)
+- **Passive injection lives in the system prompt and is query-ranked per turn** → it sits in the
+  **uncached `dynamic` tier** and is **re-billed at full price every turn** (even turns that need no
+  procedure). Query-ranked + cacheable are mutually exclusive; the only cacheable passive form is a
+  *static, query-independent* block (breadth, not bodies).
+- **Pull puts content in the messages** (tool results): written once, then **read from cache** on every
+  later turn, and **only on the turns that actually pull**. Pay-once + on-demand vs pay-every-turn.
+- **Procedures are situational, not always-relevant.** Facts/decisions are broadly useful → worth the
+  per-turn passive cost (the existing design already pays it). Procedures matter only when the task
+  matches → on-demand pull is the correct cost model. This *validates* the existing architecture's split
+  (auto-inject facts/decisions; pull procedures/episodes/chunks).
+- **Behavioral evidence (Step 0):** the agent already uses `recall_deep` 88×/38min; when cued it pulls
+  and follows the body 6/6; and the **agent selects the right procedure better than the cosine ranker**
+  (it knows its task) — which also sidesteps the 0.40-floor/selection problems entirely.
+
+### What we build (one coherent unit) — and what we drop
+**DROP** (cache-hostile, redundant with pull): P2.1 conversation-frame procedure budget; P2.2 score-floor
+lowering. (They only mattered *if* we kept passive injection.) Passive procedure injection stays as-is
+(effectively dormant) — we don't invest in it.
+
+**BUILD:**
+1. **Richer `recall_deep` procedure bodies (the depth).** `_to_recall_result` (`heart.py:1122`) returns
+   more than `name: description`. **DTO change** (not a one-liner — verified): `ProcedureSummary`
+   (`heart/schemas.py:270`) has no body fields, so add optional `core_patterns` / `implementation_notes`
+   → populate from the full `Procedure` ORM at `procedures.py:383` (in scope, no extra query/migration)
+   → read at `heart.py:1122`. **Keep it to ONE capped, newline-stripped line per procedure** (~200-300
+   chars): this survives the runner's SmartCompress of `recall_deep` (string-array head/tail line
+   selection) and avoids the embedded-newline/marker issues. Flag `NOUS_RECALL_FULL_BODIES` (default off).
+   - SmartCompress note (code-verified): `recall_deep` IS compressed and its original is **not** cached
+     (`smart_compress.py:294` — `original_text` only set for non-re-fetchable tools), so multi-line
+     bodies would be shredded + unrecoverable. The one-line cap keeps each procedure a single
+     head/tail-selectable line → no shredding, no `NON_REFETCHABLE_TOOLS` change needed.
+2. **Static awareness directive (the cue).** A small, **fully static** section in the cached `static`
+   tier (`SECTION_TIERS`): e.g. "You have learned procedures. When you start a task that may match one,
+   call `recall_deep` to retrieve it and follow its steps before acting." Static = written into the
+   cached block once, ~free every turn, **never busts** (no per-turn or CRUD change). This is what flips
+   the agent from uncued→0 to cued→pull (Step 0). No static *name catalog* in v1 — `recall_deep` is
+   query-based and finds the relevant procedure from the task; the directive only needs to remind the
+   agent to search. (A static name catalog is a later option if breadth-awareness proves necessary; it
+   would need its own cache block to avoid busting `static` on procedure CRUD — deferred.) Flag
+   `NOUS_PROC_AWARENESS_CUE` (default off).
+3. **Decision `pattern` fix (bonus).** `tools.py:389` already has `pattern` on `DecisionSummary` but
+   doesn't print it — print it. No schema, no flag, ships in the same PR.
+
+### Deferred (explicit follow-ups, not this PR)
+- **P1.2 — reinforce pulls.** Today recall_deep/get_procedure results are invisible to post-turn
+  reinforcement. Worth doing, but it's a *learning* concern (orthogonal to the delivery decision) and
+  carries real complexity: must **decouple from `activation_count`** (which gates F037 + retire/star) and
+  add a tool-loop→post_turn channel (contextvar like F071 `CURRENT_TURN_EXCLUDE_IDS`, threading
+  `recalled_content_map`). Separate PR.
+- Static name-catalog awareness (own cache block) — only if the directive alone proves insufficient.
+
+### Acceptance / validation
+- Flags off ⇒ byte-identical (recall_deep returns today's `name: description`; no awareness section).
+- `NOUS_RECALL_FULL_BODIES` on ⇒ a procedure pulled via `recall_deep` carries a one-line capped body
+  (verbatim slice, newline-stripped) — PG-required test (search path), ban mocking the data source.
+- `NOUS_PROC_AWARENESS_CUE` on ⇒ a static `## ...` section appears in the `static` tier; byte-stable
+  across turns.
+- Live: on the eval instance, a task turn with the cue on → agent calls `recall_deep` → gets a usable
+  body. (Grade the pull + body, not prose.)
+- **Caching invariant:** nothing new added to the per-turn `dynamic` tier; the awareness cue is static
+  (cache-stable); bodies ride in messages (cached as history). Confirm the `static` block hash is
+  unchanged turn-over-turn with the cue on.

--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -1018,6 +1018,9 @@ def _decisions_to_pipeline(
                 "stakes": d.stakes,
                 "confidence": d.confidence,
                 "raw_score": d.score,
+                # F079 P1: surface the abstract pattern so recall_deep delivers it
+                # (it's on DecisionSummary but was previously dropped by the formatter).
+                "pattern": d.pattern,
             },
         )
         for d in decisions

--- a/nous/api/tools.py
+++ b/nous/api/tools.py
@@ -385,9 +385,12 @@ def _format_pipeline_text(
                 category = dec.metadata.get("category", "")
                 stakes = dec.metadata.get("stakes", "")
                 confidence = dec.metadata.get("confidence", 0.0)
+                # F079 P1: include the abstract pattern when present (B-pull-thin).
+                pattern = dec.metadata.get("pattern")
+                pattern_str = f" | pattern: {pattern}" if pattern else ""
                 results_text.append(
                     f"{i}. {dec.description} | {category} | {stakes} | "
-                    f"confidence: {confidence:.2f} "
+                    f"confidence: {confidence:.2f}{pattern_str} "
                     f"(id: {dec.id}{score_str})"
                 )
             for j, n in enumerate(brain_graph, len(decision_results) + 1):

--- a/nous/cognitive/context.py
+++ b/nous/cognitive/context.py
@@ -32,6 +32,7 @@ TIER1_FACT_CATEGORIES = ["preference", "person", "rule"]
 SECTION_TIERS: dict[str, str] = {
     "Identity": "static",
     "Context Safety": "static",
+    "Procedure Awareness": "static",  # F079 P1: static cue -> cached, never busts
     "Epistemic Routing": "dynamic",  # §2
     "User Profile": "semi_stable",
     "Active Censors": "semi_stable",
@@ -226,6 +227,30 @@ class ContextEngine:
                     content=anti_halluc,
                     token_estimate=self._estimate_tokens(anti_halluc),
                     tier=SECTION_TIERS.get("Context Safety", "dynamic"),
+                )
+            )
+
+        # F079 P1: static procedure-awareness cue. Procedures are delivered via the
+        # PULL path (recall_deep/get_procedure), not auto-injected — this directive
+        # tells the agent to search for a relevant procedure before acting. It is
+        # FULLY STATIC (no per-turn / no CRUD dependency) so it caches once and never
+        # busts; bodies ride in the messages on demand. Flag-gated; off => no section.
+        if getattr(self._settings, "proc_awareness_cue", False):
+            awareness_text = (
+                "You have a library of learned procedures (reusable how-to knowledge "
+                "captured from past work). They are NOT auto-loaded into this prompt. "
+                "When you start a task that may match one — implementing, fixing, "
+                "generating a report, sending email, debugging, researching, etc. — "
+                "call `recall_deep` first to retrieve the relevant procedure, then "
+                "follow its steps before acting (use `get_procedure` for the full body)."
+            )
+            sections.append(
+                ContextSection(
+                    priority=2,
+                    label="Procedure Awareness",
+                    content=awareness_text,
+                    token_estimate=self._estimate_tokens(awareness_text),
+                    tier=SECTION_TIERS.get("Procedure Awareness", "static"),
                 )
             )
 

--- a/nous/config.py
+++ b/nous/config.py
@@ -134,7 +134,10 @@ class Settings(BaseSettings):
     # F079 P1: pull-path delivery (procedures reach the model via recall_deep, not
     # passive injection). Both default OFF (dark-launch).
     recall_full_bodies: bool = False  # recall_deep returns a usable procedure body slice
-    recall_body_max_chars: int = Field(default=240, ge=1)  # one-line body cap (SmartCompress-safe)
+    # One-line body cap. Bounded: keep (cap x procedures-per-recall) well under
+    # NOUS_TOOL_SOFT_TRIM_CHARS (4000) so a richer recall_deep result isn't soft-trimmed
+    # (which would shred middle results, and recall_deep originals aren't cached).
+    recall_body_max_chars: int = Field(default=240, ge=1, le=1000)
     proc_awareness_cue: bool = False  # static cached directive: "pull a relevant procedure first"
 
     # F017: Diminishing returns cutoff (used by adaptive relevance filter)

--- a/nous/config.py
+++ b/nous/config.py
@@ -131,6 +131,12 @@ class Settings(BaseSettings):
     # F038-2.1: Procedure score floor (embedding mode only)
     procedure_score_floor: float = 0.40
 
+    # F079 P1: pull-path delivery (procedures reach the model via recall_deep, not
+    # passive injection). Both default OFF (dark-launch).
+    recall_full_bodies: bool = False  # recall_deep returns a usable procedure body slice
+    recall_body_max_chars: int = Field(default=240, ge=1)  # one-line body cap (SmartCompress-safe)
+    proc_awareness_cue: bool = False  # static cached directive: "pull a relevant procedure first"
+
     # F017: Diminishing returns cutoff (used by adaptive relevance filter)
     relevance_drop_ratio: float = 0.5
 

--- a/nous/heart/heart.py
+++ b/nous/heart/heart.py
@@ -72,11 +72,17 @@ def _format_procedure_recall_summary(item, full_bodies: bool, cap: int) -> str:
     summary = f"{item.name}: {item.description}" if item.description else item.name
     if not full_bodies:
         return summary
-    parts = list(item.implementation_notes or []) + list(item.core_patterns or [])
+    # core_patterns first (concise "what to do"), then implementation_notes (verbose).
+    parts = list(item.core_patterns or []) + list(item.implementation_notes or [])
     body = " ".join(" ".join(str(p).split()) for p in parts if str(p).strip())
-    if body:
+    if body and cap > 0:
         if len(body) > cap:
-            body = body[:cap].rstrip() + "…"
+            cut = body[:cap]
+            # Prefer a word boundary so we don't end mid-word (only if not too short).
+            sp = cut.rfind(" ")
+            if sp > cap // 2:
+                cut = cut[:sp]
+            body = cut.rstrip() + "…"
         summary = f"{summary} | {body}"
     return summary
 

--- a/nous/heart/heart.py
+++ b/nous/heart/heart.py
@@ -61,6 +61,26 @@ from nous.storage.models import ConversationState
 logger = logging.getLogger(__name__)
 
 
+def _format_procedure_recall_summary(item, full_bodies: bool, cap: int) -> str:
+    """F079 P1: build the recall_deep summary line for a procedure.
+
+    Off (default): legacy ``"name: description"`` (byte-identical). On: append a
+    usable body slice (implementation_notes + core_patterns) as ONE
+    whitespace-collapsed, char-capped line so it survives the runner's SmartCompress
+    of recall_deep (head/tail line selection) without multi-line shredding.
+    """
+    summary = f"{item.name}: {item.description}" if item.description else item.name
+    if not full_bodies:
+        return summary
+    parts = list(item.implementation_notes or []) + list(item.core_patterns or [])
+    body = " ".join(" ".join(str(p).split()) for p in parts if str(p).strip())
+    if body:
+        if len(body) > cap:
+            body = body[:cap].rstrip() + "…"
+        summary = f"{summary} | {body}"
+    return summary
+
+
 class Heart:
     """Memory organ for Nous agents.
 
@@ -1119,7 +1139,12 @@ class Heart:
                 },
             )
         elif isinstance(item, ProcedureSummary):
-            summary = f"{item.name}: {item.description}" if item.description else item.name
+            # F079 P1: pull path delivers a usable body slice (not just name+desc).
+            summary = _format_procedure_recall_summary(
+                item,
+                getattr(self.settings, "recall_full_bodies", False),
+                getattr(self.settings, "recall_body_max_chars", 240),
+            )
             return RecallResult(
                 type="procedure",
                 id=item.id,

--- a/nous/heart/procedures.py
+++ b/nous/heart/procedures.py
@@ -389,6 +389,10 @@ class ProcedureManager:
                     activation_count=p.activation_count or 0,
                     effectiveness=effectiveness,
                     score=final_score,
+                    # F079 P1: carry body fields for the pull path (recall_deep).
+                    # `p` is the full ORM row already in scope — no extra query.
+                    core_patterns=list(p.core_patterns or []),
+                    implementation_notes=list(p.implementation_notes or []),
                 )
             )
 

--- a/nous/heart/schemas.py
+++ b/nous/heart/schemas.py
@@ -277,6 +277,11 @@ class ProcedureSummary(BaseModel):
     activation_count: int
     effectiveness: float | None
     score: float | None = None
+    # F079 P1: optional body fields, populated only on the recall search path so the
+    # pull (recall_deep) can return usable steps. Default empty -> other construction
+    # sites (list_all etc.) are unaffected.
+    core_patterns: list[str] = []
+    implementation_notes: list[str] = []
 
 
 class EvolutionCandidate(BaseModel):

--- a/tests/test_f079_pull_delivery.py
+++ b/tests/test_f079_pull_delivery.py
@@ -1,0 +1,69 @@
+"""F079 P1 — pull-path delivery: richer recall_deep procedure bodies + awareness cue.
+
+The body-formatting logic is a pure helper (no DB), unit-tested here. The flag-gated
+awareness section + live recall_deep behavior are validated on the eval instance.
+"""
+
+from nous.cognitive.context import SECTION_TIERS
+from nous.heart.heart import _format_procedure_recall_summary
+from nous.heart.schemas import ProcedureSummary
+
+
+def _proc(**kw) -> ProcedureSummary:
+    base = dict(
+        id="00000000-0000-0000-0000-000000000001",
+        name="send-email",
+        domain="comms",
+        description="Send email via the guarded tool",
+        activation_count=5,
+        effectiveness=0.9,
+        score=0.7,
+    )
+    base.update(kw)
+    return ProcedureSummary(**base)
+
+
+class TestRecallSummary:
+    def test_off_is_byte_identical_legacy(self):
+        p = _proc(implementation_notes=["step one", "step two"])
+        assert _format_procedure_recall_summary(p, False, 240) == "send-email: Send email via the guarded tool"
+
+    def test_off_no_description(self):
+        p = _proc(description=None)
+        assert _format_procedure_recall_summary(p, False, 240) == "send-email"
+
+    def test_on_appends_body(self):
+        p = _proc(implementation_notes=["use the send_email tool", "verify recipient"])
+        out = _format_procedure_recall_summary(p, True, 240)
+        assert out.startswith("send-email: Send email via the guarded tool | ")
+        assert "use the send_email tool" in out and "verify recipient" in out
+
+    def test_on_collapses_newlines_to_one_line(self):
+        # codex-relevant: verbatim multiline fields must NOT produce multiple lines
+        # (would be shredded by SmartCompress).
+        p = _proc(implementation_notes=["line a\n- embedded bullet\nline b"])
+        out = _format_procedure_recall_summary(p, True, 240)
+        assert "\n" not in out
+        assert "line a - embedded bullet line b" in out
+
+    def test_on_caps_length_with_ellipsis(self):
+        p = _proc(implementation_notes=["x" * 1000])
+        out = _format_procedure_recall_summary(p, True, 50)
+        body = out.split(" | ", 1)[1]
+        assert len(body) <= 51  # 50 + the ellipsis char
+        assert body.endswith("…")
+
+    def test_on_empty_body_no_separator(self):
+        p = _proc(implementation_notes=[], core_patterns=[])
+        assert _format_procedure_recall_summary(p, True, 240) == "send-email: Send email via the guarded tool"
+
+    def test_on_includes_core_patterns_after_notes(self):
+        p = _proc(implementation_notes=["note1"], core_patterns=["pattern1"])
+        out = _format_procedure_recall_summary(p, True, 240)
+        assert out.index("note1") < out.index("pattern1")
+
+
+class TestAwarenessTier:
+    def test_awareness_section_is_static_tier(self):
+        # Static => cached, never busts (the caching invariant of the design).
+        assert SECTION_TIERS.get("Procedure Awareness") == "static"

--- a/tests/test_f079_pull_delivery.py
+++ b/tests/test_f079_pull_delivery.py
@@ -4,6 +4,8 @@ The body-formatting logic is a pure helper (no DB), unit-tested here. The flag-g
 awareness section + live recall_deep behavior are validated on the eval instance.
 """
 
+import pytest
+
 from nous.cognitive.context import SECTION_TIERS
 from nous.heart.heart import _format_procedure_recall_summary
 from nous.heart.schemas import ProcedureSummary
@@ -57,13 +59,105 @@ class TestRecallSummary:
         p = _proc(implementation_notes=[], core_patterns=[])
         assert _format_procedure_recall_summary(p, True, 240) == "send-email: Send email via the guarded tool"
 
-    def test_on_includes_core_patterns_after_notes(self):
+    def test_on_core_patterns_lead(self):
+        # core_patterns (concise "what to do") lead the body, then implementation_notes.
         p = _proc(implementation_notes=["note1"], core_patterns=["pattern1"])
         out = _format_procedure_recall_summary(p, True, 240)
-        assert out.index("note1") < out.index("pattern1")
+        assert out.index("pattern1") < out.index("note1")
+
+    def test_on_truncates_on_word_boundary(self):
+        p = _proc(core_patterns=["alpha beta gamma delta epsilon zeta eta theta iota"])
+        out = _format_procedure_recall_summary(p, True, 30)
+        body = out.split(" | ", 1)[1]
+        assert body.endswith("…")
+        # No mid-word cut: the char before the ellipsis is part of a whole word.
+        assert "  " not in body
 
 
 class TestAwarenessTier:
     def test_awareness_section_is_static_tier(self):
         # Static => cached, never busts (the caching invariant of the design).
         assert SECTION_TIERS.get("Procedure Awareness") == "static"
+
+
+class TestAwarenessCueBuild:
+    """Behavioral: the cue section appears in ContextEngine.build output (flag on),
+    lands in the static tier, and is byte-stable across turns (caching invariant)."""
+
+    def _engine(self, cue: bool):
+        from unittest.mock import AsyncMock, MagicMock
+        from nous.cognitive.context import ContextEngine
+        from nous.config import Settings
+        heart = MagicMock()
+        for m in ("search_procedures", "search_facts", "search_episodes",
+                  "list_facts_by_category", "list_censors", "list_episodes"):
+            setattr(heart, m, AsyncMock(return_value=[]))
+        heart.get_procedure_by_name = AsyncMock(return_value=None)
+        settings = Settings(_env_file=None, proc_awareness_cue=cue, relevance_floor_enabled=False)
+        brain = MagicMock(); brain.embeddings = None; brain.query = AsyncMock(return_value=[])
+        return ContextEngine(brain, heart, settings, identity_prompt="Test")
+
+    @staticmethod
+    def _frame():
+        from nous.cognitive.schemas import FrameSelection
+        return FrameSelection(frame_id="task", frame_name="Task", confidence=0.9, match_method="test")
+
+    @pytest.mark.asyncio
+    async def test_cue_present_static_and_byte_stable(self):
+        engine = self._engine(cue=True)
+        r1 = await engine.build(agent_id="t", session_id="s1", input_text="do a task", frame=self._frame())
+        aware = [s for s in r1.sections if s.label == "Procedure Awareness"]
+        assert len(aware) == 1
+        assert aware[0].tier == "static"
+        r2 = await engine.build(agent_id="t", session_id="s1", input_text="another task", frame=self._frame())
+        aware2 = [s for s in r2.sections if s.label == "Procedure Awareness"]
+        assert aware2[0].content == aware[0].content  # byte-stable -> cache-safe
+
+    @pytest.mark.asyncio
+    async def test_cue_absent_when_flag_off(self):
+        engine = self._engine(cue=False)
+        r = await engine.build(agent_id="t", session_id="s1", input_text="do a task", frame=self._frame())
+        assert not any(s.label == "Procedure Awareness" for s in r.sections)
+
+
+def test_decision_pipeline_carries_pattern():
+    """F079 P1: recall_deep delivers the decision abstract pattern (was dropped)."""
+    from datetime import datetime, timezone
+    from uuid import uuid4
+    from nous.api.retrieval_pipeline import _decisions_to_pipeline
+    from nous.brain.schemas import DecisionSummary
+    d = DecisionSummary(
+        id=uuid4(), description="chose cursor pagination", confidence=0.8,
+        category="tooling", stakes="medium", outcome="success",
+        pattern="prefer-cursor-pagination", created_at=datetime.now(timezone.utc),
+    )
+    out = _decisions_to_pipeline([d])
+    assert out[0].metadata["pattern"] == "prefer-cursor-pagination"
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_recall_search_populates_body_from_orm(heart, session):
+    """PG-required: a stored procedure's body fields flow from the ORM into the
+    ProcedureSummary on the search path (data source NOT mocked)."""
+    from nous.heart.schemas import ProcedureInput
+    # Unique nonce so the search retrieves THIS procedure regardless of other rows
+    # in the DB (robust to a populated/shared test DB).
+    nonce = "zqxnonce42marker"
+    await heart.store_procedure(
+        ProcedureInput(
+            name="proc-" + nonce, domain="reporting",
+            description=f"{nonce} produce the quarterly report",
+            core_patterns=[f"{nonce} start with an executive summary"],
+            implementation_notes=[f"{nonce} gather metrics", "write three sections"],
+        ),
+        session=session,
+    )
+    results = await heart.search_procedures(nonce, session=session)
+    mine = [r for r in results if nonce in r.name]
+    assert mine, "expected the seeded procedure to be retrieved"
+    top = mine[0]
+    # Body fields populated from the ORM (the P1 enrichment source).
+    assert top.implementation_notes or top.core_patterns
+    summary = _format_procedure_recall_summary(top, True, 240)
+    assert "executive summary" in summary or "gather metrics" in summary


### PR DESCRIPTION
## What
F079 P1 implements the §8 decision: deliver **procedures via the PULL path** (`recall_deep`/`get_procedure`), **not** per-turn passive injection. Chosen on **prompt-caching** grounds + Step-0 behavioral evidence.

### Why pull, not passive (caching-driven)
- Passive injection is **query-ranked → uncached `dynamic` tier → re-billed every turn** (even turns needing no procedure). Pull content lands in **messages** → **cached + on-demand** (pay once, only when needed).
- Procedures are **situational**, not always-relevant → on-demand fits (validates the existing split: auto-inject facts/decisions; pull procedures/episodes/chunks).
- Step 0: the agent already uses `recall_deep` 88×, selects better than the cosine ranker, and follows bodies when it has them.

## Changes (all flag-gated, default OFF, dark-launch)
1. **Richer `recall_deep` bodies** — `ProcedureSummary` gains optional `core_patterns`/`implementation_notes`, populated from the full ORM row on the search path (no extra query/migration); `recall_deep` returns a **one whitespace-collapsed, word-boundary-truncated, capped line** (`_format_procedure_recall_summary`) — survives the runner's SmartCompress without multi-line shredding. Flag `NOUS_RECALL_FULL_BODIES`.
2. **Static awareness cue** — a fully-static section in the cached `static` tier telling the agent to `recall_deep` a relevant procedure before acting (flips uncued→0 to cued→pull). Static ⇒ cached once, never busts. Flag `NOUS_PROC_AWARENESS_CUE`.
3. **Decision `pattern`** now delivered by `recall_deep` (was dropped by the formatter).
4. Config: `recall_full_bodies`, `recall_body_max_chars` (ge=1, le=1000; bounded to stay under the 4000-char soft-trim), `proc_awareness_cue`.

## Multi-agent review (addressed)
Architecture + devil's-advocate = **APPROVE-WITH-CHANGES**; prod-hardening's concerns covered by convergent findings. Fixed: ship decision-`pattern` (M1); word-boundary truncation + `core_patterns`-first (m2); bound the cap (m1); added the build-output (caching-invariant) test + the **PG-required search-path test** (data source not mocked) + decision-pattern test.

## Validation
- **13 tests pass incl. Postgres** (the PG test proves body flows from the ORM into `ProcedureSummary`; byte-identical OFF path; cue static-tier + byte-stable).
- **Live on the eval instance:** with the cue on, a *plain* task turn (no explicit "follow the procedure" wording) triggered `recall_deep` + `get_procedure` — the cue → pull behavior, end to end.

## Caching invariant
Nothing new added to the per-turn `dynamic` tier; the awareness cue is static (cache-stable, doesn't consume a breakpoint); bodies ride in messages (cached as history).

## Deferred follow-ups (tracked, not this PR)
- **P1.2 reinforce pulls** (pulled procedures still invisible to post-turn reinforcement; needs decoupling from `activation_count` + a tool-loop→post_turn channel).
- Gate the cue on an **eval selection-accuracy measurement** (cue→pull AND over-pull) before flipping flags in prod (both default OFF).
- Graph-neighbor procedures don't get body enrichment (known boundary).

Builds on Phase 0 (PR #485, the delivery telemetry that makes this measurable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)