### PR TITLE
feat(procedures): dedup Phase 0 + create/import fixes (consolidation, loop-close, learn_skill, parser)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,10 @@ nous.db
 # gen_nous_procedure_qrels.py against your own nous-prod-snapshot.
 tests/fixtures/qrels_nous_prod*.jsonl
 tests/fixtures/qrels_longmemeval.jsonl
+
+# F074: BEAM harness — sibling clone of mohammadtavakoli78/BEAM
+tools/beam/
+# F074: per-run reports
+reports/beam/
+# F074: HuggingFace cache (~/.cache/nous-eval/beam) is outside repo
+scripts/diag/_proc_*.json

--- a/nous/api/tools.py
+++ b/nous/api/tools.py
@@ -958,18 +958,19 @@ def create_nous_tools(brain: Brain, heart: Heart, settings: Settings | None = No
             missing_requires = [var for var in manifest.requires if not _os.environ.get(var)]
             skill_active = len(missing_requires) == 0
 
-            # 3. Check for existing procedure with same name (dedup)
+            # 3. Check for existing procedure with same name (dedup, case-insensitive)
             existing = await heart.get_procedure_by_name(manifest.name)
-            updated = False
-            if existing:
-                await heart.retire_procedure(existing.id)
-                updated = True
+            updated = existing is not None
 
-            # 4. Convert to ProcedureInput and store
+            # 4. Convert to ProcedureInput and store / update in place
             proc_input = _skill_parser.to_procedure_input(manifest)
-            if not skill_active:
-                proc_input.active = False
-            result = await heart.store_procedure(proc_input)
+            proc_input.active = skill_active
+            if existing:
+                # Update in place to preserve activation/success/failure counts and
+                # task affinity (retire+store reset them — audit bug 9).
+                result = await heart.update_procedure_body(existing.id, proc_input)
+            else:
+                result = await heart.store_procedure(proc_input)
 
             action = "updated" if updated else "registered"
             if not skill_active:

--- a/nous/heart/heart.py
+++ b/nous/heart/heart.py
@@ -436,6 +436,27 @@ class Heart:
 
         return result
 
+    async def update_procedure_body(
+        self, procedure_id: UUID, input: ProcedureInput, session: AsyncSession | None = None
+    ) -> ProcedureDetail:
+        """Refresh a procedure's body in place, preserving learned stats (audit bug 9)."""
+        result = await self.procedures.update_body(procedure_id, input, session)
+
+        # Mirror store_procedure: re-link the refreshed body in the graph.
+        if self._bus is not None:
+            await self._bus.emit(Event(
+                type="procedure_stored",
+                agent_id=self.agent_id,
+                data={
+                    "procedure_id": str(result.id),
+                    "name": input.name,
+                    "domain": input.domain or "",
+                    "description": input.description or "",
+                    "tags": input.tags or [],
+                },
+            ))
+        return result
+
     async def activate_procedure(self, procedure_id: UUID, session: AsyncSession | None = None) -> ProcedureDetail:
         """Mark a procedure as activated."""
         return await self.procedures.activate(procedure_id, session)
@@ -489,6 +510,10 @@ class Heart:
     async def get_procedure_by_name(self, name: str, session: AsyncSession | None = None) -> ProcedureDetail | None:
         """Fetch active procedure by exact name."""
         return await self.procedures.get_by_name(name, session)
+
+    async def is_procedure_name_superseded(self, name: str, session: AsyncSession | None = None) -> bool:
+        """True if a consolidated (archived) procedure with this name exists (dedup Phase 0)."""
+        return await self.procedures.is_name_superseded(name, session)
 
     async def reactivate_procedure(self, procedure_id: UUID, session: AsyncSession | None = None) -> None:
         """Reactivate an inactive procedure."""

--- a/nous/heart/procedures.py
+++ b/nous/heart/procedures.py
@@ -10,7 +10,7 @@ import logging
 from datetime import UTC, datetime
 from uuid import UUID
 
-from sqlalchemy import select, text
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from nous.brain.embeddings import EmbeddingProvider
@@ -99,6 +99,28 @@ class ProcedureManager:
                 return result
         return await self._store(input, session)
 
+    async def _embed_with_retry(self, embed_text: str, *, attempts: int = 2) -> list[float] | None:
+        """Embed with one retry; on final failure log ERROR (not a quiet warning).
+
+        A NULL embedding makes the row invisible to vector search and the dedup
+        cosine gate (audit bug 8), so the failure must be loud, not swallowed.
+        """
+        if not self.embeddings:
+            return None
+        for attempt in range(1, attempts + 1):
+            try:
+                return await self.embeddings.embed(embed_text)
+            except Exception:
+                if attempt >= attempts:
+                    logger.error(
+                        "Embedding generation failed after %d attempts; storing procedure with "
+                        "NULL embedding (invisible to vector search/dedup until reembed_all)",
+                        attempts,
+                    )
+                    return None
+                logger.warning("Embedding attempt %d/%d failed for procedure, retrying", attempt, attempts)
+        return None
+
     async def _store(self, input: ProcedureInput, session: AsyncSession) -> ProcedureDetail:
         # Generate embedding from all body fields (issue #197)
         embedding = None
@@ -108,10 +130,7 @@ class ProcedureManager:
                 input.goals, input.core_tools, input.core_concepts,
                 input.implementation_notes,
             )
-            try:
-                embedding = await self.embeddings.embed(embed_text)
-            except Exception:
-                logger.warning("Embedding generation failed for procedure store")
+            embedding = await self._embed_with_retry(embed_text)
 
         procedure = Procedure(
             agent_id=self.agent_id,
@@ -143,6 +162,63 @@ class ProcedureManager:
             "tags": input.tags or [],
         })
 
+        return self._to_detail(procedure)
+
+    # ------------------------------------------------------------------
+    # update_body() — in-place skill refresh (audit bug 9)
+    # ------------------------------------------------------------------
+
+    async def update_body(
+        self, procedure_id: UUID, input: ProcedureInput, session: AsyncSession | None = None
+    ) -> ProcedureDetail:
+        """Refresh a procedure's body fields in place, preserving learned stats.
+
+        Used by learn_skill on a name collision instead of retire+store, which
+        reset activation/success/failure counts and orphaned task affinity
+        (audit bug 9). Counts, created_at, and supersession state are untouched.
+        """
+        if session is None:
+            async with self.db.session() as session:
+                result = await self._update_body(procedure_id, input, session)
+                await session.commit()
+                return result
+        return await self._update_body(procedure_id, input, session)
+
+    async def _update_body(
+        self, procedure_id: UUID, input: ProcedureInput, session: AsyncSession
+    ) -> ProcedureDetail:
+        procedure = await self._get_procedure_orm(procedure_id, session)
+        if procedure is None:
+            raise ValueError(f"Procedure {procedure_id} not found")
+
+        embedding = procedure.embedding
+        if self.embeddings:
+            embed_text = _build_embed_text(
+                input.name, input.description, input.core_patterns,
+                input.goals, input.core_tools, input.core_concepts,
+                input.implementation_notes,
+            )
+            # Re-embed from the new body. On failure _embed_with_retry returns None and
+            # logs ERROR; store NULL (consistent with _store) rather than keep the now-stale
+            # vector for the old body — otherwise the row is served/deduped under an obsolete
+            # embedding and reembed_all can't tell it needs repair.
+            embedding = await self._embed_with_retry(embed_text)
+
+        procedure.name = input.name
+        procedure.domain = input.domain
+        procedure.description = input.description
+        procedure.goals = input.goals or None
+        procedure.core_patterns = input.core_patterns or None
+        procedure.core_tools = input.core_tools or None
+        procedure.core_concepts = input.core_concepts or None
+        procedure.implementation_notes = input.implementation_notes or None
+        procedure.tags = input.tags or None
+        procedure.runtime_metadata = input.runtime_metadata
+        if input.active is not None:
+            procedure.active = input.active
+        procedure.embedding = embedding
+        procedure.updated_at = datetime.now(UTC)
+        await session.flush()
         return self._to_detail(procedure)
 
     # ------------------------------------------------------------------
@@ -628,6 +704,26 @@ class ProcedureManager:
         procedure = await self._get_procedure_orm(procedure_id, session)
         if procedure is None:
             raise ValueError(f"Procedure {procedure_id} not found")
+        if procedure.active:
+            return
+        # B6: an active row with the same lower(name) already exists -> flipping this
+        # one active would violate the (agent_id, lower(name)) WHERE active unique index
+        # (migration 058) and, uncaught, abort the whole reactivate_skills loop. Skip
+        # with a warning instead (the live row already provides the capability).
+        clash = await session.execute(
+            select(Procedure.id)
+            .where(func.lower(Procedure.name) == (procedure.name or "").lower())
+            .where(Procedure.agent_id == self.agent_id)
+            .where(Procedure.active == True)  # noqa: E712
+            .where(Procedure.id != procedure_id)
+            .limit(1)
+        )
+        if clash.scalars().first() is not None:
+            logger.warning(
+                "Skipping reactivation of %s — an active procedure with the same name exists",
+                procedure.name,
+            )
+            return
         procedure.active = True
         await session.flush()
 
@@ -692,8 +788,34 @@ class ProcedureManager:
             .where(Procedure.agent_id == self.agent_id)
             .where(Procedure.active == False)  # noqa: E712
             .where(Procedure.tags.contains(["skill"]))
+            # Dedup Phase 0: never resurrect a deliberately-consolidated duplicate.
+            # A superseded row was archived because its capability now lives in the
+            # canonical procedure; reactivate_skills must not un-archive it.
+            .where(Procedure.superseded_by.is_(None))
         )
         return [self._to_detail(p) for p in result.scalars().all()]
+
+    async def is_name_superseded(self, name: str, session: AsyncSession | None = None) -> bool:
+        """True if an archived (consolidated) procedure with this exact name exists.
+
+        Dedup Phase 0: the bootstrap re-import path checks this before recreating a
+        skill from disk. A superseded row means the capability was merged into a
+        canonical procedure — recreating it would resurrect the duplicate.
+        """
+        if session is None:
+            async with self.db.session() as session:
+                return await self._is_name_superseded(name, session)
+        return await self._is_name_superseded(name, session)
+
+    async def _is_name_superseded(self, name: str, session: AsyncSession) -> bool:
+        result = await session.execute(
+            select(Procedure.id)
+            .where(func.lower(Procedure.name) == name.lower())
+            .where(Procedure.agent_id == self.agent_id)
+            .where(Procedure.superseded_by.isnot(None))
+            .limit(1)
+        )
+        return result.scalars().first() is not None
 
     async def get_by_name(self, name: str, session: AsyncSession | None = None) -> ProcedureDetail | None:
         """Fetch active procedure by exact name match."""
@@ -709,10 +831,11 @@ class ProcedureManager:
         # activation_count, which changes per use and would make the resolved row drift, and
         # whose NULLs sort first under DESC). This is the SAME ordering the Procedure Catalog
         # uses to pick its displayed winner (list_all is created_at desc, id), so the catalog
-        # entry and the loaded body always agree. Exact (case/whitespace-sensitive) match.
+        # entry and the loaded body always agree. Case-insensitive match (B6) — pairs with the
+        # (agent_id, lower(name)) WHERE active unique index so a casing variant still resolves.
         result = await session.execute(
             select(Procedure)
-            .where(Procedure.name == name)
+            .where(func.lower(Procedure.name) == name.lower())
             .where(Procedure.agent_id == self.agent_id)
             .where(Procedure.active == True)  # noqa: E712
             .order_by(Procedure.created_at.desc(), Procedure.id)

--- a/nous/skills/bootstrap.py
+++ b/nous/skills/bootstrap.py
@@ -49,6 +49,14 @@ async def bootstrap_local_skills(workspace_dir: str, heart: Heart) -> int:
                 logger.debug("Skill %s already registered, skipping", manifest.name)
                 continue
 
+            # Dedup Phase 0: don't resurrect a deliberately-consolidated duplicate.
+            # If a row with this name was archived (superseded_by set) its capability
+            # now lives in a canonical procedure — recreating it from disk would
+            # reintroduce the duplicate on every restart (the audit's B1 loop).
+            if await heart.is_procedure_name_superseded(manifest.name):
+                logger.info("Skill %s was consolidated into a canonical procedure, skipping re-import", manifest.name)
+                continue
+
             proc_input = parser.to_procedure_input(manifest)
             await heart.store_procedure(proc_input)
             registered += 1

--- a/nous/skills/parser.py
+++ b/nous/skills/parser.py
@@ -87,12 +87,27 @@ def _parse_frontmatter(text: str) -> dict[str, str | list[str] | dict[str, str]]
     # `current_pending` is True after we see `key:` with empty value but
     # before we know if it's a list (`  - item`) or dict (`  sub: val`).
     current_pending: bool = False
+    # Block scalar (`key: |` literal / `key: >` folded). Without this, a
+    # `description: |` line captured the literal "|" as the value and the
+    # indented body was silently dropped (audit: empty-description rows).
+    current_scalar_style: str | None = None  # 'literal' | 'folded'
+    current_scalar_lines: list[str] | None = None
 
     def _flush_block() -> None:
         nonlocal current_key, current_list, current_dict, current_pending
+        nonlocal current_scalar_style, current_scalar_lines
         if current_key is None:
             return
-        if current_list is not None:
+        if current_scalar_style is not None:
+            raw = current_scalar_lines or []
+            indents = [len(ln) - len(ln.lstrip()) for ln in raw if ln.strip()]
+            base = min(indents) if indents else 0
+            dedented = [ln[base:] if len(ln) >= base else ln.lstrip() for ln in raw]
+            if current_scalar_style == "folded":
+                result[current_key] = " ".join(s.strip() for s in dedented if s.strip())
+            else:
+                result[current_key] = "\n".join(dedented).strip()
+        elif current_list is not None:
             result[current_key] = current_list
         elif current_dict is not None:
             result[current_key] = current_dict
@@ -103,8 +118,18 @@ def _parse_frontmatter(text: str) -> dict[str, str | list[str] | dict[str, str]]
         current_list = None
         current_dict = None
         current_pending = False
+        current_scalar_style = None
+        current_scalar_lines = None
 
     for line in lines:
+        # Block scalar continuation: collect blank or more-indented lines.
+        if current_key is not None and current_scalar_style is not None:
+            if line.strip() == "" or re.match(r"^\s", line):
+                current_scalar_lines.append(line)
+                continue
+            # dedent: a non-indented, non-blank line ends the scalar.
+            _flush_block()
+
         # Block list continuation: "  - item"
         list_match = re.match(r"^\s+-\s+(.*)", line)
         if current_key and (current_list is not None or current_pending) and list_match:
@@ -136,6 +161,12 @@ def _parse_frontmatter(text: str) -> dict[str, str | list[str] | dict[str, str]]
                 # Start of a block — kind (list vs dict) determined by next line.
                 current_key = key
                 current_pending = True
+            elif re.match(r"^[|>][+-]?\d*$", value):
+                # YAML block scalar: `|` literal / `>` folded (with optional
+                # chomping/indent indicator). Body is the following indented lines.
+                current_key = key
+                current_scalar_style = "folded" if value[0] == ">" else "literal"
+                current_scalar_lines = []
             else:
                 parsed = _parse_yaml_value(value)
                 result[key] = parsed

--- a/nous/storage/models.py
+++ b/nous/storage/models.py
@@ -555,6 +555,13 @@ class Procedure(Base):
     active: Mapped[bool | None] = mapped_column(Boolean, server_default="true")
     encoded_frame: Mapped[str | None] = mapped_column(String(100))
     encoded_censors = mapped_column(JSONB, nullable=True)
+    # Dedup Phase 0 (migration 057): supersession bookkeeping. superseded_by points
+    # at the canonical procedure that absorbed this one during consolidation; the
+    # restart resurrection loop (bootstrap/reactivate) keys off it. Plain UUID (no DB
+    # FK) — we never hard-delete procedures, so ON DELETE behavior is moot, and a
+    # constraint-free column keeps migration 057 splitter-safe for the auto-migrator.
+    superseded_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    archived_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), server_default=func.now())
 

--- a/scripts/diag/_apply_via_splitter.py
+++ b/scripts/diag/_apply_via_splitter.py
@@ -1,0 +1,32 @@
+"""Apply given migration files THROUGH the real migrator splitter, to validate that
+nous/storage/migrator.py can actually parse+run them (psql tolerates DO blocks the
+splitter cannot). Connects via DB_* env. Usage: python _apply_via_splitter.py f1.sql f2.sql
+"""
+import asyncio
+import sys
+
+from sqlalchemy import text
+
+from nous.config import Settings
+from nous.storage.database import Database
+from nous.storage.migrator import _split_sql_statements
+
+
+async def main() -> int:
+    db = Database(Settings())
+    await db.connect()
+    async with db.engine.begin() as conn:  # mirror run_migrations: one tx per file-set
+        for path in sys.argv[1:]:
+            with open(path, encoding="utf-8") as f:
+                sql = f.read()
+            stmts = _split_sql_statements(sql)
+            print(f"{path}: {len(stmts)} statement(s)")
+            for stmt in stmts:
+                await conn.execute(text(stmt))
+            print(f"  applied OK")
+    await db.disconnect()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/diag/_proc_bodies.py
+++ b/scripts/diag/_proc_bodies.py
@@ -1,0 +1,102 @@
+"""Read-only dump of full procedure bodies for the dedup consolidation review.
+
+Pulls description / core_patterns / implementation_notes / core_tools / core_concepts /
+goals / censor_ids / related_procedures / tags for a fixed set of procedure IDs (the
+duplicate clusters + the empty-description rows), so canonical selection and body-coverage
+can be judged before any archive. Secrets come from PROD_SSH_* env vars.
+Writes scripts/diag/_proc_bodies.json.
+"""
+import json
+import os
+
+import paramiko
+
+host = os.environ["PROD_SSH_HOST"]
+user = os.environ["PROD_SSH_USER"]
+pw = os.environ["PROD_SSH_PW"]
+port = int(os.environ.get("PROD_SSH_PORT", "22"))
+agent = os.environ.get("PROD_AGENT_ID", "nous-default")
+
+IDS = [
+    # email cluster
+    "54fedf18-1299-41ae-8ad8-e7a795f4f70a",  # send_email (canonical candidate)
+    "97cb7b96-41f2-400f-bef1-b6d1ae38f77f",  # validated-email-sending
+    "47fbb706-7aff-4811-8136-8973f4894197",  # Send Email via Gmail SMTP #1
+    "2a1f583b-d495-4a0e-9131-30d27dfc30c5",  # Send Email via Gmail SMTP #2
+    "576e10f4-4a45-4e3b-a7aa-8efd962c588a",  # Send Email via Gmail SMTP #3
+    "828da799-9890-4a52-b99a-87bed68731be",  # email
+    "a45afe76-2a31-435c-8e05-060e4a477dae",  # notify_tim
+    "b6af7630-4fc6-4c21-8c68-5f63e74c317b",  # internal-comms
+    "6a4cebf2-44a4-40fc-b0af-c4e75525be72",  # talk_to_emerson
+    # actiongate cluster
+    "a1cefc07-80cb-45cd-84ff-497564eab187",  # duplicate_action_gate_recovery
+    "408d59db-3cb1-4eb3-be75-1cd7045dc1d4",  # duplicate-action-gate-acknowledgment
+    # compaction cluster
+    "656693fb-1319-4e92-89ee-0668246a4e1c",  # Conversation Compaction Awareness
+    "f045d70f-332e-4f14-b667-74aff68f7553",  # Conversation Compaction Management
+    # context cluster
+    "003835b1-2759-4227-8200-75b2f380496f",  # context-degradation
+    "9d0ebef0-b41d-4070-aa24-37952556e7d7",  # context-compression
+    "5a1cdf77-53de-406f-b906-0af088b6f21c",  # context-fundamentals
+    # empty-description rows (goal 1b)
+    "f6515b17-5a8a-4696-a425-3714dddcffdc",  # deep-researcher
+    "84a25199-a70f-4a26-a022-57f670e1feed",  # investigate
+    "de9ff940-6e8c-4ffa-b292-3f519ca3ded2",  # cso
+    "87dceb55-8d5d-406f-ae94-0103899ed2d3",  # office-hours
+]
+
+cli = paramiko.SSHClient()
+cli.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+cli.connect(host, port=port, username=user, password=pw, timeout=20)
+
+
+def run(cmd: str):
+    _i, o, e = cli.exec_command(cmd)
+    return o.read().decode("utf-8", "replace"), e.read().decode("utf-8", "replace")
+
+
+def qj(sql: str):
+    w = "SELECT coalesce(json_agg(row_to_json(t)),json_build_array()) FROM (" + sql + ") t"
+    out, err = run('docker exec nous-postgres psql -U nous -d nous -tAc "' + w + '"')
+    ln = next((l for l in out.splitlines() if l.strip().startswith("[")), None)
+    if ln is None:
+        print("ERR sql:", err[:600])
+        return []
+    return json.loads(ln)
+
+
+id_list = ",".join(f"'{i}'" for i in IDS)
+rows = qj(
+    "SELECT id::text, name, domain, tags::text AS tags, description, "
+    "goals::text AS goals, core_patterns::text AS core_patterns, "
+    "core_tools::text AS core_tools, core_concepts::text AS core_concepts, "
+    "implementation_notes::text AS implementation_notes, "
+    "censor_ids::text AS censor_ids, related_procedures::text AS related_procedures, "
+    "activation_count, success_count, failure_count, active, "
+    "created_at::text AS created_at "
+    f"FROM heart.procedures WHERE agent_id='{agent}' AND id IN ({id_list}) "
+    "ORDER BY name, created_at"
+)
+
+# affinity rows for the same ids (to size the merge)
+aff = qj(
+    "SELECT procedure_id::text, frame_type, activation_count, success_count, failure_count, active "
+    f"FROM heart.procedure_task_affinity WHERE agent_id='{agent}' AND procedure_id IN ({id_list}) "
+    "ORDER BY procedure_id, frame_type"
+)
+
+# incident graph edges for the same ids
+edges = qj(
+    "SELECT id::text, source_id::text, source_type, target_id::text, target_type, relation "
+    "FROM brain.graph_edges "
+    f"WHERE agent_id='{agent}' AND ((source_id IN ({id_list}) AND source_type='procedure') "
+    f"OR (target_id IN ({id_list}) AND target_type='procedure'))"
+)
+
+out = {"agent": agent, "procedures": rows, "affinity": aff, "edges": edges}
+path = os.path.abspath("scripts/diag/_proc_bodies.json")
+with open(path, "w", encoding="utf-8") as f:
+    json.dump(out, f, indent=2, ensure_ascii=False)
+print(f"WROTE {path}")
+print(f"procedures: {len(rows)}  affinity rows: {len(aff)}  incident edges: {len(edges)}")
+cli.close()

--- a/scripts/diag/_seed_dedup_test.py
+++ b/scripts/diag/_seed_dedup_test.py
@@ -1,0 +1,119 @@
+"""Seed nous_dedup_test (5433) with the real cluster data from _proc_bodies.json.
+
+Inserts the 20 cluster procedures + their affinity rows + incident graph edges so the
+consolidation tool can be validated end-to-end against prod-shaped data on a throwaway DB.
+Array columns are passed as their PostgreSQL array-literal strings (the canonical output
+format is also valid input) and cast in SQL. Connects via DB_* env vars.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+from sqlalchemy import text
+
+from nous.config import Settings
+from nous.storage.database import Database
+
+AGENT = os.environ.get("PROC_CONSOLIDATE_AGENT", "nous-default")
+
+
+def arr(v):
+    """PG array-literal string or None -> param value (None stays None)."""
+    if v in (None, "", "{}"):
+        return None
+    return v
+
+
+async def main() -> int:
+    with open(os.path.abspath("scripts/diag/_proc_bodies.json"), encoding="utf-8") as f:
+        data = json.load(f)
+
+    db = Database(Settings())
+    await db.connect()
+    async with db.engine.connect() as conn:
+        trans = await conn.begin()
+        # idempotent: clear any prior seed for this agent's cluster ids
+        ids = [p["id"] for p in data["procedures"]]
+        await conn.execute(
+            text("DELETE FROM heart.procedure_task_affinity WHERE procedure_id = ANY(CAST(:ids AS uuid[]))"),
+            {"ids": ids},
+        )
+        await conn.execute(
+            text("DELETE FROM brain.graph_edges WHERE (source_id = ANY(CAST(:ids AS uuid[])) "
+                 "OR target_id = ANY(CAST(:ids AS uuid[])))"),
+            {"ids": ids},
+        )
+        await conn.execute(
+            text("DELETE FROM heart.procedures WHERE id = ANY(CAST(:ids AS uuid[]))"),
+            {"ids": ids},
+        )
+
+        for p in data["procedures"]:
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO heart.procedures
+                        (id, agent_id, name, domain, description, tags, goals, core_patterns,
+                         core_tools, core_concepts, implementation_notes, censor_ids,
+                         related_procedures, activation_count, success_count, failure_count,
+                         active, created_at)
+                    VALUES
+                        (CAST(:id AS uuid), :agent, :name, :domain, :description,
+                         CAST(CAST(:tags AS text) AS text[]), CAST(CAST(:goals AS text) AS text[]),
+                         CAST(CAST(:core_patterns AS text) AS text[]), CAST(CAST(:core_tools AS text) AS text[]),
+                         CAST(CAST(:core_concepts AS text) AS text[]), CAST(CAST(:implementation_notes AS text) AS text[]),
+                         CAST(CAST(:censor_ids AS text) AS uuid[]),
+                         CAST(CAST(:related_procedures AS text) AS uuid[]), :ac, :sc, :fc, :active,
+                         CAST(CAST(:created_at AS text) AS timestamptz))
+                    """
+                ),
+                {
+                    "id": p["id"], "agent": AGENT, "name": p["name"], "domain": p["domain"],
+                    "description": p["description"], "tags": arr(p["tags"]), "goals": arr(p["goals"]),
+                    "core_patterns": arr(p["core_patterns"]), "core_tools": arr(p["core_tools"]),
+                    "core_concepts": arr(p["core_concepts"]),
+                    "implementation_notes": arr(p["implementation_notes"]),
+                    "censor_ids": arr(p["censor_ids"]), "related_procedures": arr(p["related_procedures"]),
+                    "ac": p["activation_count"], "sc": p["success_count"], "fc": p["failure_count"],
+                    "active": p["active"], "created_at": p["created_at"],
+                },
+            )
+
+        for a in data["affinity"]:
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO heart.procedure_task_affinity
+                        (procedure_id, frame_type, activation_count, success_count,
+                         failure_count, active, agent_id)
+                    VALUES (CAST(:pid AS uuid), :ft, :ac, :sc, :fc, :active, :agent)
+                    """
+                ),
+                {"pid": a["procedure_id"], "ft": a["frame_type"], "ac": a["activation_count"],
+                 "sc": a["success_count"], "fc": a["failure_count"], "active": a["active"], "agent": AGENT},
+            )
+
+        for e in data["edges"]:
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO brain.graph_edges
+                        (id, source_id, source_type, target_id, target_type, relation, agent_id)
+                    VALUES (CAST(:id AS uuid), CAST(:sid AS uuid), :st, CAST(:tid AS uuid), :tt, :rel, :agent)
+                    ON CONFLICT (id) DO NOTHING
+                    """
+                ),
+                {"id": e["id"], "sid": e["source_id"], "st": e["source_type"],
+                 "tid": e["target_id"], "tt": e["target_type"], "rel": e["relation"], "agent": AGENT},
+            )
+
+        await trans.commit()
+    await db.disconnect()
+    print(f"seeded {len(data['procedures'])} procedures, {len(data['affinity'])} affinity, {len(data['edges'])} edges")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/diag/backfill_proc_descriptions.py
+++ b/scripts/diag/backfill_proc_descriptions.py
@@ -1,0 +1,103 @@
+"""Backfill descriptions for procedures broken by the pre-fix SkillParser.
+
+The old _parse_frontmatter captured the YAML block-scalar indicator ("|"/">") as the
+literal description and dropped the body (audit goal 1b). These rows are heavily used
+(deep-researcher act 656, investigate act 244) but show a useless one-char description in
+the F079 catalog. The parser is fixed going forward; these existing rows need a one-time
+data fix (re-import isn't possible — sources are gstack-ported / inline). Descriptions are
+synthesized from each row's own goals / core_patterns / implementation_notes.
+
+Idempotent: only updates rows whose description is still a block-scalar marker, so a re-run
+(or a later real description) is untouched. Connects via DB_* env vars.
+Modes: --dry-run (default) / --commit.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+
+from sqlalchemy import text
+
+from nous.config import Settings
+from nous.storage.database import Database
+
+AGENT = os.environ.get("PROC_CONSOLIDATE_AGENT", "nous-default")
+
+# id -> (name, synthesized description). Descriptions distilled from the live bodies
+# (scripts/diag/_proc_bodies.json), matching each skill's goals/patterns.
+BACKFILL: dict[str, tuple[str, str]] = {
+    "f6515b17-5a8a-4696-a425-3714dddcffdc": (
+        "deep-researcher",
+        "Conduct rigorous multi-source research: evaluate source credibility, triangulate "
+        "claims across 3+ independent sources, separate established fact from speculation, "
+        "and deliver structured reports with explicit confidence ratings.",
+    ),
+    "84a25199-a70f-4a26-a022-57f670e1feed": (
+        "investigate",
+        "Root-cause debugging: investigate errors, failures, and regressions to find the "
+        "underlying cause before applying any fix — no symptom patching.",
+    ),
+    "de9ff940-6e8c-4ffa-b292-3f519ca3ded2": (
+        "cso",
+        "Security audit and threat modeling: OWASP review, vulnerability and supply-chain "
+        "scanning with confidence-gated findings (daily vs comprehensive scope modes).",
+    ),
+    "87dceb55-8d5d-406f-ae94-0103899ed2d3": (
+        "office-hours",
+        "Brainstorming / product 'office hours': think through whether and how to build an "
+        "idea, choosing startup vs builder mode from the stated goal.",
+    ),
+}
+
+# Block-scalar markers the broken parser left behind.
+_MARKERS = ("|", ">", "|-", ">-", "|+", ">+")
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser(description="Backfill broken procedure descriptions")
+    ap.add_argument("--commit", action="store_true", help="COMMIT (default dry-run)")
+    args = ap.parse_args()
+    mode = "COMMIT" if args.commit else "DRY-RUN"
+
+    db = Database(Settings())
+    await db.connect()
+    try:
+        async with db.engine.connect() as conn:
+            trans = await conn.begin()
+            updated = 0
+            for pid, (name, desc) in BACKFILL.items():
+                row = (
+                    await conn.execute(
+                        text("SELECT name, description FROM heart.procedures WHERE id=:i AND agent_id=:a"),
+                        {"i": pid, "a": AGENT},
+                    )
+                ).mappings().first()
+                if row is None:
+                    print(f"  SKIP {name}: not found")
+                    continue
+                cur = (row["description"] or "").strip()
+                if cur not in _MARKERS:
+                    print(f"  SKIP {name}: description not a block-scalar marker ({cur!r:.40})")
+                    continue
+                print(f"  FIX  {name}: {cur!r} -> {desc[:60]!r}…")
+                res = await conn.execute(
+                    text(
+                        "UPDATE heart.procedures SET description=:d, updated_at=now() "
+                        "WHERE id=:i AND agent_id=:a AND trim(description) = ANY(:markers)"
+                    ),
+                    {"d": desc, "i": pid, "a": AGENT, "markers": list(_MARKERS)},
+                )
+                updated += res.rowcount or 0
+            print(f"[{mode}] {updated} row(s) would be updated" if not args.commit else f"[COMMIT] {updated} row(s) updated")
+            if args.commit:
+                await trans.commit()
+            else:
+                await trans.rollback()
+    finally:
+        await db.disconnect()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/diag/proc_consolidate.py
+++ b/scripts/diag/proc_consolidate.py
@@ -1,0 +1,349 @@
+"""Procedure dedup Phase 0 — one-time, operator-gated consolidation.
+
+Collapses the known duplicate clusters (audit:
+docs/reviews/procedure-subsystem-audit-2026-06-06.md §6) into a single canonical
+procedure each, archiving siblings (active=false, archived_at, superseded_by=canonical),
+folding their per-frame procedure_task_affinity counts into the canonical, and deleting
+their incident brain.graph_edges. Every cluster is one transaction; the whole run is one
+transaction. Idempotent: a second run is a no-op (siblings already superseded are skipped,
+their affinity rows already deleted).
+
+Connection comes from the standard DB_* env vars (DB_HOST/DB_PORT/DB_USER/DB_PASSWORD/
+DB_NAME) via nous.config.Settings — point them at a throwaway DB (5433) to validate before
+prod. Agent id from PROC_CONSOLIDATE_AGENT (default nous-default).
+
+Modes:
+  --dry-run   (default) run everything in a transaction, print the diff, ROLLBACK.
+  --commit    run and COMMIT.
+
+SAFETY: refuses to touch any cluster whose siblings carry non-null censor_ids or
+related_procedures (those outbound arrays would be silently lost — handle by hand).
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+
+from sqlalchemy import text
+
+from nous.config import Settings
+from nous.storage.database import Database
+
+AGENT = os.environ.get("PROC_CONSOLIDATE_AGENT", "nous-default")
+
+# Canonical selection rationale is in the audit; bodies were reviewed via _proc_bodies.json.
+CLUSTERS: list[dict] = [
+    {
+        "name": "email",
+        # send_email: richest body (12 patterns / 5 notes), domain=communication,
+        # the F078 guarded-tool path, clears the cold-start floor (act>=5).
+        "canonical": "54fedf18-1299-41ae-8ad8-e7a795f4f70a",
+        "siblings": [
+            "47fbb706-7aff-4811-8136-8973f4894197",  # Send Email via Gmail SMTP (skill,inline)
+            "2a1f583b-d495-4a0e-9131-30d27dfc30c5",  # Send Email via Gmail SMTP (skill,inline)
+            "576e10f4-4a45-4e3b-a7aa-8efd962c588a",  # Send Email via Gmail SMTP (skill,local)
+            "828da799-9890-4a52-b99a-87bed68731be",  # email (skill,local)
+            "97cb7b96-41f2-400f-bef1-b6d1ae38f77f",  # validated-email-sending (skill,inline)
+        ],
+        # Fold validated-email-sending's unique capability (delivery validation/logging)
+        # into the canonical so nothing is lost on archive.
+        "enrich_notes": [
+            "When email delivery must be audited: capture the SMTP response code, append the "
+            "send to a persistent log file, and record the outcome as a fact (folded in from "
+            "validated-email-sending on consolidation).",
+        ],
+    },
+    {
+        "name": "action_gate",
+        # duplicate_action_gate_recovery is the superset (verify-state + direct-exec, 8 patterns).
+        "canonical": "a1cefc07-80cb-45cd-84ff-497564eab187",
+        "siblings": [
+            "408d59db-3cb1-4eb3-be75-1cd7045dc1d4",  # duplicate-action-gate-acknowledgment
+        ],
+        "enrich_notes": [],
+    },
+    {
+        "name": "compaction",
+        # Conversation Compaction Management is the richer of the 0.943-cosine pair.
+        "canonical": "f045d70f-332e-4f14-b667-74aff68f7553",
+        "siblings": [
+            "656693fb-1319-4e92-89ee-0668246a4e1c",  # Conversation Compaction Awareness
+        ],
+        "enrich_notes": [],
+    },
+]
+
+
+async def _fetch_row(conn, pid: str) -> dict | None:
+    r = await conn.execute(
+        text(
+            "SELECT id::text, name, active, superseded_by::text AS superseded_by, "
+            "censor_ids::text AS censor_ids, related_procedures::text AS related_procedures "
+            "FROM heart.procedures WHERE id = :id AND agent_id = :agent"
+        ),
+        {"id": pid, "agent": AGENT},
+    )
+    m = r.mappings().first()
+    return dict(m) if m else None
+
+
+async def _preflight(conn) -> list[str]:
+    """Validate every cluster; return a list of human-readable problems (empty = OK)."""
+    problems: list[str] = []
+    for c in CLUSTERS:
+        canon = await _fetch_row(conn, c["canonical"])
+        if canon is None:
+            problems.append(f"[{c['name']}] canonical {c['canonical']} not found for agent {AGENT}")
+            continue
+        if not canon["active"]:
+            problems.append(f"[{c['name']}] canonical {canon['name']} is not active")
+        if canon["superseded_by"] is not None:
+            problems.append(f"[{c['name']}] canonical {canon['name']} is itself superseded")
+        for sid in c["siblings"]:
+            sib = await _fetch_row(conn, sid)
+            if sib is None:
+                problems.append(f"[{c['name']}] sibling {sid} not found")
+                continue
+            # B3: outbound arrays would be silently lost — refuse rather than drop.
+            if sib["censor_ids"] not in (None, "", "{}"):
+                problems.append(f"[{c['name']}] sibling {sib['name']} has censor_ids={sib['censor_ids']} (union by hand)")
+            if sib["related_procedures"] not in (None, "", "{}"):
+                problems.append(f"[{c['name']}] sibling {sib['name']} has related_procedures={sib['related_procedures']} (union by hand)")
+    return problems
+
+
+async def _consolidate_cluster(conn, c: dict, *, verbose: bool) -> None:
+    canon = c["canonical"]
+    sibs = c["siblings"]
+    params = {"canon": canon, "sibs": sibs, "agent": AGENT}
+
+    # 1. Fold sibling per-frame affinity into the canonical (sum). Gated on the sibling
+    #    not yet being superseded so a re-run cannot double-count.
+    await conn.execute(
+        text(
+            """
+            INSERT INTO heart.procedure_task_affinity
+                (procedure_id, frame_type, activation_count, success_count,
+                 failure_count, last_activated_at, active, agent_id)
+            SELECT :canon, s.frame_type,
+                   SUM(s.activation_count), SUM(s.success_count), SUM(s.failure_count),
+                   MAX(s.last_activated_at), bool_or(s.active), :agent
+            FROM heart.procedure_task_affinity s
+            JOIN heart.procedures p ON p.id = s.procedure_id AND p.superseded_by IS NULL
+            WHERE s.agent_id = :agent AND s.procedure_id = ANY(CAST(:sibs AS uuid[]))
+            GROUP BY s.frame_type
+            ON CONFLICT (procedure_id, frame_type, agent_id) DO UPDATE SET
+                activation_count = heart.procedure_task_affinity.activation_count + EXCLUDED.activation_count,
+                success_count    = heart.procedure_task_affinity.success_count + EXCLUDED.success_count,
+                failure_count    = heart.procedure_task_affinity.failure_count + EXCLUDED.failure_count,
+                last_activated_at = GREATEST(heart.procedure_task_affinity.last_activated_at, EXCLUDED.last_activated_at),
+                active = heart.procedure_task_affinity.active OR EXCLUDED.active
+            """
+        ),
+        params,
+    )
+
+    # 2. Remove the now-redundant sibling affinity rows (counts preserved in canonical).
+    await conn.execute(
+        text(
+            "DELETE FROM heart.procedure_task_affinity "
+            "WHERE agent_id = :agent AND procedure_id = ANY(CAST(:sibs AS uuid[]))"
+        ),
+        params,
+    )
+
+    # 2b. Fold the siblings' procedure-level outcome counters into the canonical so the
+    #     merged capability keeps its learned effectiveness/usage signal (F037 reads
+    #     activation/success/failure on the row). Gated on superseded_by IS NULL so a
+    #     re-run sums over zero rows (idempotent); the raw counts stay on the archived
+    #     rows as an audit trail (harmless — inactive rows are never searched/scored).
+    await conn.execute(
+        text(
+            """
+            UPDATE heart.procedures c SET
+                activation_count = coalesce(c.activation_count, 0) + agg.act,
+                success_count    = coalesce(c.success_count, 0) + agg.succ,
+                failure_count    = coalesce(c.failure_count, 0) + agg.fail,
+                neutral_count    = coalesce(c.neutral_count, 0) + agg.neu,
+                updated_at = now()
+            FROM (
+                SELECT coalesce(sum(activation_count), 0) AS act,
+                       coalesce(sum(success_count), 0)    AS succ,
+                       coalesce(sum(failure_count), 0)    AS fail,
+                       coalesce(sum(neutral_count), 0)    AS neu
+                FROM heart.procedures s
+                WHERE s.agent_id = :agent
+                  AND s.id = ANY(CAST(:sibs AS uuid[]))
+                  AND s.superseded_by IS NULL
+            ) agg
+            WHERE c.id = :canon AND c.agent_id = :agent
+            """
+        ),
+        params,
+    )
+
+    # 3. Optional canonical body enrichment (append unique notes not already present).
+    for note in c.get("enrich_notes", []):
+        await conn.execute(
+            text(
+                "UPDATE heart.procedures "
+                "SET implementation_notes = array_append(coalesce(implementation_notes, ARRAY[]::text[]), :note), "
+                "    updated_at = now() "
+                "WHERE id = :canon AND agent_id = :agent "
+                "AND NOT (:note = ANY(coalesce(implementation_notes, ARRAY[]::text[])))"
+            ),
+            {"canon": canon, "agent": AGENT, "note": note},
+        )
+
+    # 4. Delete incident graph edges referencing the siblings (no FK/CASCADE; blast radius ~0).
+    await conn.execute(
+        text(
+            "DELETE FROM brain.graph_edges WHERE agent_id = :agent AND ("
+            "(source_id = ANY(CAST(:sibs AS uuid[])) AND source_type = 'procedure') OR "
+            "(target_id = ANY(CAST(:sibs AS uuid[])) AND target_type = 'procedure'))"
+        ),
+        params,
+    )
+
+    # 5. Archive the siblings (idempotent via the superseded_by IS NULL guard).
+    await conn.execute(
+        text(
+            "UPDATE heart.procedures "
+            "SET active = false, archived_at = now(), superseded_by = :canon "
+            "WHERE agent_id = :agent AND id = ANY(CAST(:sibs AS uuid[])) AND superseded_by IS NULL"
+        ),
+        params,
+    )
+
+
+async def _report(conn) -> None:
+    """Print before-state + planned actions for each cluster."""
+    for c in CLUSTERS:
+        canon = await _fetch_row(conn, c["canonical"])
+        print(f"\n=== cluster: {c['name']} ===")
+        print(f"  canonical : {canon['name'] if canon else '??'}  ({c['canonical']})")
+        # affinity that will fold in
+        r = await conn.execute(
+            text(
+                "SELECT frame_type, SUM(activation_count) a, SUM(success_count) s, SUM(failure_count) f "
+                "FROM heart.procedure_task_affinity "
+                "WHERE agent_id = :agent AND procedure_id = ANY(CAST(:sibs AS uuid[])) "
+                "GROUP BY frame_type ORDER BY frame_type"
+            ),
+            {"agent": AGENT, "sibs": c["siblings"]},
+        )
+        aff = r.mappings().all()
+        edge_r = await conn.execute(
+            text(
+                "SELECT count(*) FROM brain.graph_edges WHERE agent_id = :agent AND ("
+                "(source_id = ANY(CAST(:sibs AS uuid[])) AND source_type='procedure') OR "
+                "(target_id = ANY(CAST(:sibs AS uuid[])) AND target_type='procedure'))"
+            ),
+            {"agent": AGENT, "sibs": c["siblings"]},
+        )
+        edge_n = edge_r.scalar() or 0
+        for sid in c["siblings"]:
+            sib = await _fetch_row(conn, sid)
+            print(f"  archive   : {sib['name'] if sib else '??'}  ({sid})")
+        cnt = (
+            await conn.execute(
+                text(
+                    "SELECT coalesce(sum(activation_count),0) a, coalesce(sum(success_count),0) s, "
+                    "coalesce(sum(failure_count),0) f, coalesce(sum(neutral_count),0) n "
+                    "FROM heart.procedures WHERE agent_id=:agent AND id = ANY(CAST(:sibs AS uuid[]))"
+                ),
+                {"agent": AGENT, "sibs": c["siblings"]},
+            )
+        ).mappings().first()
+        print(f"  counters folding into canonical: act={int(cnt['a'])} succ={int(cnt['s'])} fail={int(cnt['f'])} neu={int(cnt['n'])}")
+        print(f"  affinity folding in: {[(m['frame_type'], int(m['a']), int(m['s']), int(m['f'])) for m in aff]}")
+        print(f"  incident edges to delete: {edge_n}")
+        if c.get("enrich_notes"):
+            print(f"  canonical enrich notes: {len(c['enrich_notes'])}")
+
+
+async def _verify(conn) -> list[str]:
+    """Post-consolidation invariants (run inside the same tx)."""
+    problems: list[str] = []
+    for c in CLUSTERS:
+        canon = await _fetch_row(conn, c["canonical"])
+        if not canon or not canon["active"] or canon["superseded_by"] is not None:
+            problems.append(f"[{c['name']}] canonical not healthy post-merge")
+        for sid in c["siblings"]:
+            sib = await _fetch_row(conn, sid)
+            if sib is None:
+                problems.append(f"[{c['name']}] sibling {sid} vanished")
+                continue
+            if sib["active"]:
+                problems.append(f"[{c['name']}] sibling {sib['name']} still active")
+            if sib["superseded_by"] != c["canonical"]:
+                problems.append(f"[{c['name']}] sibling {sib['name']} superseded_by != canonical")
+            # affinity rows for the sibling must be gone
+            r = await conn.execute(
+                text("SELECT count(*) FROM heart.procedure_task_affinity WHERE procedure_id = :id"),
+                {"id": sid},
+            )
+            if (r.scalar() or 0) != 0:
+                problems.append(f"[{c['name']}] sibling {sib['name']} still has affinity rows")
+            # incident edges must be gone
+            r = await conn.execute(
+                text(
+                    "SELECT count(*) FROM brain.graph_edges WHERE "
+                    "(source_id = :id AND source_type='procedure') OR (target_id = :id AND target_type='procedure')"
+                ),
+                {"id": sid},
+            )
+            if (r.scalar() or 0) != 0:
+                problems.append(f"[{c['name']}] sibling {sib['name']} still has incident edges")
+    return problems
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser(description="Procedure dedup Phase 0 consolidation")
+    ap.add_argument("--commit", action="store_true", help="COMMIT (default is dry-run + rollback)")
+    args = ap.parse_args()
+    mode = "COMMIT" if args.commit else "DRY-RUN"
+
+    settings = Settings()
+    db = Database(settings)
+    await db.connect()
+    rc = 0
+    try:
+        # Explicit transaction so dry-run can ROLLBACK and --commit can COMMIT
+        # without fighting begin()'s implicit auto-commit-on-exit.
+        async with db.engine.connect() as conn:
+            trans = await conn.begin()
+            print(f"[{mode}] agent={AGENT} db={settings.db_name}@{settings.db_host}:{settings.db_port}")
+            problems = await _preflight(conn)
+            if problems:
+                print("PREFLIGHT FAILED:")
+                for p in problems:
+                    print("  -", p)
+                await trans.rollback()
+                return 2
+            await _report(conn)
+            for c in CLUSTERS:
+                await _consolidate_cluster(conn, c, verbose=False)
+            verify_problems = await _verify(conn)
+            if verify_problems:
+                print("\nVERIFY FAILED (rolling back):")
+                for p in verify_problems:
+                    print("  -", p)
+                await trans.rollback()
+                return 3
+            n_arch = sum(len(c["siblings"]) for c in CLUSTERS)
+            print(f"\n[{mode}] verified OK — {n_arch} siblings archived across {len(CLUSTERS)} clusters")
+            if args.commit:
+                await trans.commit()
+                print("[COMMIT] changes persisted")
+            else:
+                await trans.rollback()
+                print("[DRY-RUN] transaction rolled back — no changes persisted")
+    finally:
+        await db.disconnect()
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/sql/migrations/057_procedure_supersession.sql
+++ b/sql/migrations/057_procedure_supersession.sql
@@ -1,0 +1,32 @@
+-- Procedure dedup Phase 0: supersession bookkeeping on heart.procedures.
+-- Audit: docs/reviews/procedure-subsystem-audit-2026-06-06.md (§6 B1).
+--
+-- Closes the restart "resurrection loop": when a duplicate procedure is archived
+-- (active=false), bootstrap_local_skills re-imports the skill,local SKILL.md and
+-- reactivate_skills un-archives it on next boot, because both keyed off the active
+-- flag alone. These columns let those paths key off superseded_by instead
+-- (superseded_by IS NOT NULL = "deliberately consolidated -> redirect to canonical,
+-- do NOT recreate/reactivate"), distinct from active=false-for-missing-requires.
+--
+-- Additive (nullable columns only) -> safe to deploy at any time. The
+-- (agent_id, lower(name)) WHERE active uniqueness index ships in migration 058 and
+-- must NOT deploy until the consolidation has removed the active duplicates.
+--
+-- NOTE: statements are kept splitter-safe for the auto-migrator (nous/storage/
+-- migrator.py) — no DO $$ blocks (the splitter does not understand dollar quoting)
+-- and no BEGIN/COMMIT (run_migrations wraps every file in one transaction).
+-- superseded_by is a plain UUID, not an FK: procedures are never hard-deleted.
+
+ALTER TABLE heart.procedures ADD COLUMN IF NOT EXISTS superseded_by UUID DEFAULT NULL;
+
+ALTER TABLE heart.procedures ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ DEFAULT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_procedures_superseded_name
+    ON heart.procedures (agent_id, name)
+    WHERE superseded_by IS NOT NULL;
+
+COMMENT ON COLUMN heart.procedures.superseded_by IS
+    'Dedup Phase 0: id of the canonical procedure that absorbed this one during consolidation. NOT NULL = consolidated duplicate; bootstrap/reactivate must redirect to the canonical instead of recreating/reactivating this row.';
+
+COMMENT ON COLUMN heart.procedures.archived_at IS
+    'Dedup Phase 0: timestamp this procedure was archived by consolidation. Paired with superseded_by. NULL for live rows and for rows deactivated by other paths (e.g. missing requires).';

--- a/tests/test_procedure_dedup.py
+++ b/tests/test_procedure_dedup.py
@@ -1,0 +1,190 @@
+"""Procedure dedup Phase 0 — supersession bookkeeping + restart-loop close.
+
+Covers migration 057 columns and the B1 resurrection-loop fix (audit
+docs/reviews/procedure-subsystem-audit-2026-06-06.md): a consolidated duplicate
+(archived with superseded_by set) must NOT be recreated by bootstrap or
+un-archived by reactivate.
+
+All tests require real Postgres (array columns + the new columns). The first three
+use the rollback-isolated ``session`` fixture; the bootstrap/reactivate tests commit
+uniquely-named rows (those code paths open their own sessions) and clean up after.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+from nous.heart import ProcedureInput
+from nous.skills.bootstrap import bootstrap_local_skills, reactivate_skills
+
+pytestmark = pytest.mark.postgres_only
+
+
+def _inp(name: str, **ov) -> ProcedureInput:
+    d = dict(
+        name=name,
+        domain="general",
+        description=f"desc for {name}",
+        core_patterns=["p"],
+        implementation_notes=["n"],
+        tags=["skill", "local"],
+    )
+    d.update(ov)
+    return ProcedureInput(**d)
+
+
+async def _supersede(heart, *, sibling_id, canonical_id) -> None:
+    """Archive sibling_id as superseded by canonical_id (committed, own session)."""
+    async with heart.db.session() as s:
+        await s.execute(
+            text(
+                "UPDATE heart.procedures SET active=false, archived_at=now(), superseded_by=:c "
+                "WHERE id=:i"
+            ),
+            {"c": canonical_id, "i": sibling_id},
+        )
+        await s.commit()
+
+
+async def _delete(heart, *names) -> None:
+    async with heart.db.session() as s:
+        await s.execute(
+            text("DELETE FROM heart.procedures WHERE agent_id=:a AND name = ANY(:names)"),
+            {"a": heart.agent_id, "names": list(names)},
+        )
+        await s.commit()
+
+
+# ---------------------------------------------------------------------------
+# 1. migration columns round-trip
+# ---------------------------------------------------------------------------
+
+
+async def test_supersession_columns_roundtrip(heart, session):
+    canon = await heart.store_procedure(_inp("dedup-canon"), session=session)
+    sib = await heart.store_procedure(_inp("dedup-sib"), session=session)
+    await session.execute(
+        text(
+            "UPDATE heart.procedures SET active=false, archived_at=now(), superseded_by=:c WHERE id=:i"
+        ),
+        {"c": canon.id, "i": sib.id},
+    )
+    row = (
+        await session.execute(
+            text("SELECT active, superseded_by::text AS sb, archived_at FROM heart.procedures WHERE id=:i"),
+            {"i": sib.id},
+        )
+    ).mappings().first()
+    assert row["active"] is False
+    assert row["sb"] == str(canon.id)
+    assert row["archived_at"] is not None
+
+
+# ---------------------------------------------------------------------------
+# 2. is_name_superseded
+# ---------------------------------------------------------------------------
+
+
+async def test_is_name_superseded(heart, session):
+    canon = await heart.store_procedure(_inp("dedup-keep"), session=session)
+    sib = await heart.store_procedure(_inp("dedup-dup"), session=session)
+    assert await heart.is_procedure_name_superseded("dedup-dup", session=session) is False
+    await session.execute(
+        text("UPDATE heart.procedures SET active=false, superseded_by=:c WHERE id=:i"),
+        {"c": canon.id, "i": sib.id},
+    )
+    assert await heart.is_procedure_name_superseded("dedup-dup", session=session) is True
+    # a name that was never seen is not superseded
+    assert await heart.is_procedure_name_superseded("never-existed-xyz", session=session) is False
+
+
+# ---------------------------------------------------------------------------
+# 3. reactivation list excludes superseded rows
+# ---------------------------------------------------------------------------
+
+
+async def test_list_inactive_skills_excludes_superseded(heart, session):
+    canon = await heart.store_procedure(_inp("dedup-canon3"), session=session)
+    plain = await heart.store_procedure(_inp("dedup-plain-inactive", active=False), session=session)
+    sup = await heart.store_procedure(_inp("dedup-superseded-inactive", active=False), session=session)
+    await session.execute(
+        text("UPDATE heart.procedures SET superseded_by=:c WHERE id=:i"),
+        {"c": canon.id, "i": sup.id},
+    )
+    names = {p.name for p in await heart.procedures.list_inactive_skills(session=session)}
+    assert "dedup-plain-inactive" in names           # ordinary inactive skill: eligible
+    assert "dedup-superseded-inactive" not in names  # superseded: never resurrected
+    assert plain.id is not None and sup.id is not None
+
+
+# ---------------------------------------------------------------------------
+# 4. bootstrap does not recreate a superseded skill (the B1 loop)
+# ---------------------------------------------------------------------------
+
+
+async def test_bootstrap_skips_superseded_name(heart, tmp_path):
+    name = f"Dedup Bootstrap Skill {uuid.uuid4().hex[:8]}"
+    try:
+        canon = await heart.store_procedure(_inp("dedup-boot-canon"))
+        sib = await heart.store_procedure(_inp(name))
+        await _supersede(heart, sibling_id=sib.id, canonical_id=canon.id)
+
+        # a SKILL.md on disk with the superseded name
+        skill_dir = tmp_path / "skills" / "dedup-boot"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: should not be re-imported\n---\nbody\n",
+            encoding="utf-8",
+        )
+
+        registered = await bootstrap_local_skills(str(tmp_path), heart)
+        assert registered == 0  # skipped, not re-imported
+
+        # and there is still no ACTIVE row with that name
+        async with heart.db.session() as s:
+            n_active = (
+                await s.execute(
+                    text("SELECT count(*) FROM heart.procedures WHERE agent_id=:a AND name=:n AND active"),
+                    {"a": heart.agent_id, "n": name},
+                )
+            ).scalar()
+        assert n_active == 0
+    finally:
+        await _delete(heart, name, "dedup-boot-canon")
+
+
+# ---------------------------------------------------------------------------
+# 5. reactivate does not un-archive a superseded skill
+# ---------------------------------------------------------------------------
+
+
+async def test_reactivate_skips_superseded(heart, monkeypatch):
+    var = f"DEDUP_REQ_{uuid.uuid4().hex[:8].upper()}"
+    monkeypatch.setenv(var, "1")
+    sup_name = f"dedup-react-superseded-{uuid.uuid4().hex[:6]}"
+    ctl_name = f"dedup-react-control-{uuid.uuid4().hex[:6]}"
+    try:
+        canon = await heart.store_procedure(_inp("dedup-react-canon"))
+        sup = await heart.store_procedure(
+            _inp(sup_name, active=False, core_concepts=[f"requires:{var}"])
+        )
+        ctl = await heart.store_procedure(
+            _inp(ctl_name, active=False, core_concepts=[f"requires:{var}"])
+        )
+        await _supersede(heart, sibling_id=sup.id, canonical_id=canon.id)
+
+        await reactivate_skills(heart)
+
+        async with heart.db.session() as s:
+            sup_active = (
+                await s.execute(text("SELECT active FROM heart.procedures WHERE id=:i"), {"i": sup.id})
+            ).scalar()
+            ctl_active = (
+                await s.execute(text("SELECT active FROM heart.procedures WHERE id=:i"), {"i": ctl.id})
+            ).scalar()
+        assert sup_active is False  # superseded: stays archived
+        assert ctl_active is True   # control: requires satisfied -> reactivated
+    finally:
+        await _delete(heart, sup_name, ctl_name, "dedup-react-canon")

--- a/tests/test_procedure_import.py
+++ b/tests/test_procedure_import.py
@@ -1,0 +1,144 @@
+"""Procedure create/import algorithm fixes (audit §6 PR2).
+
+- update_body refreshes a skill in place, preserving learned stats (bug 9).
+- get_procedure_by_name / is_name_superseded match case-insensitively (B6).
+- embedding failure retries then stores NULL loudly rather than raising (bug 8).
+
+Requires real Postgres (array columns + pgvector embedding).
+"""
+from __future__ import annotations
+
+import pytest
+
+from nous.heart import ProcedureInput
+from nous.heart.procedures import ProcedureManager
+
+pytestmark = pytest.mark.postgres_only
+
+
+def _inp(name: str, **ov) -> ProcedureInput:
+    d = dict(
+        name=name, domain="general", description=f"desc for {name}",
+        core_patterns=["p"], implementation_notes=["n"], tags=["skill"],
+    )
+    d.update(ov)
+    return ProcedureInput(**d)
+
+
+async def test_update_body_preserves_counts(heart, session):
+    p = await heart.store_procedure(_inp("import-stats"), session=session)
+    await heart.activate_procedure(p.id, session=session)
+    await heart.activate_procedure(p.id, session=session)
+    await heart.record_procedure_outcome(p.id, "success", session=session)
+    await heart.record_procedure_outcome(p.id, "success", session=session)
+
+    updated = await heart.update_procedure_body(
+        p.id, _inp("import-stats", description="rewritten body", implementation_notes=["x", "y"]),
+        session=session,
+    )
+    assert updated.description == "rewritten body"
+    assert updated.implementation_notes == ["x", "y"]
+    # learned stats survive the in-place update (the bug-9 regression)
+    assert updated.activation_count == 2
+    assert updated.success_count == 2
+
+
+async def test_get_by_name_case_insensitive(heart, session):
+    await heart.store_procedure(_inp("CaseSensitive Skill"), session=session)
+    hit = await heart.get_procedure_by_name("casesensitive skill", session=session)
+    assert hit is not None
+    assert hit.name == "CaseSensitive Skill"
+
+
+async def test_is_name_superseded_case_insensitive(heart, session):
+    from sqlalchemy import text
+
+    canon = await heart.store_procedure(_inp("CI-canon"), session=session)
+    sib = await heart.store_procedure(_inp("CI-Dup-Name"), session=session)
+    await session.execute(
+        text("UPDATE heart.procedures SET active=false, superseded_by=:c WHERE id=:i"),
+        {"c": canon.id, "i": sib.id},
+    )
+    assert await heart.is_procedure_name_superseded("ci-dup-name", session=session) is True
+
+
+async def test_reactivate_skips_name_collision(heart, session):
+    # B6/C2: reactivating an inactive row whose lower(name) matches a live row must
+    # skip (not flip), else it violates the unique index and aborts reactivate_skills.
+    await heart.store_procedure(_inp("ReactClash"), session=session)  # active
+    inactive = await heart.store_procedure(_inp("reactclash", active=False), session=session)
+    await heart.reactivate_procedure(inactive.id, session=session)
+    detail = await heart.get_procedure(inactive.id, session=session)
+    assert detail.active is False  # skipped due to active same-name row
+
+
+async def test_reactivate_succeeds_when_no_collision(heart, session):
+    inactive = await heart.store_procedure(_inp("react-unique-name", active=False), session=session)
+    await heart.reactivate_procedure(inactive.id, session=session)
+    detail = await heart.get_procedure(inactive.id, session=session)
+    assert detail.active is True
+
+
+class _FailingEmbeddings:
+    async def embed(self, text: str):
+        raise RuntimeError("embedding backend down")
+
+    async def embed_batch(self, texts):
+        raise RuntimeError("embedding backend down")
+
+    async def close(self):
+        pass
+
+
+async def test_embed_with_retry_returns_none(db, session):
+    mgr = ProcedureManager(db, _FailingEmbeddings(), "test-import-agent")
+    result = await mgr._embed_with_retry("anything", attempts=2)
+    assert result is None
+
+
+class _GoodEmbeddings:
+    async def embed(self, text: str):
+        return [0.1] * 1536
+
+    async def embed_batch(self, texts):
+        return [[0.1] * 1536 for _ in texts]
+
+    async def close(self):
+        pass
+
+
+async def test_update_body_nulls_stale_embedding_on_failure(db, session):
+    from sqlalchemy import text
+
+    good = ProcedureManager(db, _GoodEmbeddings(), "test-import-agent2")
+    detail = await good._store(_inp("embed-update-skill"), session)
+    before = (
+        await session.execute(
+            text("SELECT embedding IS NOT NULL FROM heart.procedures WHERE id=:i"), {"i": detail.id}
+        )
+    ).scalar()
+    assert before is True
+
+    bad = ProcedureManager(db, _FailingEmbeddings(), "test-import-agent2")
+    await bad._update_body(detail.id, _inp("embed-update-skill", description="changed"), session)
+    after = (
+        await session.execute(
+            text("SELECT embedding IS NULL FROM heart.procedures WHERE id=:i"), {"i": detail.id}
+        )
+    ).scalar()
+    assert after is True  # stale vector cleared, not kept
+
+
+async def test_store_survives_embedding_failure(db, session):
+    # _store must not raise when embeddings fail; it stores a NULL-embedding row.
+    mgr = ProcedureManager(db, _FailingEmbeddings(), "test-import-agent")
+    detail = await mgr._store(_inp("embed-fail-skill"), session)
+    assert detail.name == "embed-fail-skill"
+    from sqlalchemy import text
+
+    emb = (
+        await session.execute(
+            text("SELECT embedding IS NULL FROM heart.procedures WHERE id=:i"), {"i": detail.id}
+        )
+    ).scalar()
+    assert emb is True

--- a/tests/test_skill_parser.py
+++ b/tests/test_skill_parser.py
@@ -34,6 +34,25 @@ class TestParseFrontmatter:
         result = _parse_frontmatter(text)
         assert result["triggers"] == ["web search", "google", "find online"]
 
+    def test_block_scalar_literal(self):
+        # `description: |` must capture the indented body, not the literal "|"
+        # (audit: empty-description rows like investigate/cso/office-hours).
+        text = "name: investigate\ndescription: |\n  Root-cause debugging.\n  No fixes first.\ndomain: debug"
+        result = _parse_frontmatter(text)
+        assert result["description"] == "Root-cause debugging.\nNo fixes first."
+        assert result["domain"] == "debug"
+
+    def test_block_scalar_folded(self):
+        # `description: >` folds lines with spaces.
+        text = "name: dr\ndescription: >\n  Multi-source research\n  with confidence ratings.\n"
+        result = _parse_frontmatter(text)
+        assert result["description"] == "Multi-source research with confidence ratings."
+
+    def test_block_scalar_with_chomping_indicator(self):
+        text = "name: x\ndescription: |-\n  one line\n"
+        result = _parse_frontmatter(text)
+        assert result["description"] == "one line"
+
     def test_mixed_scalars_and_lists(self):
         text = (
             "name: serper-search\n"
@@ -254,6 +273,7 @@ class TestLearnSkillTool:
         mock_detail.id = uuid4()
         mock_detail.active = True
         heart.store_procedure = AsyncMock(return_value=mock_detail)
+        heart.update_procedure_body = AsyncMock(return_value=mock_detail)
         heart.retire_procedure = AsyncMock()
 
         return heart
@@ -323,8 +343,11 @@ class TestLearnSkillTool:
 
         text = result["content"][0]["text"]
         assert "updated successfully" in text
-        mock_heart.retire_procedure.assert_called_once_with(existing.id)
-        mock_heart.store_procedure.assert_called_once()
+        # bug 9 fix: update in place (preserve counts) instead of retire+store
+        mock_heart.update_procedure_body.assert_called_once()
+        assert mock_heart.update_procedure_body.call_args.args[0] == existing.id
+        mock_heart.retire_procedure.assert_not_called()
+        mock_heart.store_procedure.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_learn_skill_local_file_not_found(self, mock_brain, mock_heart, mock_settings):
@@ -706,6 +729,7 @@ class TestGetProcedureTool:
         mock_detail.effectiveness = 0.8
         heart.get_procedure = AsyncMock(return_value=mock_detail)
         heart.store_procedure = AsyncMock(return_value=mock_detail)
+        heart.update_procedure_body = AsyncMock(return_value=mock_detail)
         heart.retire_procedure = AsyncMock()
 
         return heart


### PR DESCRIPTION
Executes the procedure-subsystem audit (`docs/reviews/procedure-subsystem-audit-2026-06-06.md`, §6 authoritative; §7 = execution). Collapses the duplicate clusters the F079 catalog would faithfully list **and** fixes the create/import paths that let duplicates/broken rows accumulate. Self-contained and deploy-safe — the only piece that must wait for the prod consolidation is the unique index, shipped separately in #489.

## Dedup execution
- **migration 057** — nullable `superseded_by` + `archived_at` (+ redirect index). Additive, splitter-safe for the auto-migrator (no `DO $$`, no `BEGIN/COMMIT`), plain UUID.
- **B1 restart-loop close** — bootstrap skips re-importing a consolidated name; `reactivate_skills` no longer un-archives superseded rows. Keyed on `superseded_by`.
- **`scripts/diag/proc_consolidate.py`** (operator-gated `--dry-run`/`--commit`) — per cluster, one tx: UPSERT-SUM affinity into canonical → **fold procedure-level outcome counters** → delete redundant sibling affinity → enrich canonical → delete incident `graph_edges` → archive siblings. Idempotent; refuses non-null outbound arrays. Canonicals: email→`send_email`, action_gate→`recovery`, compaction→`Management`; context trio kept. **Net 62 → 55.**

## Create/import algorithm fixes (audit §6 PR2)
- `learn_skill` **updates in place** on a name collision (`Heart.update_procedure_body`) instead of retire+store, which reset counts and orphaned task affinity (bug 9).
- **SkillParser handles YAML block scalars** (`description: |` / `>`) — root cause of the empty one-char catalog descriptions on heavily-used skills (`deep-researcher`, `investigate`, `cso`, `office-hours`). `backfill_proc_descriptions.py` fixes the 4 existing rows (idempotent, gated).
- case-insensitive `get_procedure_by_name`/`is_name_superseded`; reactivate name-collision precheck; embedding-failure retry that logs ERROR + stores NULL (store **and** update paths).

## Validation
Through the **real auto-migrator splitter** on a throwaway DB (5433) seeded from prod cluster data: 057 applies; consolidation sums affinity (388) **and** counters (send_email 112+655=767) correctly and is re-run **idempotent**; siblings archived w/ `superseded_by`; edges/affinity gone. 77 tests green. Addresses codex P1 (fold counters; route `learn_skill` through `update_body`) + P2 (NULL stale embedding).

## ⚠ Deploy ordering
Deploy this PR → run `proc_consolidate.py --commit` + `backfill_proc_descriptions.py --commit` on prod → then merge/deploy **#489** (the unique index, which fails while active dups exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)