### PR TITLE
feat(procedures): migration 058 — (agent_id, lower(name)) WHERE active unique index

### DIFF
--- a/sql/migrations/058_procedure_name_uniqueness.sql
+++ b/sql/migrations/058_procedure_name_uniqueness.sql
@@ -1,0 +1,26 @@
+-- Procedure dedup PR2: enforce one active procedure per (agent_id, lower(name)).
+-- Audit: docs/reviews/procedure-subsystem-audit-2026-06-06.md (§6 B6).
+--
+-- ⚠ DEPLOY ORDER MATTERS. This runs on every deploy regardless of feature flags.
+-- It CANNOT succeed while duplicate active names exist (e.g. the 3 live
+-- "Send Email via Gmail SMTP" rows). Run the Phase 0 consolidation FIRST
+-- (scripts/diag/proc_consolidate.py --commit on prod) so the DB is collision-free,
+-- THEN deploy this migration. If deployed early, CREATE UNIQUE INDEX fails with
+-- Postgres' own "could not create unique index ... contains duplicated values"
+-- and the deploy aborts loudly — re-run the consolidation, then redeploy.
+--
+-- Splitter-safe for the auto-migrator: a plain CREATE UNIQUE INDEX, no DO $$ block
+-- (the migrator's SQL splitter does not understand dollar quoting) and no
+-- BEGIN/COMMIT (run_migrations wraps the file in one transaction).
+--
+-- Precheck the collision set before deploying with:
+--   SELECT agent_id, lower(name), count(*) FROM heart.procedures WHERE active
+--   GROUP BY agent_id, lower(name) HAVING count(*) > 1;
+--
+-- Case-insensitive, agent-scoped, active-only. Pairs with the case-insensitive
+-- get_procedure_by_name lookup so write paths (learn_skill, bootstrap, K-line) can
+-- no longer mint a second active row that differs only by casing/whitespace.
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_procedures_active_lower_name
+    ON heart.procedures (agent_id, lower(name))
+    WHERE active;


### PR DESCRIPTION
**Stacked on #488. Deploy ONLY after #488 is deployed and the prod consolidation has run** (collision-free) — the unique index fails to create while duplicate active names still exist.

Single migration: partial unique index `(agent_id, lower(name)) WHERE active`, pairing with #488's case-insensitive name lookups so write paths can no longer mint a second active row differing only by casing/whitespace. Splitter-safe plain `CREATE UNIQUE INDEX`; deploy-order documented in the migration header.

Base retargets to `main` automatically once #488 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)