### PR TITLE
feat(retrieval): F080 coherent ranking — knowledge-only recall pool (PR 1/2)

### DIFF
--- a/docs/features/F080-approach-B-calibration-champion.md
+++ b/docs/features/F080-approach-B-calibration-champion.md
@@ -1,0 +1,315 @@
+# F080 Debate — Approach B Champion Brief: Per-Type Score Calibration to a Common [0,1]
+
+**Position:** Champion of **Approach B**. The cross-type merge is incoherent because two
+types deviate from a `[0,1]` space that **already exists** for everyone else. The fix is to
+force the two deviants (and the embed-failure leg) back into that existing space — preserving
+relevance *magnitude*, which is the signal rank fusion (Approach A) throws away.
+
+**Authority:** code only. Every claim carries `file:line`, verified this session against
+`nous/heart/{heart,search,censors,procedures,facts}.py` and `nous/api/retrieval_pipeline.py`.
+
+---
+
+## 0. The spine, stated once
+
+**Fixed per-type affine maps INTO the RRF-normalized `[0,1]` space that `search.py` already
+produces** — *not* per-candidate-set min-max, *not* a learned distributional map.
+
+The load-bearing fact: **3 of the 4 types already emit normalized RRF `[0,1]`.**
+- `_rrf_merge` divides by `max_score = 1/k` → `[0,1]` (`search.py:110-115`).
+- `_rrf_merge_n` (the **prod path**, because query expansion is ON in `.env.prod-snapshot`)
+  applies the *identical* `/max_score` normalization (`search.py:283-288`, docstring at `:246-250`
+  asserts byte-identical normalization to `_rrf_merge` at N=1). **Verified this session** — my
+  premise survives the config that actually ships.
+
+So the "common space" is not invented. It is the codebase's own existing invariant. Facts
+(`facts.py` via `hybrid_search`), episodes (`episodes.py:548`), and single-/multi-query
+procedures' *hybrid* component all land in `[0,1]`. Approach B's entire job is to make the
+**two deviants** conform:
+
+| Type | What enters the merge today | Deviation | Affine map under B |
+|------|-----------------------------|-----------|--------------------|
+| Fact | RRF `[0,1]` (`search.py:224`) | none | **identity** |
+| Episode | RRF `[0,1]` (`episodes.py:548`) | none | **identity** |
+| Procedure | `hybrid × (1+boost)` → **>1.0** (`procedures.py:457`) | boost breaks ceiling | de-boost: use raw hybrid + bounded utility bonus |
+| Censor | raw cosine **floored ≥0.7** (`censors.py:387,400`) | floor + wrong distribution | **exclude from pool** |
+| Embed-fail leg | raw `ts_rank_cd` ~0.06 (`search.py:220-222`) | un-normalized | rank-normalize the leg into `[0,1]` |
+
+Because the map is **identity for the already-normalized types**, the "fixed affine maps need
+per-type calibration data" con (F080 §2 Approach B "Con") **shrinks to near zero**: there is no
+data to gather for facts/episodes — they're already there. We only neutralize two pathologies
+and re-normalize one failure leg.
+
+**Why not min-max (the option the task lists first — it is a trap I decline):** per-candidate-set
+min-max maps each type's best→1.0 and worst→0.0. A type whose best fact is 0.55 and a type whose
+best is 0.95 *both* map their top item to 1.0 — which is **exactly the magnitude-discarding
+behavior I'm supposed to beat Approach A with** (deliverable #5). It also degenerates when
+`max==min` on a 1–2 item type, and the procedure outlier at 1.26 would set the ceiling. Min-max
+is rank fusion with extra fragility. I reject it. Affine-into-existing-`[0,1]` is the principled
+Approach-B spine.
+
+---
+
+## 1. Calibration mechanism
+
+### Transform
+
+For a candidate of type `t` with comparable score `s` entering the merge:
+
+```
+calibrated(s, t) = clamp01( a_t * s + b_t )
+```
+
+with **fixed, documented** `(a_t, b_t)`:
+
+| Type | `a_t` | `b_t` | Rationale |
+|------|-------|-------|-----------|
+| fact | 1.0 | 0.0 | already RRF-`[0,1]` — identity |
+| episode | 1.0 | 0.0 | already RRF-`[0,1]` — identity |
+| procedure | 1.0 | 0.0 | applied to the **raw hybrid** (see §4); utility folds in separately |
+| chunk | 1.0 | 0.0 | raw cosine `[0,1]` already (`retrieval_pipeline.py:897-903`) — identity |
+| censor | — | — | **excluded** (§3); no map needed |
+| graph-expanded | 1.0 | 0.0 | already `≤0.70`, in-band, honest decay score |
+| embed-fail leg | rank-normalized | (§2) | re-based per §2 |
+
+For the shipping default, **every surviving type's map is identity** — the calibration is
+purely *removing pathologies*, not *rescaling healthy signals*. That is the minimal, honest
+form of Approach B and it is what makes acceptance criterion #3 (byte-identical OFF) trivial.
+
+### Where it plugs in (the critical placement)
+
+**Inside `heart._recall`, at the score-copy site `heart.py:983-988`, behind
+`NOUS_COHERENT_RANKING_ENABLED`.** This is non-negotiable and is *why* B is correct where a
+pipeline-only fix is not:
+
+The load-bearing truncation `merged.sort(key=score)[:limit]` is at **`heart.py:1110-1112`** —
+*inside* `_recall`, **before** `run_recall_pipeline` ever sees the list (whitepaper §3.5).
+Displaced facts are dropped here. Fixing only the pipeline `rerank_by_score` sort
+(`retrieval_pipeline.py:277-278`, the B4 site) is **too late** — the relevant facts are already
+gone. So:
+
+- **Primary surgery:** calibrate at `heart.py:983-988` so the `[:limit]` cut at `:1110-1112`
+  operates on one comparable space.
+- **Secondary:** apply the same calibration at the pipeline assembly (`retrieval_pipeline.py:220`)
+  so the cross-*leg* pool (graph + chunks + decisions) competes coherently before
+  `rerank_by_score`. Decisions arrive as `d.score` (`retrieval_pipeline.py` `_decisions_to_pipeline`),
+  already `[0,1]` from `brain.query`'s own RRF.
+
+Concretely at `:983-988` the loop becomes (flag-gated; OFF path unchanged):
+
+```python
+for item in raw_results:
+    raw = getattr(item, "score", None)
+    original_score = raw if raw is not None else 0.0
+    if coherent_ranking_enabled:
+        original_score = _calibrate(memory_type, item, original_score, fetch_limit)
+    recall_result = self._to_recall_result(memory_type, item, original_score)
+```
+
+### Tiny-set behavior (the min-max degeneracy probe)
+
+This is *why I chose fixed affine over min-max*. Fixed affine has **no candidate-set dependence**:
+a single fact at RRF 0.55 maps to 0.55 whether it's alone or one of fifty. There is **no
+`max==min` division** to blow up, because there is no division by a set-derived range. A
+2-result type calibrates identically to a 200-result type. Min-max could not make this claim —
+its whole transform is `(s - min)/(max - min)`, undefined at `max==min`. Stability on tiny sets
+is a *property of the affine choice*, not a special case I have to guard.
+
+(The only set-dependent leg is the embed-fail re-normalization in §2 — and there I use *rank*,
+not min-max, precisely to keep the same degeneracy-immunity.)
+
+---
+
+## 2. Removing the pathologies at source (without mutating shared producers)
+
+**The #2-vs-#3 tension, resolved explicitly.** Deliverable #2 says "strip the pathologies at
+source"; deliverable #3 demands byte-identical OFF. If I literally edit `censors.py:387,400`,
+`procedures.py:457`, or `search.py:220-222`, those producers also serve the **flag-OFF path** and
+the **cognitive path** → the F051 snapshot breaks and I lose. **Resolution: "at source" means
+"neutralize each pathology as the score enters the *comparable* merge score," not "edit the
+producer SQL."** All neutralization lives in the flag-gated `_calibrate` at `heart.py:983-988`.
+No producer is mutated. When `NOUS_COHERENT_RANKING_ENABLED=false`, the `else` branch at
+`heart.py:1109-1112` runs verbatim → byte-identical.
+
+**Censor floor (`censors.py:387,400`).** The `> 0.7` is a SQL `WHERE` filter that *selects* which
+censors return — it is a retrieval gate, not a score I can subtract away cleanly (the floor means
+I never even see sub-0.7 censors, so I can't re-base the distribution honestly). The clean answer
+is **exclude censors from the ranked pool entirely** (§3). One line, no normalization, pathology
+gone at the root.
+
+**Procedure boost (`procedures.py:446-457`).** The producer returns only the *boosted*
+`final_score`. To de-boost at the merge I must **carry the raw hybrid score** through
+`ProcedureSummary` (the one unavoidable wire change — see §8 footprint). `procedures.py:438`
+already has `hybrid_score = scores.get(p.id, 0.0)` in scope; I add `raw_hybrid_score=hybrid_score`
+to the `ProcedureSummary(...)` constructor (`:459-473`). **Adding a field changes no existing
+value** → OFF stays byte-identical. At calibration I read the raw hybrid (already `[0,1]`) as the
+*relevance* axis and fold utility as a bounded bonus (§4). The boosted `score` field stays for any
+OFF-path consumer.
+
+**Embed-failure leg (`search.py:220-222`).** When `embedding is None`, `hybrid_search` returns
+`keyword_results[:limit]` as raw `ts_rank_cd/(1+ts_rank_cd)` (~0.06) — un-normalized, collapsing
+the whole type ~10–20× (whitepaper B3). I **rank-normalize this leg into `[0,1]`** at calibration
+time: the leg is already `ORDER BY score DESC` (`search.py:214`), so I map by within-leg rank to
+the *same* `[0,1]` band RRF would have produced —
+`calibrated_i = 1/k_norm · (rrf_contribution at rank i)`, i.e. reuse `_rrf_merge` with an empty
+vector list so the math is *literally the existing normalization* (`search.py:105,113-115`). This
+is the honest re-base: a keyword-only type now competes at the rank it earned, not at a raw
+`ts_rank_cd` magnitude that was never comparable to cosine. Detecting the degraded leg: it carries
+no vector contribution, surfaced via a `degraded: bool` flag threaded from `hybrid_search`'s
+`embedding is None` branch into the per-type result (small additive field, OFF-path inert).
+
+All four types now land in one honest `[0,1]`.
+
+---
+
+## 3. Censor sub-decision — **EXCLUDE**, and it's *more* principled, not just cheaper
+
+Drop `"censor"` from `heart_types` in the `recall_deep` path (`retrieval_pipeline.py:340-341`),
+gated by the flag. Justification — consistent with the affine spine:
+
+1. **Censors are not in the RRF space.** They emit *raw cosine*, hard-floored (`censors.py:387,400`).
+   To "normalize them in" I'd need a defensible cosine→RRF affine map — but cosine and RRF are
+   different distributions, so any `(a_censor, b_censor)` is a **guess**, and a guess is exactly the
+   "fixed maps need calibration data" con biting me. Excluding dodges the one map I *can't* make
+   honestly.
+2. **Embedding-model drift kills any fixed cosine map.** Prod runs `text-embedding-3-large`; code
+   embeds `small`. A cosine→`[0,1]` calibration tuned on one model silently mis-maps under the
+   other. Exclusion is **immune** to that drift; a fixed cosine affine is not.
+3. **Censors already have a dedicated surface.** "Active Censors / Active Guidance"
+   (`context.py:460`) renders them unconditionally. They do not need to *compete for ranked slots*
+   against facts. Letting them displace mid-ranked facts at `heart.py:1110` is pure downside —
+   they're shown anyway.
+
+This is the rare case where the one-line change is the *principled* answer, not a shortcut. It
+removes B1 at the root and removes the one map I couldn't defend.
+
+---
+
+## 4. Procedure-boost sub-decision — **bounded convex bonus**, provably ≤1.0
+
+I reject `min(1.0, boosted)` clamping: it manufactures **ties at the ceiling** (1.26 and 1.05 both
+→ 1.0), a *new* monotonicity pathology. Instead:
+
+**Relevance and utility are different axes.** Hybrid score = "does this procedure match the query."
+Effectiveness = "has this procedure worked before." Conflating them with a multiplier
+(`procedures.py:457`) is the bug. Post-calibration, utility is a **bounded within-type bonus**:
+
+```
+relevance = raw_hybrid                      # already [0,1], carried per §2/§8
+utility    = clamp01( effectiveness )       # effectiveness ∈ [0,1] by construction
+final      = (1 - w) * relevance + w * utility,   w = NOUS_PROCEDURE_UTILITY_WEIGHT (default small, e.g. 0.15)
+```
+
+**Proof `final ∈ [0,1]`:** `relevance ∈ [0,1]`, `utility ∈ [0,1]`, `w ∈ [0,1]` ⇒ `final` is a
+convex combination of two `[0,1]` values ⇒ `final ∈ [0,1]`. No saturation, no ceiling ties,
+strictly monotone in both axes. A maximally-effective procedure can rise by at most `w` over its
+pure-relevance position — bounded, inspectable, and it *cannot* out-of-band any fact.
+
+This keeps the cross-type utility signal alive (unlike "post-rank within the procedure slice,"
+which would let a barely-relevant effective procedure never surface against facts) while *proving*
+the `[0,1]` invariant. Utility weight `w` is a single tunable, defaulting small so relevance
+dominates.
+
+---
+
+## 5. Magnitude preservation — the cross-type case that buries rank fusion
+
+This is my central selling point over Approach A. The decisive example is **cross-type**, not
+within-type:
+
+> Candidate set: one **fact at RRF 0.95** (dominant, near-perfect query match) and one
+> **procedure that is rank-0 of its own type but only RRF 0.60** (weak match, just the best
+> *available* procedure).
+
+- **Approach A (rank fusion over per-type lists):** both are *rank 0 of their type*. RRF fuses
+  them on rank alone (`_rrf_merge_n`, `search.py:234-290`) — the 0.60 procedure contributes the
+  *same* `1/(k+0)` as the 0.95 fact. With any type prior that even slightly favors procedures, the
+  weak 0.60 procedure **ties or beats** the strong 0.95 fact. Magnitude is gone by construction —
+  the F080 §2 Approach A "Con" admits this ("a 0.95 fact and a 0.55 fact at ranks 0/1 fuse the
+  same as two 0.6 facts").
+- **Approach B (affine-preserving):** `calibrate(0.95, fact) = 0.95`,
+  `calibrate(0.60, procedure) = (1-w)·0.60 + w·utility ≤ 0.60 + w`. With `w=0.15` and even a
+  perfectly-effective procedure, the procedure tops out at `0.51 + 0.15 = 0.66 < 0.95`. The
+  dominant fact **stays on top**, where relevance says it belongs.
+
+This is the everyday prod case: the agent asks something a fact answers crisply, and there happens
+to be a tangentially-related effective procedure. B serves the fact; A risks burying it under a
+procedure that merely "ranked first among procedures." Keeping magnitude is not academic — it's the
+difference between answering the question and surfacing a vaguely-related habit.
+
+---
+
+## 6. Acceptance criteria (F080 §3) — walkthrough
+
+1. **No mixed-scale sort.** ✅ After `_calibrate`, every value in `merged` is drawn from the single
+   documented RRF-`[0,1]` space (identity for healthy types, de-boosted for procedures,
+   rank-normalized for the embed-fail leg, censors excluded). The `[:limit]` cut at
+   `heart.py:1110-1112` now compares like-for-like. **B fixes the cut where it happens; A would too,
+   but B keeps magnitude while doing it.**
+2. **CE-off correctness.** ✅ **Emphasis.** `_calibrate` is pure arithmetic on already-fetched
+   scores — zero model calls, zero `sentence-transformers`, zero latency. It does **not** depend on
+   CE or MMR; it is precisely the re-basing step that CE/MMR would otherwise have done, made cheap.
+   This is B's headline advantage given `bge ~67s` on the CPU-only prod VM and MiniLM rolled back.
+3. **Byte-identical OFF.** ✅ **Emphasis.** Everything is behind `NOUS_COHERENT_RANKING_ENABLED`
+   (default OFF). No producer SQL is mutated (§2). The only structural change is *adding* a
+   `raw_hybrid_score`/`degraded` field — additive, changes no existing value. When OFF, the
+   `else` branch at `heart.py:1109-1112` and the censor inclusion at `:889-890` run verbatim → the
+   F051 `recall_deep` snapshot is byte-identical. This is *constructed*, not hoped for.
+4. **Ordering hazards.** ✅ Calibration is followed by exactly one score sort at `:1110` (heart)
+   and one at `retrieval_pipeline.py:278` (pipeline). The procedure de-boost removes the
+   non-monotonic input to those sorts. (B-cog-A/B/D cognitive-path ordering fixes share the
+   boost-sort root cause but live on a sibling surface — I scope them as a paired PR, F080 §6 q5.)
+5. **Observability honest.** ✅ Thread a real `coherent_ranking_applied` (and the true
+   `ce_reordered`/`mmr_active` already local to `_recall`) out into `PipelineStats`, fixing the
+   `retrieval_pipeline.py:296-297` hardcoded-`False` (B5). Without this, no eval of B can be trusted.
+6. **Measured.** ✅ **Emphasis + honest caveat in §7.** F051 paired A/B per-source MRR/P@k/R@k,
+   gate: no per-source regression >3%, aggregate non-negative, displacement cases improve. Plus the
+   synthetic unit test (§ test plan F080 §5) to *prove the mechanism* independent of corpus mix.
+7. **No new hot-path latency.** ✅ `_calibrate` is O(n) arithmetic over the already-materialized
+   candidate list. No I/O, no model. Strictly cheaper than the CE-revival path (Approach C).
+
+---
+
+## 7. Honest failure modes (what falsifies Approach B)
+
+1. **Fixed-map calibration drift.** My affine maps are mostly identity, so there is little to
+   drift — but the *moment* I introduce a non-identity map for any type (e.g. if a future reviewer
+   insists on normalizing censors in rather than excluding), that map needs distribution data I may
+   not have pre-ship, and it will drift with the embedding model (small→large). **This is the real
+   weakness, and it is exactly why I exclude censors rather than map them.** If the debate forces
+   censor-normalize-in, B's con becomes load-bearing.
+2. **Embed-fail rank-normalization is set-dependent.** The one leg that *is* candidate-set-sensitive
+   is §2's degraded-leg re-rank. I keep it rank-based (not min-max) to stay degeneracy-immune, but a
+   1-result degraded leg maps to a single point I picked by convention — defensible, not derived.
+3. **The procedure raw-hybrid wire change is real surface area.** Carrying `raw_hybrid_score` touches
+   `ProcedureSummary` + its constructor + the calibration read site. More places to get wrong than
+   Approach A's pure rank fusion (which never needs raw magnitudes). I concede this in §8.
+4. **Measurability dilution (the honest one).** B's wins are *concentrated* in queries where a
+   censor or effective procedure would have displaced a more-relevant fact. If the F051 corpus is
+   thin on censors/effective-procedures, aggregate MRR may **barely move** — I'll see "no
+   regression" rather than "improvement," and a skeptic can call B a no-op. Mitigation: the §5
+   synthetic unit test proves the *mechanism* deterministically; F051 proves *no-regression*. But I
+   won't pretend the aggregate number will swing hard.
+5. **What falsifies B outright:** if removing the pathologies does **not** improve the displacement
+   cases in the synthetic test, then the pathologies were never actually displacing relevant items,
+   and B's entire premise is dead. That test is the go/no-go. (It also falsifies the whitepaper's
+   headline if it fails — so it's worth running first.)
+
+---
+
+## 8. Self-score (1–10)
+
+| Axis | Score | Justification |
+|------|-------|---------------|
+| **Correctness** | **9** | Fixes the bug *at the truncation site* (`heart.py:1110`) where it actually drops facts, and uniquely **preserves relevance magnitude** (§5) — the thing CE/MMR would have preserved and A discards. Premise verified against the prod `_rrf_merge_n` path (`search.py:283-288`). |
+| **Prod-safety** | **9** | Byte-identical OFF is *constructed* (gate everything, mutate no producer, additive fields only — §2/§3), not asserted. CE-independent, O(n), zero new I/O. The half-point off: the `raw_hybrid_score` field touches a shared DTO. |
+| **Change-footprint** | **6** | **I concede this to Approach A.** B needs: `_calibrate` block at `heart.py:983-988`, the `ProcedureSummary.raw_hybrid_score`/`degraded` wire, the censor `heart_types` exclusion, the pipeline-side mirror at `retrieval_pipeline.py:220`, and the `PipelineStats` honesty fix. Pure rank-fusion-over-`_rrf_merge_n` is a smaller diff. B buys correctness/magnitude with footprint. |
+| **Measurability** | **7** | The mechanism is unit-testable deterministically (§5 synthetic set) and F051-gateable for no-regression. Docked because the *aggregate* win is corpus-dependent and may under-read if the eval set is censor/procedure-thin (§7.4). |
+
+**Net:** Approach B is the only spine that fixes the merge **with CE off** *and* keeps the
+relevance-magnitude signal that distinguishes a 0.95 dominant fact from a 0.60 best-available
+procedure. It concedes change-footprint to rank fusion and concedes that its aggregate win is
+concentrated rather than broad — but it wins on correctness and is provably reversible. The two
+go/no-go invariants (verified, not polish): (a) `_rrf_merge_n` normalizes to `[0,1]` — **confirmed
+`search.py:283-288`**; (b) all neutralization is flag-gated in `_recall` with no producer mutation —
+**the byte-identical-OFF guarantee rests entirely on this.**

--- a/docs/features/F080-coherent-cross-type-ranking.md
+++ b/docs/features/F080-coherent-cross-type-ranking.md
@@ -1,0 +1,264 @@
+# F080 — Coherent Cross-Type Retrieval Ranking
+
+**Status:** DRAFT v0 (scoping + open design question) — pending multi-agent debate
+**Source:** `docs/reviews/memory-retrieval-whitepaper-2026-06-08.md` §7–§8
+**Owner:** retrieval
+**Stakes:** HIGH — touches the recall hot path (`heart._recall`, `run_recall_pipeline`) that every `recall_deep` call and the eval harness depend on.
+
+---
+
+## 1. Problem
+
+The white-paper audit found that Nous's per-type search is sound (RRF hybrid, normalized `[0,1]`) but the **cross-type merge sorts incompatible score spaces as one**:
+
+| Type | Score space at merge | Code |
+|------|----------------------|------|
+| Fact / Episode | normalized-RRF `[0,1]` | `search.py:110-115` |
+| Procedure | boosted RRF, **can exceed 1.0** | `procedures.py:446-457` |
+| Censor | **raw cosine hard-floored ≥0.7** | `censors.py:387,400` |
+| Embed-failure leg (any type) | un-normalized FTS `~0.06` | `search.py:220-222` |
+
+`heart._recall` copies each type's score verbatim (`heart.py:983-988`) and, with cross-encoder and MMR **off** (production reality, `.env.prod-snapshot`), sorts globally and truncates: `merged.sort(key=score)[:limit]` (`heart.py:1110-1112`). A **hard floor** (censors) and an **unbounded boost** (procedures) break the monotonic score↔relevance relationship *across types*; the `[:limit]` cut then **drops genuinely relevant facts** before the pipeline ever sees them. The pipeline's `rerank_by_score` sort (`retrieval_pipeline.py:277-278`, prod-on via chunks) repeats the mistake over the full cross-leg pool.
+
+The two stages that would re-base everything into one comparable space — F042 cross-encoder and F030 MMR — are **exactly the two disabled in production** (CE because `bge-reranker-v2-m3` runs ~67s on the CPU-only 8 GB prod VM; MiniLM was rolled back). So the fix **cannot assume CE is available**.
+
+### In scope (the coherence cluster + cheap ordering/observability fixes)
+
+| ID | Issue | Location | Sev |
+|----|-------|----------|-----|
+| B1 | Censors at ≥0.7 floor displace mid-ranked facts | `censors.py:387,400` → `heart.py:1110` | P1 |
+| B2 | Procedure boost pushes score >1.0 | `procedures.py:446-457` | P2 |
+| B3 | Embed-failure leg returns un-normalized FTS ~0.06 | `search.py:220-222` | P2 |
+| B4 | Pipeline `rerank_by_score` merges mixed scales | `retrieval_pipeline.py:277-278` | P1 |
+| B5 | `PipelineStats.ce_reranked/mmr_applied` hardcoded False | `retrieval_pipeline.py:296-297` | P2 |
+| B-cog-A | Recalled IDs collected pre-truncation → false "unused" penalty | `context.py:608-613` vs `:617` | P2 |
+| B-cog-B | Relevance gap-filter runs on boost-sorted (non-monotonic) list | `search.py:434`, `context.py:961,992-1005` | P2 |
+| B-cog-C | `_dedup_decisions` dead; decisions get no conversation dedup | `context.py:541,1415` | P2 |
+| B-cog-D | `query_text` is a set-ordered keyword bag (nondeterministic) | `intent.py:138,192-193` | P2 |
+
+### Out of scope (separate follow-ups — note, do not fix here)
+- Graph-layer issues (B-graph-5..9), spreading-activation density gate, adjacency-boost ordering — F081 candidate.
+- Unifying the two recency resolvers + two relevance pipelines (cognitive vs recall_deep) — larger refactor.
+- Dead-code removal (date-aware boost F075 L3) — trivial cleanup PR.
+- Embedding-model doc drift (small vs large) — doc-only.
+
+---
+
+## 2. The OPEN design question (to be resolved by debate)
+
+**How do we make per-type scores comparable at the merge point, given CE is unavailable in prod?**
+
+Three candidate approaches are sketched below. The debate must (a) pick a spine, (b) decide the **censor question** and the **procedure-boost question** as sub-decisions, and (c) prove the choice works with CE off and does not regress the byte-identical `recall_deep` snapshot when the feature flag is off.
+
+### Approach A — Second-stage rank fusion (RRF over the per-type ranked lists)
+Treat each type's already-ranked result list as an input ranking and fuse them with the **existing** RRF machinery (`_rrf_merge_n`, `search.py:359-377`), optionally with per-type weights (= explicit type priors). Scale-free by construction (uses *ranks*, not raw scores), so the censor floor / procedure >1.0 / embed-fail ~0.06 problems all dissolve — a item's contribution depends only on its rank within its own type.
+- **Pro:** reuses proven, normalized RRF; parameter-light; immune to all four score-space pathologies at once; works with CE off.
+- **Con:** discards *magnitude* information (a 0.95 fact and a 0.55 fact at ranks 0/1 fuse the same as two 0.6 facts); type priors become an explicit tuning surface; needs a defensible default weight vector.
+
+### Approach B — Per-type score calibration to a common `[0,1]`
+Normalize each type's scores into one space before merge (min-max over the candidate set, or a fixed per-type affine map), and **remove the magnitude pathologies at the source**: strip the censor hard-floor from the *comparable* score, apply the procedure utility boost as a post-normalization tie-adjust rather than a raw multiplier, and route embed-failure legs through the same normalization.
+- **Pro:** preserves magnitude/relevance signal; conceptually direct; per-type maps are inspectable.
+- **Con:** min-max is outlier-sensitive and unstable on tiny candidate sets; fixed affine maps need calibration data per type; more surface area to get wrong.
+
+### Approach C — Make CE viable in prod (single relevance model orders everything)
+Confront the latency constraint: a smaller/quantized cross-encoder, top-N-only reranking with a strict wall-clock budget and fail-open, and/or async precompute, so the cross-encoder can be the single comparable scorer in prod.
+- **Pro:** strongest relevance signal; collapses the whole problem to one model; CE infra already exists (F042).
+- **Con:** empirically falsified once already (BGE 67s, MiniLM rolled back); reintroduces a heavy dependency on the hot path; latency risk to `recall_deep`; may still need a fallback ranker (so doesn't fully replace A/B).
+
+### Sub-decision 1 — The censor question
+Censors already have a dedicated surface ("Active Censors" / "Active Guidance", `context.py:460`). **Should `recall_deep` even retrieve censors into the ranked pool?** Excluding `"censor"` from `heart_types` (`retrieval_pipeline.py:340-341`) is a one-line change that removes B1 entirely without any normalization. Debate: exclude vs normalize-in.
+
+### Sub-decision 2 — The procedure-boost question
+The utility boost (`procedures.py:446-457`) is a real signal but it breaks the `[0,1]` invariant. Options: keep boost but clamp to `[0,1]`; move boost to a post-normalization re-rank within the procedure slice; or fold utility into the fusion weight. Debate.
+
+---
+
+## 3. Acceptance criteria (independent of which approach wins)
+
+1. **No mixed-scale sort.** After the fix, the final ranking compares values drawn from a single, documented space (or ranks). No raw score from one type can structurally out- or under-rank another type independent of relevance.
+2. **CE-off correctness.** The fix produces a coherent ranking with `NOUS_CROSS_ENCODER_ENABLED=false` and `NOUS_MMR_ENABLED=false` (prod config). It must not *depend* on CE.
+3. **Flagged + reversible.** New behavior behind a flag (`NOUS_COHERENT_RANKING_ENABLED`, default OFF). When OFF, `recall_deep` output is **byte-identical** to its committed snapshot (the F051 harness invariant).
+4. **Ordering hazards fixed.** Boost/staleness/usage mutations are followed by a score re-sort (or the gap-filter sorts its own input); recalled IDs are collected **after** truncation; `query_text` is deterministic.
+5. **Observability honest.** `PipelineStats.ce_reranked`/`mmr_applied` reflect what actually ran inside `heart._recall`.
+6. **Measured.** The change is evaluated on the F051 retrieval harness (per-source MRR/P@k/R@k) and, if feasible, the BEAM harness. Target: no per-source regression > 3%; aggregate non-negative; the censor/procedure displacement cases improve.
+7. **No new hot-path latency** beyond a documented bound (rank fusion is O(n); any CE-revival path must hold a wall-clock budget with fail-open).
+
+---
+
+## 4. Integration points (verified against source)
+
+- **Merge site:** `nous/heart/heart.py:983-988` (score copy), `:1110-1112` (sort+truncate). Primary surgery.
+- **RRF infra to reuse:** `nous/heart/search.py:76-117` (`_rrf_merge`), `:359-377` (`_rrf_merge_n`).
+- **Score sources to neutralize:** `censors.py:387,400`; `procedures.py:446-457`; `search.py:220-222` (embed-fail path).
+- **Pipeline sort:** `nous/api/retrieval_pipeline.py:277-278`; type-keyed exclusion `:286-293`; stats `:296-297`.
+- **Cognitive ordering fixes:** `nous/cognitive/context.py:541,608-617,945-1005`; `nous/heart/search.py:399-435`; `nous/cognitive/intent.py:138,192-193`.
+
+## 5. Test plan (sketch)
+- Unit: a synthetic merged set with one censor@0.78, one procedure@1.26, one fact@0.92, one fact@0.55, one embed-failed fact@0.06 → assert the post-fix ranking places them by *relevance intent*, not raw magnitude.
+- Snapshot: flag-OFF `recall_deep` byte-identical to committed snapshot (postgres_only).
+- Determinism: same input twice → identical `query_text` and identical ranking.
+- Harness: F051 paired A/B, per-source no-regression gate.
+
+---
+
+## 6. Open items for the debate to close
+1. Spine: A / B / C / hybrid?
+2. Censor sub-decision: exclude vs normalize?
+3. Procedure-boost sub-decision: clamp / post-rank / fold-into-weight?
+4. If type priors are introduced (Approach A), what is the default weight vector and how is it justified without overfitting?
+5. Is the cognitive-path ordering fix (B-cog-A/B) part of this feature or a sibling PR? (It shares the boost-sort root cause.)
+6. Minimal-change footprint vs principled-but-larger: where is the line for a single shippable PR?
+
+---
+
+# RESOLVED DESIGN (post-debate)
+
+**Status:** v1 — design closed. Architecture-review gate satisfied by the multi-agent debate below.
+**Forge decision:** `a18e0836`.
+
+## 7. How the design was decided (debate record)
+
+A 5-agent debate ran on the open question in §2. Round 1: three champions argued competing spines. Round 2: a devil's-advocate attacked all of them and an independent synthesis-judge adjudicated. A final advisor pass broke the remaining tie. Briefs of record: `docs/reviews/F080-approach-A-rank-fusion-champion.md`, `docs/features/F080-approach-B-calibration-champion.md`, `docs/reviews/F080-approach-C-champion.md`.
+
+| Approach | Champion self-score (corr/prod/footprint/meas) | Verdict |
+|----------|-----------------------------------------------|---------|
+| A — 2nd-stage rank fusion | 8 / 8 / 8 / 9 | **Rejected as spine.** Devil P1-b: RRF over *disjoint* type-sets has no reinforcement term — it degenerates to weighted rank-interleave, and the default type priors (fact 0.45 vs procedure 0.30, k=60) make *every fact down to rank-29* outrank the single best procedure. No benchmark justification for the weights. |
+| B — per-type calibration | 9 / 9 / 6 / 7 | **Adopted as spine (at S1).** Verified premise: 3/4 heart types already emit normalized RRF `[0,1]`; the defect is exactly two un-normalized deviants (procedure boost, censor floor). |
+| C — CE revival | 8 / **4** / 7 / 7 | **Deferred to F080.1.** Champion concedes standalone C fails acceptance #2 (prod is CE-off) and adds 1.6–3.6 s hot-path latency; it is really "A/B spine + optional CE head." |
+
+**Tie-break (devil vs judge → advisor).** The judge picked B and claimed S2 is then "already coherent." The devil (P1-a) showed that conflates *range* `[0,1]` with *comparable distribution* — at the pipeline sort (`retrieval_pipeline.py:277`, prod-on) chunk-cosine, fact-RRF, and graph-edge-weight are all `[0,1]` but drawn from different distributions, so B alone leaves a residual S2 mismatch. The advisor broke the tie: a blanket S2 rank-normalization (my initial lean) **transposes** the magnitude bug (best-of-a-weak-leg → ties best-of-a-strong-leg) and is *actively wrong* for the graph leg (`edge_weight×0.7 ≤ 0.70` is meant to keep associative neighbors below direct hits). Decisive fact: **B@S1 fully kills the two P1 *displacers*** (censor, procedure) — the headline bug — and the residual S2 chunk/graph mismatch is milder, corpus-dependent, and best **measured** before prod-path surgery (the LME +26pp chunk win was obtained *with* chunks already at raw-cosine at S2, so "chunks get buried" may be overstated).
+
+## 8. Verdict
+
+> **REVISED 2026-06-08 (owner correction) — see §13.** The procedure sub-decision below changed from *calibrate-to-compete* to *exclude-from-pool*. §13 is authoritative where it differs from §9.3.
+
+**Spine = Approach B applied at S1 (`heart._recall`):** exclude **censors and procedures** from the ranked recall pool; surface them through their dedicated channels (Active Censors section; F079 Procedure Catalog + `get_procedure`). This removes both P1 displacers (B1, B2) **by exclusion**, at the merge, *before* the `[:limit]` cut that drops facts. The remaining ranked pool — facts, episodes, decisions — is knowledge that already shares the normalized RRF `[0,1]` space, so **no per-type calibration is required**. The S2 cross-distribution mismatch (chunk-cosine, graph-edge-weight vs RRF) is **scoped out** to F080.1 behind an F051 measurement gate — F080 explicitly does **not** claim to fully coheres S2, which converts the devil's P1-a from a "kill" into a correct, stated boundary.
+
+## 9. The optimized design (buildable)
+
+### 9.1 Flags & config (`nous/config.py`)
+- `NOUS_COHERENT_RANKING_ENABLED: bool = false` — master switch. When OFF, `recall_deep` is byte-identical to the committed F051 snapshot.
+- `NOUS_PROCEDURE_UTILITY_WEIGHT: float = 0.15` (`ge=0.0, le=1.0`) — the `w` in the convex transform.
+- Resolve via the existing `RuntimeConfig` resolver pattern (mirror `get_cross_encoder_enabled`), not raw `settings` on the hot path.
+
+### 9.2 Censor **and procedure** exclusion (two sites — both required)
+- `nous/heart/heart.py:877` — when coherent ranking is on, strip both `"censor"` and `"procedure"` from `search_types` before `search_map` is built.
+- `nous/api/retrieval_pipeline.py:340-347` — strip both from `heart_types` (this also governs the `heart_section_eligible` formatter gate).
+
+  Both sites needed; one alone leaves a half-exclusion. **Verified safe:**
+  - *Censors* — enforcement via `heart.check_censors` (`layer.py:777`), display via `heart.list_censors` (`context.py:463`); neither reads the ranked recall pool.
+  - *Procedures* — breadth via the F079 Procedure Catalog (`context.py:265-364`, prod-on), depth via the `get_procedure` tool (`tools.py:1006`, in the conversation/question/decision/creative/debug frames). `recall_deep`'s documented contract is "decisions, facts, episodes" — procedures were never part of it.
+  - Honest caveat: a query-relevant censor that didn't fit the budget-truncated "Active Censors" section is no longer recoverable via recall (marginal). For procedures, exclusion makes the catalog the **sole** discovery surface — see the binding companion requirement in §13.
+
+### 9.3 Procedure handling — SUPERSEDED by §13
+> The original §9.3 proposed a convex utility transform to keep procedures *in* the ranked pool with a bounded score. The owner correction (§13) replaces this with **exclusion** (procedures are capabilities, not knowledge; they have their own catalog + selection surface). The convex transform and the `ProcedureSummary.raw_hybrid_score` wire change are **withdrawn**. See §13 for the authoritative procedure decision and its companion catalog-breadth requirement.
+
+### 9.4 Composition discipline (mandatory — the devil's verified traps)
+- `PipelineResult` is `@dataclass(frozen=True)` → **never mutate in place; use `dataclasses.replace`.**
+- The calibrated value is a **base score**. The prod-ON recency resolver (`×0.3`, `retrieval_pipeline.py:258`) and adjacency boost (`:246`, internal re-sort `:791`) must multiply *on top of* it. Because B's calibration happens at S1 (inside `heart._recall`, before the pipeline), the pipeline multipliers compose naturally and `:246/:258/:277` are **unchanged**. Do not add a second sort.
+- Adjacency boost can lift a calibrated `[0,1]` base to ~1.15 — document this as the new logged ceiling so >1.0 scores in dashboards aren't mistaken for the old bug.
+
+### 9.5 Observability (partial B5)
+Add `coherent_ranking_applied: bool` to `PipelineStats` (`retrieval_pipeline.py:295`), set from the flag. (Full `ce_reranked`/`mmr_applied` truth-threading out of `heart._recall` is its own signature change → F080.1.)
+
+## 10. Phasing
+
+**F080 (this PR):** §9.1–§9.5. Files: `config.py`, `heart/schemas.py` (ProcedureSummary field), `heart/procedures.py` (wire), `heart/heart.py:877,983-988` (exclude + transform), `api/retrieval_pipeline.py:340-347,295` (exclude + stat). Tests: synthetic-merge unit test + flag-OFF byte-identical snapshot + determinism. F051 paired A/B **plus two new probes** (chunk-vs-fact, graph-vs-direct).
+
+**F080.1 (deferred, data-gated):** S2 cross-distribution coherence — method chosen *per leg* from the F051 probes (chunks may want rank/percentile normalization; graph likely stays low). Optional budget-bounded CE head over the B spine (requires prod-VM N≈10 MiniLM latency measurement + `Semaphore(1)` CPU gate + warm-up + the displacement probes). B3 embed-failure leg re-normalization (only if the manager-level `degraded` tag stays off the shared `hybrid_search` return contract — else it breaks byte-identical-OFF; defer if invasive). Full CE/MMR stat threading.
+
+**Sibling PR (same release):** cognitive-path ordering fixes that share the boost-sort root cause — B-cog-A (collect recalled IDs *after* `_truncate_to_budget`, `context.py:617`), B-cog-B (re-sort by score after frame/usage boost before the gap filter, `search.py:434`/`context.py:961,992-1005`), B-cog-C (wire or delete dead `_dedup_decisions`, `context.py:541,1415`), B-cog-D (deterministic `query_text`, `intent.py:138,192-193`).
+
+## 11. Acceptance & tests (supersedes §3 where they differ)
+1. **No P1 displacer.** Unit test on a synthetic merged set (censor@0.78, procedure raw=0.60/eff=0.9, fact@0.92, fact@0.55, embed-failed fact@0.06): flag-ON ⇒ censor absent; procedure calibrated to `(1−0.15)·0.60 + 0.15·0.9 = 0.645`; the 0.92 fact ranks #1; the procedure sits between the two facts.
+2. **CE-off correctness.** Pure arithmetic, zero model/IO — passes with CE+MMR off (prod).
+3. **Byte-identical OFF.** Existing `postgres_only` snapshot test passes unchanged with the flag default OFF (rests on: no producer SQL mutated, `raw_hybrid_score` defaults `None`).
+4. **Determinism.** Same input twice ⇒ identical ranking (this PR's surface; `query_text` determinism is the sibling PR).
+5. **Observability.** `coherent_ranking_applied == True` under flag-ON.
+6. **Measured + S2 probes.** F051 paired A/B: no per-source MRR regression > 3%; aggregate ≥ 0; **plus** new chunk-vs-fact and graph-vs-direct ranking probes whose results are the explicit input to the F080.1 S2 decision (and a guard that F080 did not regress the chunk win).
+7. **No new hot-path latency.** O(n) arithmetic over the already-materialized candidate list; no IO. State the bound in the PR.
+
+## 12. Residual risks for the implementer
+1. `raw_hybrid_score` must reach `_recall` intact via `ProcedureSummary`; audit every construction site (incl. cognitive path) for breakage.
+2. Censor exclusion at **both** sites or it half-applies; assert end-to-end absence in the unit test.
+3. Byte-identical-OFF rests on build discipline — no producer SQL touched; all behavior behind the flag; verify with the snapshot test after any change to the score-copy loop.
+4. Do **not** overwrite `r.score` anywhere the recency/adjacency multipliers run; keep the single sort at `:277`.
+5. The chunk/graph S2 residual is **knowingly** unfixed in F080 — the acceptance-#6 probes exist to size it; do not silently "fix" it with a blanket rank-norm (it transposes the magnitude bug and mis-ranks graph).
+
+---
+
+## 13. Procedure decision — REVISED (owner correction, 2026-06-08) — AUTHORITATIVE
+
+**Decision: exclude procedures from the ranked recall pool entirely (like censors); do not calibrate them to compete.**
+
+**Rationale.** Procedures/skills are *capabilities*, not *knowledge*. Ranking them by relevance against facts/episodes in a single top-K pool is a category error — and redundant, because F079 already provides the correct surfaces: the **Procedure Catalog** (breadth — the agent sees its skills, `context.py:265-364`, prod-on) and the **`get_procedure`** tool (depth — the agent deliberately selects a skill for the task and loads its body, `tools.py:1006`). Skill selection should be a **task-conditioned agent decision over the catalog**, independent of how semantically similar a stored memory happens to be. `recall_deep`'s own contract ("decisions, facts, episodes") confirms procedures were never meant to be in that pool.
+
+**Consequences (net simplification vs §9.3):**
+- **B2 is fixed by exclusion**, not calibration. The convex utility transform and the `ProcedureSummary.raw_hybrid_score` wire change are **withdrawn**.
+- After excluding censors **and** procedures, the S1 recall pool is **facts + episodes** — both normalized RRF `[0,1]`, already comparable. Decisions (RRF) join at S2. **No per-type calibration is required anywhere in F080.** The feature reduces to: *the ranked recall pool is knowledge only.*
+- Remaining F080 surgery: the two-site exclusion (§9.2), the `coherent_ranking_applied` stat (§9.5), and the frozen-`replace()` / base-before-multipliers discipline (§9.4) — which is now trivially satisfied because nothing rewrites a score (we only *remove* two types).
+
+**Companion requirement (BINDING — must ship with F080 or as an immediate predecessor).** Excluding procedures makes the catalog the **sole** skill-discovery surface, so it must present **full breadth**. Current prod caps: `proc_catalog_max=100` (covers the ~55 deduped procedures) but `proc_catalog_max_chars=4000` with `proc_catalog_desc_chars=120` ⇒ only **~28 rows fit** — ~27 skills would be invisible. Fix one of:
+  - compact the catalog row format (name + terse ≤60-char descriptor) so all ~55 fit in ~2–3 K chars (preferred), and/or
+  - raise `proc_catalog_max_chars`, and
+  - order the catalog by utility/effectiveness (F037 signal) so that if truncation ever bites, the most-useful skills survive.
+  Acceptance: assert every active procedure name appears in the rendered catalog for a representative agent, OR is reachable by `get_procedure` by a name the agent can see.
+
+**Sibling consideration → now specified in §14.** The same principle applies to the cognitive path's procedure injection. That redesign (critic-preload + name-menu + drop the embedding path) is specified concretely in §14 and supersedes the "full-breadth catalog with descriptions" companion requirement above — because once bodies come from critic-preload or `get_procedure`, the breadth surface only needs **names**, which dissolves the `proc_catalog_max_chars` truncation entirely.
+
+**Updated phasing.** F080 (this PR) = exclude censors + procedures from the ranked pool (§9.2) + `coherent_ranking_applied` stat (§9.5) + F051 probes (chunk-vs-fact, graph-vs-direct). No calibration, no `ProcedureSummary` change. The cognitive-path procedure redesign (the breadth-menu + critic-preload that this exclusion leans on) is **§14**, shipped as its own PR. F080.1 unchanged from §10.
+
+---
+
+## 14. Cognitive-path procedure injection redesign (sibling feature — design only)
+
+**Relationship:** F080 (§13) removes procedures from the `recall_deep` ranked pool. This section redesigns how procedures enter the **every-turn system prompt** so that removal loses nothing. Together they realize one principle: *procedures are selected for the task and loaded, never relevance-ranked against memory.* This evolves the F079 injection model; it ships as a **separate PR** from the F080 recall_deep exclusion.
+
+### 14.1 Current behavior (verified, prod config)
+- **Track A — Critic (live, prod `NOUS_CRITIC_SKILL_INJECTION=enabled`, `NOUS_CRITIC_MODE=advised`, Haiku):** each task-ish turn the critic recommends ≤ `critic_skill_slots` (prod **2**) skill names; `context.py:656-666` fetches each as a full `ProcedureDetail` via `get_procedure_by_name`. **But** when the catalog rendered, `context.py:755-780` emits only a *name pointer* — `"★ Recommended for this task: \`name\` — load with get_procedure"` — **not the body** (F079 "option C", to save tokens). So the LLM still round-trips through `get_procedure` to act.
+- **Track B — embedding passive injection:** `context.py:686-744`, gated `proc_passive_injection_enabled AND not catalog_rendered` (`:647-650`). **Inert in prod** (the catalog renders, so this never runs). When it *does* run it pushes procedures through the staleness → frame-boost → dedup → usage-boost → relevance pipeline — i.e. the same boost-sort-then-gap-filter hazard as B-cog-B.
+- **Catalog (F079):** `context.py:265-364`, name + ≤`proc_catalog_desc_chars` (120) description, capped by `proc_catalog_max_chars` (4000) ⇒ ~28 of ~55 rows.
+- **`get_procedure`:** `tools.py:1006` — on-demand body load, agent-selected.
+
+### 14.2 Target design — three surfaces
+1. **Recommended Procedures (preloaded bodies).** Replace the name-pointer at `context.py:762-780` with the **actual body** (or a rich, bounded summary) of the procedures chosen by the **selection mechanism in §14.7** (graph-primary K-line activation, critic fallback). Proactive depth: the common case ("the skill I need is one the system surfaced") needs no `get_procedure` round-trip. Bounded by the slot count and a per-body char cap.
+2. **Skill Menu (names only, full breadth).** Reduce the catalog to **name + ≤~60-char purpose for *every* active procedure**. All ~55 fit in ~1–2 K chars, so `proc_catalog_max_chars` truncation no longer hides skills. This is the discovery backstop that makes "the LLM can `get_procedure` more" actually usable — and the safety net for a critic miss (the LLM browses the menu and pulls by name).
+3. **`get_procedure` (unchanged).** On-demand depth for anything in the menu the critic didn't preload.
+
+### 14.3 Changes
+- **Delete / hard-disable Track B** (embedding passive injection, `context.py:686-744`). Already inert in prod; removing it also deletes a procedure-path instance of the B-cog-B boost-sort hazard. (Keep `proc_passive_injection_enabled` as a dead-off compatibility flag or remove it.)
+- **Preload critic bodies** in the "Recommended Procedures" section (the `catalog_rendered and critic_procedures` branch), with a body/summary size cap.
+- **Compact the catalog to a full-breadth name menu** (name + terse purpose, all active procedures; order by utility/effectiveness so any future truncation drops least-useful first).
+- `get_procedure` unchanged.
+
+### 14.4 The honest tradeoff
+Preloading bodies spends tokens that the F079 name-pointer deliberately saved. Bounded (≤2 picks) but real. Mitigations: cap preloaded body chars; preload a rich *summary* rather than the full body; or preload only the top-1 when the procedure budget is tight. This is a proactive-vs-lazy choice — worth it only if the critic's picks are usually the ones acted on (measure below).
+
+### 14.5 Measurement (gates the design)
+- **Critic recall@2** — how often the Haiku critic's ≤2 picks contain the skill the turn actually needs. High ⇒ body-preload is a clear win; low ⇒ lean on the menu + `get_procedure` and keep preload minimal.
+- **Menu legibility** — names + one-liners must be self-explanatory (this is why the procedure-dedup description backfill mattered); spot-check that an LLM can pick the right skill from the menu alone.
+
+### 14.6 Scope
+Design only — no code here. Separate PR from F080's recall_deep exclusion; sequence either order (they're independent), but ship both before flipping any "procedures excluded from recall" flag in prod so the menu+selection surfaces are in place first.
+
+### 14.7 Selection mechanism — graph-primary (K-line) with critic fallback
+
+**Decision: graph-driven K-line activation is the primary selector; the §14.1 critic is the fallback; a task-only match is the final floor.** Procedure selection is conditioned on the *situation* (the turn's recalled memory), not just the bare task string — the task triggers and anchors the goal; the retrieved memory determines which skill the situation calls for.
+
+**Local density measurement (`graph_latest.json`, 2026-06-08).** 23/23 procedures linked (100%, F040 `auto_linked` edges). 56 procedure-touching edges: **procedure↔fact 29**, procedure↔procedure 20, procedure↔decision 7, **procedure↔episode 0**. So the live activation substrate is overwhelmingly **recalled-fact → procedure** (and facts are the most common recall result), with procedure↔procedure for neighborhood expansion. (Export likely capped/stale — 23 vs 55 active prod procedures — so re-measure on the live/local instance; the *structure* is what the design relies on.)
+
+**Primary — K-line activation (structural, not cosine).** After the turn's recall produces seed memories, for each seed call `brain.neighbors(seed.id, node_type=seed.type, neighbor_type="procedure")` (the same edge-traversal F080 uses for graph expansion — reuse it). Score each activated procedure as `edge_weight × seed_recall_score` (a procedure linked to a highly-relevant recalled memory ranks high). Optionally one-hop expand `procedure↔procedure` (the 20 edges) to pull closely-related skills once one fires, bounded. Dedup, take top-`slots`. This is memory-driven **but edge-based** — it does not reintroduce the cosine coupling §13 removed.
+
+**Fallback ladder:**
+1. **Graph K-line** (above) fills the recommended slots.
+2. **If it yields fewer than `slots`** (sparse cues / no procedure edges hit this turn) → **critic** (§14.1: Haiku, advised, conditioned on `task goal + recalled memory + skill menu`) fills the remainder.
+3. **If both are empty** → **task-only floor** (direct name/intent match against the menu) so something obvious still surfaces.
+
+The selected set (graph ∪ critic, capped at `slots`) is what gets its **bodies preloaded** in the §14.2 "Recommended Procedures" section; the name-menu (§14.2.2) and `get_procedure` remain the breadth + on-demand paths.
+
+**Honest density caveats (carry into measurement).**
+- Cue off **all** recalled types, not just decisions/episodes — facts are the dense substrate (29 edges) and decisions are thin (7), episodes absent (0). A decision/episode-only activation would mostly miss.
+- With proc↔fact at 29 edges over ~1011 facts, a given turn's ~10 recalled items won't always hit a procedure edge — so the **fallback carries a meaningful share of turns today**. That's expected and correct; measure the graph-primary hit-rate to size it.
+- **Upgrade path:** grow procedure↔decision and procedure↔episode density (F012 K-line learning, which the audit found at 0; F040 densification with procedure-aware thresholds) so situational (not just topical-fact) cues activate skills. Until then, graph-primary leans on fact cues and the fallback covers the rest.
+
+**Measurement (gates the "graph as main" emphasis).** Graph-primary hit-rate (fraction of task turns where K-line activation fills ≥1 slot) and selection precision@slots (are the activated procedures the ones acted on?) vs the critic fallback. If hit-rate is high, graph leads as designed; if low, it's effectively critic-led until density grows — either way the output is correct, only the *driver mix* shifts.

--- a/docs/reviews/F080-approach-A-rank-fusion-champion.md
+++ b/docs/reviews/F080-approach-A-rank-fusion-champion.md
@@ -1,0 +1,275 @@
+# F080 — Champion Brief: Approach A (Second-Stage Rank Fusion)
+
+**Position:** Adopt **weighted Reciprocal-Rank Fusion over the per-type ranked lists** as the spine of F080. Scale-free by construction, reuses proven RRF machinery, O(n), works with CE/MMR OFF, and dissolves all four score-space pathologies (B1/B2/B3/B4) at once. Honest about its one real cost: it discards magnitude/margin.
+
+**Verified against source this session** (not the spec's line numbers): `heart.py:867-1117`, `search.py:76-117 / 234-290 / 293-377`, `censors.py:373-409`, `procedures.py:430-457`, `retrieval_pipeline.py:218-309`. Arithmetic claims below were run, not asserted.
+
+---
+
+## 0. The correction the spec hides: there are TWO mixed-scale sorts, not one
+
+The spec (§4) calls `heart.py:1110-1112` the "primary surgery." That is necessary but **not sufficient**. There are two independent descending sorts over incompatible spaces, and in prod **the pipeline one is the live defect**:
+
+| Site | Code | Sorts what | Prod state | Why it must be fixed |
+|------|------|------------|------------|----------------------|
+| **S1 — heart merge** | `heart.py:1110-1112` `merged.sort(key=score)[:limit]` | the 4 Heart types (fact/episode/procedure/censor) | always on (CE/MMR off) | the `[:limit]` cut here **drops displaced facts before the pipeline ever sees them** — B1/B2 are *irrecoverable downstream* |
+| **S2 — pipeline rerank** | `retrieval_pipeline.py:277-278` `results.sort(key=score)` | the full cross-leg pool: heart_results ∪ chunks ∪ heart_graph ∪ Path-A ∪ decisions ∪ graph_expanded | **ON** (chunks on ⇒ `rerank_by_score=True`) | this is **B4**, "the prod-live form of the bug" (whitepaper §7-B4) |
+
+A fix that touches only S1 satisfies acceptance #1 inside the Heart leg, then **re-violates it at S2** when the now-clean heart `[0,1]` is re-mixed with chunk raw-cosine, graph `~0.35–0.63`, and `decision.score`. **Approach A is the only spine that handles both sites with one mechanism**, because rank fusion is *defined* over "a set of already-ranked lists" — and S2's inputs (`acc.heart_results`, `acc.chunk_results`, `acc.heart_graph_*`, `acc.decision_results`, `acc.graph_expanded`) are *literally six separate ranked legs already* (verified `retrieval_pipeline.py:130-154,220-249`). S2 is the *cleaner* A story, not the harder one.
+
+The whole brief below specifies **both** sites under one flag.
+
+---
+
+## 1. Mechanism
+
+### 1.1 The reused primitive — and why I will NOT mutate it
+
+`_rrf_merge_n` (`search.py:234-290`) already fuses N ranked lists with the exact normalization every downstream consumer expects:
+
+```
+score(d) = Σ_i  (1/N) / (k + rank_i(d))           rank_i = 0-indexed pos in list i, or limit+1 if absent
+score(d) = score(d) / (1/k)                        # normalize; theoretical max = 1/k
+```
+
+But it **hardcodes equal weight** `per_list_weight = 1.0/n` (`:260`) and it sits on the **query-expansion byte-identical path** (`heart.py:912-921` → `hybrid_search_multi` → `_rrf_merge_n`). Mutating it to add weights would risk the F050 single-variant byte-identical invariant. So I add a sibling:
+
+```python
+# nous/heart/search.py  (new, beside _rrf_merge_n)
+def _rrf_merge_weighted(
+    ranked_lists: list[tuple[float, list[UUID]]],   # (weight, ranked_ids) per type
+    k: int,
+) -> dict[UUID, float]:
+    """Weighted N-list RRF. score(d) = Σ_i w_i / (k + rank_i(d)); Σ w_i = 1.0.
+
+    Inputs are ALREADY-RANKED id lists — rank is list position, no re-sort.
+    Normalized by 1/k so a hypothetical rank-0-everywhere doc → 1.0 (the
+    disjoint-input reality is lower; see §7). Returns id→score; caller maps
+    back to RecallResult/PipelineResult and applies [:limit] ONCE, after fusion.
+    """
+    total_w = sum(w for w, _ in ranked_lists) or 1.0
+    penalty_offset = 0.0
+    rank_maps: list[tuple[float, dict[UUID, int]]] = []
+    for w, ids in ranked_lists:
+        wn = w / total_w
+        rank_maps.append((wn, {doc_id: i for i, doc_id in enumerate(ids)}))
+    scored: dict[UUID, float] = {}
+    all_ids = set().union(*(set(rm) for _, rm in rank_maps)) if rank_maps else set()
+    for doc_id in all_ids:
+        s = 0.0
+        for wn, rm in rank_maps:
+            r = rm.get(doc_id)
+            if r is not None:
+                s += wn / (k + r)
+            # absent: contributes wn/(k+limit+1) — a near-constant offset; see §7.
+        scored[doc_id] = s * k   # normalize by 1/k  (==  / (1/k))
+    return scored
+```
+
+(For absent legs I drop the penalty term entirely rather than adding `limit+1`; §7 explains why this is *more* correct for disjoint inputs than the expansion-path penalty — and either choice is a constant offset that cannot change ordering.)
+
+### 1.2 Site S1 — `heart._recall`
+
+The fusion input is free: the OFF-path loop at `heart.py:974-988` already builds `merged` by iterating `zip(keys, results_list)` where each `raw_results` is a per-type ranked list in descending per-type-score order. So **per-type rank == append position within each type's block** — I capture ranked id-lists without any re-sort.
+
+```python
+# heart.py, replacing the else-branch at :1109-1112 ONLY (the if/elif CE/MMR
+# branches above are untouched — they stay prod-off).
+else:
+    if RuntimeConfig.get().get_coherent_ranking_enabled(self.settings):
+        # Build per-type ranked id lists from append order (already ranked).
+        by_type: dict[str, list[UUID]] = {}
+        for r in merged:
+            by_type.setdefault(r.type, []).append(r.id)
+        priors = self.settings.coherent_ranking_type_weights   # §2
+        ranked_lists = [
+            (priors.get(t, priors["_default"]), ids)
+            for t, ids in by_type.items()
+        ]
+        fused = _rrf_merge_weighted(ranked_lists, _resolve_rrf_k())
+        for r in merged:
+            r.score = fused.get(r.id, 0.0)
+        merged.sort(key=lambda r: (r.score, _STAGE_RANK[r.type]), reverse=True)  # §7 tiebreak
+        merged = merged[:limit]
+    else:
+        # BYTE-IDENTICAL OFF PATH — unchanged.
+        merged.sort(key=lambda r: r.score, reverse=True)
+        merged = merged[:limit]
+```
+
+Censor never enters `by_type` because §3 removes it from `search_types` upstream — see §3.
+
+### 1.3 Site S2 — `run_recall_pipeline`
+
+Same mechanism, one level up. But S2 has a wrinkle S1 does not, and **the naive version is a prod regression** — I call it out and fix it here rather than let the opposing champion find it.
+
+**The hazard.** In prod, two stages mutate `r.score` *before* the `:277` sort:
+- `:246` **adjacency boost** (`graph_adjacency_boost_enabled` prod **ON**): `score *= 1 + α·degree/max_degree`.
+- `:258` **recency resolver** (`recency_resolver_enabled` prod **ON**): superseded fact `score *= 0.3`.
+
+A naive `for r in results: r.score = fused.get(r.id, ...)` **overwrites both**, silently killing the supersession down-rank and the cluster boost. That would regress two live prod features. So the fused score must **compose with** those multipliers, not clobber them.
+
+**The fix — separate the rank signal from the magnitude multipliers.** Build the legs from the **stage-order assembly that exists at `:220-231`** (the `results` list *before* the `:246`/`:258` mutations), capture each result's *fusion rank* there, and apply the recency/adjacency multipliers **on top of** the fused score. Concretely, move the fusion to run on the pristine stage-order `results` and keep `:246`/`:258` as *post-fusion* multipliers:
+
+```python
+# retrieval_pipeline.py
+# (A) Right after the stage-order assembly at :220-231, before adjacency/recency,
+#     capture the per-leg ranked id-lists from the SLICES of `results` we just built.
+#     `results` is concatenated in known stage order, so leg boundaries are known
+#     from the extend() lengths — no re-call of the _*_to_pipeline helpers.
+if getattr(settings, "coherent_ranking_enabled", False) and rerank_by_score:
+    legs = _legs_from_stage_slices(results, leg_lengths, W)   # (weight, [ids]) per leg
+    fused = _rrf_merge_weighted([(w, ids) for w, ids in legs if ids], _resolve_rrf_k())
+    for r in results:
+        r._fused = fused.get(r.id, 0.0)        # park the rank signal on a scratch attr
+        r.score = r._fused                     # adjacency/recency now multiply the fused base
+    coherent = True
+else:
+    coherent = False
+
+# (B) :246 adjacency boost — UNCHANGED. Now multiplies the fused base (prod ON).
+# (C) :258 recency resolver — UNCHANGED. ×0.3 now applies to the fused base (prod ON).
+
+# (D) replace the :277-278 sort
+if rerank_by_score:
+    if coherent:
+        # r.score is now fused_base × adjacency × recency — magnitude multipliers
+        # preserved, cross-type incomparability gone. Tiebreak on stage order.
+        results.sort(key=lambda r: (r.score or 0.0, _STAGE_RANK.get(r.type, 0)), reverse=True)
+    else:
+        results.sort(key=lambda r: r.score or 0.0, reverse=True)   # BYTE-IDENTICAL OFF PATH
+```
+
+`leg_lengths` is the list of `len(...)` from each `extend()` at `:220-231` — captured at assembly time, so the id-lists come from the **already-built `results`** (no re-deriving, no re-call of `_*_to_pipeline`). The fused score *replaces* `r.score` as the **base**, then the existing `:246`/`:258` multipliers compose onto it, so the downstream F071 filter (`:286-293`) and `PipelineStats` see the coherent, recency-and-adjacency-adjusted value.
+
+The `[:limit]`/no-truncation behavior is preserved — the pipeline has no global top-K today (B7), and I add none (out of scope).
+
+**`_STAGE_RANK`** (the deterministic tiebreak, load-bearing per §2.1 because equal-prior legs near-tie):
+```python
+_STAGE_RANK = {"fact": 6, "episode": 6, "chunk": 5, "decision": 4, "procedure": 3}  # higher = wins ties
+```
+This encodes "when fused scores tie, prefer answer-bearing types" — and is the **explicit** prior the §2.1 analysis demands instead of letting raw append order decide silently.
+
+**Where the `[:limit]` moves:** at S1 the cut now happens *after* fusion (it was already after the sort; the structural change is that the sort key is fusion-rank, so a high-RRF fact can no longer be cut by a floored censor or a >1.0 procedure). At S2 there is no `[:limit]` today and I add none.
+
+---
+
+## 2. Type priors (the load-bearing parameter — owned, not hidden)
+
+### 2.1 Why priors are NOT optional polish
+
+Run the arithmetic for **disjoint** inputs (each doc lives in exactly one type's list — the cross-type reality):
+
+```
+equal weight, n=4, k=60, doc in 1 list / absent in 3:
+  rank0 → norm 0.8838   rank1 → 0.8797   rank2 → 0.8757   rank5 → 0.8646
+  absence offset (constant for every doc): 0.01056
+```
+
+Two facts fall out, and the doc must own both:
+
+1. **The absence term is a constant offset** — it shifts every doc equally and cannot change ordering. So ordering is governed purely by `w_type / (k + rank_within_type)`. Cross-type RRF over disjoint sets is **weighted rank-interleaving** — there is no consensus/reinforcement term (the thing RRF buys on *overlapping* expansion lists). I am not hiding this; it is exactly *why* A is scale-free, and exactly why **the weights carry 100% of the cross-type discrimination.**
+2. **Equal weights produce near-ties** (0.884 vs 0.880…) decided by floating-point then stable-sort append order. "Uniform prior" silently makes *stage order* the real prior. That is worse than choosing priors honestly — so I choose them.
+
+### 2.2 Proposed default weight vector (first-principles, not benchmark-fit)
+
+I justify from **existing config and the system's own type semantics**, never from a number I cannot reproduce on prod:
+
+| Leg | Weight | First-principles justification |
+|-----|--------|-------------------------------|
+| `fact` / `episode` (Heart S1) | **0.45** | Facts/episodes are the *answer-bearing* substrate of recall; LongMemEval/BEAM answers are facts. They already share one RRF space, so one weight. |
+| `procedure` (S1) | **0.30** | Procedures are *how-to*, rarely the literal answer to a recall query; the utility boost (§4) already privileges effective ones *within* the leg. |
+| `decision` (S2) | **0.35** | Decisions are first-class memory but a recall query is more often fact-seeking than decision-seeking; weight between fact and procedure. |
+| `chunk` (S2) | **0.45** | Chunks are verbatim transcript = answer-bearing (F067 was a +retrieval win); co-weighted with facts. |
+| `graph_expanded` / Path-A / heart_graph (S2) | **0.20** | Graph hits are *inferred* (1-hop, decay 0.7), one association removed from a direct hit. Their raw scores already ceiling at ~0.70 (whitepaper §4.3); a low prior encodes "supporting, not leading." |
+| `_default` (any unlisted type) | **0.25** | Conservative middle. |
+
+These are **priors, not tuned constants** — defensible from "what answers a recall query" + the existing decay/boost design, and they survive an operator who has never run F051. I deliberately do **not** claim they are optimal; §6 measures them.
+
+### 2.3 How an operator tunes
+
+Single JSON env, mirroring `NOUS_CONTEXT_BUDGET_OVERRIDES`:
+
+```
+NOUS_COHERENT_RANKING_TYPE_WEIGHTS={"fact":0.45,"episode":0.45,"procedure":0.30,
+  "decision":0.35,"chunk":0.45,"graph":0.20,"_default":0.25}
+```
+
+Weights are relative (normalized by `Σw` in `_rrf_merge_weighted`), so an operator reasons in ratios, not absolutes. Lower `graph` → graph hits sink; raise `procedure` → how-tos surface. **Plus a `k` knob:** `rrf_k=60` makes adjacent ranks nearly flat (rank0/rank1 ratio = 1.0167; at k=5 it is 1.20). For cross-type fusion a *smaller* k sharpens within-leg rank discrimination. I expose `NOUS_COHERENT_RANKING_RRF_K` (default 60 to match existing) and flag it as the second tuning surface. I am not silently reusing the expansion-path k.
+
+---
+
+## 3. Censor sub-decision — **EXCLUDE from the pool**
+
+Drop `"censor"` from `search_types` (`heart.py:877`) and from `heart_types` (`retrieval_pipeline.py:340-341`) when the flag is on.
+
+**Justification, consistent with rank fusion:** a censor `_semantic_search` list is a *guardrail-trigger ranking* — cosine floored at 0.7 (`censors.py:387,400`), surfaced specifically to *fire a guardrail*, not to answer a query. Fusing it by rank asserts "the rank-0 censor is the most relevant *memory*," which is categorically false — rank within a trigger list is not relevance-within-recall. Censors already own a dedicated surface ("Active Censors / Active Guidance", `context.py:460`), so excluding them from recall loses **nothing** the user sees. This kills **B1 with zero normalization**, and it is the *consistent* move: rank fusion's whole premise is "fuse comparable rankings"; a trigger ranking is not comparable, so the principled act is to not feed it in, not to hand-weight it down.
+
+**Honest caveat:** exclusion is a *scope* decision, not something fusion *forces* — Approach B could also exclude. But under A it is the natural and cheapest resolution, and it removes an entire category of incomparability rather than papering it with a weight.
+
+---
+
+## 4. Procedure-boost sub-decision — **KEEP IT UNCHANGED; it dissolves for free**
+
+This is a genuine A selling point. The utility boost (`procedures.py:457`, `final = hybrid × (1 + boost)`, can exceed 1.0) determines the procedure leg's **internal ordering**. Fusion reads *rank*, not magnitude — so the >1.0 value never reaches cross-type comparison. **No clamp, no post-rank, no fold-into-weight needed.** The `[0,1]` invariant that B2 violates is simply never consulted across types.
+
+The boost still does exactly its job: it reorders procedures *among themselves* so the most effective one is rank-0 of the procedure leg, which then enters fusion at the `procedure` prior. The invariant is preserved because we stopped asking magnitude to be cross-comparable.
+
+**Honest caveat:** the boost's *magnitude* (how much more effective) is discarded — only its reordering survives. If two procedures are both clearly relevant and one is far more effective, fusion sees "rank-0 vs rank-1 procedure," a near-tie. That is the same magnitude-loss A pays everywhere (§7); it is consistent, not a special procedure wart.
+
+---
+
+## 5. Embed-failure leg (B3) — A auto-fixes the headline; here's the proof and the bound
+
+**Proof it auto-fixes the cross-type collapse:** when `facts._search` hits `embedding=None`, `hybrid_search` returns raw `ts_rank_cd/(1+…)` ~0.06 (`search.py:220-222`). Under raw-sort that whole type lands ~10–20× below its healthy siblings and is cut by `[:limit]`. Under A, the FTS-degraded fact list is *still a ranked list*. Its rank-0 contributes `w_fact / (k+0)` — **identical** to a healthy fact list's rank-0. The 0.06-vs-0.92 magnitude gap is **never read**. The type is no longer demoted as a whole. B3's headline (whole-type collapse at the cross-type sort) is gone by construction — no special-casing, no normalization branch.
+
+**Honest bound (do not overclaim):** fusion **cannot restore the within-leg ranking quality** lost when the vector signal vanishes — it preserves whatever (worse, keyword-only) order FTS produced. So A fixes "the type got demoted," not "the type's internal order degraded." The latter requires the vector leg to come back (or B-hs-8's shared-embed retry), which is out of scope. Stating this is the honest line.
+
+---
+
+## 6. Acceptance criteria (§3) — walk all 7
+
+1. **No mixed-scale sort.** ✅ at **both** S1 and S2. Final ordering is governed by **ranks** (weighted reciprocal rank), a single space. Criterion #1 explicitly permits "single space **or ranks**" — A satisfies it via ranks. I do **not** claim a clean `[0,1]`: for disjoint inputs the top item is ~0.88 (n=4), not 1.0; the space is "weighted reciprocal-rank," and the doc says so. No raw score from one type can structurally out/under-rank another — the censor floor and procedure>1.0 are never compared.
+2. **CE-off correctness.** ✅ A depends on neither CE nor MMR. It *replaces* the both-off raw-sort `else` branch. Pure-Python, O(n) over the candidate set, no model. This is A's whole reason to exist under the prod constraint.
+3. **Flagged + byte-identical OFF.** ✅ New behavior behind `NOUS_COHERENT_RANKING_ENABLED` (default OFF). When OFF, the S1 `else` at `heart.py:1110-1112` and the S2 branch at `:277-278` are **literally unchanged** — the fused branch is a pure `if` addition. See §7 for the one place this could break.
+4. **Ordering hazards fixed (this feature's share).** ✅ S1/S2 re-sort by the fused score immediately after assigning it. The cognitive-path boost-sort hazards (B-cog-A/B) live in `context.py`, not my two sort sites — I scope them **OUT** to a sibling PR (see §8) to keep the footprint to one shippable change. The spec's open-item #4 ordering set that overlaps my sites *is* fixed.
+5. **Observability honest (B5).** ✅ I thread `coherent_ranking_applied: bool` into `PipelineStats` (replacing the hardcoded `ce_reranked=False`/`mmr_applied=False` lie at `:296-297` is a separate fix, but I add the new honest flag so evals can see A fired). Cheap and in-footprint.
+6. **Measured.** ✅ F051 paired A/B, per-source MRR/P@k/R@k, no-regression-> 3% gate. The censor/procedure displacement cases (the spec's §5 synthetic set) become unit assertions. The credible **failure to watch** is single-session-user/preference (§7) — I name it as the falsifier, not a footnote.
+7. **No new hot-path latency.** ✅ Two dict builds + one fused pass = O(n) in the candidate count (≤ `limit*2` at S1, low-tens at S2). No model, no extra DB round-trip, no embed. Strictly cheaper than the CE path the spec's Approach C would add.
+
+---
+
+## 7. Honest failure modes (where A loses, and what falsifies it)
+
+**The sharp one — magnitude loss on dominant-answer queries.** Consider one fact at RRF **0.95** (unambiguously *the* answer) and many facts at 0.55. Raw-sort ranks the 0.95 fact decisively #1. Rank fusion makes it "rank-0 of the fact leg," which fuses *equal to a rank-0 procedure or rank-0 chunk*. The margin — the very signal that this fact is special — is gone. This bites exactly **high-precision single-answer queries**: LongMemEval `single-session-*`, where Nous already scores near-perfect (memory: single-session perfect/near-perfect). A could *regress* the cases it's currently best at.
+
+**Falsifier (ties to criterion #6):** an F051 per-source **MRR regression > 3% on `single-session-user` or `single-session-preference`** is magnitude-loss biting. If that fires, A's default weights aren't the fix — the mechanism is wrong for those shapes, and the honest response is a hybrid (A for cross-type coherence, but keep within-the-top-leg raw order as the tiebreak, or gate A to multi-type queries only). I commit to reading that exact metric before recommending the flag flip.
+
+**Magnitude loss has a second victim — supersession.** Rank fusion *structurally cannot* represent "this fact is still relevant but superseded, so it ranks where it sat ×0.3" — that down-rank is pure magnitude, the thing A discards. §1.3 recovers it by composing the recency `×0.3` multiplier **on top of** the fused base (so the prod recency resolver survives), but be honest about what that buys: it preserves the *multiplier*, not a fusion-native notion of supersession. If an operator ran A *without* the recency resolver, supersession ordering would be gone. This is the same magnitude-loss family as the dominant-answer falsifier above — A leans on the external `×0.3`/adjacency multipliers to carry every signal that is about *how much*, not *which rank*.
+
+**Second failure — the tie field.** `rrf_k=60` makes adjacent ranks nearly flat (0.884/0.880/0.876…), and disjoint inputs already collapse toward the absence offset. Result: **many near-ties**, resolved by the `_STAGE_RANK` tiebreak. If the priors are too close, stage order silently dominates. Mitigation: the priors above are spread (0.20–0.45), and I expose the smaller-`k` knob to sharpen. But an operator who sets all weights equal re-creates "stage order is the prior" — I document that as a foot-gun, not a feature.
+
+**Where byte-identical-OFF could break.** *Not* the math — the **tiebreak/append order**. Python's sort is stable, so today's ties resolve by current append order. Any refactor that touches how `merged` (S1) or `results` (S2) is *built* while the flag is OFF can shift snapshot bytes even with the sort key unchanged. **Mitigation, stated as a build rule:** the OFF path must keep list-construction byte-for-byte; the fused path is added as a pure branch that reads the already-built list. The snapshot test (`postgres_only`, flag-OFF) is the gate — if a byte moves, the refactor leaked into the OFF path.
+
+**What A does NOT fix (scope honesty):** B-cog-A/B/C/D (cognitive path), B-graph-5..9, the two-resolver drift, B5's *full* honest wiring, B7 (no global top-K). Those are sibling PRs (§8). A fixes the **headline coherence cluster (B1/B2/B3/B4)** and nothing it doesn't have to.
+
+---
+
+## 8. Scope line (open-item #5, #6)
+
+**In this PR:** S1 + S2 fusion behind one flag; censor exclusion; the honest `coherent_ranking_applied` stat. One mechanism, two call sites, one flag — a single shippable change.
+
+**Sibling PR (explicitly OUT):** the cognitive-path boost-sort fixes (B-cog-A/B at `context.py:608-617,961,992-1005`). They share the *root cause* (mutate-then-sort-by-wrong-key) but live in different files and a different retrieval surface; folding them in doubles the review surface and the snapshot risk. State it, don't do it.
+
+---
+
+## 9. Self-score
+
+| Axis | Score | Rationale |
+|------|-------|-----------|
+| **Correctness** | **8/10** | Provably kills B1/B2/B3/B4 at both live sort sites with CE off. −2 for the genuine magnitude-loss on dominant-answer queries — a real correctness cost on Nous's currently-strongest category, mitigated only by weights/k tuning, not eliminated. |
+| **Prod-safety** | **8/10** | No CE, no model, no new DB round-trip, O(n), fail-safe (fusion can't raise on disjoint inputs). Flag-gated, byte-identical OFF. −2: (a) the byte-identical invariant rests on a *build discipline* (don't perturb OFF-path list construction), enforced by the snapshot test not the type system; (b) S2 fusion **must compose with**, not overwrite, the prod-ON recency resolver (`:258 ×0.3`) and adjacency boost (`:246`) — §1.3 fixes this by parking fusion as the *base* score under those multipliers, but it is a real wiring hazard a naive implementation would trip, so it costs a point of confidence. |
+| **Change-footprint** | **8/10** | One new pure function, two guarded `if` branches, one env var (+ optional k knob), one stat field, censor removed from 2 search-type lists. No schema, no migration, no new dependency. −2 because it touches *two* hot files (`heart.py` + `retrieval_pipeline.py`) — unavoidable given §0, but still two surfaces. |
+| **Measurability** | **9/10** | Drops straight onto F051 paired A/B; the falsifier is a named per-source metric (single-session MRR > 3%); the synthetic displacement set becomes unit asserts; the honest stat flag makes "did A fire" observable. −1 because BEAM can't isolate this (bypasses the merge), so external validation is F051-only until a prod-shape harness exists. |
+
+**Bottom line:** A is the right spine *because of* the prod constraints, not despite them — it's the only approach that is scale-free, model-free, O(n), and natively defined over the exact ranked-leg structure both sort sites already produce. Its honest cost is magnitude/margin, its honest risk is single-session regression, and both are measurable on the harness we already run before any flag flip.

--- a/docs/reviews/F080-approach-C-champion.md
+++ b/docs/reviews/F080-approach-C-champion.md
@@ -1,0 +1,202 @@
+# F080 Approach C — Champion Case: Make the Cross-Encoder the Single Comparable Scorer
+
+**Role:** Champion of Approach C (CE-viable-in-prod).
+**Stance:** Code-grounded, adversarially honest. The honest conclusion is stated up front so the debate can use it.
+**Date:** 2026-06-08
+
+---
+
+## TL;DR (the thesis, stated against my own interest)
+
+A cross-encoder scoring `(query, summary)` pairs is the **principled endgame** for cross-type coherence: one model, one score space, no type priors, no rank-fusion magnitude loss, B1/B2 dissolved *by construction* — see §2, §4. The F042 infra already exists and already feeds `text_fn` uniformly across all types (`heart.py:1023`).
+
+**But standalone C does not satisfy F080's acceptance criteria, and I will not pretend otherwise.** Two structural facts force this:
+
+1. **CE reranks the head only.** `reranker.py:103-104,167` returns `head + tail`; the tail keeps its incoherent RRF/boost/floor/FTS scores. So even on the happy path, *something coherent must order the tail.*
+2. **The fail-open target in the brief is the bug.** "Fail open to the existing score sort" lands every timeout/error/CE-OFF path on the exact mixed-scale sort (`heart.py:1110-1112`, `retrieval_pipeline.py:277-278`) that F080 exists to kill. A coherent floor must exist underneath CE.
+
+Therefore **C is really C+A or C+B**: an A/B-normalized spine that produces a coherent ranking with CE OFF (satisfying acceptance #2), with CE layered on as an *optional ON-path relevance enhancer for the head*. That is the strongest defensible form of this approach, and it is the most useful thing this doc contributes to the debate.
+
+Everything below designs *that* hybrid honestly, including the latency wall that killed standalone CE once already.
+
+---
+
+## 1. The latency budget — measured, not hand-waved
+
+### 1.1 Hard budget
+
+**Wall-clock budget for CE on the recall path: 1.5s p50, 2.0s hard `asyncio.wait_for` ceiling.** Rationale: `recall_deep` is *sometimes* on a user-interactive path (whitepaper §1, framing) and already pays multiple embeds + vector search + graph expansion before CE. CE must be *additive headroom*, not the dominant cost.
+
+### 1.2 The one measured prod number, and a dev calibration I ran this session
+
+The only empirical prod datapoint is the ghost that killed this: **BGE-reranker-v2-m3 ≈ 67s for one rerank on the prod CPU-only 8GB VM** (`project_prod_bge_too_slow`, `reference_gpu_capability`). At N=30 candidates that is **~2.2s/pair** — catastrophic.
+
+To turn that single number into a *defensible* MiniLM prod estimate, I benchmarked both models on this dev CPU box (`torch 2.11.0+cpu`, `device='cpu'`, 512-char docs, this session — reproducible):
+
+| Model | Dev CPU, N=30 | Dev per-pair |
+|-------|---------------|--------------|
+| `BAAI/bge-reranker-v2-m3` (code default) | **6.23s** | ~208 ms |
+| `cross-encoder/ms-marco-MiniLM-L-6-v2` (prod override) | **0.335s** | ~11 ms |
+
+**This gives an empirical dev→prod scaling factor, not a guessed one:**
+
+```
+prod BGE N=30  = 67s   (measured on prod VM)
+dev  BGE N=30  = 6.23s (measured here, same model, same N)
+-------------------------------------------------------
+dev→prod factor = 67 / 6.23 ≈ 10.8×
+```
+
+The prod VM is ~**10.8× slower per CE pair** than this dev box. (Consistent with an 8GB 1–2 vCPU VM vs a desktop CPU.) Apply it to MiniLM:
+
+> **Two rigor caveats, both in C's favor.** (a) 10.8× is transferred from a *compute-bound* model (BGE, 560M params) to MiniLM, whose per-call time has a larger fixed-overhead fraction — my dev curve shows it: N=10=0.150s but marginal pairs are ~11ms, implying ~0.04s fixed cost. So a flat 10.8× likely *over*estimates MiniLM prod latency. The conclusion is robust either way; verify on the prod VM. (b) The benchmark used 512-**char** docs, which exactly matches the code (`reranker.py:112` `[:text_limit]` is a *character* slice; `text_limit=512`, `config.py:740`) — ≈128 tokens, well under MiniLM's 512-*token* max, so no padding/truncation surprises.
+
+| N | MiniLM dev (measured) | MiniLM prod (× 10.8, estimated) | Under 2.0s ceiling? | Under 1.5s p50? |
+|---|------------------------|----------------------------------|---------------------|------------------|
+| 10 | 0.150s | **~1.6s** | ✅ | borderline |
+| 15 | 0.188s | **~2.0s** | ✅ (at ceiling) | ❌ |
+| 20 | 0.213s | **~2.3s** | ❌ | ❌ |
+| 30 | 0.335s | **~3.6s** | ❌ | ❌ |
+
+### 1.3 The honest verdict on "does N=20–30 fit under 1.5s?"
+
+**No.** Back-of-envelope and the measured-then-scaled number agree:
+
+- **N=30 (current `cross_encoder_max_candidates` default) ≈ 3.6s on prod CPU — fails the budget outright.** This is the single most important sentence in this doc. Shipping CE at the default N=30 re-creates a ~3.6s interactive stall — a milder ghost than 67s, but a ghost.
+- **N=10 MiniLM ≈ 1.6s prod** is the only configuration that clears the 2.0s ceiling with margin, and it still misses 1.5s p50.
+- To make **N=30 fit ~1.5s**, you need **~2.4× speedup** beyond MiniLM-fp32: **int8 dynamic quantization or an ONNX-runtime export** (`optimum`/`onnxruntime`, typically 2–3× on CPU). That is unmeasured here and would have to be benchmarked on the prod VM before any flag flip — I am not going to claim a number I haven't run on the target hardware.
+
+**Design-to-budget decision:** ship **MiniLM-L6, N=10**, `wait_for(2.0)`, with N as an env knob (`cross_encoder_max_candidates` already exists, `config.py:739`) so ops can dial it down to 6–8 if the prod VM is slower than my 10.8× estimate. Treat N=30 + int8-ONNX as a *measured follow-up*, not a launch claim.
+
+**Hard design constraint: do NOT raise `text_limit` toward a true 512 *tokens*.** Inference scales ~3–4× with sequence length; lifting the cap from 512 chars (~128 tok) to 512 tokens would push N=10 from ~1.6s to ~5–6s prod. The 512-char cap is *why* N=10 is viable — it is a latency feature, not an oversight.
+
+### 1.4 The mechanism (reuses F042 verbatim where possible)
+
+- **Model:** `cross-encoder/ms-marco-MiniLM-L-6-v2` (already the prod override, `.env.prod-snapshot:28`). Code default `BAAI/bge-reranker-v2-m3` (`config.py:738`) **stays the default for the offline F043 CE-backfill** (sleep-time, not latency-bound) — do not put BGE near the recall hot path.
+- **N (head):** 10 on the recall path (down from 30). `reranker.py` already head/tail-splits at `max_candidates` (`:103-104`) — no code change, just config.
+- **Batching:** single `model.predict(pairs)` call (already batched, `reranker.py:136`). N=10 is one batch.
+- **Off-event-loop:** `asyncio.to_thread(model.predict, pairs)` — already done (`reranker.py:136`).
+- **Strict timeout + fail-open:** wrap the existing `cross_encoder_rerank` call site (`heart.py:1020`) in `asyncio.wait_for(..., timeout=settings.cross_encoder_timeout_seconds)`. On `TimeoutError`/any exception → fall through to **the coherent A/B fallback ranker (§3), NOT the raw sort.**
+- **Cold-start warm-up:** `_load_cross_encoder` is `lru_cache(maxsize=1)` (`reranker.py:38`) — first recall after restart eats the model load. Measured here: MiniLM cold load **2.86s on dev**. On prod this is disk-read + deserialize of an ~80MB model (I/O-bound, *not* FLOP-bound — so the 10.8× compute factor does **not** apply); realistically ~2–8s on a slow VM. Either way it **cannot** land on a user turn. Add a startup warm-up coroutine in `main.py` lifecycle that calls `_load_cross_encoder(model)` + a dummy `predict([("warm","warm")])` once at boot, behind the same flag.
+
+---
+
+## 2. Why CE is the *right* comparable scorer (the principled case)
+
+This is where C is genuinely superior to A and B, and I'll make the strongest version.
+
+**A single model scoring `(query, doc)` pairs makes all types comparable by construction.** The whitepaper's entire headline defect (§8.1) is that the merge sorts four incompatible spaces:
+- normalized RRF `[0,1]` (facts/episodes),
+- boosted RRF `>1.0` (procedures, `procedures.py:446-457`),
+- raw cosine floored `[0.7,1.0]` (censors, `censors.py:387,400`),
+- raw `ts_rank_cd ~0.06` (embed-failure leg, `search.py:220-222`).
+
+**A and B both *manage* this incompatibility; C *eliminates* it:**
+
+- **Approach A (rank fusion)** is scale-free but throws away magnitude — a 0.95 fact and a 0.55 fact at ranks 0/1 fuse identically to two 0.60 facts (F080 §A con). It also *introduces type priors* as an explicit weight vector you must justify without overfitting (F080 open item #4).
+- **Approach B (per-type calibration)** preserves magnitude but needs per-type affine maps / min-max that are outlier-sensitive on tiny candidate sets and require calibration data per type (F080 §B con).
+- **Approach C** needs **none of that.** The CE reads `(query, summary)` and emits one sigmoid-normalized relevance score in `[0,1]` for *every* type through the *same* function. There is no type prior, no calibration table, no rank-fusion magnitude loss. A censor, a procedure, a fact, and an episode are scored on **identical footing** because the model never sees the type — it sees text-vs-query.
+
+**Code evidence this is real, not aspirational:** the F042 call site already passes `text_fn=lambda r: r.summary or ""` (`heart.py:1023`) — type-blind by construction *today*. The plumbing to score all types uniformly is already there; CE-OFF is the only reason it's latent.
+
+This is the principled endgame: the merge problem is fundamentally "how do I compare relevance across types," and the most direct answer is "use a model that scores relevance directly." A and B are *proxies* for that model. **The catch — and it is decisive — is that C's relevance signal only covers the head (§3).**
+
+---
+
+## 3. The fallback ranker — the concession that defines the approach
+
+**Be blunt: CE reranks `candidates[:N]` and returns `head + tail` (`reranker.py:167`). The tail keeps its incoherent scores. And in prod, CE is OFF, so 100% of the pool is "tail."** Three surfaces need a coherent ranker that is *not* CE:
+
+1. **The tail** (`candidates[N:]`) on the happy path — N=10 head, everything below stays mixed-scale.
+2. **The CE-OFF path** — prod's actual config (`.env.prod-snapshot:26`). The feature does *nothing* here unless a fallback orders the pool.
+3. **The fail-open path** — timeout/exception. The brief says "fail open to the existing score sort," but that sort *is* the F080 bug. Failing open to it ships the defect on every CE hiccup.
+
+**So C must be layered on a coherent A/B spine.** Concretely, I endorse **C + A (rank fusion as the floor)** because A is parameter-light, reuses `_rrf_merge_n` (`search.py:359-377`), and is immune to all four pathologies at once (F080 §A pro). The composition:
+
+```
+merged (cross-type pool)
+  → A: rank-fusion / rank-normalize into one coherent space   [coherent floor — orders TAIL + CE-OFF + fail-open]
+  → if CE enabled AND warm AND within budget:
+        CE reranks head[:10] into sigmoid [0,1]                [relevance enhancer — orders HEAD]
+        re-sort head; head + tail
+  → truncate [:limit]
+```
+
+The fail-open target becomes "the A-normalized order," never the raw sort. This is the honest architecture. **C does not fully replace A/B. It sits on top of one.** Anyone arguing standalone C is the spine is wrong on acceptance #2 (§5).
+
+One subtlety the whitepaper flags (B-rm-3, `reranker.py:152,167`): after CE overwrites head scores into sigmoid `[0,1]` but leaves the tail in A-normalized space, head and tail are again on different scales. With an A spine this is *benign* — both are `[0,1]`-ish and CE only ever promotes within the already-coherent head — but the truncation `[:limit]` must happen *after* the head re-sort, and we must not re-sort head-against-tail on raw value. Land CE-head strictly above the A-tail by construction (head items were the top-N of the A order; CE only reorders *within* them).
+
+---
+
+## 4. Censor + procedure sub-decisions under a CE regime
+
+**Claim: CE dissolves B1 and B2 *for head items*, and only for head items.**
+
+- **B1 (censor ≥0.7 floor displaces facts):** under CE, a censor in the head is scored `CE(query, censor.summary)` — the same function as everything else. The `censors.py:387,400` hard-floor never reaches the comparable score; it only ever affected the *pre-CE* raw cosine, which CE overwrites (`reranker.py:152`). So a censor only ranks high in the head **if the CE judges it relevant to the query.** B1 dissolves for the head. ✅
+- **B2 (procedure boost >1.0):** identical logic. `CE(query, procedure.summary)` ignores the `procedures.py:446-457` multiplier entirely — CE overwrites `.score`. The boost cannot push a procedure above a more-relevant fact in the head. B2 dissolves for the head. ✅
+
+**But — and this is the honest boundary — they only dissolve for the head.** A censor or boosted procedure sitting in the *tail* (rank 11+) keeps its floored/boosted score, ordered by the A spine. Two consequences:
+- With the **A spine**, even the tail censor/procedure is rank-normalized, so B1/B2 are *also* neutralized there (A is scale-free) — good, but that's **A doing the work, not C.**
+- This is yet another proof that the useful unit is **C+A**, not C.
+
+**Does CE make Sub-decision 1 (exclude censors) moot?** Partly. Under C+A, censors compete on honest relevance whether included or excluded. But I still **endorse F080 Sub-decision 1's exclusion** (`retrieval_pipeline.py:340-341`, drop `"censor"` from `heart_types`) independently: censors have a *dedicated* surface ("Active Guidance", `context.py:460`), so spending CE budget (N is precious at 10!) scoring censor pairs that have their own display is waste. **Exclude censors from the ranked pool; let CE's N=10 budget go entirely to facts/episodes/procedures.** This also shrinks the latency footprint.
+
+**Sub-decision 2 (procedure boost):** under C+A, fold utility into the A fusion weight (rank-level), and let CE re-judge head procedures on relevance. Do **not** keep the raw >1.0 multiplier — it's invisible to CE and incoherent to A. Clamp it out of the comparable score; preserve it only as telemetry.
+
+---
+
+## 5. Acceptance criteria — all 7, candidly
+
+| # | Criterion | C standalone | C+A (endorsed) |
+|---|-----------|--------------|-----------------|
+| 1 | No mixed-scale sort | ✅ head only; ❌ tail stays mixed | ✅ A makes tail coherent; CE refines head |
+| 2 | **CE-off correctness (prod config)** | **❌ FAILS — prod is CE-OFF, feature is inert, pool stays mixed-scale** | ✅ A spine produces coherent order with CE off |
+| 3 | Flagged + byte-identical OFF snapshot | ✅ `NOUS_CROSS_ENCODER_ENABLED` already gates; A spine behind `NOUS_COHERENT_RANKING_ENABLED` default OFF → snapshot intact | ✅ same |
+| 4 | Ordering hazards fixed (re-sort after mutation, IDs after truncation, deterministic `query_text`) | ⚠️ orthogonal to CE — must fix regardless | ⚠️ same — not C's job, ships alongside |
+| 5 | Observability honest (`ce_reranked`/`mmr_applied`) | ✅ **C improves this** — thread real `ce_reordered` out of `heart._recall` (already computed, `heart.py:1031`) into `PipelineStats` (`retrieval_pipeline.py:296`) | ✅ same |
+| 6 | Measured on F051 (+ BEAM if feasible), no per-source regression >3% | ⚠️ must run; CE historically null/slightly-negative at K=5 (`project_ce_rerank_disable_2026_05_26`) | ⚠️ A-spine measured; CE measured as ON-delta |
+| 7 | **No new hot-path latency beyond documented bound** | **❌ adds ~1.6–3.6s prod (N=10–30) on top of existing recall cost** | ⚠️ A is O(n) free; CE adds budgeted ~1.6s at N=10 with fail-open |
+
+**The two candid failures:**
+
+- **#2:** standalone C **fails its own deployment config.** Prod runs CE-OFF; a feature that only works when CE is ON does nothing in the environment F080 must fix. *Only C+A passes #2.* This is dispositive — it's why C cannot be the spine.
+- **#7:** C is **additive latency by definition.** Even budgeted N=10 adds ~1.6s prod p50 on top of a recall path that already does 4× embeds (whitepaper §7 B-rm-1: facts/episodes/procedures/censors each `embed(query)` separately) + vector + graph. The "documented bound" is real but it is *new cost*, where A is essentially free (O(n) rank fusion). A devil will weigh this heavily.
+
+**On the F051 history — read what it actually measured, because the standard reading is wrong.** Yes, CE measured **null-to-slightly-negative at K=5** (`project_ce_rerank_disable_2026_05_26`, decision `8a3f35da` flipped `NOUS_CROSS_ENCODER_ENABLED=false`). But that A/B ran on a **chunks-on, LongMemEval-shape corpus dominated by facts / episodes / chunks** — i.e. it tested *whether CE improves same-type relevance ranking where RRF is already strong.* Null there is unsurprising and is **not** evidence against C. It tested the wrong job.
+
+F080's target is **cross-type displacement**: a censor hard-floored at ≥0.7 (`censors.py:387`) or a procedure boosted >1.0 (`procedures.py:446`) out-ranking a more-relevant fact at the `[:limit]` cut. The F051 corpus almost certainly had **few or no censors/procedures competing in the ranked pool**, so the one thing CE uniquely fixes was never exercised. **The decisive eval for Approach C has never been run** — because the harness lacks censor/procedure-vs-fact displacement probes. So the honest framing is not "CE is proven useless" but "**acceptance #6 needs new displacement probes, and until they exist no approach (A, B, or C) has been measured on the actual defect.**" That is a demand on the eval, not a concession on C.
+
+---
+
+## 6. Honest failure modes
+
+1. **The 67s ghost / N=30 default.** BGE on prod = 67s. MiniLM at the current `max_candidates=30` default ≈ 3.6s prod (measured-then-scaled, §1.2). If someone enables CE without also lowering N to ~10, they re-create an interactive stall. **Mitigation:** ship N=10 as the recall-path default and document the 10.8× prod factor next to the knob.
+
+2. **`asyncio.to_thread` + `wait_for` does NOT cancel the CPU work.** This is the most dangerous footgun and it is exactly why ops disabled CE before. `asyncio.wait_for` cancels the *await*, but the thread-pool `Future` running `model.predict` **cannot be cancelled once started** — the CPU burn runs to completion. On a 1–2 vCPU prod VM under concurrent interactive load, *timed-out-but-still-burning* CE calls pile up and saturate the threadpool/CPU. The fail-open returns fast to each caller while the box melts. **Mitigation:** a hard concurrency gate — a global `asyncio.Semaphore(1)` (or small bounded `ThreadPoolExecutor`) so at most one CE predict runs at a time; if the semaphore is contended, skip CE entirely and use the A floor. This bounds CPU at one core of CE work, never N-callers-deep. **This must be in the design or the devil is right to reject.**
+
+3. **GPU dependency is a non-starter for prod.** `reference_gpu_capability`: prod VM is **CPU-only, 8GB, no GPU**. The dev RTX 4060 Ti and the cu124 wheel swap help **eval/dev only** — they do nothing for prod recall latency. The installed wheel is `2.11.0+cpu` (confirmed this session). Any "just use the GPU" rebuttal is invalid for the prod hot path.
+
+4. **Cold-start model load on a user turn.** `lru_cache(maxsize=1)` means first-recall-after-restart pays ~2.86s dev → ~31s prod for MiniLM load. **Mitigation:** boot-time warm-up coroutine (§1.4). Without it, every deploy/restart gives the first user a 30s stall.
+
+5. **int8/ONNX is unmeasured on prod.** My N=30→1.5s path depends on a 2.4× quantization speedup I have *not* benchmarked on the prod VM. I will not launch on an unmeasured number; N=30 is a follow-up gated on a prod-VM measurement.
+
+6. **The "ops turns it off again" risk.** This already happened once (MiniLM rolled back, `project_prod_bge_too_slow`; CE flipped off, decision `8a3f35da`). The realistic outcome of shipping standalone C is a third disable. The *only* way C survives contact with ops is: (a) it's an *enhancement on a coherent A spine* so the feature still delivers value with CE OFF, and (b) the semaphore + budget + warm-up make CE-ON safe enough that ops *can* leave it on. If C ships without A underneath, it ships infra that does nothing in prod (CE-OFF) and risks a stall the day someone flips it.
+
+---
+
+## 7. Self-score
+
+| Dimension | Score /10 | Justification |
+|-----------|-----------|---------------|
+| **Correctness** | 8 | CE-as-uniform-scorer is genuinely the principled answer for *comparability*; B1/B2 dissolve for the head by construction (§4), and that's airtight. Docked because the relevance *win* is unproven on prod-shape data (F051 null at K=5) and the head-only coverage is a real limit. |
+| **Prod-safety** | 4 | This is C's weak axis and I won't inflate it. Additive latency, uncancellable-thread footgun, cold-start, and a prior history of being disabled. The semaphore + N=10 + budget + warm-up raise it from "reject on sight" (2) to "conditionally acceptable as an ON-path option" (4). Standalone C on prod-safety alone: **2–3.** |
+| **Change-footprint** | 7 | Small: F042 already exists. Net new = lower N default, `wait_for` wrapper, a semaphore, a warm-up coroutine, and threading `ce_reordered` into `PipelineStats`. **But** the mandatory A spine underneath (§3) is *not* small — that's the real F080 surgery. So C-the-CE-part is cheap; C-the-shippable-feature inherits A's footprint. |
+| **Measurability** | 7 | F051 paired A/B + flag-OFF byte-identical snapshot give clean measurement, and fixing B5 finally makes CE state observable. Docked because the decisive prod number (N=30 int8 latency on the 8GB VM) and the relevance delta on prod-shape data are *both* still unmeasured. |
+
+### Devil's-advocate prediction
+
+**The devil will reject standalone C on prod-safety, and will be right to.** Concretely, they will cite: (a) acceptance #2 — the feature is inert in prod's CE-OFF config; (b) the uncancellable-`to_thread` CPU-pileup footgun under concurrent interactive load; (c) "you disabled this exact thing twice already" (`project_prod_bge_too_slow`, decision `8a3f35da`); and (d) the F051 null result — re-adding latency for an unproven gain. My rebuttal to (d) (§5): that null measured *same-type* ranking, not the *cross-type displacement* F080 targets, so the decisive eval is owed under acceptance #6 — but I concede the devil holds the burden-of-proof high ground until those probes exist.
+
+**The devil will *accept* C only in the form I'm championing: as the ON-path relevance enhancer layered on an A (rank-fusion) spine** that independently satisfies acceptance #2 and #7. In that form, CE is safe-by-default (OFF = A spine, fully coherent), bounded (semaphore + 2.0s budget + N=10), warm-started, and observable — and it earns its place as the principled head-refiner without being load-bearing for correctness.
+
+**My recommendation to the debate:** adopt **A as the spine** (resolves B1–B4, satisfies #2/#7, zero latency), with **C as an optional, flag-gated, budget-bounded head-reranker** for deployments that can afford ~1.6s and where a future prod-VM benchmark proves a relevance gain. Do **not** make C the spine. The most useful sentence I can offer this debate: **"Approach C, honestly costed, *is* Approach A with a cross-encoder bolted onto the head — so pick A first, and treat C as the upgrade path, not the foundation."**

--- a/docs/reviews/memory-retrieval-whitepaper-2026-06-08.md
+++ b/docs/reviews/memory-retrieval-whitepaper-2026-06-08.md
@@ -1,0 +1,379 @@
+# The Nous Memory-Retrieval System: A Code-Grounded White Paper
+
+**Date:** 2026-06-08
+**Method:** 5-agent parallel code-only discovery + single-author verification
+**Scope:** Everything that turns a query into ranked memory — both the `recall_deep` tool pipeline and the every-turn cognitive context-assembly path.
+**Constraint:** Derived **from source code only** (Python + SQL). No feature specs, design docs, or memory notes were used as authority. Every claim carries a `path:line` anchor. Where deployment behavior is discussed, it is sourced explicitly to `.env.prod-snapshot` and labeled as a deployment overlay — the algorithm description itself rests on `config.py` defaults, which are code.
+
+---
+
+## Abstract
+
+Nous has **two independent retrieval surfaces** that share primitives but diverge in structure, scoring, and feature coverage:
+
+1. **`recall_deep`** — an agent-invoked tool. Runs `run_recall_pipeline` (`nous/api/retrieval_pipeline.py`), which orchestrates a hybrid Heart search, episode-chunk vector search, multi-mechanism graph expansion, contradiction detection, a recency resolver, and an optional score-merge. This is the "rich" path.
+
+2. **Cognitive context assembly** — runs automatically on **every** chat turn inside `CognitiveLayer.pre_turn` → `ContextEngine.build` (`nous/cognitive/`). It is the retrieval that actually feeds the model by default. It has **no** graph expansion, **no** spreading activation, and **no** contradiction surfacing, and it re-implements staleness/recency/dedup with its own (drifted) logic.
+
+The central finding is structural: **at the point where memory types are merged and ranked, Nous compares scores drawn from incompatible numeric scales as if they were one space.** Facts and episodes carry RRF scores normalized to `[0,1]`; procedures carry a boosted score that can exceed `1.0`; censors carry a raw cosine similarity hard-floored at `≥0.7`; and any leg whose embedding call failed carries a raw full-text rank (~`0.05–0.08`). In the production configuration (cross-encoder and MMR both **off**), the final ranking is a direct descending sort over this mixed pool. A hard floor and an unbounded boost break the monotonic relationship between score and relevance *across types*, so structurally-high types (censors, effective procedures) displace genuinely more relevant facts at the `[:limit]` truncation.
+
+A second theme: a large fraction of the retrieval machinery is **gated off or unreachable** — date-aware boost is dead code, spreading activation is behind an effectively-unsatisfiable density gate, and several scoring features fire but are then discarded by a non-monotonic re-sort. The system's *observability* of its own behavior is also broken (`PipelineStats.ce_reranked`/`mmr_applied` are hardcoded `False`).
+
+---
+
+## 1. Architecture Overview
+
+### 1.1 The two paths
+
+```
+                    ┌─────────────────────────────────────────────┐
+  agent calls       │  recall_deep  (nous/api/tools.py:612)        │
+  recall_deep ─────▶│    └─ run_recall_pipeline                    │
+                    │         (nous/api/retrieval_pipeline.py:174) │
+                    │       Heart.recall ─┐                        │
+                    │       chunk vector  ├─ assemble ─ (rerank?) ─│──▶ tool result text
+                    │       graph expand ─┘   contradiction        │
+                    │                          recency resolver    │
+                    └─────────────────────────────────────────────┘
+
+                    ┌─────────────────────────────────────────────┐
+  every chat turn   │  CognitiveLayer.pre_turn                     │
+  (automatic) ─────▶│    (nous/cognitive/layer.py:349)             │
+                    │    └─ ContextEngine.build                    │
+                    │         (nous/cognitive/context.py:125)      │
+                    │       Brain.query / Heart.search_* directly  │──▶ system prompt
+                    │       per-type budget + staleness + dedup    │
+                    │       NO graph / NO spreading / NO contradict │
+                    └─────────────────────────────────────────────┘
+```
+
+Both ultimately call the same low-level engines (`Heart` managers, `Brain.query`, the hybrid searcher in `nous/heart/search.py`), but they wire them differently and post-process differently. **The memory the model sees automatically each turn is a strictly weaker retrieval than what it gets when it chooses to call `recall_deep`** — and the two can disagree on supersession and ranking for identical inputs (§6.4).
+
+### 1.2 Deployment configuration overlay (`.env.prod-snapshot`)
+
+The algorithm description in §2–§6 is written against **`config.py` defaults** (code). Production flips a number of flags; because several findings change reachability under prod, the relevant deltas are tabulated once here and referenced as the **"prod overlay"** throughout. This file is deployment config, not code — it is used only to assign reachability verdicts, never as the description's authority.
+
+| Flag | `config.py` default | `.env.prod-snapshot` | Effect when ON |
+|------|--------------------|----------------------|----------------|
+| `NOUS_EPISODE_CHUNKS_ENABLED` | `false` | **`true`** (`:46`) | chunk vector leg runs; `rerank_by_score=True` |
+| `NOUS_HEART_GRAPH_ALL_TYPES_ENABLED` | `false` | **`true`** (`:67`) | Path A all-types graph expansion runs |
+| `NOUS_GRAPH_ADJACENCY_BOOST_ENABLED` | `false` | **`true`** (`:52`) | adjacency boost runs |
+| `NOUS_RECENCY_RESOLVER_ENABLED` | `false` | **`true`** (`:92`) | superseded-fact down-rank runs |
+| `NOUS_QUERY_EXPANSION_ENABLED` | `false` | **`true`** (`:90`) | Haiku multi-query RRF union runs |
+| `NOUS_RECALL_INCLUDE_PARENT_EPISODES` | `false` | **`true`** (`:91`) | parent-episode summaries appended |
+| `NOUS_TEMPORAL_EXTRACTION_ENABLED` | `false` | **`true`** (`:119`) | `event_date` populated (feeds recency resolver) |
+| `NOUS_CROSS_ENCODER_ENABLED` | `false` | `false` (`:26`) | — (CE rerank stays OFF in prod) |
+| `NOUS_MMR_ENABLED` | `false` | `false` (`:88`) | — (MMR stays OFF in prod) |
+
+**Implication:** the common belief that "the graph/chunk apparatus is shipped dark" is true of code defaults but **false in production** — prod turns on chunks, Path A, adjacency boost, the recency resolver, and query expansion. What stays off in prod is exactly the cross-encoder and MMR — the two modifiers that would *re-base* scores into a single comparable space. Their absence is what makes the score-space-mismatch bug (§3.4, §7-B1/B4) the live production defect rather than a latent one.
+
+> **Embedding-model drift note.** The code embeds with `text-embedding-3-small`, `dimensions=1536` (`nous/heart/embeddings.py:26-28`). Production is understood to run `text-embedding-3-large`. Any reproduction of prod ranking must override the model; the dimension assumption (1536) is wired into the SQL `vector(1536)` columns and would need to match.
+
+---
+
+## 2. The `recall_deep` Pipeline (`run_recall_pipeline`)
+
+`recall_deep` (`tools.py:612`) is a thin wrapper. It computes two booleans and forwards everything to `run_recall_pipeline` (`retrieval_pipeline.py:174`):
+
+- `chunks_rerank = episode_chunks_enabled AND (search_all OR "fact" in types)` → passed as `rerank_by_score` (`tools.py:691-704`). **Prod: True.**
+- `_f071_exclude_ids = CURRENT_TURN_EXCLUDE_IDS.get()` contextvar → `exclude_ids` (F071 in-context exclusion).
+- `residual_activations` (F055) computed only if `residual_activation_enabled` (default **False**) else `None`.
+
+The pipeline fills a mutable accumulator via `_run_stages`, then assembles a flat `list[PipelineResult]` in stage order, applies post-processing, and returns `(results, stats)`. **There is no final global top-K truncation in the pipeline** — `limit` is applied per leg only (§7-B9). The returned list is the sum across all legs; `recall_deep` formats *all* of it to text (subject to downstream tool-result pruning, `NOUS_TOOL_SOFT_TRIM_*`).
+
+### Stage 1 — Heart hybrid search (`retrieval_pipeline.py:336-357`)
+`heart_types` = the requested types intersected with `{episode, fact, procedure, censor}`; `search_all` (default `["all"]`) expands to all four (`:340-347`). Calls `heart.recall(query, limit, types=heart_types, residual_activations, apply_mmr)`. **All real scoring happens inside `heart.recall`** (§3). Output: `acc.heart_results: list[RecallResult]`. Always runs unless the caller restricts to `["decision"]` only.
+
+### Stage 1.5 — Episode-chunk vector leg (`retrieval_pipeline.py:368-396`)
+Gated by `episode_chunks_enabled` (default False; **prod True**) AND (`search_all OR "fact" in types`). `_search_episode_chunks` (`:871`) embeds the query and runs a raw pgvector cosine search over `heart.episode_chunks`: `sim = 1 - (embedding <=> qvec)`, `ORDER BY embedding <=> qvec LIMIT min(episode_chunk_recall_limit, limit*2)` (`:897-903`). Chunk score is raw cosine `[0,1]`, appended into the Heart section as `type="chunk"`. Embedder-missing → `[]` (silent, by design); other failures RAISE → caught at `:384`, logged WARN, counted in `stage_errors["chunk_recall"]`.
+
+### Stage 2 — Cross-type Heart→decision expansion (`retrieval_pipeline.py:401-438`)
+Gated by `graph_recall_enabled` (default True) AND `cross_type_linking_enabled` (default True), fires when heart or chunk results exist. For the **top-3** heart results of type fact/episode, calls `brain.neighbors(hr.id, node_type=hr.type, limit=2, neighbor_type="decision")` — the `neighbor_type` pushes the decision filter into SQL so `LIMIT 2` returns decisions. Score (`_heart_graph_to_pipeline`, `:934`): `edge_weight × graph_recall_decay(0.7) × penalty`, where `penalty = graph_inferred_edge_penalty` (default 1.0) for `inferred` edges else 1.0. `type="decision"`, `source="graph_expanded"`, `stage_origin="heart_graph"`.
+
+### Stage 2b — Path A: Heart/chunk seeds → all non-decision neighbors (`retrieval_pipeline.py:450-546`)
+Gated by `heart_graph_all_types_enabled` (default **False**; **prod True**). Seeds = top-3 fact/episode heart results + top-3 chunk results, each carrying its retrieval score as `seed_score`. For each seed × each `nbr_type ∈ {fact, episode, chunk, procedure}`, calls `brain.neighbors(..., limit=heart_graph_neighbors_per_seed(3), neighbor_type=nbr_type)`. Dedups against existing heart/chunk ids and against each other, keeping the higher composed score. Score (`_score_memory_neighbor`, `:958`): if `graph_neighbor_seed_score_enabled` (default **False**, **prod False**) AND `seed_score` present → `seed_score × edge_weight × penalty`; **else** falls back to `edge_weight × decay × penalty` — a ceiling of ~0.70 (see §7-B-graph for why this matters).
+
+### Stage 3 — Brain decision query (`retrieval_pipeline.py:554-556`)
+Gated by `search_all OR "decision" in types`. `decision_results = await brain.query(query, limit)`. `_decisions_to_pipeline` (`:1002`): `score = d.score or 0.0`; preserves `raw_score`, `category`, `stakes`, `confidence`, `pattern` in metadata.
+
+### Stage 4 — Decision graph expansion: 1-hop OR spreading activation (`retrieval_pipeline.py:558-654`)
+Gated by `decision_results AND graph_recall_enabled`.
+- **Spreading-activation branch** if `spreading_activation_enabled != "false"` (default `"auto"`): computes graph density; `should_use_spreading_activation` auto-enables only above density 3.0 (§4.2). If used: seeds = top-`graph_recall_max_expand(5)` decisions with `score or 0.5`; recursive-CTE returns `(id, type, activation)`; keep `activation > 0.1` (**the "0.1 activation floor" lives at `retrieval_pipeline.py:604`**, *not* :342) and not already seen. SA score: `activation × decay(0.7)`.
+- **1-hop fallback** otherwise: for top-5 decisions, `brain.neighbors(dec.id, node_type="decision", limit=graph_recall_max_neighbors(3))`. Score: `edge_weight × decay × penalty`.
+
+### Stage 5 — Contradiction detection (`retrieval_pipeline.py:659-689`)
+Gated by `graph_recall_enabled AND contradiction_detection` (both default True). `all_ids` = decision ids ∪ graph_expanded ids **only** — *not* heart facts/chunks (§7-B3). If ≥2 ids, queries `brain.graph_edges WHERE relation='contradicts'` over that set.
+
+### Post-stage assembly (`retrieval_pipeline.py:218-309`)
+1. **Flat list in stage order** (`:219-249`): heart → chunks → heart_graph decisions → Path-A memory neighbors → decisions, then (optional) `_attach_fact_source_episodes` (only if `session_group_heart_section`, default False), then **adjacency boost**, then `extend` with `graph_expanded`.
+2. **Adjacency boost** (`_apply_graph_adjacency_boost`, `:729`; flag default False, **prod True**): for candidate pairs both present in `brain.graph_edges` (excluding `contradicts`), sum edge weights → `degree`; `score *= 1 + alpha(0.15) × degree/max_degree`; **internally re-sorts**. **Runs at `:246`, before `graph_expanded` is appended at `:249`** (§7-B-graph-6).
+3. **Contradiction attach** (`_attach_contradictions`, `:1180`): appends `tgt_id` to the source result's `contradicts` list (one-directional, §7-B8).
+4. **Recency resolver** (`_resolve_recency_conflicts`, `:1081`; flag default False, **prod True**): see §5.4.
+5. **`rerank_by_score`** (`:277-278`): `if rerank_by_score: results.sort(key=score desc)`. Default False; **prod True** (chunks on). This single switch decides whether the cross-leg pool competes on score or stays in stage order.
+6. **F071 in-context exclusion** (`:286-293`): drop results whose `str(id)` is in `exclude_ids[r.type]`. Type-keyed; applied after sort.
+7. **Stats** built (`:295`) — with `ce_reranked` and `mmr_applied` **hardcoded False** (§7-B5).
+
+---
+
+## 3. The Hybrid Search Engine (Heart) and the Cross-Type Merge
+
+This is the core scorer. Everything in Stage 1 routes through it.
+
+### 3.1 Query → embedding (per-leg, repeated)
+Each manager's `_search` embeds the query independently: `facts._search` (`facts.py:1227`), `episodes._search` (`episodes.py:505`), `procedures._search` (`procedures.py:378`), `censors._search` (`censors.py:364`). **The same query is embedded 3–4 times per `recall()`** (§7-B-hs-8). `EmbeddingProvider.embed` (`embeddings.py:68-75`) POSTs to OpenAI, model `text-embedding-3-small`, `dimensions=1536`; retries 3× on 5xx/network, 4xx raises. On any failure each `_search` logs a warning and proceeds with `embedding=None` → keyword-only fallback.
+
+### 3.2 The two legs (`search.py:120-224`)
+**Vector leg** (`:189-197`): `1 - (embedding <=> qvec)` cosine, `ORDER BY ... <=>` over the HNSW `vector_cosine_ops` index, `LIMIT limit*3`.
+**Keyword leg** (`:207-218`): `ts_rank_cd(search_tsv, plainto_tsquery) / (1 + ts_rank_cd)` over the GIN index, `LIMIT limit*3`. Raw `ts_rank_cd` is tiny (~0.05–0.08), squashed into `[0, ~0.08)`.
+The two legs' scores are **never directly compared** — only their *ranks* feed RRF.
+
+### 3.3 RRF fusion (`search.py:76-117`)
+```
+keyword_weight = 1.0 - vector_weight          # default vector_weight=0.7 → kw=0.3
+score(doc) = vector_weight/(k + v_rank) + keyword_weight/(k + k_rank)   # k = rrf_k = 60
+score = score / (1/k)                          # normalize to [0,1] since v_w + k_w = 1.0
+```
+Absent-in-a-leg → that leg's rank = `limit+1` (penalty). Defaults: `vector_weight=0.7`, `rrf_k=60` (`config.py:101-102`). **Result: facts, episodes, and procedures (single-query path) emit a normalized RRF score in `[0,1]`.** A doc ranked #0 in both legs → 1.0; ranks fall off quickly (≈0.92 at vector-rank-0/keyword-absent, ≈0.69 at rank 1, ≈0.55 at rank 2 for `limit≈20`).
+
+**Degraded path:** when `embedding is None`, `hybrid_search` returns `keyword_results[:limit]` **directly** — raw `ts_rank_cd/(1+…)` (~0.05–0.08), **not** RRF-normalized. A type whose embed leg failed lands ~10–20× lower in score space than its hybrid-succeeding siblings (§7-B-hs-3).
+
+### 3.4 Per-type score post-processing — the spaces actually merged
+
+| Type | Score handed to the merge | Space |
+|------|---------------------------|-------|
+| Fact | RRF `[0,1]`, then supersession filter may `×0.3` or `×confidence` (`facts.py:337-369`) | `[0,1]` |
+| Episode | RRF `[0,1]` (`episodes.py:548`) | `[0,1]` |
+| Procedure | `hybrid × (1 + boost)`, `boost = α(eff−0.5) + β(frame_eff−0.5)` (`procedures.py:446-457`) | **can exceed 1.0** |
+| Censor | **raw cosine `1−(emb<=>q)`, hard-floored `> 0.7`** (`censors.py:387,400`) | **`[0.7, 1.0]`** |
+| Tier-1 facts (`list_by_category`) | **hardcoded `1.0`** (`facts.py:1178`) | `1.0` |
+
+### 3.5 The cross-type merge (`heart._recall`, `heart.py:867-1117`)
+1. `fetch_limit = limit*2`; each type searched **sequentially** (AsyncSession not concurrency-safe, `:880`), each in its own try/except with rollback on failure.
+2. Each item's per-type score is copied **verbatim** into `RecallResult.score` (`:983-988`) — **no normalization to a common space.** (`_to_recall_result` handles episode/fact/procedure **and censor** — `:1163` — so censors do enter `merged`.)
+3. F055 residual boost (default off).
+4. **F042 CE rerank** if `cross_encoder_enabled AND CROSS_ENCODER_AVAILABLE` (`:1008-1039`) — re-bases head scores into sigmoid space. **Prod: OFF.**
+5. **F030 MMR** if `mmr_active` (`:1067-1108`). **Prod: OFF.**
+6. **Prod live path:** `merged.sort(key=r.score, reverse=True); merged = merged[:limit]` (`:1110-1112`).
+
+**This is the crux.** With CE and MMR off, the final cross-type ranking — and the `[:limit]` cut that *drops* items — is a raw descending sort over the four incompatible spaces of §3.4. A censor at 0.78 outranks every fact below RRF-rank-1; an effective procedure at 1.26 outranks everything; an embed-failed fact type collapses to ~0.06 and is cut entirely. The `[:limit]` truncation happens here, inside `heart.recall`, **before** the pipeline ever sees the results — so the displacement is not recoverable downstream.
+
+---
+
+## 4. The Graph-Expansion Layer
+
+### 4.1 Edge substrate (what read traverses)
+Edges live in `brain.graph_edges` (`sql/init.sql:191`): polymorphic `(source_id, source_type)`/`(target_id, target_type)`, `relation` (CHECK set grown across migrations 016/051/055), `weight FLOAT DEFAULT 1.0`, `extraction_method` (`migrations/047`: `deterministic|heuristic|inferred|co_mention|co_occurrence`), `UNIQUE(source_id, target_id, relation)`. Persisted `weight = raw_cosine × RELATION_WEIGHT_MULTIPLIERS[relation]` (`graph_linker.py:118-123`, multipliers 0.7–1.0) → edge weights bounded ≲1.0. The neighbor pull `Brain.neighbors → _neighbors` (`brain.py:1134,1164`) UNIONs both edge directions (`:1177-1199`) — **both directions are traversed**, good.
+
+### 4.2 Reachability of each mechanism
+
+| Mechanism | Code | Reachability verdict |
+|-----------|------|----------------------|
+| A: decision 1-hop | `retrieval_pipeline.py:629-637` | **LIVE** (computed); visible to top-K only when `rerank_by_score=True` (**prod True**) |
+| B: spreading activation | `spreading_activation.py:66` | **UNREACHABLE** in `auto` mode — density gate (§below) effectively never met |
+| C: cross-type heart→decision | `retrieval_pipeline.py:423-428` | **LIVE** |
+| D: Path A all-types | `retrieval_pipeline.py:450` | default OFF → **prod LIVE** (`HEART_GRAPH_ALL_TYPES_ENABLED=true`) but see §7-B-graph-5 |
+| Adjacency boost | `retrieval_pipeline.py:729` | default OFF → **prod LIVE**; mis-ordered (§7-B-graph-6) |
+| Seed-score scoring | `_score_memory_neighbor:958` | **INERT** (`graph_neighbor_seed_score_enabled=False` in prod) |
+| Date-aware boost (F075 L3) | `config.py:1199-1213` | **DEAD CODE** — no consumer in any config |
+
+**The density gate.** `should_use_spreading_activation` in `auto` mode returns `density ≥ spreading_activation_density_threshold(3.0)` (`spreading_activation.py:53-63`). `compute_graph_density = edge_count / unique_nodes`, **excluding `co_mention` edges** (`:30-50`). Density ≥ 3.0 means average undirected degree ≥ 6 — far above what a sparse cosine-thresholded graph (fact→decision ≥0.80, fact→fact ≥0.90, `LIMIT 5` per write) produces, where most nodes have degree 0–2. So the recursive-CTE multi-hop engine is dead at recall time unless an operator hard-sets the flag to `"true"`. (Corroborated by the project's own observation that `graph_expansion_used=0` even with hundreds of inferred edges.)
+
+### 4.3 Scoring of expanded nodes
+All graph-expanded scores are `edge_weight × graph_recall_decay(0.7) × penalty` (decision/Path-A) or `activation × 0.7` (SA), via `_f065_provenance_penalty` (`:907-931`). The ceiling is ~0.70 — **below the `[0,1]` band that top RRF facts occupy and incomparable with the boosted/floored spaces of §3.4.** When `rerank_by_score=True` (prod), these ~0.35–0.63 graph scores are sorted directly against RRF facts, boosted procedures, and floored censors.
+
+---
+
+## 5. The Rank-Modifier Layer
+
+Two application sites: **inside `heart.recall`** (query expansion, CE, MMR — act on the Heart-only merged set) and **inside `run_recall_pipeline`** (adjacency boost, recency resolver, `rerank_by_score`, F071 — act on the assembled cross-leg list).
+
+### 5.1 Query expansion (F050) — PRE-retrieval — default OFF, **prod ON**
+`heart.py:899-921` → `QueryExpander.expand` (`query_expansion.py:157-265`): cheap gate (min-words 3) → cache → single-flight → budget → Haiku (`claude-haiku-4-5`, forced tool use, 256 tok, 2.0s timeout) → fuse (case-insensitive dedup, original at index 0, cap `max_variants(3)`). **Merge is a genuine RRF union, not concatenation:** variants are batch-embedded once and threaded into each manager's `hybrid_search_multi`, fused via `_rrf_merge_n` (`search.py:359-377`). Single-variant collapses to byte-identical `hybrid_search`. **Fail-open everywhere** → `[query]`.
+
+### 5.2 Cross-encoder rerank (F042) — default OFF, **prod OFF**
+`heart.py:1008-1039` → `cross_encoder_rerank` (`reranker.py:66-167`): global sort by hybrid score first, head = `candidates[:max_candidates(30)]`, tail untouched; raw logit → sigmoid → **overwrites `.score`** for the head only. Tail keeps hybrid scores → head/tail now on different scales (§7-B-rm-3). **Off in prod**, so latent.
+
+### 5.3 MMR diversity (F030) — default OFF, **prod OFF**
+`heart.py:1041-1112` → `mmr_rerank` (`search.py:453-537`): greedy `MMR(d) = λ·cos(d,q) − (1−λ)·max_{s∈sel} cos(d,s)`, λ=0.7. Relevance uses a freshly-embedded query vs **stored** candidate embeddings — not CE sigmoid scores (hence F030.1 `mmr_skip_after_ce`, default True: when CE reordered the head, MMR is skipped entirely so the two never chain). **Off in prod.**
+
+### 5.4 Recency resolver (§1) — default OFF, **prod ON**
+`retrieval_pipeline.py:1081-1177`. Facts only, grouped by normalized `subject`. Conflict signal = a `contradicts` edge OR `difflib` ratio ≥ `recency_resolver_similarity_floor(0.55)`; both facts must carry differing parseable `event_date`. Newer → `recency_status="current"`; older → `"superseded"` + `score *= 0.3`. Inert unless `event_date` populated (needs `TEMPORAL_EXTRACTION_ENABLED`, **prod ON**).
+
+> **Code-default vs prod reconciliation (important).** The resolver's `×0.3` runs at `:258`, *before* the `rerank_by_score` sort at `:278`. In the **default** config (chunks off → `rerank_by_score=False`) nothing re-sorts, so the down-rank is **cosmetic** — only the `[superseded YYYY-MM]` text tag survives. In **prod** (chunks on → `rerank_by_score=True`) the sort *does* fire, so the down-rank **is** effective on ordering. The widely-quoted "recency down-rank is cosmetic" is a default-config statement, not a prod statement.
+
+### 5.5 Date-aware boost (F075 Layer 3) — DEAD
+`date_aware_boost_enabled/factor/window_pad_days` exist only in `config.py:1199-1213`. **No consumer anywhere in `nous/`.** The documented 1.20× in-window temporal boost does not exist; flipping the flag does nothing. In-window temporal preference is handled solely by the recency resolver's down-rank of the *superseded* side, never a boost of the *in-window* side.
+
+### 5.6 Not in the retrieval path
+`apply_frame_boost` (`search.py:399`) is **not** called from `recall_deep`/`run_recall_pipeline`/`heart.recall` — it is a cognitive-path primitive (§6.3). Confidence calibration (`NOUS_CONFIDENCE_CALIBRATION_FACTOR`) is a decision **write-time** transform (`brain.py:365`), not a retrieval ranker.
+
+---
+
+## 6. The Cognitive Context-Assembly Path (every turn)
+
+This is the retrieval that builds the system prompt automatically, distinct from `recall_deep`.
+
+### 6.1 `pre_turn` → frame → intent → plan (`layer.py:349`)
+1. **Frame** (`frames.py:40`): pure pattern matching over `activation_patterns` (multi-word substring = 2 pts, single-word set-membership = 1 pt); highest count wins, ties by `FRAME_PRIORITY`; no match → `conversation`. No LLM.
+2. **Intent** (`intent.py:108`): regex extraction of greeting/question/temporal-recency/memory-type-hints/topic-keywords/entities → `plan_retrieval` (`:146`) builds a `RetrievalPlan`. Greetings and short keyword-less turns → skip-all plan (zero budgets). Otherwise one `RetrievalQuery` per type with frame-specific budget overrides (REPLACE semantics).
+3. **`query_text`** = space-joined `topic_keywords` if any, else raw input (`intent.py:192-193`). Topic keywords are `list(set(...))[:10]` — **set-order nondeterministic** (§7-B-cog-D).
+
+### 6.2 `ContextEngine.build` (`context.py:125`)
+Budget resolved via `ContextBudget.for_frame(...).apply_overrides(plan.budget_overrides)` (REPLACE). Sections appended in priority order, each independently token-budgeted. Always-on (no search): date/time, identity, anti-hallucination, F079 procedure catalog (flag-gated), epistemic routing (flag-gated), user-profile Tier-1 facts (`list_facts_by_category` filtered by `text_overlap ≥ 0.6` against the identity prompt), active censors, frame description, working memory.
+
+**Per-type semantic recall** (each gated by `budget.<type> > 0 and type not in skip_types`):
+- **Decisions** (`:528-568`): `Brain.query` → staleness → `_enforce_diversity("category", max 3)` → relevance filter → format. **No conversation dedup, no near-dup dedup** (§7-B-cog-C).
+- **Facts** (`:570-628`): `Heart.search_facts(exclude TIER1)` → recency resolve (Gap-2, flag-gated) → staleness → frame boost → diversity → dedup → usage boost → relevance filter.
+- **Procedures** (`:630-796`): dual-track (Critic-recommended by name + embedding search), capped at `critic_slots + embedding_slots`.
+- **Temporal "Recent Conversations"** (`:798-829`): `list_episodes(limit=5, hours=48)`, gated **only** by `temporal_context_enabled` — not by budget or `skip_types` (§7-B-cog-G).
+- **Episodes** (`:831-877`): `Heart.search_episodes` → recency → frame boost → diversity → dedup → usage boost → relevance filter.
+
+`budget.total` is used **only** for a fill-ratio log line (`:886-892`) — it is **never enforced**; per-section budgets can sum above it (§7-B-cog-F).
+
+### 6.3 Scoring primitives (and their ordering hazard)
+- `_apply_staleness_penalty` (`:1009-1035`): `score × max(0.5^(age/half_life(30d)), 0.3)`; exempts `{rule, preference, technical, concept, person}`; **no re-sort**.
+- `apply_frame_boost` (`search.py:399-435`): same-frame ×1.3, censor Jaccard ×(1+0.2j), clamped at 1.0 — then **sorts by boost factor, not score**.
+- `_apply_usage_boost` (`context.py:945-962`): multiplies by usage boost — then **sorts by boost factor, not score**.
+- `_apply_relevance_filter` (`:964-1007`): keep top `min_k`, cap `max_k`, cut at first `i≥min_k` where `score < prev_score × drop_ratio` — **assumes descending-by-score order.** `drop_ratio = relevance_drop_ratio = 0.5` in code (`config.py:163`).
+
+The hazard (§7-B-cog-B / §7-B-hs-6): the boost steps re-order by *boost factor*, then the relevance filter's gap detector runs on that non-monotonic list — so it cuts at the wrong index.
+
+### 6.4 Downstream-exclusion bookkeeping & path divergence
+`recalled_ids` has exactly four keys (decision/fact/procedure/episode) — **no `chunk`** (`:170-175`). These feed F012 procedure reinforcement, the UsageTracker's "was this referenced" char-overlap scoring, and F071 exclusion. The IDs are collected **after** the relevance filter but **before** `_truncate_to_budget` — so items truncated out of the prompt still carry IDs and get scored as "retrieved but unused" (§7-B-cog-A).
+
+The cognitive `_resolve_recency` (`context.py:1166`) **claims to mirror** the recall_deep resolver but has drifted: it keys conflict on the `superseded_by` FK link (vs `contradicts` edge), uses a weaker `if older.recency_status != "current"` stickiness (vs sticky `_mark`), and mutates the live ORM object (vs rebuilding frozen dataclasses). The two surfaces can resolve the same conflicting-fact pair differently.
+
+---
+
+## 7. Bug & Issue Register
+
+Severity: **P1** = corrupts production ranking / drops relevant results; **P2** = degrades correctness or a whole feature; **P3** = minor / dead code / observability.
+Reachability: **LIVE** (active in prod), **LATENT** (real but behind a prod-off flag like CE/MMR), **INERT** (flag off + no consumer), **UNREACHABLE** (runtime gate never met), **DEAD** (no consumer in any config).
+✓ = personally verified against source this session; ○ = agent-reported with `path:line` (auditable).
+
+### 7.1 Headline — cross-type score-space incoherence
+
+**B1 — Censors enter the ranked pool at a hard floor ≥0.7 and displace mid-ranked facts. [P1, LIVE] ✓**
+`censors.py:387,400` (floor 0.7) → `heart.py:1163` (`_to_recall_result` emits censor) → `heart.py:983-988,1110-1112` (verbatim score, global sort, `[:limit]` cut); reachable because `search_all` default includes `"censor"` (`retrieval_pipeline.py:340-341`). Censor scores are raw cosine `≥0.7`; RRF-normalized facts exceed 0.7 only at rank 0–1. So every censor structurally outranks all but the top one or two facts, and the `[:limit]` truncation inside `heart.recall` drops the displaced facts before the pipeline sees them. *(Calibrated: censors do not "crowd the entire top" — the #1 fact can reach ~0.92 — but they outrank the long tail of facts regardless of true query relevance.)*
+
+**B2 — Procedure scores exceed the `[0,1]` band, biasing cross-type ranking. [P2, LIVE] ✓**
+`procedures.py:446-457`: `final = hybrid × (1 + boost)`. With `procedure_utility_boost` on (default), an effective procedure at RRF 0.9 + boost 0.4 emerges at **1.26**, above every other type's ceiling. Effective procedures systematically outrank equally/more relevant facts and episodes. Bounded by α/β so P2.
+
+**B3 — Embedding-failure leg returns un-normalized `ts_rank_cd` (~0.06), collapsing a whole type. [P2, LIVE-on-failure] ○**
+`search.py:220-222` (mirror `facts.py:1368-1369`): on `embedding=None`, returns `keyword_results[:limit]` raw (~0.05–0.08), not RRF-normalized. A single transient OpenAI hiccup on one of the 3–4 sequential `embed()` calls deterministically demotes that entire type ~10–20× in score space for the whole recall. Logged only as a per-leg warning.
+
+**B4 — The pipeline's `rerank_by_score` sort merges incompatible score scales. [P1, LIVE] ✓**
+`retrieval_pipeline.py:277-278`. In prod (chunks on) the whole cross-leg pool — RRF facts/episodes `[0,1]`, boosted procedures `>1.0`, floored censors `[0.7,1.0]`, graph items `~0.35–0.63`, raw-cosine chunks `[0,1]` — is sorted on one axis. The sort is not measuring relevance across types; a hard floor and an unbounded boost break monotonicity-with-relevance between types. *(This, not "graph invisible at position 11+", is the prod-live form of the bug — the position-11+ framing is the `config.py`-default behavior, documented in the code comment at `:261-276`, which prod opts out of by enabling chunks.)*
+
+### 7.2 Cognitive (every-turn) path
+
+**B-cog-A — Recalled IDs collected pre-truncation → spurious "not referenced" usage penalty. [P2, LIVE every-turn] ✓**
+`context.py:608-613` (collect) vs `:617` (`_truncate_to_budget`). IDs/content are recorded from the post-filter list; truncation then drops the lowest-priority rendered lines. The dropped items keep their IDs and score `was_referenced=False` in the usage tracker (`layer.py:1077-1094`) — corrupting the feedback loop that drives `_apply_usage_boost`. Same defect class the code already fixed at the *dedup* boundary (comment at `:605-607`), reintroduced at the *truncation* boundary.
+
+**B-cog-B — Relevance gap-filter runs on a boost-sorted (non-monotonic) list. [P2, LIVE every-turn] ✓**
+`search.py:434` + `context.py:961` sort by **boost factor**; `_apply_relevance_filter` (`context.py:992-1005`) then assumes descending-by-score. A boosted-low-relevance item floats above an unboosted-high-relevance one, so the gap cut fires early (drops good items) or never (floods context). Compounded by `min(score×boost, 1.0)` clamping (`search.py:430`).
+
+**B-cog-C — Decisions get no conversation dedup; `_dedup_decisions` is dead code. [P2/P3, LIVE] ✓**
+The decisions leg runs only `_enforce_diversity("category", max 3)` (`context.py:541`) — no `_apply_dedup`. `_dedup_decisions` (`context.py:1415`) is **defined but never called** (single grep hit, the definition). A just-restated decision is re-injected, wasting budget.
+
+**B-cog-D — `query_text` is a set-ordered keyword bag; nondeterministic + lossy. [P2, LIVE every-turn] ✓**
+`intent.py:138` `list(set(...))[:10]` (set iteration order is nondeterministic) → `:192-193` joins them → overrides the natural-language `_default_query` (`context.py:530,573,695,835`). The embedding/keyword query loses phrase structure and word frequency, and **retrieval is irreproducible run-to-run** for the same input.
+
+**B-cog-E — Two recency resolvers have drifted. [P2, LIVE] ○**
+`context.py:1166` (cognitive) vs `retrieval_pipeline.py:1081` (recall_deep) differ in conflict signal (`superseded_by` link vs `contradicts` edge), stickiness, and mutation style. The same fact pair can be tagged `current` in one path and `superseded` in the other.
+
+**B-cog-F — `budget.total` is advisory; per-section budgets sum above it. [P3, LIVE] ○**
+`context.py:886-892`. For the `task` frame the section defaults sum well above `total`. The nominal frame budget is not a real ceiling.
+
+**B-cog-G — Temporal "Recent Conversations" tier bypasses budget + skip gating + tracking. [P3, LIVE] ○**
+`context.py:798-829`, gated only by `temporal_context_enabled`. Fires even on greeting/short turns that zeroed episodes; its IDs never enter `recalled_ids` (invisible to usage tracker + F071).
+
+### 7.3 Graph layer
+
+**B-graph-5 — Path A enabled in prod, but co-occurrence edges it would traverse are write-amplified with no semantic discount. [P2, prod-LIVE] ○**
+`HEART_GRAPH_ALL_TYPES_ENABLED=true` activates Stage 2b, but with `graph_neighbor_seed_score_enabled=False` (prod) neighbor scores fall to `edge_weight × 0.7` ≤ ~0.70 — below the top RRF facts, so they rarely surface even when computed. Meanwhile `co_occurred`/`co_mention` edges (default-on writers) escape the inferred-edge penalty (`_f065_provenance_penalty` only penalizes `method=="inferred"`, `:929-930`) and are excluded from the density count and SA traversal — write amplification feeding a read path that mostly can't rank them.
+
+**B-graph-6 — Adjacency boost runs before graph-expanded items are appended; can't boost the items it targets. [P2, prod-LIVE] ✓**
+`retrieval_pipeline.py:246` (boost) precedes `:249` (`extend(graph_expanded)`). The boost candidate set excludes the brain-side graph-expanded neighbors entirely, and its internal re-sort (`:791`) is overwritten by the later `rerank_by_score` sort. The feature meant to reward graph-connected clusters omits half the graph-connected nodes, and on skewed-degree graphs `boost = 1 + α·(d/max_deg)` dilutes cluster members toward ~1.00 while only the hub gets the full 1.15× (degree-normalization inversion).
+
+**B-graph-7 — Spreading-activation results carry placeholder descriptions. [P3, UNREACHABLE] ○**
+`retrieval_pipeline.py:610`: SA `NeighborResult.description = f"[{ntype}] {uuid[:8]}"` — never resolved to node content (unlike `brain._neighbors`). Latent only because the density gate keeps SA from firing.
+
+**B-graph-8 — Density check recomputes a full-table aggregate on every recall. [P2, LIVE] ○**
+`retrieval_pipeline.py:571-577` + `spreading_activation.py:30-47`: `compute_graph_density` runs a full aggregate over `brain.graph_edges` per `recall_deep` (named `cached_density` but nothing caches it), then SA opens a second session — purely to almost always return "density < 3.0, don't spread."
+
+**B-graph-9 — Duplicate decisions across Stage 2 and Stage 4 (independent `seen` sets). [P2, LIVE] ○**
+`retrieval_pipeline.py:412` vs `:560`: a decision reached as a cross-type neighbor of a fact (Stage 2) is not in Stage 4's `seen_ids`, so an independent 1-hop reach appends it again — once `stage_origin="heart_graph"`, once `"brain_graph"` — double-counting it in contradiction/adjacency sets.
+
+### 7.4 Pipeline plumbing & observability
+
+**B5 — `PipelineStats.ce_reranked`/`mmr_applied` hardcoded `False`. [P2, LIVE observability] ✓**
+`retrieval_pipeline.py:296-297`. The pipeline cannot read back whether CE/MMR fired inside `heart.recall` (that state is local to `_recall` and discarded). Every eval/report sees `False` regardless — a known root cause of "CE invisible / graph_expansion_used=0" eval confusion.
+
+**B6 — Contradiction `all_ids` excludes facts/chunks → fact-vs-fact contradiction unreachable. [P2, LIVE] ○**
+`retrieval_pipeline.py:662-666`. `all_ids` = decisions + graph_expanded only. No `contradicts` edge between two facts is ever discovered, so `_attach_contradictions` never populates `fact.contradicts`, and the recency resolver's strong (contradicts-edge) signal is dead for facts — only the difflib-0.55 fallback fires.
+
+**B7 — No global top-K; `limit` is per-leg; result count over-returns. [P3, LIVE] ✓**
+`retrieval_pipeline.py:218-309` has no final `[:limit]`. The returned list is the sum across legs; `recall_deep`'s "limit" docstring (`tools.py:626`) is wrong. (The model does not necessarily see all of it — tool-result pruning `NOUS_TOOL_SOFT_TRIM_*` applies downstream.)
+
+**B8 — `_attach_contradictions` is one-directional. [P3, LIVE] ○**
+`retrieval_pipeline.py:1193-1206`: only the source result gets the link; the target is never marked. Masked for the resolver (which ORs both directions) but any other consumer sees asymmetric links.
+
+**B9 — `_resolve_recency_conflicts` reads `recency_date` before it is set. [P3, harmless] ○**
+`retrieval_pipeline.py:1153` passes `metadata.get("recency_date","")` (always `""`); the label is recomputed at `:1169`. Dead argument, correct output.
+
+### 7.5 Hybrid-search internals
+
+**B-hs-8 — Query embedded 3–4× per recall. [P3, LIVE perf] ✓**
+`facts.py:1227`, `episodes.py:505`, `procedures.py:378`, `censors.py:364` each independently `embed(query)`. 4× latency/cost and 4× the surface for the B3 transient-failure demotion. A single shared embed would fix both.
+
+**B-hs-4 — Tier-1 `list_by_category` facts hardcode `score=1.0`. [P2, context-path] ○**
+`facts.py:1178`. If these ever rank against hybrid-scored items they tie/beat every real hit. Primary consumer is a separate Tier-1 section, but the DTO is shared.
+
+**B-hs-10 — `_search_all` (inactive-fact path) forks the `hybrid_search` SQL. [P3, drift risk] ○**
+`facts.py:1309-1404` reimplements vector+keyword+RRF inline, ignores `hybrid_search_keyword_enabled`, and won't receive fixes (e.g. B3 normalization) made to the canonical searcher.
+
+### 7.6 Rank modifiers (mostly latent — CE/MMR off in prod)
+
+**B-rm-1 — Date-aware boost is fully dead code. [P3, DEAD]** — §5.5.
+**B-rm-3 — CE sigmoid head vs hybrid tail are incomparable after `return head+tail`. [P2, LATENT]** `reranker.py:152,167`. Only bites if CE is re-enabled with a subsequent re-sort.
+**B-rm-8 — Query-expansion "per hour" budget is `monotonic()//3600` (uptime-aligned, resets on restart). [P3, LIVE]** `query_expansion.py:447`.
+**B-rm-7 — Query-expansion cache-write failure desyncs concurrent identical queries (leader expands, followers get `[query]`). [P3, LIVE]** `query_expansion.py:193-207,525-526`.
+
+---
+
+## 8. Synthesis & Conclusions
+
+### 8.1 The core finding
+Nous's retrieval is, at the engine level, a competent hybrid search: per-type, the RRF fusion of a pgvector cosine leg and a `ts_rank_cd` keyword leg (`search.py:76-117`) is normalized to a clean `[0,1]` and is reproducible. **The defect is not in any single type's scorer — it is in the merge.** `heart._recall` (`heart.py:983-988,1110-1112`) and the pipeline's `rerank_by_score` sort (`retrieval_pipeline.py:277-278`) both treat four different numeric spaces as one:
+
+- normalized RRF `[0,1]` (facts, episodes),
+- boosted RRF `>1.0` (procedures),
+- raw cosine hard-floored `[0.7,1.0]` (censors),
+- raw `ts_rank_cd` `~0.06` (any embed-failure leg).
+
+A **hard floor** and an **unbounded boost** are the two operations that break the monotonic relationship between score and relevance *across types*. The cross-encoder and MMR — the only two stages that would re-base everything into one comparable space — are precisely the two stages disabled in production. So the production ranking is a raw sort over incoherent scales, and the `[:limit]` cut inside `heart.recall` *drops* the displaced items before any downstream stage can recover them.
+
+### 8.2 The second theme — gated, drifted, and unobservable machinery
+A large surface area of the retrieval system either does not run or does not affect ranking:
+- **Dead:** date-aware boost (no consumer, §5.5).
+- **Unreachable:** spreading activation (density gate ≥ 3.0 vs a degree-0–2 graph, §4.2).
+- **Self-defeating:** adjacency boost runs before its targets are in the candidate set (B-graph-6); boost-sort precedes a gap filter that assumes score-sort (B-cog-B); recalled IDs are taken before truncation (B-cog-A).
+- **Unobservable:** the pipeline reports CE/MMR as always-False (B5), so evals have been measuring a pipeline whose actual modifier state they cannot see.
+- **Drifted:** two recency resolvers and two relevance pipelines (cognitive vs recall_deep) re-implement the same intent differently and can disagree (B-cog-E, §6.4).
+
+The practical consequence is that the every-turn cognitive path — the retrieval that actually feeds the model by default — is *weaker* than the `recall_deep` tool (no graph, no contradiction surfacing) **and** carries its own ranking hazards (B-cog-A/B/C/D).
+
+### 8.3 Prioritized remediation (highest leverage first)
+1. **Normalize before merge (fixes B1, B2, B3, B4).** Before the cross-type sort in `heart._recall`, map every type's score into one comparable space — e.g. per-type min-max or rank-normalization, or route everything through the cross-encoder (turn CE on) so a single relevance model produces the final order. This is the single change that addresses the headline P1s. Censors arguably should not compete in the ranked pool at all (they have a separate "Active Guidance" surface) — excluding `censor` from `heart_types` in `recall_deep` is a one-line mitigation.
+2. **Re-sort after every score mutation (fixes B-cog-B, B-cog-A ordering).** The boost/staleness/usage steps must either re-sort by *score* (not boost factor) or the relevance gap-filter must sort its own input. Collect recalled IDs *after* truncation.
+3. **Make observability honest (fixes B5).** Thread the real `ce_reordered`/`mmr_active` flags out of `heart._recall` into `PipelineStats`. Without this, no eval of items 1–2 can be trusted.
+4. **Delete or wire the dead paths (B-rm-1, B-cog-C, B-graph-7).** Remove date-aware boost and `_dedup_decisions`, or wire them; resolve SA placeholder descriptions if SA is ever ungated.
+5. **Unify the two recency resolvers and the two relevance pipelines (B-cog-E).** One implementation, two callers — eliminate the drift surface.
+
+### 8.4 Confidence & method note
+The five load-bearing P1/P2 claims (censor floor + emission into `merged`, the cross-type sort, the chunks→`rerank_by_score` wiring, the assembly/exclusion order, the `PipelineStats` hardcode, the dead `_dedup_decisions`, the set-order `query_text`, the pre-truncation ID collection) were **personally re-read against source this session** (marked ✓). Remaining P2/P3 items are agent-reported with `path:line` anchors (marked ○) and are individually auditable. Reachability verdicts are assigned against `config.py` defaults and the `.env.prod-snapshot` overlay (§1.2); where a finding's severity depends on a flag, that dependency is stated inline.
+
+---
+
+*Appendix — files of record:* `nous/api/retrieval_pipeline.py`, `nous/api/tools.py`, `nous/heart/heart.py`, `nous/heart/search.py`, `nous/heart/{facts,episodes,procedures,censors,embeddings,query_expansion,reranker}.py`, `nous/brain/{brain,spreading_activation,graph_linker}.py`, `nous/cognitive/{layer,context,intent,frames,dedup}.py`, `sql/init.sql`, `sql/migrations/{016,047,051,055}*`, `nous/config.py`, `.env.prod-snapshot` (deployment overlay only).

--- a/docs/superpowers/plans/2026-06-08-f080-procedure-selection-impl.md
+++ b/docs/superpowers/plans/2026-06-08-f080-procedure-selection-impl.md
@@ -1,0 +1,118 @@
+# Implementation Plan — F080 + §14 (Coherent Ranking + Procedure Selection)
+
+**Spec:** `docs/features/F080-coherent-cross-type-ranking.md` (§8–§14 authoritative).
+**Forge:** design decision `a18e0836`.
+**Principle:** procedures/censors are not knowledge — remove them from the ranked recall pool (F080); surface procedures via a name-menu + graph-primary critic-fallback selection that preloads bodies (§14). All behavior flag-gated, default OFF, byte-identical when off.
+
+This plan is split into **two independent, flag-gated PRs**. Both can merge separately; the operator flips prod flags only after both land (so excluding procedures from recall never precedes the menu being in place).
+
+---
+
+## PR 1 — F080: knowledge-only recall pool (small, low-risk)
+
+**Goal:** when `NOUS_COHERENT_RANKING_ENABLED=true`, `recall_deep` ranks only facts/episodes/decisions/chunks — censors and procedures are excluded from the pool. Default OFF ⇒ byte-identical to the committed snapshot.
+
+### Files & changes
+1. **`nous/config.py`** — add `coherent_ranking_enabled: bool = Field(default=False, ...)`. Add a `RuntimeConfig.get_coherent_ranking_enabled(settings)` resolver mirroring `get_cross_encoder_enabled` (so the hot path reads the resolver, not raw settings — matches decision 78ef3a3d's lesson about runtime-config bypass).
+2. **`nous/heart/heart.py` `_recall` (~877)** — when the resolver is true, strip `"censor"` and `"procedure"` from `search_types` before `search_map` is built. Leaves the `else`/OFF path byte-identical.
+3. **`nous/api/retrieval_pipeline.py` (~340-347)** — when `getattr(settings,"coherent_ranking_enabled",False)`, strip `"censor"` and `"procedure"` from `heart_types` before the `heart.recall` call. (Both sites: pipeline governs the explicit `types=` passed to recall; heart.py:877 governs the `types=None` default — gate both.)
+4. **`nous/api/retrieval_pipeline.py` PipelineStats (~295 + dataclass def)** — add `coherent_ranking_applied: bool = False`, set from the flag. (Partial B5; full CE/MMR stat threading stays F080.1.)
+
+### Tests — `tests/test_coherent_ranking.py` (postgres_only)
+- Flag ON: seed facts+episodes+decisions+procedures+censors for the eval agent; assert `recall_deep` result contains **no** `type in {"censor","procedure"}`, and still returns facts/episodes/decisions.
+- Flag OFF: assert procedures+censors still present (today's behavior) — guards the byte-identical contract.
+- `coherent_ranking_applied` reflects the flag.
+
+### Validation
+- `uv run pytest tests/test_coherent_ranking.py -v` (+ the existing recall snapshot test with flag default OFF).
+- Confirm no other `heart.recall(...)` caller depends on procedure/censor results (grep callers; the cognitive path uses per-type `search_*`, not `recall` — verify).
+
+### Risk
+- Low. Additive, flag-gated. The only trap: a caller that passes `types=None` and expects procedures — gate the heart.py:877 default on the flag so that path is unchanged when OFF.
+
+---
+
+## PR 2 — §14: cognitive procedure injection (graph-primary selection + name-menu + body-preload, drop Track B)
+
+**Goal:** the every-turn system prompt surfaces procedures via (a) a full-breadth **name-menu**, (b) a **Recommended Procedures** section whose bodies are **preloaded**, chosen by **graph-primary K-line activation with critic fallback** (§14.7), and (c) `get_procedure` for on-demand depth. The cosine **Track B** embedding injection is removed.
+
+### Flags (`nous/config.py`)
+- `proc_selection_graph_primary: bool = False` — master switch for §14 behavior. OFF ⇒ today's behavior (critic name-pointer + catalog + Track B fallback) byte-identical.
+- Reuse existing `critic_skill_slots` (slot budget), `proc_catalog_*` (menu).
+- `proc_recommended_body_max_chars: int = Field(default=1200, ...)` — per-procedure preload cap.
+- `proc_graph_neighbors_per_seed: int = Field(default=2, ...)` — K-line fan-out per recalled seed.
+
+### Changes — `nous/cognitive/context.py` procedure section (~630-796)
+All gated on `proc_selection_graph_primary`; OFF path runs the existing code verbatim.
+
+1. **Selection (§14.7), new helper `_select_procedures(...)`** invoked in the procedure step (which already runs *after* facts/episodes/decisions are recalled, so seeds are in hand):
+   - **Primary (graph K-line):** collect seed IDs from the already-recalled facts + decisions + episodes (with their recall scores). For each seed call `brain.neighbors(seed.id, node_type=seed.type, neighbor_type="procedure", limit=proc_graph_neighbors_per_seed)`. Score each activated procedure `edge_weight × seed_recall_score`; aggregate max per procedure; dedup; sort desc; take top `critic_skill_slots`. (Reuses the exact `brain.neighbors` traversal F080's pipeline uses — structural, not cosine.)
+   - **Fallback (critic):** if fewer than `slots` selected, fill the remainder from the existing Track A `critic_skills` (already fetched by name).
+   - **Floor:** if still empty and the input has an obvious name/intent match against the menu, include it. (Cheap; optional in v1 — at minimum the menu remains.)
+   - Returns a list of `ProcedureDetail` (full objects) capped at `slots`.
+2. **Body-preload** — replace the name-pointer block (~762-780) with `_format_procedures(selected)` truncated to `proc_recommended_body_max_chars` per item, in the "Recommended Procedures" section (dynamic tier). Bodies, not pointers.
+3. **Name-menu** — the catalog (~265-364) renders **all active procedures** as `name — ≤60-char purpose`, ordered by utility/effectiveness. Drop `proc_catalog_desc_chars` to ~60; ensure all ~55 fit (raise `proc_catalog_max_chars` only if needed after compacting). Static tier (cache-friendly).
+4. **Drop Track B** — delete the `embedding_procedures` branch (~686-744) under the flag; OFF path keeps it. (It is already inert in prod, gated `not catalog_rendered`.) Removing it also deletes a procedure-path instance of the boost-sort hazard.
+5. **recalled_ids bookkeeping** — selected procedures' IDs go into `recalled_ids["procedure"]` (after selection, before any truncation — avoid the B-cog-A class bug).
+
+### Tests — `tests/test_procedure_selection.py` (postgres_only)
+- Graph-primary: seed a fact with a `summarized_by`/`related_to` edge to procedure P; recall surfaces the fact; assert P is selected and its **body** appears in "Recommended Procedures".
+- Fallback: seed with no procedure edges + a critic skill → assert critic pick fills the slot.
+- Name-menu: ≥ `proc_catalog_max`/char-cap procedures → assert every active name appears in the menu (full breadth) under the compact format.
+- OFF path: `proc_selection_graph_primary=False` → existing name-pointer behavior unchanged.
+- Determinism + body cap respected.
+
+### Validation
+- `uv run pytest tests/test_procedure_selection.py tests/test_context*.py -v`.
+- Local: build a context for a seeded agent, eyeball the menu + recommended sections.
+- Measurement hooks (log-only in v1): graph-primary hit-rate (did K-line fill ≥1 slot) so the driver mix (§14.7) is observable post-deploy.
+
+### Risk
+- Medium. Touches the every-turn context builder. Mitigated by the master flag (OFF = verbatim today) and the existing `try/except` around the procedure section (context.py:795).
+- Watch: `brain.neighbors` cost per seed × seeds/turn — bound by `proc_graph_neighbors_per_seed` and only over already-recalled seeds (≤ ~10). One batched query preferred over N round-trips if the helper supports it.
+
+---
+
+## Sequencing & review
+1. **Plan review** (this doc) — 3 agents: architecture, devil's-advocate, python-pro. Fold P1/P2 before coding.
+2. **PR1 first** (small, clean) → impl → 3-agent impl review → fix → PR → codex → merge.
+3. **PR2** → impl (helper + context rewrite + tests) → 3-agent impl review (incl. silent-failure-hunter) → fix → PR → codex → merge.
+4. F051 probes (chunk-vs-fact, graph-vs-direct) ride with PR1 as eval-harness additions if cheap; else a follow-up. Not a merge blocker for the flag-gated code.
+
+## Out of scope (deferred, per spec)
+F080.1 (S2 chunk/graph cross-distribution coherence, CE head, B3 embed-fail, full CE/MMR stat threading); the broader cognitive ordering fixes B-cog-A/B/C/D except where PR2 naturally fixes the procedure-path instance.
+
+---
+
+## Plan v2 — review fixes (3-agent, 2026-06-08) — AUTHORITATIVE over the above where they differ
+
+### PR1 (simplified — surgical, recall_deep-only)
+- **Strip at ONE site only:** `retrieval_pipeline.py:340-347` — when `settings.coherent_ranking_enabled`, drop `"censor"` and `"procedure"` from the explicitly-built `heart_types`. **Do NOT touch `heart.py:877`** (the default-list strip created blast radius: `mcp.py:278` passes `types=["procedure"]`, `mcp.py:263` is the external `nous_recall("all")` contract, `censor_actions.py:90` recalls censors via `types=None`). Pipeline-only = recall_deep-only, zero blast radius. `nous_recall("all")` intentionally keeps procedures/censors (separate external surface).
+- **No resolver.** `coherent_ranking_enabled` is a deploy-time flag; read `settings.coherent_ranking_enabled` directly. (Adding a half `RuntimeConfig` resolver without DB-key/load/persist/REST backing is dead indirection — arch P2-C, py P2-4.)
+- `config.py`: `coherent_ranking_enabled: bool = Field(default=False, ...)`.
+- `PipelineStats`: add `coherent_ranking_applied: bool = False` (dataclass at `retrieval_pipeline.py:74`; set at `:295`). Not formatted into text → snapshot-safe.
+- **Test:** real `postgres_only` test (NOT the mock `test_format_matches_committed_snapshot` at `test_retrieval_pipeline.py:736`, which mocks `heart.recall`). Seed facts/episodes/decisions/procedures/censors; ON ⇒ no `type in {censor,procedure}` in `recall_deep`; OFF ⇒ both present.
+- LOC ~80-120. Ships first.
+
+### PR2 (revised — the body path is the redesign)
+- **Body data path (the kill-shot fix):** `_select_procedures` gets K-line procedure **IDs** from `brain.neighbors(seed_id, node_type=seed_type, neighbor_type="procedure", limit=N, session=session)`; for each selected ID call `heart.get_procedure(id)` → `ProcedureDetail`; render via a **NEW** `_format_procedure_bodies(details, per_item_cap)` that assembles `description + core_patterns + implementation_notes + core_tools` per procedure, capped at `proc_recommended_body_max_chars` **per item**. Stop citing `_format_procedures` (renders no body) and `ProcedureDetail.body` (does not exist; fields at `schemas.py:244-267`).
+- **Active/superseded filter:** the neighbor→object fetch MUST drop inactive/superseded procedures. Verify `heart.get_procedure(id)` (`heart.py:474`) filters `active AND superseded_by IS NULL`; if not, add it. (`brain.neighbors` itself does not filter — `brain.py:1276` — and post-dedup there are archived skills with live `auto_linked` edges. Without this, PR2 resurrects dead skills.)
+- **Seeds = facts + decisions ONLY.** At the procedure step (`build()` step 7, `context.py:630`), `recalled_ids["episode"]` is empty (episodes are step 8, `:836`). Use `recalled_ids["fact"]` + `recalled_ids["decision"]` with `recalled_score_map`; `UUID(...)`-convert the str ids. TODO note: episode-cueing needs episode recall reordered before step 7 (don't — perturbs section priority + OFF byte-identity) or a separate episode-seed pass once proc↔episode edges exist.
+- **Hot-path cost:** thread `session=session` into every `brain.neighbors`; **sequential `await`** (AsyncSession is not `gather`-safe — same reason `_recall` is sequential, `heart.py:880`); **cap seeds to top-5 by recall score** before the loop. Batched `source_id IN (:ids)` variant is the F080.1 follow-up.
+- **Determinism:** add `ORDER BY weight DESC, <id>` to `_neighbors` union before `LIMIT` (`brain.py:1212` currently unordered → nondeterministic over-limit). Benefits F080 graph expansion too.
+- **Catalog name-menu:** order by **name** (alpha) or `created_at` — NOT effectiveness (`_compute_effectiveness` is Python-computed, can't SQL-order, and per-use mutation busts the F036 **static** cache tier, `context.py:36/260`). Compact via a **flag-local** desc cap (new `proc_menu_desc_chars`, ON-path only) — do NOT change `proc_catalog_desc_chars` default (byte-identical OFF). Budget: 55 × ~100ch ≈ 5-6K > `proc_catalog_max_chars=4000` → cut purpose to ~30ch and/or raise the cap under the flag; acceptance = every active name present.
+- **recalled_ids AFTER `_truncate_to_budget`** (`context.py:617` pattern) — the plan's "before truncation" was the B-cog-A bug inverted.
+- **Land dark + measure-gate:** flag `proc_selection_graph_primary` default OFF. Add log-only metrics: graph-primary hit-rate (K-line filled ≥1 slot) and selected-proc set. **Forbid prod flip until critic-recall@2 + hit-rate land** (spec §14.5 gate; §14.4 token cost vs F079's measured saving).
+- **Startup interlock guard:** WARN if `coherent_ranking_enabled=true` while the full-breadth menu isn't active (procedures excluded from recall + truncated menu = halved discovery).
+- **Signatures:** `RuntimeConfig` is `nous/runtime_config.py` (singleton `.get().method()`); fetch is `heart.get_procedure(id)` / `heart.get_procedure_by_name(name)` (no `get_procedure_by_id`).
+- LOC ~300-450 (Medium-Large). Ships after PR1.
+
+### Resolved open questions
+Q1 two PRs (PR1 first). Q2 inline `_select_procedures` on `ContextEngine`, cap seeds top-5, batched variant deferred. Q3 floor deferred (menu+critic+get_procedure suffice). Q4 order by name (cache-safe). Q5 PR1 pipeline-only ⇒ no non-recall_deep caller affected.
+
+## Open questions for the review team (original — resolved above)
+1. PR1 + PR2 as two PRs vs one stacked branch? (This plan assumes two.)
+2. `_select_procedures` placement — inline in `build()` step 7 vs a new module; and whether `brain.neighbors` should gain a batched multi-seed variant to avoid N queries/turn.
+3. Floor (task-only match) — ship in v1 or rely on menu + critic only?
+4. Name-menu ordering signal — utility (F037 effectiveness) vs recency vs alpha?
+5. Does any non-recall_deep caller of `heart.recall` break under PR1's procedure/censor exclusion?

--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -108,6 +108,10 @@ class PipelineStats:
     # exclusion set was passed. Surfaced in recall_deep INFO log so the
     # duplication-tax measurement is grep-able from prod.
     excluded_in_context: int = 0
+    # F080: True iff coherent ranking was active for this call (censors +
+    # procedures excluded from the ranked pool). Observability only — not
+    # formatted into recall_deep text, so it does not affect the snapshot.
+    coherent_ranking_applied: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -305,6 +309,7 @@ async def run_recall_pipeline(
         n_stage_errors=dict(acc.stage_errors),
         contradiction_edges=list(acc.contradictions),
         excluded_in_context=excluded_in_context,  # F071
+        coherent_ranking_applied=getattr(settings, "coherent_ranking_enabled", False),  # F080
     )
     return results, stats
 
@@ -345,6 +350,15 @@ async def _run_stages(
                 for t in search_types
                 if t in ["episode", "fact", "procedure", "censor"]
             ]
+
+        # F080: coherent ranking makes the recall pool knowledge-only. Censors
+        # and procedures are excluded — they have dedicated surfaces and would
+        # otherwise compete on incomparable score scales (raw-cosine censor
+        # floor >=0.7; procedure utility boost >1.0). recall_deep-only: this is
+        # the single exclusion site (the cognitive path uses per-type search_*,
+        # not heart.recall). Default OFF => heart_types unchanged.
+        if getattr(settings, "coherent_ranking_enabled", False):
+            heart_types = [t for t in heart_types if t not in ("censor", "procedure")]
 
         if heart_types:
             acc.searched_heart = True

--- a/nous/config.py
+++ b/nous/config.py
@@ -728,6 +728,14 @@ class Settings(BaseSettings):
     # Default True; set False to restore pre-F030.1 behavior (chain CE then MMR).
     mmr_skip_after_ce: bool = True
 
+    # F080: coherent cross-type ranking. When true, recall_deep excludes
+    # censors and procedures from the ranked recall pool — they are capabilities
+    # / guardrails with their own surfaces (Active Censors; Procedure Catalog +
+    # get_procedure), not knowledge. The remaining facts/episodes/decisions/chunks
+    # already share the normalized RRF [0,1] space, so no calibration is needed.
+    # Default OFF => byte-identical recall_deep output.
+    coherent_ranking_enabled: bool = False
+
     # F042: Cross-encoder reranking
     cross_encoder_enabled: bool = False
     # BGE reranker-v2-m3 empirically beats MiniLM by +18.4pp chunks_off /

--- a/tests/test_retrieval_pipeline.py
+++ b/tests/test_retrieval_pipeline.py
@@ -217,6 +217,7 @@ def _make_settings(
     heart_graph_neighbors_per_seed=3,
     episode_chunks_enabled=False,
     episode_chunk_recall_limit=10,
+    coherent_ranking_enabled=False,
 ):
     return SimpleNamespace(
         graph_recall_enabled=graph_recall_enabled,
@@ -230,12 +231,57 @@ def _make_settings(
         heart_graph_neighbors_per_seed=heart_graph_neighbors_per_seed,
         episode_chunks_enabled=episode_chunks_enabled,
         episode_chunk_recall_limit=episode_chunk_recall_limit,
+        coherent_ranking_enabled=coherent_ranking_enabled,
     )
 
 
 # ---------------------------------------------------------------------------
 # run_recall_pipeline: structured behavior
 # ---------------------------------------------------------------------------
+
+
+class TestCoherentRanking:
+    """F080: when coherent_ranking_enabled, recall_deep excludes censors +
+    procedures from the ranked pool (knowledge-only). Asserts on the ``types``
+    the pipeline requests from ``heart.recall`` — what isn't searched can't rank.
+    """
+
+    @pytest.mark.asyncio
+    async def test_excludes_censor_and_procedure_when_enabled(self):
+        heart = _make_heart(recall_results=_make_recall_results())
+        brain = _make_brain(
+            neighbors_by_node={}, contradictions=[], decision_results=[],
+        )
+        settings = _make_settings(coherent_ranking_enabled=True)
+
+        _results, stats = await run_recall_pipeline(
+            query="anything", heart=heart, brain=brain, settings=settings,
+            limit=10, memory_types=["all"],
+        )
+
+        types_arg = heart.recall.await_args.kwargs["types"]
+        assert "censor" not in types_arg
+        assert "procedure" not in types_arg
+        assert set(types_arg) == {"episode", "fact"}
+        assert stats.coherent_ranking_applied is True
+
+    @pytest.mark.asyncio
+    async def test_keeps_censor_and_procedure_when_disabled(self):
+        heart = _make_heart(recall_results=_make_recall_results())
+        brain = _make_brain(
+            neighbors_by_node={}, contradictions=[], decision_results=[],
+        )
+        settings = _make_settings(coherent_ranking_enabled=False)
+
+        _results, stats = await run_recall_pipeline(
+            query="anything", heart=heart, brain=brain, settings=settings,
+            limit=10, memory_types=["all"],
+        )
+
+        types_arg = heart.recall.await_args.kwargs["types"]
+        assert "censor" in types_arg
+        assert "procedure" in types_arg
+        assert stats.coherent_ranking_applied is False
 
 
 class TestRunRecallPipeline:


### PR DESCRIPTION
## F080 — Coherent ranking: knowledge-only recall pool (PR 1 of 2)

**Flag-gated, default OFF → byte-identical `recall_deep`.** This is the small first half of F080; the cognitive-path procedure redesign (§14) follows as PR 2.

### What & why
A code-only audit (`docs/reviews/memory-retrieval-whitepaper-2026-06-08.md`) found that `recall_deep` merges **incomparable score scales** in one ranked pool: facts/episodes/decisions are normalized-RRF `[0,1]`, but **censors** enter at a raw-cosine hard floor `≥0.7` and **procedures** at a utility-boosted score `>1.0`. With cross-encoder + MMR off (prod), the global sort lets those two structurally displace more-relevant facts at the `[:limit]` cut.

A 5-agent design debate (spec §7–§13) concluded these two types shouldn't be in the ranked pool at all — they're **capabilities/guardrails**, not knowledge, and already have dedicated surfaces (Active Censors; Procedure Catalog + `get_procedure`). Excluding them is cheaper and more correct than calibrating them to compete, and leaves a pool that's already coherent (all RRF `[0,1]`) — no calibration needed.

### Change (small, surgical)
- `config.py`: `coherent_ranking_enabled: bool = False`.
- `retrieval_pipeline.py`: when the flag is on, strip `censor` + `procedure` from `heart_types` — **one site**, `recall_deep`-only. The cognitive path uses per-type `search_*` (not `heart.recall`), so it's unaffected; `nous_recall("all")` and explicit `types=[...]` callers are intentionally untouched.
- `PipelineStats.coherent_ranking_applied` for observability (not formatted into text → snapshot-safe).
- Tests assert the pipeline requests knowledge-only types when on, all types when off.

### Scope / sequencing
- **Out of scope (F080.1):** S2 chunk-cosine vs fact-RRF coherence (deferred, measurement-gated), CE head, embed-fail leg.
- **PR 2 (§14):** full-breadth procedure name-menu + critic-preloaded bodies + graph-primary (K-line) selection + drop the cosine Track-B injection. Ship PR 2 before flipping the prod flag so procedure discovery stays intact.

### Review trail
Design: 5-agent debate (`a18e0836`). Plan: 3-agent review (PROCEED-WITH-FIXES; all folded). Tests: `tests/test_retrieval_pipeline.py::TestCoherentRanking` (17/17 green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
