### PR TITLE
feat(cognitive): F080 §14 graph-primary procedure selection + body preload (PR 2/2)

### DIFF
--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -1217,16 +1217,28 @@ class Brain:
                 source_q = source_q.where(GraphEdge.target_id.in_(_active_proc))
                 target_q = target_q.where(GraphEdge.source_id.in_(_active_proc))
 
-        # F080: order by edge weight (best first) with a stable id tiebreak BEFORE
-        # the LIMIT, so a per-seed cap keeps the strongest edges rather than an
-        # arbitrary subset (codex P1), and results are deterministic run-to-run.
+        # F080: order strongest-edge-first, then deduplicate to ONE row per
+        # neighbor in Python before applying the fan-out cap (codex P1). A node
+        # linked via multiple edges (e.g. informed_by from the graph linker +
+        # related_to from the densifier) otherwise returns several rows that
+        # consume the cap and crowd out other neighbors. DB-agnostic (no Postgres
+        # DISTINCT ON, so SQLite-backed tests still run); a generous SQL bound caps
+        # the fetch on god-nodes while preserving the strongest edges for dedup.
         union_q = (
             source_q.union_all(target_q)
             .order_by(text("edge_weight DESC"), text("neighbor_id"))
-            .limit(limit)
+            .limit(max(limit * 5, 50))
         )
         result = await session.execute(union_q)
-        rows = result.all()
+        rows = []
+        _seen_neighbor_ids: set = set()
+        for r in result.all():
+            if r.neighbor_id in _seen_neighbor_ids:
+                continue  # keep only the max-weight edge per neighbor (ordered above)
+            _seen_neighbor_ids.add(r.neighbor_id)
+            rows.append(r)
+            if len(rows) >= limit:
+                break
 
         if not rows:
             return []

--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
-from sqlalchemy import delete, select, text
+from sqlalchemy import delete, func, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -1217,28 +1217,45 @@ class Brain:
                 source_q = source_q.where(GraphEdge.target_id.in_(_active_proc))
                 target_q = target_q.where(GraphEdge.source_id.in_(_active_proc))
 
-        # F080: order strongest-edge-first, then deduplicate to ONE row per
-        # neighbor in Python before applying the fan-out cap (codex P1). A node
-        # linked via multiple edges (e.g. informed_by from the graph linker +
-        # related_to from the densifier) otherwise returns several rows that
-        # consume the cap and crowd out other neighbors. DB-agnostic (no Postgres
-        # DISTINCT ON, so SQLite-backed tests still run); a generous SQL bound caps
-        # the fetch on god-nodes while preserving the strongest edges for dedup.
+        # F080: deduplicate to ONE row per neighbor (the max-weight edge) and cap,
+        # all in SQL via a window function, so the dedup happens BEFORE the cap
+        # (codex P1) — a node linked via multiple edges (informed_by from the graph
+        # linker + related_to from the densifier) can't consume the fan-out cap with
+        # duplicates. COALESCE sorts NULL weights LAST (Postgres would otherwise put
+        # NULL first under DESC). ROW_NUMBER works on both Postgres and the SQLite
+        # used in tests (avoids Postgres-only DISTINCT ON).
+        combined = source_q.union_all(target_q).subquery()
+        _w = func.coalesce(combined.c.edge_weight, -1.0)
+        ranked = (
+            select(
+                combined.c.neighbor_id,
+                combined.c.neighbor_type,
+                combined.c.edge_relation,
+                combined.c.edge_weight,
+                combined.c.extraction_method,
+                func.row_number()
+                .over(
+                    partition_by=combined.c.neighbor_id,
+                    order_by=[_w.desc(), combined.c.neighbor_id],
+                )
+                .label("rn"),
+            )
+            .subquery()
+        )
         union_q = (
-            source_q.union_all(target_q)
-            .order_by(text("edge_weight DESC"), text("neighbor_id"))
-            .limit(max(limit * 5, 50))
+            select(
+                ranked.c.neighbor_id,
+                ranked.c.neighbor_type,
+                ranked.c.edge_relation,
+                ranked.c.edge_weight,
+                ranked.c.extraction_method,
+            )
+            .where(ranked.c.rn == 1)
+            .order_by(func.coalesce(ranked.c.edge_weight, -1.0).desc(), ranked.c.neighbor_id)
+            .limit(limit)
         )
         result = await session.execute(union_q)
-        rows = []
-        _seen_neighbor_ids: set = set()
-        for r in result.all():
-            if r.neighbor_id in _seen_neighbor_ids:
-                continue  # keep only the max-weight edge per neighbor (ordered above)
-            _seen_neighbor_ids.add(r.neighbor_id)
-            rows.append(r)
-            if len(rows) >= limit:
-                break
+        rows = result.all()
 
         if not rows:
             return []

--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -1208,6 +1208,14 @@ class Brain:
         if neighbor_type:
             source_q = source_q.where(GraphEdge.target_type == neighbor_type)
             target_q = target_q.where(GraphEdge.source_type == neighbor_type)
+            # F080: for procedure neighbors, exclude edges pointing at inactive /
+            # superseded skills BEFORE the LIMIT, so a capped fetch returns N
+            # *active* procedures rather than N edges that may be filtered to
+            # fewer (mirrors the F070 neighbor_type pushdown rationale above).
+            if neighbor_type == "procedure":
+                _active_proc = select(Procedure.id).where(Procedure.active == True)  # noqa: E712
+                source_q = source_q.where(GraphEdge.target_id.in_(_active_proc))
+                target_q = target_q.where(GraphEdge.source_id.in_(_active_proc))
 
         union_q = source_q.union_all(target_q).limit(limit)
         result = await session.execute(union_q)

--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -1217,7 +1217,14 @@ class Brain:
                 source_q = source_q.where(GraphEdge.target_id.in_(_active_proc))
                 target_q = target_q.where(GraphEdge.source_id.in_(_active_proc))
 
-        union_q = source_q.union_all(target_q).limit(limit)
+        # F080: order by edge weight (best first) with a stable id tiebreak BEFORE
+        # the LIMIT, so a per-seed cap keeps the strongest edges rather than an
+        # arbitrary subset (codex P1), and results are deterministic run-to-run.
+        union_q = (
+            source_q.union_all(target_q)
+            .order_by(text("edge_weight DESC"), text("neighbor_id"))
+            .limit(limit)
+        )
         result = await session.execute(union_q)
         rows = result.all()
 

--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -1272,11 +1272,16 @@ class Brain:
             for c in c_result.all():
                 descriptions[c.id] = (c.content, c.created_at)
 
-        # Procedure: heart.procedures.description
+        # Procedure: heart.procedures.description. F080: only ACTIVE procedures —
+        # archived/superseded skills (active=false, set by name-dedup) must never
+        # be surfaced as graph neighbors. Inactive ids are simply absent from
+        # ``descriptions`` and dropped in the results loop below (this also fixes
+        # a live Path-A resurrection of dead skills via auto_linked edges).
         if ids_by_type.get("procedure"):
             p_result = await session.execute(
                 select(Procedure.id, Procedure.description, Procedure.created_at)
                 .where(Procedure.id.in_(ids_by_type["procedure"]))
+                .where(Procedure.active == True)  # noqa: E712
             )
             for p in p_result.all():
                 # Procedure.description is nullable — fall back to placeholder
@@ -1294,6 +1299,11 @@ class Brain:
         results = []
         for r in rows:
             ntype, rel, weight, method = edge_map[r.neighbor_id]
+            # F080: an inactive/superseded procedure was filtered out of the
+            # description resolution above — drop it rather than surfacing an
+            # archived skill as a "[procedure] <uuid>" placeholder.
+            if ntype == "procedure" and r.neighbor_id not in descriptions:
+                continue
             if r.neighbor_id in descriptions:
                 desc, created = descriptions[r.neighbor_id]
                 # Defensive: keep placeholder if resolved description is empty

--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
-from sqlalchemy import delete, func, select, text
+from sqlalchemy import case, delete, func, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -1180,6 +1180,7 @@ class Brain:
             GraphEdge.relation.label("edge_relation"),
             GraphEdge.weight.label("edge_weight"),
             GraphEdge.extraction_method.label("extraction_method"),
+            GraphEdge.id.label("edge_id"),
         ).where(
             GraphEdge.source_id == node_id,
             GraphEdge.source_type == node_type,
@@ -1192,6 +1193,7 @@ class Brain:
             GraphEdge.relation.label("edge_relation"),
             GraphEdge.weight.label("edge_weight"),
             GraphEdge.extraction_method.label("extraction_method"),
+            GraphEdge.id.label("edge_id"),
         ).where(
             GraphEdge.target_id == node_id,
             GraphEdge.target_type == node_type,
@@ -1236,7 +1238,15 @@ class Brain:
                 func.row_number()
                 .over(
                     partition_by=combined.c.neighbor_id,
-                    order_by=[_w.desc(), combined.c.neighbor_id],
+                    # Deterministic tie-break for equal-weight duplicate edges
+                    # (common with the default weight 1.0): prefer NON-inferred
+                    # provenance (so F065 penalties are stable), then the unique
+                    # edge id. partition_by neighbor_id can't tie-break itself.
+                    order_by=[
+                        _w.desc(),
+                        case((combined.c.extraction_method == "inferred", 1), else_=0).asc(),
+                        combined.c.edge_id,
+                    ],
                 )
                 .label("rn"),
             )

--- a/nous/cognitive/context.py
+++ b/nous/cognitive/context.py
@@ -652,27 +652,40 @@ class ContextEngine:
                     cap = getattr(
                         self._settings, "proc_recommended_body_max_chars", 1200,
                     )
-                    proc_text = self._format_procedure_bodies(selected, cap)
-                    proc_text = self._truncate_to_budget(
-                        proc_text, self._scaled_budget(budget.procedures),
-                    )
-                    sections.append(
-                        ContextSection(
-                            priority=7,
-                            label="Recommended Procedures",
-                            content=proc_text,
-                            token_estimate=self._estimate_tokens(proc_text),
-                            tier=SECTION_TIERS.get("Recommended Procedures", "dynamic"),
+                    blocks = self._format_procedure_bodies(selected, cap)
+                    # B-cog-A: accumulate bodies under the procedure budget and keep
+                    # the recalled-ids set in sync with what actually survives — a
+                    # tail body cut by the budget must NOT be recorded as "shown"
+                    # (else F071 would exclude it from recall_deep though the LLM
+                    # never saw it). The first block always shows (a single body can
+                    # exceed a tiny budget; the per-item cap bounds it).
+                    budget_tokens = self._scaled_budget(budget.procedures)
+                    shown_blocks: list[str] = []
+                    shown_procs: list = []
+                    used = 0
+                    for p, block in zip(selected, blocks):
+                        cost = self._estimate_tokens(block)
+                        if shown_blocks and used + cost > budget_tokens:
+                            break
+                        shown_blocks.append(block)
+                        shown_procs.append(p)
+                        used += cost
+                    if shown_procs:
+                        proc_text = "\n\n".join(shown_blocks)
+                        sections.append(
+                            ContextSection(
+                                priority=7,
+                                label="Recommended Procedures",
+                                content=proc_text,
+                                token_estimate=self._estimate_tokens(proc_text),
+                                tier=SECTION_TIERS.get("Recommended Procedures", "dynamic"),
+                            )
                         )
-                    )
-                    # B-cog-A: collect ids AFTER the section is built. Bodies are
-                    # per-item capped, not row-dropped, so every selected procedure
-                    # is shown — the recalled ids match what the LLM sees.
-                    for p in selected:
-                        mid = str(p.id)
-                        recalled_ids["procedure"].append(mid)
-                        recalled_content_map[mid] = getattr(p, "name", "")
-                        recalled_score_map[mid] = 1.0
+                        for p in shown_procs:
+                            mid = str(p.id)
+                            recalled_ids["procedure"].append(mid)
+                            recalled_content_map[mid] = getattr(p, "name", "")
+                            recalled_score_map[mid] = 1.0
             except Exception as e:
                 logger.warning("F080 §14.7 procedure selection failed: %s", e)
 
@@ -1344,8 +1357,8 @@ class ContextEngine:
                     seed_uuid, node_type=stype, neighbor_type="procedure",
                     limit=per_seed, session=session,
                 )
-            except Exception:
-                logger.warning("F080 §14.7: neighbor fetch failed for seed %s", mid)
+            except Exception as e:
+                logger.warning("F080 §14.7: neighbor fetch failed for seed %s: %s", mid, e)
                 continue
             for n in neighbors:
                 score = (getattr(n, "edge_weight", 0.0) or 0.0) * seed_score
@@ -1354,9 +1367,12 @@ class ContextEngine:
                     continue
                 try:
                     detail = await self._heart.get_procedure(n.id, session=session)
-                except Exception:
-                    continue  # not found / fetch error → skip
-                if detail is None or not getattr(detail, "active", False):
+                except ValueError:
+                    continue  # stale edge → procedure deleted; benign
+                except Exception as e:
+                    logger.warning("F080 §14.7: get_procedure failed for %s: %s", n.id, e)
+                    continue
+                if not getattr(detail, "active", False):
                     continue  # archived/superseded → never surface
                 best[n.id] = (score, detail)
 
@@ -1371,19 +1387,21 @@ class ContextEngine:
                     break
                 try:
                     detail = await self._heart.get_procedure_by_name(name, session=session)
-                except Exception:
+                except Exception as e:
+                    logger.warning("F080 §14.7: critic-skill lookup failed for %r: %s", name, e)
                     continue
                 if detail is not None and detail.id not in have and getattr(detail, "active", True):
                     selected.append(detail)
                     have.add(detail.id)
         return selected[:slots]
 
-    def _format_procedure_bodies(self, details: list, per_item_cap: int) -> str:
-        """Render selected procedures with their BODIES (steps), per-item capped.
+    def _format_procedure_bodies(self, details: list, per_item_cap: int) -> list[str]:
+        """Render selected procedures as per-item BODY blocks (steps), each capped.
 
         Body = description + core patterns + implementation notes + tools,
         assembled compactly so the agent can act without a get_procedure
-        round-trip for the surfaced picks.
+        round-trip. Returns one block per procedure (aligned with ``details``)
+        so the caller can fit them to budget and keep recalled-ids in sync.
         """
         blocks: list[str] = []
         for p in details:
@@ -1406,7 +1424,7 @@ class ContextEngine:
             if len(block) > per_item_cap:
                 block = block[:per_item_cap].rstrip() + "…"
             blocks.append(block)
-        return "\n\n".join(blocks)
+        return blocks
 
     def _format_episodes(self, episodes: list) -> str:
         """Format episodes for context.

--- a/nous/cognitive/context.py
+++ b/nous/cognitive/context.py
@@ -637,13 +637,28 @@ class ContextEngine:
             and getattr(self._settings, "proc_selection_graph_primary", False)
         ):
             try:
+                # Respect critic injection mode for the fallback (codex P1): only
+                # "enabled" actually injects critic skills; "log_only" logs intent
+                # without injecting; "disabled" suppresses them entirely — matching
+                # the passive Track-A semantics below.
+                injection_mode = getattr(
+                    self._settings, "critic_skill_injection", "disabled",
+                )
+                fallback_skills = (
+                    list(critic_skills or []) if injection_mode == "enabled" else []
+                )
+                if injection_mode == "log_only" and critic_skills:
+                    logger.info(
+                        "F080 §14.7 log_only: would use critic skills as fallback: %s",
+                        critic_skills,
+                    )
                 slots = (
                     self._settings.critic_skill_slots
                     + self._settings.embedding_skill_slots
                 )
                 selected = await self._select_procedures(
                     slots=slots,
-                    critic_skills=critic_skills or [],
+                    critic_skills=fallback_skills,
                     recalled_ids=recalled_ids,
                     recalled_score_map=recalled_score_map,
                     session=session,
@@ -1345,7 +1360,10 @@ class ContextEngine:
         seeds.sort(key=lambda s: recalled_score_map.get(s[0], 0.0) or 0.0, reverse=True)
 
         per_seed = getattr(self._settings, "proc_graph_neighbors_per_seed", 3)
-        best: dict[UUID, tuple[float, object]] = {}
+        # Phase 1: graph traversal — collect the best score per procedure id WITHOUT
+        # fetching bodies (codex P2: avoid up to seeds*per_seed get_procedure calls
+        # just to keep `slots`). Bodies are fetched once, ranked, in phase 2.
+        scores: dict[UUID, float] = {}
         for mid, stype in seeds[:_SEED_CAP]:
             try:
                 seed_uuid = UUID(mid)
@@ -1362,22 +1380,25 @@ class ContextEngine:
                 continue
             for n in neighbors:
                 score = (getattr(n, "edge_weight", 0.0) or 0.0) * seed_score
-                prev = best.get(n.id)
-                if prev is not None and prev[0] >= score:
-                    continue
-                try:
-                    detail = await self._heart.get_procedure(n.id, session=session)
-                except ValueError:
-                    continue  # stale edge → procedure deleted; benign
-                except Exception as e:
-                    logger.warning("F080 §14.7: get_procedure failed for %s: %s", n.id, e)
-                    continue
-                if not getattr(detail, "active", False):
-                    continue  # archived/superseded → never surface
-                best[n.id] = (score, detail)
+                if score > scores.get(n.id, -1.0):
+                    scores[n.id] = score
 
-        selected = [d for _s, d in sorted(best.values(), key=lambda x: (-x[0], str(x[1].id)))]
-        selected = selected[:slots]
+        # Phase 2: rank by score, fetch bodies only for enough top candidates to
+        # fill the slots (skip stale/inactive and continue down the ranked list).
+        selected: list = []
+        for pid, _score in sorted(scores.items(), key=lambda x: (-x[1], str(x[0]))):
+            if len(selected) >= slots:
+                break
+            try:
+                detail = await self._heart.get_procedure(pid, session=session)
+            except ValueError:
+                continue  # stale edge → procedure deleted; benign
+            except Exception as e:
+                logger.warning("F080 §14.7: get_procedure failed for %s: %s", pid, e)
+                continue
+            if not getattr(detail, "active", False):
+                continue  # archived/superseded → never surface
+            selected.append(detail)
 
         # Fallback: critic-recommended skills fill remaining slots.
         if len(selected) < slots and critic_skills:

--- a/nous/cognitive/context.py
+++ b/nous/cognitive/context.py
@@ -627,13 +627,66 @@ class ContextEngine:
             except Exception as e:
                 logger.warning("Heart.search_facts failed during context build: %s", e)
 
+        # 7. F080 §14.7: graph-primary procedure selection — preloads the BODIES of
+        # procedures activated via K-line graph edges from recalled facts/decisions,
+        # with critic-recommended skills as fallback. Replaces the passive-injection
+        # path below when the flag is on (default OFF => passive path unchanged).
+        if (
+            budget.procedures > 0
+            and "procedure" not in skip_types
+            and getattr(self._settings, "proc_selection_graph_primary", False)
+        ):
+            try:
+                slots = (
+                    self._settings.critic_skill_slots
+                    + self._settings.embedding_skill_slots
+                )
+                selected = await self._select_procedures(
+                    slots=slots,
+                    critic_skills=critic_skills or [],
+                    recalled_ids=recalled_ids,
+                    recalled_score_map=recalled_score_map,
+                    session=session,
+                )
+                if selected:
+                    cap = getattr(
+                        self._settings, "proc_recommended_body_max_chars", 1200,
+                    )
+                    proc_text = self._format_procedure_bodies(selected, cap)
+                    proc_text = self._truncate_to_budget(
+                        proc_text, self._scaled_budget(budget.procedures),
+                    )
+                    sections.append(
+                        ContextSection(
+                            priority=7,
+                            label="Recommended Procedures",
+                            content=proc_text,
+                            token_estimate=self._estimate_tokens(proc_text),
+                            tier=SECTION_TIERS.get("Recommended Procedures", "dynamic"),
+                        )
+                    )
+                    # B-cog-A: collect ids AFTER the section is built. Bodies are
+                    # per-item capped, not row-dropped, so every selected procedure
+                    # is shown — the recalled ids match what the LLM sees.
+                    for p in selected:
+                        mid = str(p.id)
+                        recalled_ids["procedure"].append(mid)
+                        recalled_content_map[mid] = getattr(p, "name", "")
+                        recalled_score_map[mid] = 1.0
+            except Exception as e:
+                logger.warning("F080 §14.7 procedure selection failed: %s", e)
+
         # 7. Procedures (dual-track: Critic reserved slots + embedding slots, issue #229)
         # F079 unified pull: `proc_passive_injection_enabled=False` removes only the
         # EMBEDDING (Track B) passive slots — those duplicate the recall_deep cosine path,
         # so they are the bloat. Critic-recommended skills (Track A) are NOT gated: they are
         # a classifier-driven push with no pull-path equivalent (recall_deep is pure cosine),
         # so disabling them would silently kill F024 skill injection (review M1).
-        if budget.procedures > 0 and "procedure" not in skip_types:
+        if (
+            budget.procedures > 0
+            and "procedure" not in skip_types
+            and not getattr(self._settings, "proc_selection_graph_primary", False)
+        ):
             try:
                 injection_mode = self._settings.critic_skill_injection
                 critic_slot_count = self._settings.critic_skill_slots
@@ -1251,6 +1304,109 @@ class ContextEngine:
             desc_str = f": {desc} | " if desc else ": "
             lines.append(f"- **{name}** ({domain}){desc_str}activated {count}x{eff_str}")
         return "\n".join(lines)
+
+    async def _select_procedures(
+        self,
+        *,
+        slots: int,
+        critic_skills: list[str],
+        recalled_ids: dict[str, list[str]],
+        recalled_score_map: dict[str, float],
+        session,
+    ) -> list:
+        """F080 §14.7: graph-primary (K-line) procedure selection with critic fallback.
+
+        Primary: for each already-recalled fact/decision seed (episodes are
+        recalled later in build(), and carry no procedure edges today), pull
+        procedure neighbors via the graph — structural, not cosine — and score
+        each ``edge_weight * seed_recall_score``. Fetch the body and drop
+        inactive/superseded skills. Fallback: critic-recommended skills fill any
+        remaining slots. Returns active ``ProcedureDetail`` objects, best first.
+        """
+        # Top-N seeds by recall score keep the per-turn graph fan-out bounded.
+        _SEED_CAP = 8
+        seeds: list[tuple[str, str]] = (
+            [(mid, "fact") for mid in recalled_ids.get("fact", [])]
+            + [(mid, "decision") for mid in recalled_ids.get("decision", [])]
+        )
+        seeds.sort(key=lambda s: recalled_score_map.get(s[0], 0.0) or 0.0, reverse=True)
+
+        per_seed = getattr(self._settings, "proc_graph_neighbors_per_seed", 3)
+        best: dict[UUID, tuple[float, object]] = {}
+        for mid, stype in seeds[:_SEED_CAP]:
+            try:
+                seed_uuid = UUID(mid)
+            except (ValueError, TypeError):
+                continue
+            seed_score = recalled_score_map.get(mid, 0.0) or 0.0
+            try:
+                neighbors = await self._brain.neighbors(
+                    seed_uuid, node_type=stype, neighbor_type="procedure",
+                    limit=per_seed, session=session,
+                )
+            except Exception:
+                logger.warning("F080 §14.7: neighbor fetch failed for seed %s", mid)
+                continue
+            for n in neighbors:
+                score = (getattr(n, "edge_weight", 0.0) or 0.0) * seed_score
+                prev = best.get(n.id)
+                if prev is not None and prev[0] >= score:
+                    continue
+                try:
+                    detail = await self._heart.get_procedure(n.id, session=session)
+                except Exception:
+                    continue  # not found / fetch error → skip
+                if detail is None or not getattr(detail, "active", False):
+                    continue  # archived/superseded → never surface
+                best[n.id] = (score, detail)
+
+        selected = [d for _s, d in sorted(best.values(), key=lambda x: (-x[0], str(x[1].id)))]
+        selected = selected[:slots]
+
+        # Fallback: critic-recommended skills fill remaining slots.
+        if len(selected) < slots and critic_skills:
+            have = {getattr(d, "id", None) for d in selected}
+            for name in list(dict.fromkeys(critic_skills)):
+                if len(selected) >= slots:
+                    break
+                try:
+                    detail = await self._heart.get_procedure_by_name(name, session=session)
+                except Exception:
+                    continue
+                if detail is not None and detail.id not in have and getattr(detail, "active", True):
+                    selected.append(detail)
+                    have.add(detail.id)
+        return selected[:slots]
+
+    def _format_procedure_bodies(self, details: list, per_item_cap: int) -> str:
+        """Render selected procedures with their BODIES (steps), per-item capped.
+
+        Body = description + core patterns + implementation notes + tools,
+        assembled compactly so the agent can act without a get_procedure
+        round-trip for the surfaced picks.
+        """
+        blocks: list[str] = []
+        for p in details:
+            name = getattr(p, "name", "")
+            domain = getattr(p, "domain", None) or "general"
+            parts: list[str] = [f"### {name} ({domain})"]
+            desc = getattr(p, "description", None)
+            if desc:
+                parts.append(desc)
+            patterns = getattr(p, "core_patterns", None) or []
+            if patterns:
+                parts.append("Patterns: " + "; ".join(patterns))
+            notes = getattr(p, "implementation_notes", None) or []
+            if notes:
+                parts.append("Notes: " + "; ".join(notes))
+            tools = getattr(p, "core_tools", None) or []
+            if tools:
+                parts.append("Tools: " + ", ".join(tools))
+            block = "\n".join(parts)
+            if len(block) > per_item_cap:
+                block = block[:per_item_cap].rstrip() + "…"
+            blocks.append(block)
+        return "\n\n".join(blocks)
 
     def _format_episodes(self, episodes: list) -> str:
         """Format episodes for context.

--- a/nous/config.py
+++ b/nous/config.py
@@ -159,6 +159,18 @@ class Settings(BaseSettings):
     # proc_catalog_enabled ON (breadth via catalog, depth via get_procedure).
     proc_passive_injection_enabled: bool = True
 
+    # F080 §14.7: graph-primary procedure selection. When True, the every-turn
+    # "Recommended Procedures" section is filled by K-line graph activation
+    # (recalled facts/decisions -> brain.neighbors(neighbor_type="procedure"))
+    # with critic-recommended skills as fallback, and the selected procedures'
+    # BODIES are preloaded (not just a name pointer). Bypasses the Track-B
+    # embedding injection. Default OFF => existing passive-injection behavior.
+    proc_selection_graph_primary: bool = False
+    # Per-item char cap for a preloaded procedure body in the Recommended section.
+    proc_recommended_body_max_chars: int = 1200
+    # Graph K-line fan-out: procedure neighbors pulled per recalled seed.
+    proc_graph_neighbors_per_seed: int = 3
+
     # F017: Diminishing returns cutoff (used by adaptive relevance filter)
     relevance_drop_ratio: float = 0.5
 

--- a/tests/test_brain.py
+++ b/tests/test_brain.py
@@ -592,6 +592,47 @@ async def test_neighbors_neighbor_type_filter(brain, session):
     assert neighbors[0].id == decision.id
 
 
+async def test_neighbors_dedupes_multi_edge_neighbor(brain, session):
+    """F080 (codex P1): a neighbor connected via multiple edges (e.g. informed_by
+    from the linker + related_to from the densifier) must collapse to ONE row
+    (max weight) BEFORE the fan-out cap, so duplicate edges don't consume slots
+    and crowd out other distinct neighbors.
+    """
+    from uuid import uuid4
+
+    from nous.storage.models import GraphEdge
+
+    fact_id = uuid4()
+    d = await brain.record(_record_input(description="decision D"), session=session)
+    e = await brain.record(_record_input(description="decision E"), session=session)
+
+    # Two edges fact->D (same neighbor, different relations) + one edge fact->E.
+    session.add(GraphEdge(
+        source_id=fact_id, target_id=d.id, source_type="fact", target_type="decision",
+        agent_id=brain.agent_id, relation="informed_by", weight=0.9,
+        auto_linked=True, extraction_method="heuristic",
+    ))
+    session.add(GraphEdge(
+        source_id=fact_id, target_id=d.id, source_type="fact", target_type="decision",
+        agent_id=brain.agent_id, relation="related_to", weight=0.7,
+        auto_linked=True, extraction_method="inferred",
+    ))
+    session.add(GraphEdge(
+        source_id=fact_id, target_id=e.id, source_type="fact", target_type="decision",
+        agent_id=brain.agent_id, relation="informed_by", weight=0.8,
+        auto_linked=True, extraction_method="heuristic",
+    ))
+    await session.flush()
+
+    neighbors = await brain.neighbors(
+        fact_id, node_type="fact", limit=2, session=session, neighbor_type="decision",
+    )
+    ids = [n.id for n in neighbors]
+    assert d.id in ids and e.id in ids  # both distinct neighbors survive the cap
+    assert ids.count(d.id) == 1  # D collapsed to one row (the 0.9 edge)
+    assert len(neighbors) == 2
+
+
 # ---------------------------------------------------------------------------
 # 18a-Path-A. test_neighbors_resolves_content_for_all_node_types
 # ---------------------------------------------------------------------------

--- a/tests/test_context_dual_track.py
+++ b/tests/test_context_dual_track.py
@@ -91,7 +91,7 @@ class TestGraphPrimarySelection:
         )
 
         assert [p.id for p in selected] == [proc.id]
-        body = engine._format_procedure_bodies(selected, 1200)
+        body = "\n".join(engine._format_procedure_bodies(selected, 1200))
         assert "deploy-runbook" in body
         assert "pattern1" in body  # body (not just name) is preloaded
 
@@ -126,8 +126,47 @@ class TestGraphPrimarySelection:
         long_proc = _make_procedure_detail("x").model_copy(
             update={"description": "Z" * 5000}
         )
-        body = engine._format_procedure_bodies([long_proc], 200)
-        assert len(body) <= 201  # cap + ellipsis
+        blocks = engine._format_procedure_bodies([long_proc], 200)
+        assert len(blocks) == 1
+        assert len(blocks[0]) <= 201  # cap + ellipsis
+
+    @pytest.mark.asyncio
+    async def test_build_flag_on_renders_section_and_syncs_recalled_ids(self):
+        """End-to-end through build(): flag-ON renders 'Recommended Procedures'
+        (here via critic fallback, no graph seeds) and records exactly the shown
+        procedure's id — guards the wiring + the recalled-ids/budget sync."""
+        proc = _make_procedure_detail("runbook-x")
+        settings = Settings(
+            _env_file=None,
+            proc_selection_graph_primary=True,
+            critic_skill_injection="enabled",
+            relevance_floor_enabled=False,
+        )
+        brain = MagicMock()
+        brain.embeddings = None
+        brain.query = AsyncMock(return_value=[])
+        brain.neighbors = AsyncMock(return_value=[])  # no graph hits → critic fallback
+        heart = MagicMock()
+        heart.search_procedures = AsyncMock(return_value=[])
+        heart.search_facts = AsyncMock(return_value=[])
+        heart.search_episodes = AsyncMock(return_value=[])
+        heart.list_facts_by_category = AsyncMock(return_value=[])
+        heart.list_working_memory = AsyncMock(return_value=[])
+        heart.list_censors = AsyncMock(return_value=[])
+        heart.list_episodes = AsyncMock(return_value=[])
+        heart.list_procedures = AsyncMock(return_value=([], 0))
+        heart.get_procedure = AsyncMock()
+        heart.get_procedure_by_name = AsyncMock(return_value=proc)
+        engine = ContextEngine(brain, heart, settings, identity_prompt="Test")
+
+        result = await engine.build(
+            agent_id="test", session_id="s1", input_text="do the deploy thing",
+            frame=_frame(), critic_skills=["runbook-x"],
+        )
+
+        assert "Recommended Procedures" in result.system_prompt
+        assert "runbook-x" in result.system_prompt
+        assert result.recalled_ids.get("procedure") == [str(proc.id)]
 
 
 class TestDualTrackDisabled:

--- a/tests/test_context_dual_track.py
+++ b/tests/test_context_dual_track.py
@@ -55,6 +55,81 @@ def _make_procedure_summary(name: str, score: float = 0.8, domain: str = "test")
     )
 
 
+class TestGraphPrimarySelection:
+    """F080 §14.7: graph-primary (K-line) procedure selection with critic fallback."""
+
+    def _engine(self, *, neighbors, get_procedure=None, get_by_name=None):
+        from nous.brain.schemas import NeighborResult  # noqa: F401 (kept local)
+
+        settings = Settings(_env_file=None, proc_selection_graph_primary=True)
+        brain = MagicMock()
+        brain.neighbors = AsyncMock(return_value=neighbors)
+        heart = MagicMock()
+        heart.get_procedure = AsyncMock(return_value=get_procedure)
+        heart.get_procedure_by_name = AsyncMock(return_value=get_by_name)
+        return ContextEngine(brain, heart, settings, identity_prompt="Test")
+
+    def _nbr(self, proc_id, weight=0.8):
+        from nous.brain.schemas import NeighborResult
+
+        return NeighborResult(
+            id=proc_id, node_type="procedure", description="d",
+            edge_relation="summarized_by", edge_weight=weight,
+            created_at=datetime.now(timezone.utc), extraction_method="auto_linked",
+        )
+
+    @pytest.mark.asyncio
+    async def test_graph_primary_selects_linked_procedure_with_body(self):
+        proc = _make_procedure_detail("deploy-runbook")
+        engine = self._engine(neighbors=[self._nbr(proc.id)], get_procedure=proc)
+        fid = str(uuid4())
+
+        selected = await engine._select_procedures(
+            slots=5, critic_skills=[],
+            recalled_ids={"fact": [fid], "decision": []},
+            recalled_score_map={fid: 0.9}, session=None,
+        )
+
+        assert [p.id for p in selected] == [proc.id]
+        body = engine._format_procedure_bodies(selected, 1200)
+        assert "deploy-runbook" in body
+        assert "pattern1" in body  # body (not just name) is preloaded
+
+    @pytest.mark.asyncio
+    async def test_inactive_procedure_never_surfaced(self):
+        archived = _make_procedure_detail("archived-skill").model_copy(
+            update={"active": False}
+        )
+        engine = self._engine(neighbors=[self._nbr(archived.id)], get_procedure=archived)
+        fid = str(uuid4())
+
+        selected = await engine._select_procedures(
+            slots=5, critic_skills=[],
+            recalled_ids={"fact": [fid]}, recalled_score_map={fid: 0.9}, session=None,
+        )
+        assert selected == []  # active=False => dropped
+
+    @pytest.mark.asyncio
+    async def test_critic_fallback_when_no_graph_hits(self):
+        crit = _make_procedure_detail("critic-skill")
+        engine = self._engine(neighbors=[], get_by_name=crit)
+
+        selected = await engine._select_procedures(
+            slots=5, critic_skills=["critic-skill"],
+            recalled_ids={"fact": [str(uuid4())]}, recalled_score_map={}, session=None,
+        )
+        assert [p.id for p in selected] == [crit.id]
+
+    @pytest.mark.asyncio
+    async def test_body_format_respects_per_item_cap(self):
+        engine = self._engine(neighbors=[])
+        long_proc = _make_procedure_detail("x").model_copy(
+            update={"description": "Z" * 5000}
+        )
+        body = engine._format_procedure_bodies([long_proc], 200)
+        assert len(body) <= 201  # cap + ellipsis
+
+
 class TestDualTrackDisabled:
     """Tests when critic_skill_injection=disabled (default)."""
 

--- a/tests/test_context_dual_track.py
+++ b/tests/test_context_dual_track.py
@@ -168,6 +168,42 @@ class TestGraphPrimarySelection:
         assert "runbook-x" in result.system_prompt
         assert result.recalled_ids.get("procedure") == [str(proc.id)]
 
+    @pytest.mark.asyncio
+    async def test_build_flag_on_fallback_respects_disabled_injection(self):
+        """critic_skill_injection='disabled' must suppress the critic fallback even
+        under graph-primary selection (codex P1) — no section, no name lookup."""
+        proc = _make_procedure_detail("runbook-x")
+        settings = Settings(
+            _env_file=None,
+            proc_selection_graph_primary=True,
+            critic_skill_injection="disabled",
+            relevance_floor_enabled=False,
+        )
+        brain = MagicMock()
+        brain.embeddings = None
+        brain.query = AsyncMock(return_value=[])
+        brain.neighbors = AsyncMock(return_value=[])  # no graph hits
+        heart = MagicMock()
+        heart.search_procedures = AsyncMock(return_value=[])
+        heart.search_facts = AsyncMock(return_value=[])
+        heart.search_episodes = AsyncMock(return_value=[])
+        heart.list_facts_by_category = AsyncMock(return_value=[])
+        heart.list_working_memory = AsyncMock(return_value=[])
+        heart.list_censors = AsyncMock(return_value=[])
+        heart.list_episodes = AsyncMock(return_value=[])
+        heart.list_procedures = AsyncMock(return_value=([], 0))
+        heart.get_procedure = AsyncMock()
+        heart.get_procedure_by_name = AsyncMock(return_value=proc)
+        engine = ContextEngine(brain, heart, settings, identity_prompt="Test")
+
+        result = await engine.build(
+            agent_id="test", session_id="s1", input_text="do the deploy thing",
+            frame=_frame(), critic_skills=["runbook-x"],
+        )
+
+        assert "Recommended Procedures" not in result.system_prompt
+        heart.get_procedure_by_name.assert_not_called()
+
 
 class TestDualTrackDisabled:
     """Tests when critic_skill_injection=disabled (default)."""


### PR DESCRIPTION
## F080 §14 — Graph-primary procedure selection + body preload (PR 2 of 2)

**Flag-gated, default OFF → existing passive-injection path byte-identical.** Companion to #491 (knowledge-only recall pool). Together: procedures are **selected for the task and loaded**, never relevance-ranked against memory.

### What
When `NOUS_PROC_SELECTION_GRAPH_PRIMARY=true`, the every-turn **Recommended Procedures** section is filled by:
1. **K-line graph activation (primary):** recalled facts/decisions → `brain.neighbors(neighbor_type="procedure")`, scored `edge_weight × seed_recall_score` — **structural, not cosine** (no reintroduction of the coupling F080 removed). Local graph measurement: procedures are 100% linked, proc↔fact = 29 edges (the dense cue).
2. **Critic fallback:** critic-recommended skills fill any remaining slots.
3. **Body preload:** selected procedures' bodies (description + patterns + notes + tools, per-item capped) are inlined, so the common case needs no `get_procedure` round-trip. Bypasses the Track-B embedding injection.

The catalog (breadth name-menu) + `get_procedure` (depth) are unchanged — they already work.

### Bundled correctness fix (not flag-gated)
`brain._neighbors` now filters procedure neighbors to `active=True`. Archived/superseded skills (set `active=false` by the recent name-dedup) carry live `auto_linked` edges and were being **resurrected as graph neighbors on the prod-on Path A** — this stops that everywhere.

### Review-team fixes already folded (3-agent plan review)
- Body path: `NeighborResult.id → heart.get_procedure(id) → ProcedureDetail`, new `_format_procedure_bodies` (the old `_format_procedures` renders no body; `ProcedureDetail` has no `.body`).
- Seeds = facts + decisions only (episodes are recalled *after* the procedure step).
- Inactive/superseded dropped on fetch (`detail.active`).
- `session` threaded into `brain.neighbors`; sequential `await`; seeds capped top-8 by score.
- recalled-ids collected **after** the section is built (B-cog-A).

### Tests
`tests/test_context_dual_track.py::TestGraphPrimarySelection` (4 new: graph-selects-with-body, inactive-never-surfaced, critic-fallback, per-item-cap). Full dual-track suite 14/14 (10 existing OFF-path unchanged). Brain neighbor/graph 6/6. (7 unrelated local failures are pre-existing SQLite-vs-pgvector env limits — verified identical on clean main; CI runs postgres.)

### Sequencing
Ship before flipping `NOUS_COHERENT_RANKING_ENABLED` in prod so procedure discovery stays intact. Measurement-gated per spec §14.5 (critic-recall@2, graph hit-rate) before any prod flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
