### PR TITLE
feat(cognitive): F080 §14 cosine selection leg + enable F080+§14 by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ tools/beam/
 reports/beam/
 # F074: HuggingFace cache (~/.cache/nous-eval/beam) is outside repo
 scripts/diag/_proc_*.json
+.prod_snapshot/

--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -160,6 +160,7 @@ class _PipelineAccumulator:
     # Flags
     searched_decisions: bool = False
     searched_heart: bool = False
+    coherent_ranking_applied: bool = False  # F080: filter actually ran this call
     spreading_activation_used: bool = False
     graph_expansion_used: bool = False
     contradiction_checks_ran: bool = False
@@ -309,7 +310,7 @@ async def run_recall_pipeline(
         n_stage_errors=dict(acc.stage_errors),
         contradiction_edges=list(acc.contradictions),
         excluded_in_context=excluded_in_context,  # F071
-        coherent_ranking_applied=getattr(settings, "coherent_ranking_enabled", False),  # F080
+        coherent_ranking_applied=acc.coherent_ranking_applied,  # F080: reflects the filter actually running (search_all only)
     )
     return results, stats
 
@@ -361,6 +362,7 @@ async def _run_stages(
         # search_*, not heart.recall.
         if search_all and getattr(settings, "coherent_ranking_enabled", False):
             heart_types = [t for t in heart_types if t not in ("censor", "procedure")]
+            acc.coherent_ranking_applied = True
 
         if heart_types:
             acc.searched_heart = True

--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -351,13 +351,15 @@ async def _run_stages(
                 if t in ["episode", "fact", "procedure", "censor"]
             ]
 
-        # F080: coherent ranking makes the recall pool knowledge-only. Censors
-        # and procedures are excluded — they have dedicated surfaces and would
-        # otherwise compete on incomparable score scales (raw-cosine censor
-        # floor >=0.7; procedure utility boost >1.0). recall_deep-only: this is
-        # the single exclusion site (the cognitive path uses per-type search_*,
-        # not heart.recall). Default OFF => heart_types unchanged.
-        if getattr(settings, "coherent_ranking_enabled", False):
+        # F080: coherent ranking makes the IMPLICIT recall pool knowledge-only.
+        # Censors and procedures are excluded from the default ("all") search —
+        # they have dedicated surfaces and would otherwise compete on incomparable
+        # score scales (raw-cosine censor floor >=0.7; procedure utility boost >1.0).
+        # Gated on ``search_all`` so an EXPLICIT memory_types=["procedure"]/["censor"]
+        # request is still honored (the advertised tool contract + procedure-only
+        # eval probes, codex P1). recall_deep-only — the cognitive path uses per-type
+        # search_*, not heart.recall.
+        if search_all and getattr(settings, "coherent_ranking_enabled", False):
             heart_types = [t for t in heart_types if t not in ("censor", "procedure")]
 
         if heart_types:

--- a/nous/cognitive/context.py
+++ b/nous/cognitive/context.py
@@ -662,6 +662,7 @@ class ContextEngine:
                     recalled_ids=recalled_ids,
                     recalled_score_map=recalled_score_map,
                     session=session,
+                    query=input_text,
                 )
                 if selected:
                     cap = getattr(
@@ -1341,15 +1342,19 @@ class ContextEngine:
         recalled_ids: dict[str, list[str]],
         recalled_score_map: dict[str, float],
         session,
+        query: str = "",
     ) -> list:
-        """F080 §14.7: graph-primary (K-line) procedure selection with critic fallback.
+        """§14.7 procedure selection ladder: graph K-line -> critic -> cosine.
 
-        Primary: for each already-recalled fact/decision seed (episodes are
-        recalled later in build(), and carry no procedure edges today), pull
-        procedure neighbors via the graph — structural, not cosine — and score
-        each ``edge_weight * seed_recall_score``. Fetch the body and drop
-        inactive/superseded skills. Fallback: critic-recommended skills fill any
-        remaining slots. Returns active ``ProcedureDetail`` objects, best first.
+        Graph (primary): for each recalled fact/decision seed, pull procedure
+        neighbors via graph edges (structural K-line, scored ``edge_weight *
+        seed_score``) — precise when an edge exists. Critic: classifier-recommended
+        skills. Cosine: embedding similarity over ``query`` — carries coverage
+        because the graph is sparse (a prod-snapshot A/B judged cosine picks ~2x
+        more relevant than the graph leg, which fired on only ~43% of queries).
+        Post-F080 the cosine leg is non-redundant — procedures are excluded from
+        recall_deep, so this is the sole cosine procedure path. All legs fetch the
+        full body and drop inactive/superseded skills. Active ``ProcedureDetail``.
         """
         # Top-N seeds by recall score keep the per-turn graph fan-out bounded.
         _SEED_CAP = 8
@@ -1412,6 +1417,32 @@ class ContextEngine:
                     logger.warning("F080 §14.7: critic-skill lookup failed for %r: %s", name, e)
                     continue
                 if detail is not None and detail.id not in have and getattr(detail, "active", True):
+                    selected.append(detail)
+                    have.add(detail.id)
+
+        # Cosine fallback: embedding similarity over the query fills remaining slots.
+        # Post-F080 this is non-redundant (procedures excluded from recall_deep) and an
+        # A/B on the prod snapshot judged cosine picks ~2x more relevant than the sparse
+        # graph leg — so it carries coverage while graph/critic add precision.
+        if len(selected) < slots and query:
+            have = {getattr(d, "id", None) for d in selected}
+            try:
+                cos = await self._heart.search_procedures(
+                    query, limit=slots * 2, session=session,
+                )
+            except Exception as e:
+                logger.warning("F080 §14.7: cosine procedure fallback failed: %s", e)
+                cos = []
+            for summ in cos:
+                if len(selected) >= slots:
+                    break
+                if summ.id in have:
+                    continue
+                try:
+                    detail = await self._heart.get_procedure(summ.id, session=session)
+                except Exception:
+                    continue
+                if detail is not None and getattr(detail, "active", False):
                     selected.append(detail)
                     have.add(detail.id)
         return selected[:slots]

--- a/nous/config.py
+++ b/nous/config.py
@@ -159,13 +159,13 @@ class Settings(BaseSettings):
     # proc_catalog_enabled ON (breadth via catalog, depth via get_procedure).
     proc_passive_injection_enabled: bool = True
 
-    # F080 §14.7: graph-primary procedure selection. When True, the every-turn
-    # "Recommended Procedures" section is filled by K-line graph activation
-    # (recalled facts/decisions -> brain.neighbors(neighbor_type="procedure"))
-    # with critic-recommended skills as fallback, and the selected procedures'
-    # BODIES are preloaded (not just a name pointer). Bypasses the Track-B
-    # embedding injection. Default OFF => existing passive-injection behavior.
-    proc_selection_graph_primary: bool = False
+    # F080 §14.7: procedure selection ladder (graph K-line -> critic -> cosine).
+    # The every-turn "Recommended Procedures" section preloads the BODY of the
+    # query-relevant procedure (no get_procedure round-trip). Validated 2026-06-08
+    # on the prod snapshot: with the cosine leg it reaches 14/14 coverage at 1.64/2
+    # judged relevance (graph alone was sparse at 6/14). Default ON; set false to
+    # restore the passive name-pointer injection.
+    proc_selection_graph_primary: bool = True
     # Per-item char cap for a preloaded procedure body in the Recommended section.
     proc_recommended_body_max_chars: int = 1200
     # Graph K-line fan-out: procedure neighbors pulled per recalled seed.
@@ -745,8 +745,10 @@ class Settings(BaseSettings):
     # / guardrails with their own surfaces (Active Censors; Procedure Catalog +
     # get_procedure), not knowledge. The remaining facts/episodes/decisions/chunks
     # already share the normalized RRF [0,1] space, so no calibration is needed.
-    # Default OFF => byte-identical recall_deep output.
-    coherent_ranking_enabled: bool = False
+    # Validated 2026-06-08 on a fresh post-dedup prod snapshot: 0/12 censor+procedure
+    # leak; excluding them shifts top-10 from ~40 procedure slots to knowledge.
+    # Default ON; set false to restore the legacy ranked pool.
+    coherent_ranking_enabled: bool = True
 
     # F042: Cross-encoder reranking
     cross_encoder_enabled: bool = False

--- a/scripts/diag/_prod_psql.py
+++ b/scripts/diag/_prod_psql.py
@@ -1,0 +1,66 @@
+"""Read-only helper: run a SQL query (or pg_dump) on PROD via SSH + docker exec.
+
+Secrets come from PROD_SSH_* env vars — never the command line / this file.
+Usage:
+  PROD_SSH_HOST=.. PROD_SSH_USER=.. PROD_SSH_PW=.. \
+    uv run python scripts/diag/_prod_psql.py sql "SELECT count(*) FROM heart.facts;"
+  ... uv run python scripts/diag/_prod_psql.py dump  > prod_dump.sql
+"""
+import os
+import sys
+
+import paramiko
+
+host = os.environ["PROD_SSH_HOST"]
+user = os.environ["PROD_SSH_USER"]
+pw = os.environ["PROD_SSH_PW"]
+port = int(os.environ.get("PROD_SSH_PORT", "22"))
+container = os.environ.get("PROD_PG_CONTAINER", "nous-postgres")
+db = os.environ.get("PROD_PG_DB", "nous")
+
+cli = paramiko.SSHClient()
+cli.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+cli.connect(host, port=port, username=user, password=pw, timeout=30)
+
+
+def run(cmd: str, want_bytes: bool = False):
+    _i, o, e = cli.exec_command(cmd, timeout=600)
+    out = o.read()
+    err = e.read().decode("utf-8", "replace")
+    if err.strip():
+        sys.stderr.write("[prod stderr] " + err + "\n")
+    return out if want_bytes else out.decode("utf-8", "replace")
+
+
+mode = sys.argv[1]
+
+if mode == "sql":
+    sql = sys.argv[2].replace('"', '\\"')
+    print(run(f'docker exec {container} psql -U nous -d {db} -tAc "{sql}"'))
+
+elif mode == "schema":
+    cmd = (
+        f"docker exec {container} pg_dump -U nous -d {db} --schema-only --no-owner "
+        f"--no-privileges"
+    )
+    data = run(cmd, want_bytes=True)
+    sys.stdout.buffer.write(data)
+    sys.stderr.write(f"[schema] {len(data)} bytes\n")
+
+elif mode == "dump":
+    # Data-only dump of the memory + graph tables (prod is single-agent nous-default).
+    tables = " ".join(
+        f"-t {t}" for t in [
+            "brain.decisions", "heart.facts", "heart.episodes",
+            "heart.procedures", "heart.censors", "brain.graph_edges",
+        ]
+    )
+    cmd = (
+        f"docker exec {container} pg_dump -U nous -d {db} --data-only --no-owner "
+        f"--no-privileges {tables}"
+    )
+    data = run(cmd, want_bytes=True)
+    sys.stdout.buffer.write(data)
+    sys.stderr.write(f"[dump] {len(data)} bytes\n")
+
+cli.close()

--- a/scripts/diag/ab_section14.py
+++ b/scripts/diag/ab_section14.py
@@ -1,0 +1,145 @@
+"""§14 A/B in the eval environment: graph-primary (K-line) procedure selection vs the
+OLD embedding-cosine selection (Track B), both scored by an LLM relevance judge, on the
+fresh post-dedup prod snapshot (nous_eval_prod @ 5433, agent nous-default).
+
+Answers the advisor's open question: are §14's graph picks actually RELEVANT (so
+preloading their bodies is worth the tokens) and do they beat the cosine baseline?
+
+Run: uv run python scripts/diag/ab_section14.py
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+import httpx
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+SNAP = Path(".env.prod-snapshot")
+for raw in SNAP.read_text(encoding="utf-8").splitlines():
+    line = raw.strip()
+    if not line or line.startswith("#") or "=" not in line:
+        continue
+    k, v = line.split("=", 1)
+    os.environ[k.strip()] = v.strip().strip('"').strip("'")
+os.environ.update({
+    "DB_HOST": "127.0.0.1", "DB_PORT": "5433", "DB_NAME": "nous_eval_prod",
+    "DB_USER": "nous", "DB_PASSWORD": "nous_eval", "NOUS_AGENT_ID": "nous-default",
+    "NOUS_MCP_ENABLED": "false", "NOUS_HEARTBEAT_ENABLED": "false",
+    "NOUS_SCHEDULE_ENABLED": "false", "NOUS_EVENT_BUS_ENABLED": "false",
+})
+
+from nous.config import Settings  # noqa: E402
+from nous.storage.database import Database  # noqa: E402
+from nous.brain.embeddings import EmbeddingProvider  # noqa: E402
+from nous.brain.brain import Brain  # noqa: E402
+from nous.heart.heart import Heart  # noqa: E402
+from nous.cognitive.context import ContextEngine  # noqa: E402
+
+QUERIES = [
+    "how do I deploy nous to production",
+    "run the retrieval evaluation harness",
+    "send an email to a user",
+    "investigate a production incident",
+    "what did we decide about cross-encoder reranking",
+    "consolidate duplicate procedures",
+    "create a heartbeat check",
+    "backfill graph edges during sleep",
+    "conduct deep multi-source research",
+    "fix a failing test in the retrieval pipeline",
+    "review a pull request before merge",
+    "debug a stuck DAG orchestration run",
+    "write a feature spec and get it reviewed",
+    "summarize recent work and episodes",
+]
+
+
+async def judge(q: str, graph_name: str, graph_desc: str, cos_name: str, cos_desc: str, key: str) -> dict:
+    """OpenAI relevance judge: rate each surfaced procedure 0-2 for the task."""
+    prompt = (
+        f"Task/query: {q!r}\n\n"
+        f"Procedure A (graph): {graph_name!r} — {graph_desc[:200]!r}\n"
+        f"Procedure B (cosine): {cos_name!r} — {cos_desc[:200]!r}\n\n"
+        "For each, rate relevance to the task: 0=irrelevant, 1=loosely related, "
+        "2=directly the right procedure. If a procedure is empty/'none', score 0. "
+        'Reply ONLY JSON: {"a":<0-2>,"b":<0-2>}'
+    )
+    async with httpx.AsyncClient(timeout=30) as c:
+        r = await c.post(
+            "https://api.openai.com/v1/chat/completions",
+            headers={"Authorization": f"Bearer {key}"},
+            json={"model": "gpt-4o-mini", "temperature": 0,
+                  "messages": [{"role": "user", "content": prompt}],
+                  "response_format": {"type": "json_object"}},
+        )
+    try:
+        return json.loads(r.json()["choices"][0]["message"]["content"])
+    except Exception:
+        return {"a": 0, "b": 0}
+
+
+async def main() -> None:
+    s = Settings()
+    db = Database(s)
+    await db.connect()
+    emb = EmbeddingProvider(api_key=s.openai_api_key, model=s.embedding_model,
+                            dimensions=getattr(s, "embedding_dimensions", 1536))
+    brain = Brain(db, s, emb)
+    heart = Heart(db, s, emb, owns_embeddings=False)
+    engine = ContextEngine(brain, heart, s, identity_prompt="You are Nous.")
+
+    print(f"A/B  graph-primary (§14) vs embedding-cosine (old Track B) — judged relevance\n"
+          f"agent={s.agent_id} model={s.embedding_model}\n" + "=" * 78)
+
+    g_scores, c_scores = [], []
+    g_hits = c_hits = both_rel = body_chars_tot = 0
+    async with db.session() as sess:
+        for q in QUERIES:
+            facts = await heart.search_facts(q, limit=12, session=sess)
+            decs = await brain.query(q, limit=6)
+            rid = {"fact": [str(f.id) for f in facts], "decision": [str(d.id) for d in decs]}
+            smap = {str(x.id): (getattr(x, "score", 0.0) or 0.0) for x in list(facts) + list(decs)}
+            gsel = await engine._select_procedures(
+                slots=3, critic_skills=[], recalled_ids=rid,
+                recalled_score_map=smap, session=sess, query=q)
+            csel = await heart.search_procedures(q, limit=3, session=sess)
+
+            g0 = gsel[0] if gsel else None
+            c0 = csel[0] if csel else None
+            gname = g0.name if g0 else "none"
+            gdesc = (getattr(g0, "description", "") or "") if g0 else ""
+            cname = c0.name if c0 else "none"
+            cdesc = (getattr(c0, "description", "") or "") if c0 else ""
+            v = await judge(q, gname, gdesc, cname, cdesc, s.openai_api_key)
+            ga, cb = int(v.get("a", 0)), int(v.get("b", 0))
+            g_scores.append(ga); c_scores.append(cb)
+            if g0:
+                g_hits += 1
+                body_chars_tot += len("\n".join(engine._format_procedure_bodies(gsel, 1200)))
+            if c0:
+                c_hits += 1
+            if ga >= 1 and cb >= 1:
+                both_rel += 1
+            print(f"  {q[:38]:40s} graph={gname[:22]:24s}({ga})  cosine={cname[:22]:24s}({cb})")
+
+    n = len(QUERIES)
+    print("=" * 78)
+    print(f"  GRAPH (§14):  hit {g_hits}/{n}  mean-relevance {sum(g_scores)/n:.2f}/2  "
+          f">=1 relevant: {sum(1 for x in g_scores if x>=1)}/{n}  "
+          f"direct(2): {sum(1 for x in g_scores if x==2)}/{n}")
+    print(f"  COSINE (old): hit {c_hits}/{n}  mean-relevance {sum(c_scores)/n:.2f}/2  "
+          f">=1 relevant: {sum(1 for x in c_scores if x>=1)}/{n}  "
+          f"direct(2): {sum(1 for x in c_scores if x==2)}/{n}")
+    print(f"  body-preload token cost: ~{body_chars_tot//4} tok over {g_hits} hits "
+          f"(~{(body_chars_tot//4)//max(1,g_hits)} tok/hit) vs a name-pointer (~10 tok)")
+    print(f"\n  Read: §14 graph picks judged {'>=' if sum(g_scores)>=sum(c_scores) else '<'} "
+          f"cosine baseline. Graph fires less often (sparse edges) but when it does the pick "
+          f"is the K-line-associated skill; cosine always returns its nearest-by-text proc.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/diag/validate_f080.py
+++ b/scripts/diag/validate_f080.py
@@ -1,0 +1,185 @@
+"""F080 + §14 validation against the fresh prod snapshot (nous_eval_prod @ 5433).
+
+Exercises the REAL code paths (run_recall_pipeline, ContextEngine._select_procedures)
+against agent nous-default's post-dedup data + real graph, and prints the metrics the
+turn-on decision needs:
+
+  Part A (F080 coherent ranking): does recall_deep exclude censors+procedures when ON,
+    keep them when OFF, and does excluding them surface MORE knowledge in the top-K?
+  Part B (§14 graph-primary): structural coverage, realistic graph hit-rate over real
+    queries, body-preload sample, and the active-filter (no archived skill resurfaces).
+
+Run: uv run python scripts/diag/validate_f080.py
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from collections import Counter
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+# --- env: prod flags/keys, but point at the eval snapshot DB + nous-default ---
+SNAP = Path(".env.prod-snapshot")
+for raw in SNAP.read_text(encoding="utf-8").splitlines():
+    line = raw.strip()
+    if not line or line.startswith("#") or "=" not in line:
+        continue
+    k, v = line.split("=", 1)
+    v = v.strip().strip('"').strip("'")
+    os.environ[k.strip()] = v
+os.environ.update({
+    "DB_HOST": "127.0.0.1", "DB_PORT": "5433", "DB_NAME": "nous_eval_prod",
+    "DB_USER": "nous", "DB_PASSWORD": "nous_eval", "NOUS_AGENT_ID": "nous-default",
+    "NOUS_MCP_ENABLED": "false", "NOUS_HEARTBEAT_ENABLED": "false",
+    "NOUS_SCHEDULE_ENABLED": "false", "NOUS_EVENT_BUS_ENABLED": "false",
+})
+
+from nous.config import Settings  # noqa: E402
+from nous.storage.database import Database  # noqa: E402
+from nous.brain.embeddings import EmbeddingProvider  # noqa: E402
+from nous.brain.brain import Brain  # noqa: E402
+from nous.heart.heart import Heart  # noqa: E402
+from nous.cognitive.context import ContextEngine  # noqa: E402
+from nous.api.retrieval_pipeline import run_recall_pipeline  # noqa: E402
+
+QUERIES = [
+    "how do I deploy nous to production",
+    "run the retrieval evaluation harness",
+    "send an email to a user",
+    "investigate a production incident",
+    "what did we decide about cross-encoder reranking",
+    "consolidate duplicate procedures",
+    "create a heartbeat check",
+    "backfill graph edges during sleep",
+    "conduct deep multi-source research",
+    "fix a failing test in the retrieval pipeline",
+    "review a pull request before merge",
+    "summarize recent work and episodes",
+]
+
+
+async def main() -> None:
+    s = Settings()
+    db = Database(s)
+    await db.connect()
+    emb = EmbeddingProvider(
+        api_key=s.openai_api_key, model=s.embedding_model,
+        dimensions=getattr(s, "embedding_dimensions", 1536),
+    )
+    brain = Brain(db, s, emb)
+    heart = Heart(db, s, emb, owns_embeddings=False)
+    engine = ContextEngine(brain, heart, s, identity_prompt="You are Nous.")
+
+    s_off = s.model_copy(update={"coherent_ranking_enabled": False})
+    s_on = s.model_copy(update={"coherent_ranking_enabled": True})
+
+    print(f"model={s.embedding_model} dims={getattr(s,'embedding_dimensions',1536)} "
+          f"agent={s.agent_id} db={s.db_name}\n")
+
+    # ---------------- Part A: F080 coherent ranking ----------------
+    print("=" * 70)
+    print("PART A — F080 coherent ranking (recall_deep type composition, top-10)")
+    print("=" * 70)
+    off_types_tot, on_types_tot = Counter(), Counter()
+    a_violation = 0
+    for q in QUERIES:
+        roff, _ = await run_recall_pipeline(query=q, heart=heart, brain=brain,
+                                            settings=s_off, limit=10, memory_types=["all"])
+        ron, _ = await run_recall_pipeline(query=q, heart=heart, brain=brain,
+                                           settings=s_on, limit=10, memory_types=["all"])
+        coff = Counter(r.type for r in roff[:10])
+        con = Counter(r.type for r in ron[:10])
+        off_types_tot.update(coff)
+        on_types_tot.update(con)
+        bad = con.get("censor", 0) + con.get("procedure", 0)
+        if bad:
+            a_violation += 1
+        print(f"  q={q[:42]:44s} OFF={dict(coff)}  ON={dict(con)}")
+    print(f"\n  AGGREGATE top-10 types  OFF: {dict(off_types_tot)}")
+    print(f"  AGGREGATE top-10 types  ON : {dict(on_types_tot)}")
+    print(f"  ON censor/procedure leak: {a_violation}/{len(QUERIES)} queries  "
+          f"(must be 0)")
+    print(f"  knowledge (fact+episode+decision+chunk) in top-10  "
+          f"OFF={sum(off_types_tot[t] for t in ('fact','episode','decision','chunk'))}  "
+          f"ON={sum(on_types_tot[t] for t in ('fact','episode','decision','chunk'))}")
+
+    # ---------------- Part B: §14 graph-primary ----------------
+    print("\n" + "=" * 70)
+    print("PART B — §14 graph-primary procedure selection")
+    print("=" * 70)
+    async with db.session() as sess:
+        from sqlalchemy import text
+        cov = (await sess.execute(text("""
+            SELECT
+              (SELECT count(DISTINCT seed) FROM (
+                  SELECT source_id seed FROM brain.graph_edges e JOIN heart.procedures p
+                    ON p.id=e.target_id AND p.active WHERE e.source_type='fact' AND e.target_type='procedure' AND e.agent_id='nous-default'
+                  UNION SELECT target_id FROM brain.graph_edges e JOIN heart.procedures p
+                    ON p.id=e.source_id AND p.active WHERE e.target_type='fact' AND e.source_type='procedure' AND e.agent_id='nous-default'
+              ) x) facts_linked,
+              (SELECT count(*) FROM heart.facts WHERE agent_id='nous-default') facts_total,
+              (SELECT count(*) FROM heart.procedures WHERE agent_id='nous-default' AND NOT active
+                 AND id IN (SELECT source_id FROM brain.graph_edges UNION SELECT target_id FROM brain.graph_edges)) archived_with_edges
+        """))).first()
+    print(f"  structural coverage: {cov.facts_linked}/{cov.facts_total} facts link to an "
+          f"ACTIVE procedure ({100*cov.facts_linked/max(1,cov.facts_total):.1f}%)")
+    print(f"  archived procedures that still carry graph edges (resurrection risk): "
+          f"{cov.archived_with_edges}")
+
+    hits = 0
+    n_sel_tot = 0
+    samples = []
+    archived_leak = 0
+    async with db.session() as sess:
+        # ids of archived (inactive) procedures — for the active-filter assertion
+        from sqlalchemy import text
+        archived_ids = {
+            str(r[0]) for r in (await sess.execute(text(
+                "SELECT id FROM heart.procedures WHERE agent_id='nous-default' AND NOT active"
+            ))).all()
+        }
+        for q in QUERIES:
+            facts = await heart.search_facts(q, limit=12, session=sess)
+            decs = await brain.query(q, limit=6)
+            rid = {"fact": [str(f.id) for f in facts], "decision": [str(d.id) for d in decs]}
+            smap = {}
+            for f in facts:
+                smap[str(f.id)] = getattr(f, "score", 0.0) or 0.0
+            for d in decs:
+                smap[str(d.id)] = getattr(d, "score", 0.0) or 0.0
+            selected = await engine._select_procedures(
+                slots=5, critic_skills=[], recalled_ids=rid,
+                recalled_score_map=smap, session=sess,
+            )
+            if selected:
+                hits += 1
+                n_sel_tot += len(selected)
+            for p in selected:
+                if str(p.id) in archived_ids:
+                    archived_leak += 1
+                if not p.active:
+                    archived_leak += 1
+            if selected and len(samples) < 3:
+                blocks = engine._format_procedure_bodies(selected, 240)
+                samples.append((q, [p.name for p in selected], blocks[0] if blocks else ""))
+            print(f"  q={q[:42]:44s} graph-selected: "
+                  f"{[p.name for p in selected] or '—'}")
+
+    print(f"\n  GRAPH HIT-RATE: {hits}/{len(QUERIES)} queries activated >=1 procedure "
+          f"({100*hits/len(QUERIES):.0f}%)  avg/hit={n_sel_tot/max(1,hits):.1f}")
+    print(f"  active-filter: archived/inactive procedures selected = {archived_leak} "
+          f"(must be 0)")
+    print("\n  --- sample preloaded body (truncated 240) ---")
+    for q, names, body in samples:
+        print(f"  [{q[:40]}] -> {names}")
+        print("    " + body.replace("\n", "\n    ")[:300])
+        print()
+
+    await db.disconnect() if hasattr(db, "disconnect") else None
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_context_dual_track.py
+++ b/tests/test_context_dual_track.py
@@ -204,6 +204,48 @@ class TestGraphPrimarySelection:
         assert "Recommended Procedures" not in result.system_prompt
         heart.get_procedure_by_name.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_cosine_fallback_fills_when_graph_and_critic_empty(self):
+        """§14 ladder: graph misses + no critic -> cosine (embedding) fills the slot
+        with the query-relevant procedure (the A/B showed cosine carries coverage)."""
+        proc = _make_procedure_detail("cosine-skill")
+        settings = Settings(_env_file=None, proc_selection_graph_primary=True)
+        brain = MagicMock()
+        brain.neighbors = AsyncMock(return_value=[])  # graph misses
+        heart = MagicMock()
+        heart.get_procedure = AsyncMock(return_value=proc)
+        heart.get_procedure_by_name = AsyncMock()
+        heart.search_procedures = AsyncMock(return_value=[
+            _make_procedure_summary("cosine-skill").model_copy(update={"id": proc.id})
+        ])
+        engine = ContextEngine(brain, heart, settings, identity_prompt="Test")
+
+        selected = await engine._select_procedures(
+            slots=3, critic_skills=[], recalled_ids={"fact": [str(uuid4())]},
+            recalled_score_map={}, session=None, query="how do I do the thing",
+        )
+        assert [p.id for p in selected] == [proc.id]
+        heart.search_procedures.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cosine_fallback_skipped_without_query(self):
+        """No query -> no cosine leg (back-compat: callers that don't pass a query)."""
+        settings = Settings(_env_file=None, proc_selection_graph_primary=True)
+        brain = MagicMock()
+        brain.neighbors = AsyncMock(return_value=[])
+        heart = MagicMock()
+        heart.get_procedure = AsyncMock()
+        heart.get_procedure_by_name = AsyncMock()
+        heart.search_procedures = AsyncMock(return_value=[])
+        engine = ContextEngine(brain, heart, settings, identity_prompt="Test")
+
+        selected = await engine._select_procedures(
+            slots=3, critic_skills=[], recalled_ids={"fact": [str(uuid4())]},
+            recalled_score_map={}, session=None,  # query="" default
+        )
+        assert selected == []
+        heart.search_procedures.assert_not_called()
+
 
 class TestDualTrackDisabled:
     """Tests when critic_skill_injection=disabled (default)."""
@@ -213,6 +255,7 @@ class TestDualTrackDisabled:
         """When disabled, critic_skills param is ignored -- pure embedding path."""
         settings = Settings(
             _env_file=None,
+            proc_selection_graph_primary=False,  # these test the legacy passive path
             critic_skill_injection="disabled",
             relevance_floor_enabled=False,
         )
@@ -245,6 +288,7 @@ class TestDualTrackDisabled:
         """When critic_skills is None, pure embedding path."""
         settings = Settings(
             _env_file=None,
+            proc_selection_graph_primary=False,  # these test the legacy passive path
             critic_skill_injection="enabled",
             relevance_floor_enabled=False,
         )
@@ -300,6 +344,7 @@ class TestDualTrackEnabled:
     def _setup_engine(self, heart, mode="enabled"):
         settings = Settings(
             _env_file=None,
+            proc_selection_graph_primary=False,  # these test the legacy passive path
             critic_skill_injection=mode,
             critic_skill_slots=2,
             embedding_skill_slots=3,
@@ -438,6 +483,7 @@ class TestDualTrackLogOnly:
 
         settings = Settings(
             _env_file=None,
+            proc_selection_graph_primary=False,  # these test the legacy passive path
             critic_skill_injection="log_only",
             relevance_floor_enabled=False,
         )
@@ -468,7 +514,10 @@ class TestBuildBackwardCompat:
     @pytest.mark.asyncio
     async def test_build_without_critic_skills(self):
         """build() works without critic_skills parameter (backward compat)."""
-        settings = Settings(_env_file=None, relevance_floor_enabled=False)
+        settings = Settings(
+            _env_file=None, relevance_floor_enabled=False,
+            proc_selection_graph_primary=False,  # tests the legacy passive path
+        )
         brain = MagicMock()
         brain.embeddings = None
         brain.query = AsyncMock(return_value=[])

--- a/tests/test_f079_pull_delivery.py
+++ b/tests/test_f079_pull_delivery.py
@@ -46,6 +46,9 @@ class TestBuildSurfaces:
                   "list_censors", "list_episodes"):
             setattr(heart, m, AsyncMock(return_value=[]))
         heart.get_procedure_by_name = AsyncMock(return_value=None)
+        # F079 covers the legacy passive catalog/known-procedures delivery; pin
+        # §14 graph-primary OFF (now default-ON) unless a test overrides via **flags.
+        flags.setdefault("proc_selection_graph_primary", False)
         settings = Settings(_env_file=None, relevance_floor_enabled=False, **flags)
         brain = MagicMock(); brain.embeddings = None; brain.query = AsyncMock(return_value=[])
         return ContextEngine(brain, heart, settings, identity_prompt="Test")

--- a/tests/test_retrieval_pipeline.py
+++ b/tests/test_retrieval_pipeline.py
@@ -283,6 +283,23 @@ class TestCoherentRanking:
         assert "procedure" in types_arg
         assert stats.coherent_ranking_applied is False
 
+    @pytest.mark.asyncio
+    async def test_explicit_procedure_request_honored_when_enabled(self):
+        # codex P1: coherent ranking excludes procedures/censors only from the
+        # implicit "all" pool; an explicit memory_types=["procedure"] is honored.
+        heart = _make_heart(recall_results=_make_recall_results())
+        brain = _make_brain(
+            neighbors_by_node={}, contradictions=[], decision_results=[],
+        )
+        settings = _make_settings(coherent_ranking_enabled=True)
+
+        await run_recall_pipeline(
+            query="anything", heart=heart, brain=brain, settings=settings,
+            limit=10, memory_types=["procedure"],
+        )
+
+        assert heart.recall.await_args.kwargs["types"] == ["procedure"]
+
 
 class TestRunRecallPipeline:
     @pytest.mark.asyncio

--- a/tests/test_retrieval_pipeline.py
+++ b/tests/test_retrieval_pipeline.py
@@ -293,12 +293,14 @@ class TestCoherentRanking:
         )
         settings = _make_settings(coherent_ranking_enabled=True)
 
-        await run_recall_pipeline(
+        _r, stats = await run_recall_pipeline(
             query="anything", heart=heart, brain=brain, settings=settings,
             limit=10, memory_types=["procedure"],
         )
 
         assert heart.recall.await_args.kwargs["types"] == ["procedure"]
+        # telemetry reflects that the filter did NOT run (explicit, not search_all)
+        assert stats.coherent_ranking_applied is False
 
 
 class TestRunRecallPipeline:


### PR DESCRIPTION
## F080 §14 — cosine selection leg + enable F080 + §14 by default

Follows #491 (knowledge-only recall pool) and #492 (graph-primary selection). Validated end-to-end on a **fresh post-dedup prod snapshot** (`nous_eval_prod`: 2899 facts / 1003 decisions / **55 active procs** / real graph, `text-embedding-3-large`) — the data the procedure dedup produced.

### What the A/B found (and why this PR exists)
A judged A/B (OpenAI relevance judge, 14 real task queries) on the snapshot:

| Selector | Coverage | Mean relevance | 
|---|---|---|
| §14 graph-primary alone | 6/14 (43%) | **0.79/2** |
| embedding-cosine | 14/14 | **1.79/2** |

The procedure graph is too **sparse** (only ~2% of facts link to a procedure) for K-line to carry coverage — graph picks are *precise when they fire* (5/6 direct) but miss 57% of queries. Cosine selection is ~2× more relevant with full coverage.

**Fix:** add a **cosine leg** to the §14 ladder — `graph K-line → critic → cosine`. Post-F080 the cosine leg is **non-redundant** (procedures are excluded from `recall_deep`, so this is the *sole* cosine procedure path — the original "drop Track B" reason is gone). With it, §14 reaches **14/14 coverage at 1.64/2** while graph still adds K-line precision where edges exist (e.g. "consolidate procedures" → graph picked the right skill the cosine pick missed).

### F080 result (the other flag)
0/12 censor+procedure leak; procedures were eating **~40 of 120** top-10 recall slots (the live B2 `>1.0` boost) — excluding them shifts top-10 to knowledge (facts 18→35, episodes 14→31). Clear win on the category argument.

### Enablement
**Both flags now default ON** (`coherent_ranking_enabled`, `proc_selection_graph_primary`) — validated. Legacy passive-path tests pin `proc_selection_graph_primary=False` explicitly. Prod runs older code, so this activates on the next deploy.

### Tests
New cosine-leg unit tests (fill-when-graph-empty, skip-without-query); dual-track + retrieval + f079 suites green (62 passed) after pinning the legacy flag. Adds the prod-snapshot validation + judged-A/B harnesses under `scripts/diag/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
