### PR TITLE
fix(audit): complete Nous code audit + 9 verified P1 fixes (2026-06-09)

### DIFF
--- a/docs/reviews/agent-tools-audit-2026-06-09.md
+++ b/docs/reviews/agent-tools-audit-2026-06-09.md
@@ -1,0 +1,203 @@
+# Agent Tools Subsystem — Code-Only Audit (2026-06-09)
+
+Scope: `nous/api/tools.py`, `builtin_tools.py`, `web_tools.py`, `search_providers.py`,
+`search_router.py`, `email_tools.py`, `telegram_tools.py`, `subtask_tools.py`.
+Reachability verdicts checked against `nous/config.py` defaults and
+`.env.prod-snapshot`. Boundaries (`runner.py`, `rest.py`, `mcp.py`,
+`retrieval_pipeline.py`, `heart/*`, `brain/*`) read only to trace wiring.
+
+---
+
+## (a) How it actually works
+
+**Dispatcher.** `ToolDispatcher` (tools.py:40) holds `name → handler` and
+`name → schema` maps. `register()` clears an F036 per-frame schema cache.
+`dispatch(name, args, session_id)` (tools.py:61) injects an infrastructure
+`_session_id`/`session_id` kwarg for a *hard-coded allowlist* of tool names
+(spawn_task, cache_retrieve, run_python, ingest_document, recall_deep), calls
+`handler(**args)`, and extracts `result["content"][0]["text"]`. Every handler is
+expected to catch its own exceptions and return an MCP dict; the dispatcher's
+outer `except` only catches programming errors and returns `("Tool error: …",
+True)`. `available_tools(frame_id)` filters by `FRAME_TOOLS` (runner.py:92) with
+a `"*"` wildcard for the `task` frame.
+
+**Timeout.** Per-tool timeout (`NOUS_TOOL_TIMEOUT`, prod 2000s) is enforced only
+in the *streaming* path via `_dispatch_with_keepalive` (runner.py:2444, wraps
+`dispatch` in `asyncio.wait_for`). The *non-streaming* `_tool_loop`
+(runner.py:1728) calls `dispatch` directly with no `wait_for` — background
+subtasks/heartbeat are bounded only by their outer subtask `wait_for` and each
+tool's internal timeout.
+
+**Memory tools** (`create_nous_tools`, tools.py:433): record_decision, learn_fact,
+recall_deep (thin wrapper over `run_recall_pipeline` + `_format_pipeline_text`),
+create_censor, recall_recent, learn_skill, get_procedure, recall_hubs,
+ingest_document. **Subtask tools** (`create_subtask_tools`, tools.py:1892):
+spawn_task (with F078 censor gate at creation, F061 hardened inline executor,
+F062 payload schema), schedule_task, list_tasks, cancel_task, spawn_sync.
+**run_python** (tools.py:2918): restricted-`__builtins__` `exec` in a single
+ThreadPoolExecutor thread, memory wrappers scheduled back onto the main loop via
+`run_coroutine_threadsafe`. **builtin_tools**: bash (cwd=workspace, unrestricted
+command), read_file/write_file (`_validate_path` → `is_relative_to(workspace)`).
+**web_tools**: web_search (SearchRouter, always wired in main.py:494) and
+web_fetch (SSRF check + manual redirect re-check). **search_router**: keyword
+classify → Tavily/Brave for factual, Exa/Tavily/Brave for research, availability
+filtered, cascading fallback. **email/telegram**: guarded send_email (allowlist +
+secret scan + rate limit) and send_file (Telegram upload).
+
+---
+
+## (b) Findings register
+
+### P2
+
+**AT-1 — `schedule_task` has no censor gate (the autonomous-exfil path is unguarded).**
+Severity P2 · LIVE (`NOUS_SCHEDULE_ENABLED=true` in prod).
+`tools.py:2268-2346`. `spawn_task` explicitly treats its creation-time
+`heart.check_censors(task)` call as "the ONLY censor enforcement a subtask gets
+(the exfil path)" (tools.py:1986-2034). Scheduled tasks are equally
+non-interactive background executions, but `schedule_task` performs **no**
+censor check at all before `heart.schedules.create(...)`. An `abort`/`refuse`
+censor that would reject a `spawn_task` is silently bypassed by routing the same
+instruction through `schedule_task` (e.g. `every="in 1 minute"`).
+Evidence: no `check_censors` call anywhere in the `schedule_task` body; compare
+to spawn_task's gate. Fix: run the same F078 censor gate (reject on
+abort/refuse, inject steer directives) in `schedule_task` before create, and
+re-evaluate at fire time in the scheduler.
+
+**AT-2 — REFUTED ON VERIFICATION (2026-06-09, main-session re-check). The F067
+summarizer DOES take the same advisory lock.**
+~~Severity P2~~ → downgraded to RESOLVED/NO-ISSUE.
+Original claim: `ingest_document` (`tools.py:1240-1321`) allocates `chunk_index`
+via `MAX()+1` under `pg_advisory_xact_lock("ingest_document:{episode}")` while
+the F067 summarizer writes the same `(episode_id, chunk_index)` space without
+the lock. Verification shows `handlers/episode_summarizer.py:259-292` ("Audit
+E1 (2026-06-09)" comment, shipped in PR #495) acquires the **identical lock
+key** `ingest_document:{episode_id}` and likewise allocates from
+`MAX(chunk_index)+1` with a per-kind existence check for idempotency. The two
+writers serialize correctly at HEAD; no chunk loss path remains.
+
+**AT-3 — `spawn_sync` is omitted from the dispatcher's `_session_id` injection list → `parent_session_id` always lost.**
+Severity P2 · LATENT (`subtask_payload_schema_enabled=false` default and unset in
+prod, so `spawn_sync` is not registered today; becomes LIVE the moment the flag
+flips).
+`tools.py:72-89` (injection allowlist) vs `tools.py:2447-2485` (spawn_sync reads
+`_session_id`). The dispatcher injects `_session_id` only for spawn_task,
+run_python, ingest_document, recall_deep (and `session_id` for cache_retrieve).
+`spawn_sync` declares `_session_id: str | None = None` and forwards it to
+`spawn_task(..., _session_id=_session_id)` specifically to preserve caller
+session linkage (Codex round-14 comment, tools.py:2461-2466), but because
+dispatch never injects it, `spawn_sync` invoked by the model always runs with
+`_session_id=None`. The subtask row gets `parent_session_id=None`, defeating the
+cognitive-layer delivery sweep (`get_undelivered`) the comment is at pains to
+protect. Fix: add `spawn_sync` to the dispatch injection allowlist (or generalize
+the allowlist to any handler that declares a `_session_id` kwarg).
+
+### P3
+
+**AT-4 — `run_python` is not a real sandbox, and a non-terminating script leaks a thread.**
+Severity P3 · LIVE (`programmatic_tools_enabled=true`), but escape is
+non-escalating because every frame exposing `run_python` also exposes `bash`.
+`tools.py:2879-3026`. Restricting `__builtins__` to `SAFE_BUILTINS` does not
+sandbox CPython — attribute traversal (`().__class__.__mro__[1].__subclasses__()`)
+reaches `subprocess.Popen`/`os` without `__import__` or `open`. Treat
+`run_python` as arbitrary code execution (acceptable only because `bash`
+coexists in conversation/question/task/debug frames). Separately, the timeout is
+enforced via `asyncio.wait_for(loop.run_in_executor(...))` and on timeout the
+`finally` calls `executor.shutdown(wait=False, cancel_futures=True)` — which
+**cannot** interrupt a thread already executing `exec`. A `while True: pass`
+returns a timeout error to the model but leaks a live CPU-bound thread for the
+process lifetime. Fix: document the non-sandbox reality; consider a subprocess
+with a hard kill for true isolation, or at least cap concurrent run_python
+threads.
+
+**AT-5 — `web_fetch` SSRF check is TOCTOU / DNS-rebinding-vulnerable.**
+Severity P3 · LATENT.
+`web_tools.py:52-83, 229-263`. `_is_url_safe` resolves the hostname with
+`socket.getaddrinfo` and checks the returned IPs, then `httpx.get(current_url)`
+performs its **own** independent DNS resolution. A hostname that resolves to a
+public IP during the check and a private IP (e.g. `169.254.169.254`) during the
+fetch bypasses the guard. Redirect hops are re-checked the same (vulnerable) way.
+Fix: pin the validated IP into the connection (custom transport / resolver), or
+resolve once and connect by IP with `Host` header.
+
+**AT-6 — `send_file` reads an arbitrary filesystem path and accepts an arbitrary `chat_id`.**
+Severity P3 · LIVE (`NOUS_TELEGRAM_BOT_TOKEN` set in prod); risk bounded by
+Telegram delivery rules.
+`telegram_tools.py:67-145`. No path validation: `file_path` may be any path the
+process can read (e.g. `/app/.env`), and `chat_id` is model-controllable. Unlike
+`send_email` (allowlist-guarded), `send_file` has no recipient guard. Exfil to an
+attacker-controlled chat generally fails (the bot must be a member of the target
+chat), and the default chat is the operator's, so practical risk is modest — but
+arbitrary-file read + upload is an unguarded data-egress channel. Fix:
+`_validate_path` the file against the workspace and/or restrict `chat_id` to the
+configured operator chat.
+
+**AT-7 — `learn_fact`'s `source` parameter is advertised but silently ignored.**
+Severity P3 · LIVE.
+`tools.py:521-560`, schema `tools.py:1435`. The handler signature and JSON schema
+both expose `source` ("Where this fact came from"), but the body hard-codes
+`source="user_direct"` (for the F023/F038 +0.15 admission bonus), discarding the
+caller's value entirely. The schema therefore lies; any provenance the model
+supplies is dropped. (`run_python._learn_fact`, tools.py:2959, also hard-codes
+`user_direct` but doesn't expose the param, so it's only misleading here.) Fix:
+remove `source` from the schema, or honor it while still applying the bonus only
+for genuine direct calls.
+
+**AT-8 — `bash_tool` timeout kills only the shell, orphaning child processes.**
+Severity P3 · LIVE.
+`builtin_tools.py:76-93`. On timeout, `proc.kill()` signals only the immediate
+shell, not its process group. A `bash -c "sleep 999 & …"`-style command leaves
+orphaned children running after the timeout returns. Fix: start the subprocess in
+a new session (`start_new_session=True`) and `os.killpg` on timeout.
+
+**AT-9 — web-search rate limiter is not async-safe and charges quota for failed searches.**
+Severity P3 · LIVE.
+`web_tools.py:86-108, 131-136`. `_rate_limit` is a module-global dict mutated
+without a lock — concurrent `web_search` calls race the read/increment.
+`_check_rate_limit` also increments **before** the provider call, so timed-out or
+all-providers-failed searches still consume a daily slot. Fix: guard with an
+`asyncio.Lock`; only count successful searches (or decrement on failure).
+
+**AT-10 — `NOUS_TOOL_TIMEOUT` is not enforced on the non-streaming dispatch path.**
+Severity P3 · LIVE (fix lives in `runner.py`, a boundary file — recorded here
+because the symptom is per-tool timeout).
+`runner.py:1728` calls `self._dispatcher.dispatch(...)` with no `wait_for`,
+whereas the streaming path (`_dispatch_with_keepalive`, runner.py:2456) wraps it
+in `wait_for(timeout=tool_timeout)`. Background subtasks and heartbeat checks use
+the non-streaming loop, so a tool with no internal timeout (e.g. `recall_deep`
+stalled on a DB lock) is bounded only by the much larger outer subtask timeout
+(prod `NOUS_SUBTASK_MAX_TIMEOUT=5000`), tying up a worker for up to ~83 min. Fix
+(runner owner): wrap the non-streaming dispatch in the same `wait_for`.
+
+---
+
+## (c) Dead-code inventory
+
+- **`_web_search` direct-Brave fallback branch (web_tools.py:156-205).** DEAD in
+  production: `register_web_tools` is always called with a non-None `SearchRouter`
+  (main.py:494), so `_router is not None` is always true and the
+  `if not _settings.brave_search_api_key …` fallback is unreachable. Kept only for
+  the no-router call form, which production never uses.
+- **`_session_id` plumbing in `recall_deep` for F055** is inert unless
+  `NOUS_RESIDUAL_ACTIVATION_ENABLED` AND a `_residual_activator` is wired; prod
+  sets the flag true, so this is LIVE in prod, INERT in the eval harness — not
+  dead, noted for completeness.
+
+## (d) Improvement opportunities / resolved observations
+
+- **`_validate_path` (builtin_tools.py:31-44) correctly uses `is_relative_to` on
+  resolved paths** — the historical `startswith` prefix-collision bug
+  (`/workspace` vs `/workspace-evil`) is already fixed, and `.resolve()` collapses
+  symlinks before the check. No action needed.
+- **`bash` is intentionally unrestricted** (arbitrary command, only cwd pinned to
+  workspace; read_file/write_file are sandboxed but bash is not). By design for an
+  agent, but worth a one-line note that the workspace sandbox is advisory, not a
+  security boundary, once `bash` is in the frame.
+- **Dispatcher `_session_id` injection is an ad-hoc per-name allowlist**
+  (tools.py:73-89). Generalize to "inject for any handler whose signature declares
+  `_session_id`" to prevent recurrence of AT-3 as new session-aware tools are added.
+- **`web_fetch` `max_chars` has no `minimum`** in `_WEB_FETCH_SCHEMA`
+  (web_tools.py:345); a negative value slices `text[:negative]`. Harmless but add
+  `"minimum": 1`.
+- **send_email secret scan does not cover attachment contents** (documented,
+  email_tools.py:116-135) — acceptable given the recipient allowlist, but note it.

--- a/docs/reviews/brain-audit-2026-06-09.md
+++ b/docs/reviews/brain-audit-2026-06-09.md
@@ -1,0 +1,193 @@
+# Brain Organ Deep Audit — 2026-06-09
+
+**Scope:** `nous/brain/*` at HEAD (post PR #495 / F080 §14). Code-only — every claim verified against function bodies. Reachability verdicts checked against both `nous/config.py` defaults and the prod overlay `.env.prod-snapshot`.
+
+**Verdict tags:**
+- **LIVE** — fires under prod config as deployed
+- **LATENT** — only fires if a flag/condition flips
+- **INERT** — computed but has no consumer (or consumer never invokes it)
+- **DEAD** — unreachable code
+
+Prod overlay facts used throughout: `NOUS_CE_BACKFILL_ENABLED=true` (min_content_chars=34), `NOUS_COOCCURRENCE_LINKING_ENABLED=TRUE`, `NOUS_HEART_GRAPH_ALL_TYPES_ENABLED=true`, `NOUS_GRAPH_ADJACENCY_BOOST_ENABLED=true`, `NOUS_GRAPH_NEIGHBOR_SEED_SCORE_ENABLED=true`, `NOUS_GRAPH_HUB_AUTOSURFACE_ENABLED=true`, `NOUS_CROSS_ENCODER_ENABLED=false`, `NOUS_SLEEP_ENABLED=true`, spreading activation left at default `"auto"` (density gate 3.0), `NOUS_CONFIDENCE_CALIBRATION_FACTOR=0.7627`, `graph_inferred_edge_penalty` unset (default 1.0 = no-op).
+
+---
+
+## 1. How the subsystem actually works (from code)
+
+### 1.1 Decision lifecycle (`brain.py`)
+- `record()` → `_record()` (brain.py:331): noise pre-filter (`_is_noise_decision`, hard `ValueError`), quality score (`quality.py` — pure metadata completeness, max 1.0), embedding of `description+context+pattern` via `EmbeddingProvider`, F058 confidence scaling (`confidence = raw * 0.7627`, raw preserved in `confidence_raw`), ORM cascade insert (tags/reasons/bridge), DB audit event row, **in-process bus emit** (`decision_recorded`, brain.py:406-412), then `_auto_link` inside a SAVEPOINT (cosine ≥ `auto_link_threshold` 0.85, max 3 `related_to` decision↔decision edges, lower-UUID-normalized, ON CONFLICT by columns — the historical wrong-constraint-name no-op is fixed at HEAD).
+- `update()` (brain.py:457): rewrites fields, recalibrates confidence, recomputes quality, **re-embeds**, re-extracts bridge. Does **not** re-run auto-link or touch existing edges.
+- `delete()` (brain.py:565): NULLs heart FK references, explicitly deletes `brain.graph_edges` rows for the decision (audit D1 fix, migration 060 companion), then deletes the row. Not agent-scoped.
+- `review()` sets outcome/reviewed_at; consumed by `CalibrationEngine.compute()` (SQL-only Brier/accuracy/per-category/per-reason) which is served live via `/calibration` and `/status`. `generate_calibration_snapshot()` would persist a `CalibrationSnapshot` — **no caller exists anywhere** (see BR-20).
+- `query()` (brain.py:677): hybrid search — pgvector cosine leg + `ts_rank_cd` keyword leg fused by `_rrf_merge` (normalized to [0,1] by the 1/k theoretical max), abandoned decisions (`failure` + conf 0.0) excluded, optional `bridge_side` ILIKE join.
+- `check()` delegates to `GuardrailEngine` (CEL via celpy in a 2-worker thread pool, 0.1s timeout, fail-closed for block/absolute). **Zero runtime callers** (see BR-7).
+
+### 1.2 Graph writers
+Five writer families, all into `brain.graph_edges` (UNIQUE `(source_id, target_id, relation)`, polymorphic types, `extraction_method` provenance via `edge_provenance.classify`):
+1. **`Brain._auto_link`** at record time (decision↔decision `related_to`, inferred tier).
+2. **Event-bus linkers** (`graph_linker.py`): `FactGraphLinker` handler → `link_fact_to_decisions` (common-template re-embed, `evidence_for`) + `link_fact_to_facts` (`related_to`); `DecisionGraphLinker` handler → reverse fact→decision / episode→decision on `decision_recorded`; `link_episode_deterministic` (structural `discussed_in` / `extracted_from`) from episode summarizer / sleep.
+3. **Sleep densifier** (`graph_densifier.py`): `run_backfill_cycle()` from `sleep_handler` — orphan backfill per entity type (facts/decisions/episodes/procedures: hybrid-search candidates → optional F043 CE rerank (`backfill_rerank.py`) → cosine threshold gate (`_get_threshold` routes to relaxed CE-mode thresholds whenever `ce_backfill_enabled` is set) → `GraphLinker.create_edge` with relation-weight multipliers); F070 chunk backfill (structural `part_of`, same-episode `summarized_by`, intra-episode chunk adjacency); F075 `happened_before` SQL chain; F076 co-mention (deterministic entity extraction in `entity_extraction.py`, no cosine gate, own provenance tier); Gap-1 co-occurrence (shared `source_episode_id`, `co_occurred`, weight 0.9). `discover_clusters()` bridges disconnected components weekly (in-memory rate limit).
+4. **F070.1 cross-episode chunk methods** — defined but only invoked by `scripts/backfill_f070_chunks.py`, never from the sleep cycle (see BR-8).
+5. **Heart-side writers** (facts.py contradiction path — out of scope).
+
+### 1.3 Graph readers
+- `Brain.neighbors()` (brain.py:1179): union of both edge directions, SQL window-function dedup (max-weight edge per neighbor, non-inferred tie-break), optional `neighbor_type` pushdown, per-type content resolution (decision/fact/episode/chunk/procedure). Procedures filtered to `active=true` (F080); **facts/episodes/chunks are not active-filtered** (BR-1). Consumed by `retrieval_pipeline` Stage 2 (decision expansion), Stage 2b Path A (prod-ON), and `cognitive/context.py`.
+- `spreading_activation.py`: density (`edges/unique-nodes`, excludes `co_mention` only) gates a recursive CTE (depth ≤ 2, decay 0.5, excludes `contradicts` + `co_mention`). Consumer (`retrieval_pipeline.py:602-634`) wraps results in `NeighborResult` with **placeholder descriptions** (BR-6).
+- `top_hubs()` (brain.py:1441): undirected degree ranking + provenance breakdown; consumed by the `recall_hubs` tool and the F065 hub autosurface in `cognitive/layer.py` (prod-ON) with `hub_snapshots.py` for rank-shift detection.
+
+### 1.4 Embeddings
+`EmbeddingProvider` (embeddings.py): httpx → OpenAI, 3 retries on 5xx/some network errors, PR #495 LRU cache (model+dims+sha256 key, packed float32, defensive copy on read, batch-aware with misalignment guard). Prod model `text-embedding-3-large` truncated to 1536 dims via the `dimensions` param — consistent with `vector(1536)` columns.
+
+---
+
+## 2. Findings register
+
+### P1
+
+#### BR-1 — `Brain._neighbors` surfaces soft-deleted / superseded facts and episodes as graph neighbors
+- **Severity:** P1 **Reachability:** LIVE
+- **Where:** `nous/brain/brain.py:1316-1342` (fact/episode/chunk resolution blocks)
+- **Description:** F080 added an `active=true` filter for procedure neighbors only (brain.py:1232-1235, 1349-1359). Fact and episode neighbors are resolved with no `active` filter: `select(Fact.id, Fact.content, ...).where(Fact.id.in_(...))` and the episode equivalent. Facts are soft-deleted/superseded by setting `active=false` (+ `superseded_by`); their graph edges remain. Any superseded or soft-deleted fact reachable by an edge re-enters retrieval through: (a) Path A Stage 2b (`heart_graph_all_types_enabled=true` in prod), (b) decision 1-hop expansion (`graph_recall_enabled` default true — `neighbors()` without `neighbor_type` returns fact/episode neighbors of decisions), and (c) `cognitive/context.py:1379`. The supersession machinery (F027, recency resolver) is thereby bypassed: the graph resurrects exactly the stale memory the write path retired. The SQL pushdown rationale that justified the procedure filter (return N *valid* rows before LIMIT) applies identically to facts/episodes.
+- **Evidence:** `Fact.active` and `Episode.active` exist (`storage/models.py:496, 390`); `_ENTITY_CONFIG` itself uses `t.active = true` for orphan selection — read side is the only place the filter is missing.
+- **Fix:** mirror the F080 procedure pattern: pushdown `active=true` subselect filters for fact and episode neighbor types (both pre-LIMIT in the edge query and in content resolution); decide explicitly whether superseded facts should be reachable with a `[superseded]` marker instead of silently.
+
+### P2
+
+#### BR-2 — CE backfill min-score gate compares non-CE scores against the sigmoid floor in every fail-open path; lone cross-type candidates are always dropped
+- **Severity:** P2 **Reachability:** LIVE (`NOUS_CE_BACKFILL_ENABLED=true` in prod, sleep enabled)
+- **Where:** `nous/brain/backfill_rerank.py:187-201`; `nous/heart/reranker.py:97-98` (short-circuits); `nous/brain/graph_densifier.py:379-399` (synthetic 0.0 scores)
+- **Description:** `_backfill_cross_type` feeds candidates in as `(cid, 0.0)` synthetic rows. `cross_encoder_rerank` returns candidates **unchanged** when `len(candidates) <= 1` or on ANY internal exception (model load/predict failure — documented "never raises"). `ce_rerank_backfill_candidates` then walks the head and breaks on the first `score < ce_backfill_min_score` (0.30):
+  - **Lone cross-type candidate:** score stays 0.0 → `0.0 < 0.30` → `kept=[]` → the candidate is unconditionally dropped, zero cross-type edges for that orphan. The docstring claims "the downstream cosine gate is the correctness floor for that case" — it never gets there. Common case: 5-vector + 5-keyword candidates frequently collapse to 1 after the content-map and min-chars (prod 34) filters.
+  - **CE runtime failure (cross-type):** all synthetic-0.0 candidates dropped → cross-type backfill silently produces zero edges while logs show nothing above DEBUG. The upstream fail-open becomes a downstream fail-closed.
+  - **CE runtime failure (same-type):** surviving scores are normalized **RRF rank scores** compared against a **sigmoid-space** floor — the recurring numeric-space-mismatch class; tail candidates (RRF < 0.30) silently pruned with no CE judgment.
+  Once same-type edges exist, the node is no longer an orphan, so the missing cross-type edges are never retried — permanent loss of fact→decision / decision→fact connectivity that prod's Path A consumes.
+- **Fix:** in `ce_rerank_backfill_candidates`, detect the pass-through cases (`len(wrapped) == 1`, or reranker returned with scores untouched) and skip the `min_score` gate (let the cosine gate decide), or give `cross_encoder_rerank` an explicit failure signal instead of "unchanged list".
+
+#### BR-3 — `find_orphans` counts `co_occurred` edges as connectivity, permanently exempting such facts from F040 backfill
+- **Severity:** P2 **Reachability:** LIVE (`NOUS_COOCCURRENCE_LINKING_ENABLED=TRUE` in prod)
+- **Where:** `nous/brain/graph_densifier.py:157-171`
+- **Description:** The orphan probe excludes only `extraction_method IS DISTINCT FROM 'co_mention'`, with an explicit comment explaining why a builder-only edge must not make a node look non-orphan ("counting it here would permanently skip such facts from later backfill cycles"). Gap-1 `co_occurred` edges (extraction_method `'co_occurrence'`) have exactly the same property — they link fact↔fact within one episode and provide none of the cross-type connectivity F040 exists to build — but they are **not** excluded. With co-occurrence ON in prod, every fact that gains a `co_occurred` sibling edge before its first backfill cycle is permanently skipped: no fact↔fact cosine edges, no fact→decision edges, ever.
+- **Fix:** `AND e.extraction_method NOT IN ('co_mention', 'co_occurrence')` (keeping the `IS DISTINCT FROM`-style NULL semantics).
+
+#### BR-4 — `decision_recorded` bus event emitted before commit → reverse graph linker races an uncommitted row and silently no-ops
+- **Severity:** P2 **Reachability:** LIVE
+- **Where:** `nous/brain/brain.py:404-412` (emit), `nous/handlers/decision_graph_linker.py:72-75` (read)
+- **Description:** `_record` emits the bus event right after `flush()`, **before** the surrounding transaction commits. `EventBus.emit` enqueues immediately and the processing loop dispatches concurrently. `DecisionGraphLinker.handle` opens a **new session** and does `await self._brain.get(decision_id)`; if it wins the race against the committing transaction (the window includes `_auto_link`'s vector search + the eager re-fetch + commit — tens of ms of DB roundtrips), `get()` returns None and the handler returns silently. Reverse fact→decision / episode→decision linking is skipped for that decision. This is **not** self-healing: if `_auto_link` created any decision↔decision edge, the decision is not an orphan and the F040 backfill never revisits it.
+- **Fix:** emit the bus event after commit (e.g., from `record()`'s session-None branch post-commit, or a short retry/delay in the handler before giving up).
+
+#### BR-5 — Deliberation decisions are graph-linked on the "Plan: …" stub; `update()` never re-links, leaving edges anchored to discarded text
+- **Severity:** P2 **Reachability:** LIVE (deliberation fires for decision/debug frames)
+- **Where:** `nous/brain/brain.py:414-429` (auto_link at record), `nous/brain/brain.py:457-542` (`_update` — re-embeds, no edge maintenance); producer: `nous/cognitive/deliberation.py:108-125, 171-179`
+- **Description:** `DeliberationEngine.start` records a stub decision (`description="Plan: {task}"`, confidence 0.5). At that moment `_record` runs `_auto_link` (cosine 0.85 against the stub embedding) and emits `decision_recorded`, so `DecisionGraphLinker` also links facts/episodes against the **stub** text. `finalize` later rewrites description/context/pattern and regenerates the embedding via `update()` — which performs **no** edge maintenance: stale-similarity edges persist and no links are computed for the final text. All shared-prefix "Plan: …" stubs systematically inflate pairwise cosine, so auto-link can join unrelated deliberation decisions; the eventual decision content is never what the graph encodes. Decisions recorded via the `record_decision` tool are unaffected.
+- **Fix:** either defer linking until finalize (skip `_auto_link` + bus emit for pre-registered stubs, trigger both from `update()`), or have `_update` drop `auto_linked=true` edges and re-run `_auto_link` when description changes.
+
+#### BR-6 — Spreading-activation results reach recall output as content-free placeholders, with seed echo inflation and no cycle control
+- **Severity:** P2 **Reachability:** LATENT→LIVE (auto-gated: fires whenever non-co_mention graph density ≥ 3.0; prod runs default `"auto"`)
+- **Where:** `nous/brain/spreading_activation.py:97-131`; consumer `nous/api/retrieval_pipeline.py:618-633`
+- **Description:** Three compounding defects on the SA path:
+  1. **Placeholder output:** SA returns `(id, type, activation)` only; the consumer constructs `NeighborResult(description=f"[{ntype}] {str(nid)[:8]}")` and ships it through `_graph_expanded_to_pipeline` into the recall text. When the density gate flips, decision-graph expansion switches from 1-hop neighbors with real descriptions to **id stubs the LLM cannot use** — strictly worse than the fallback it replaces.
+  2. **Echo/cycle re-traversal:** the recursive CTE joins `(e.source_id = a.id OR e.target_id = a.id)` with no visited set — at depth 2 every edge is re-walked back to its origin, so each seed re-activates itself (`SUM` includes the echo) and every neighbor is counted once per path. With dense co_occurred/co_mention-era graphs this both distorts ranking and multiplies row counts (bounded only by `edges^depth`).
+  3. **No active filter:** inactive facts/episodes activate like any node (compare BR-1).
+  Additionally `compute_graph_density` (full `graph_edges` aggregation) runs **per recall_deep call** — the `cached_density` parameter name documents an intent no caller implements.
+- **Fix:** resolve descriptions for activated nodes (reuse `_neighbors`' per-type resolution); add `depth`-indexed visited tracking or at minimum exclude the immediate back-edge; cache density with a TTL.
+
+#### BR-7 — The decision guardrail layer (`Brain.check` / `GuardrailEngine`) has zero runtime callers
+- **Severity:** P2 **Reachability:** INERT (severed wire)
+- **Where:** `nous/brain/brain.py:831-879`, `nous/brain/guardrails.py` (entire module)
+- **Description:** Exhaustive grep over `nous/` finds no call to `brain.check(`, `guardrails.check(`, `GuardrailEngine`, or `validate_expression` outside `nous/brain/`. The deliberation engine mentions guardrails only in a docstring (`deliberation.py:95`); `mcp.py` advertises "thorough analysis with guardrails" in the `nous_decide` description but routes to the normal chat runner. `brain.guardrails` rows (seeded by seed.sql, REST-listed via `/censors`? no — censors are Heart) are never evaluated; `activation_count`/`last_activated` can never change. The architecture docs present guardrails as a live decision gate; at HEAD they gate nothing. Consequence: every guardrail-engine bug below it (BR-15, BR-16) is also inert, and F058's claim that calibrated confidence feeds "all downstream gates (guardrails…)" is vacuous for this gate.
+- **Fix:** either wire `Brain.check` into the deliberation/record path (the original 004.1 design) or delete the engine and its table to stop the architecture from lying.
+
+#### BR-8 — F070.1 cross-episode chunk backfill is not wired into any runtime cycle, while prod env tunes its thresholds
+- **Severity:** P2 **Reachability:** INERT (script-only)
+- **Where:** `nous/brain/graph_densifier.py:972-1037` (`backfill_orphan_chunks_cross_episode`), absent from `run_backfill_cycle` (graph_densifier.py:1069-1167) and from `sleep_handler`
+- **Description:** `run_backfill_cycle` invokes facts/decisions/episodes/procedures/chunks/happened_before/co_mention/co_occurrence — but never the F070.1 cross-episode pass. Its only caller is `scripts/backfill_f070_chunks.py` (one-shot manual). Prod `.env` sets `NOUS_GRAPH_THRESHOLD_CHUNK_CHUNK_CROSS=0.75` and `NOUS_GRAPH_THRESHOLD_CHUNK_FACT_CROSS=0.65`, signalling the operator expects this leg to run continuously; new chunks since the last manual script run accumulate with zero cross-episode edges, starving the F070-series retrieval consumers the prod flags enable.
+- **Fix:** add the cross-episode pass to `run_backfill_cycle` (with the `attempted`/`exclude_ids` loop the method already supports), or document that it is script-only and remove the prod env expectations.
+
+#### BR-9 — `co_occurred` edges are counted by graph density and traversed by spreading activation, unlike sibling `co_mention` edges
+- **Severity:** P2 **Reachability:** LIVE (prod co-occurrence ON; effect conditional on SA flipping)
+- **Where:** `nous/brain/spreading_activation.py:30-47` (density excludes co_mention only), `:114-121` (traversal excludes co_mention only)
+- **Description:** F076 carefully excludes `co_mention` from density and SA traversal so a default-on builder "must not silently push an agent over the threshold and flip decision retrieval before that rollout is intentional." Gap-1 `co_occurred` edges have the identical profile (default-OFF in code but **ON in prod**, weight 0.9, builder-only until consumer flags flip) and are excluded from neither: every co_occurred pair raises density toward the 3.0 auto-trip AND, once SA is on, weight-0.9 co_occurred edges are traversed for decision retrieval. `build_cooccurrence_edges`' own docstring acknowledges "the adjacency/spreading consumers would let [pairs] reinforce each other." The two sibling builders have contradictory exposure discipline with no recorded rationale.
+- **Fix:** extend both `IS DISTINCT FROM 'co_mention'` filters to also exclude `'co_occurrence'` (matching BR-3's fix), or record a decision that co_occurred is an intentional SA participant.
+
+### P3
+
+#### BR-10 — `_get_relation` emits semantically inverted relations for reversed type pairs
+- **P3, LIVE.** `nous/brain/graph_densifier.py:94-97`. The fallback `_RELATION_MAP.get((target, source))` reuses the forward relation for a reversed edge: episode-orphan→fact gets `extracted_from` ("episode extracted_from fact"), decision-orphan→fact gets `evidence_for` ("decision is evidence for fact"), procedure-orphan→decision gets `informed_by` (inverted). Consumers treat edges undirected so ranking is unaffected, but relation text shown in neighbors/dashboards/LLM context asserts backwards semantics. Fix: swap source/target when the lookup only matches reversed.
+
+#### BR-11 — CE-mode relaxed thresholds keyed on the flag, not on CE actually running
+- **P3, LATENT.** `nous/brain/graph_densifier.py:83-91`. `_get_threshold` routes to relaxed thresholds (e.g. fact-fact 0.55 vs 0.82) whenever `ce_backfill_enabled` is set; `ce_rerank_backfill_candidates` passes candidates through unfiltered when `CROSS_ENCODER_AVAILABLE=False` or `query_text` is empty. A deployment with the flag on but sentence-transformers missing gets relaxed cosine gates with no CE precision pre-filter — the exact combination F045 calibrated against. (Prod currently has the dep installed.) Fix: route on `ce_backfill_enabled and CROSS_ENCODER_AVAILABLE`.
+
+#### BR-12 — Backfill batches run inside one long transaction containing embedding API calls
+- **P3, LIVE.** `nous/brain/graph_densifier.py:453-464` (and siblings). Each `backfill_orphan_*` opens one session for the whole batch (prod caps: 200 facts, 200 episodes) and performs OpenAI embed calls per candidate inside it (`_backfill_cross_type` re-embeds every candidate); commit only at the end. One connection is held for minutes; an uncaught exception mid-batch (e.g. `hybrid_search` failure — not wrapped) loses every edge built that cycle; inserted-row locks are held the whole time. The PR #495 LRU mitigates repeat embeds but not first-pass cost. Fix: commit per-orphan (the methods are already idempotent via ON CONFLICT).
+
+#### BR-13 — `EmbeddingProvider._post_with_retry` retry tuple misses common transient httpx errors
+- **P3, LIVE.** `nous/brain/embeddings.py:135`. Retries catch `(ConnectError, ReadTimeout, WriteTimeout)` — but not `httpx.ConnectTimeout` (a `TimeoutException`, not `ConnectError`), `httpx.ReadError`, `httpx.RemoteProtocolError`, or `httpx.PoolTimeout`. A connect-timeout (the most common transient failure to a saturated endpoint) bypasses retry entirely and propagates after attempt 1, downgrading records to embedding-less and aborting linker runs. Fix: catch `httpx.TransportError`.
+
+#### BR-14 — `Brain._delete` / `_think` are not agent-scoped
+- **P3, LIVE (internal callers only).** `nous/brain/brain.py:565-601, 621-638`. `_delete` runs raw `DELETE FROM brain.decisions WHERE id = :did` plus heart-table NULL-outs and edge deletes with no `agent_id` predicate (contrast `_get_decision_orm`, which is scoped); `_think` inserts a thought for any decision id. Current callers (deliberation, REST detail paths) pass ids obtained from scoped queries, so this is defense-in-depth today — but `delete()` is a public Brain API on a multi-agent-ready schema. Fix: add `AND agent_id = :agent_id` to all four statements.
+
+#### BR-15 — Guardrail CEL evaluation blocks the event loop and can permanently wedge its 2-thread pool
+- **P3, INERT (per BR-7).** `nous/brain/guardrails.py:31-34, 158-168`. `future.result(timeout=0.1)` is a synchronous wait on the event loop (≤100 ms per guardrail, serial). On timeout the future is **not** cancelled — the worker thread keeps running celpy; after two stuck evaluations the pool is exhausted, all later submissions queue, every `result(timeout=0.1)` times out, and every block/absolute guardrail evaluates fail-closed (everything blocked) for the life of the process. Fix (if BR-7 is ever rewired): `loop.run_in_executor` + `asyncio.wait_for`, larger/recycling pool.
+
+#### BR-16 — `_jsonb_to_cel` interpolates DB values into CEL source
+- **P3, INERT.** `nous/brain/guardrails.py:292`. `f"decision.stakes == '{value}'"` — a stakes value containing a quote produces an uncompilable (or attacker-shaped) CEL expression; compile failure then **fail-closes** block-severity guardrails. Input is operator/agent-written JSONB, so impact is breakage rather than injection. Fix: validate against the stakes enum before interpolation.
+
+#### BR-17 — Reversed-direction duplicate edges across writers
+- **P3, LIVE.** `Brain._auto_link` normalizes lower-UUID-as-source (brain.py:1634-1637); `GraphLinker.create_edge` and both densifier paths write orphan→candidate unnormalized; co_mention/co_occurrence canonicalize `a<b`. The UNIQUE constraint is directional, so A→B and B→A `related_to` duplicates between the same pair are possible when different writers touch the same nodes. `_neighbors`' window dedup hides them from that consumer, but degree counts (`top_hubs`, density) and the heart-side adjacency boost count them twice. Fix: normalize direction for all symmetric relations at `create_edge`.
+
+#### BR-18 — `link_fact_to_facts` final gate compares template-vs-raw cosine against a template-calibrated threshold
+- **P3, LIVE.** `nous/brain/graph_linker.py:269-293`. The fact-to-decision path re-embeds candidates with the common template and compares template-vs-template similarity to the threshold; the fact-to-fact path gates on `row.similarity` — the **stored raw embedding** vs the new fact's **template** embedding — against `cross_type_same_threshold` (prod 0.75). The asymmetric `"fact: "` prefix systematically deflates similarity, making the effective threshold stricter than configured and inconsistent with its sibling. Fix: either skip the template for same-type (compare raw-vs-raw) or re-embed candidates like the decision path.
+
+#### BR-19 — Dangling edges for non-decision node deletions; placeholders leak into retrieval
+- **P3, LATENT.** `nous/brain/brain.py:1396-1398`. `_delete` cleanup covers decisions only. Hard deletes elsewhere (F081 procedure dedup hard-deleted 26 rows; PR #495 `--repair-dialogue` re-creates chunks under new UUIDs; episode cascade deletes chunks) strand edges. `_neighbors` then emits `"[chunk] <uuid>"` / `"[fact] <uuid>"` placeholder descriptions (procedures alone are dropped) into Path-A results. Migration 060 cleaned historical strays once; nothing prevents recurrence. Fix: drop the fallback row for fact/episode/chunk too (mirroring the procedure `continue`), and/or a periodic dangling-edge sweep in the sleep cycle.
+
+#### BR-20 — `discover_clusters`: restart-reset rate limit, full-graph load, and unconfigured chunk thresholds
+- **P3, LIVE.** `nous/brain/graph_densifier.py:1456-1596`. (a) The 7-day rate limit lives in `self._last_cluster_discovery` — every process restart re-arms it, so restart-heavy weeks run it per first-sleep. (b) It loads **all** edges into Python for union-find each run (prod graph includes ~37K chunk edges per F070 measurements). (c) Chunk-hub bridges fall through `_get_threshold` to the generic default (0.60 CE-mode) and `("chunk","episode")` bridges get relation `part_of` across unrelated components — structural semantics for a cosine bridge. Fix: persist last-run in DB, cap edge fetch, add chunk keys to the threshold maps.
+
+#### BR-21 — `top_hubs` degree includes co_mention/co_occurred webs and has no deterministic tie-break
+- **P3, LIVE (hub autosurface ON in prod).** `nous/brain/brain.py:1453-1466`. Hub ranking counts every edge — F076 excluded co_mention from *density* but not from *hub degree*, so fan-out-capped-at-20 co-mention webs can dominate the top-10 the autosurface narrates. `ORDER BY degree DESC LIMIT :limit` has no secondary sort: equal-degree nodes at the boundary flap in/out across calls, generating repeating entered/left hub-shift notices (each "left" writes a rank-NULL snapshot, then the node can "enter" again next turn). Fix: `ORDER BY degree DESC, node_id` + decide whether builder-tier edges belong in degree.
+
+#### BR-22 — `fetch_candidate_content` F054 decision guard filters description, not context; absent on the cross-type path
+- **P3, LIVE.** `nous/brain/backfill_rerank.py:96-108` vs docstring (":69-73") claiming `context.strip()` is measured — the content column for decisions is `t.description` (`_entity_config.py:21`), so the guard measures description length. Additionally `_backfill_cross_type` fetches candidate content itself (graph_densifier.py:366-375) without any `min_decision_chars` guard — the F054 fix only protects the same-type path, while the cross-type fact→decision path (F054's stated motivation, the "~5/9 evidence_for NO/WEAK verdicts") relies on the generic `ce_backfill_min_content_chars` (lowered to 34 in prod). Fix: route the cross-type fetch through `fetch_candidate_content(settings=...)`.
+
+#### BR-23 — `Brain.link` validates relation only after the edge is persisted
+- **P3, LATENT (no current callers — see dead-code inventory).** `nous/brain/brain.py:1090-1143`. `_link` inserts + flushes the edge, emits the event, **then** constructs `GraphEdgeInfo` whose `relation: RelationType` Literal excludes `happened_before`/`co_occurred` (valid per the DB CHECK). With a caller-provided session, a pydantic `ValidationError` is raised after the edge exists in the transaction — partial-effect on exception. Fix: validate relation first; add the two newer relations to `RelationType`.
+
+### INFO
+
+- **BR-24 (DEAD wire):** `generate_calibration_snapshot()` (brain.py:996-1031) has no caller anywhere; `brain.calibration_snapshots` is never written and never read (no consumer in rest.py / dashboard_queries.py / handlers). The calibration *report* path is alive (`/calibration`, `/status`); the snapshot/history loop was never closed.
+- **BR-25 (DEAD):** `Brain.link()` public method — no runtime callers (MCP/REST/cognitive all absent).
+- **BR-26 (DEAD settings):** `spreading_activation_alpha/beta/gamma` (config.py:621-623) referenced nowhere outside config.
+- **BR-27 (DEAD branch):** `_backfill_same_type`'s keyword-only weight path (graph_densifier.py:278-280) is unreachable: `find_orphans` default `require_embedding=True` guarantees `orphan_embedding` is non-NULL for every same-type caller.
+- **BR-28 (degenerate scoring):** `edge_confidence` (graph_linker.py:48-63) is only ever called with `shared_tags=0, shared_subject=False, temporal_proximity_days=0.0` (graph_densifier.py:421-426) — the multi-signal score collapses to `0.6*sim + 0.15`, and cross-type edge weights therefore live in a compressed [0.15, 0.75] band vs same-type raw-cosine weights [threshold, 1.0], systematically deprioritizing cross-type edges in weight-ordered consumers (`_neighbors` ORDER BY weight).
+- **BR-29 (INERT by config):** the whole F065 provenance-penalty machinery (`classify`, `extraction_method` threading through `_neighbors`/`NeighborResult`, `_f065_provenance_penalty`) is behaviorally inert in prod: `graph_inferred_edge_penalty` defaults to 1.0 and prod doesn't override. Intended dark launch — flagged so doc-sync doesn't claim it shapes retrieval.
+- **BR-30:** `build_comention_edges`/`build_cooccurrence_edges` report `inserted += len(batch)` / `+= 1` regardless of ON CONFLICT skips — logged/returned counts overstate actual inserts (and cooccurrence's pre-existing-edge probe only sees canonical-direction fact-fact rows of any relation, which is correct, but the counter still counts conflicts).
+- **BR-31:** `EmbeddingProvider` reads `NOUS_EMBEDDING_CACHE_SIZE` straight from `os.environ` rather than `Settings` — works (env-prefixed) but bypasses the config layer every other knob uses.
+- **BR-32:** `_is_noise_decision` rejects any description starting with a quote character (brain.py:311) — legitimate decisions quoting a term ("'Strict mode' adopted for…") are hard-rejected with ValueError.
+- **BR-33:** `hub_snapshots.record_snapshot`/`prune_older_than` swallow exceptions logging at WARN **without** `exc_info` — the failure mode is invisible (same anti-pattern the auto_link fix at brain.py:420-429 documents). `get_latest_top_n` carries unused imports (`desc`, `func`, `_select`) in the outer function.
+- **BR-34:** `FactGraphLinker.handle` logs total linking failure at **DEBUG** (fact_graph_linker.py:79) — a permanently broken event-bus linker is silent in prod logs (INFO level).
+- **BR-35:** `entity_extraction._is_capitalized` treats ALL-CAPS technical tokens as proper nouns — "REST API", "POSTGRES VECTOR" become co-mention entities; acceptable per the precision-first design but worth knowing as the main noise source for BR-21's hub webs.
+
+---
+
+## 3. Dead-code inventory
+
+| Item | Location | Note |
+|---|---|---|
+| `Brain.generate_calibration_snapshot` + `CalibrationSnapshot` table | brain.py:996; models.py:341 | never called / never read (BR-24) |
+| `Brain.link` | brain.py:1072 | no callers; post-insert validation bug (BR-23/25) |
+| `Brain.check` + `GuardrailEngine` (+ `validate_expression`) | brain.py:831; guardrails.py | no callers (BR-7) — functional code, severed wire |
+| `spreading_activation_alpha/beta/gamma` | config.py:621-623 | consumed nowhere (BR-26) |
+| `_backfill_same_type` keyword-only weight branch | graph_densifier.py:278-280 | unreachable (BR-27) |
+| `edge_confidence` parameters `shared_tags`/`shared_subject`/`temporal_proximity_days` | graph_linker.py:48 | only ever called with zeros (BR-28) |
+| `backfill_orphan_chunks_cross_episode` (runtime) | graph_densifier.py:972 | script-only; not in any cycle (BR-8) |
+| `RerankCandidate.content` round-trip via `text_fn` lambda | backfill_rerank.py | fine, but the `i` in `entity_extraction.py:104` enumerate is unused |
+
+## 4. Improvement opportunities
+
+1. **Active-filter as a shared invariant.** Every graph read path (`_neighbors`, spreading activation, top_hubs labels) should consult a single per-type "is alive" predicate — three F080-style point fixes have now each fixed one consumer for one type.
+2. **Edge lifecycle owner.** Writers are spread over 5 families with inconsistent direction normalization, weight spaces (raw cosine vs `edge_confidence` band vs fixed 0.9 vs structural 1.0 vs RRF-proxy), and provenance tags. A single `EdgeWriter` choke point (normalize direction for symmetric relations, validate relation against one enum, enforce weight-space documentation) would eliminate BR-10/17/23/28 as a class.
+3. **Density caching.** `compute_graph_density` per recall call is the most obviously avoidable hot-path cost in the organ; a 5-minute TTL cache (or compute-at-sleep and persist) is a one-liner consumer-side.
+4. **Backfill checkpointing.** Per-orphan commit + per-orphan try/except in `backfill_orphan_*` makes the sleep cycle resilient and shrinks transactions (BR-12) for free, since all writes are already ON CONFLICT-idempotent.
+5. **Fail-open vs fail-closed contract for CE.** `cross_encoder_rerank`'s "return unchanged on error" contract is the root of BR-2; returning an explicit sentinel (or raising into a caller-side fallback) would let every consumer decide its own failure semantics.
+6. **Calibration loop closure.** Either wire `generate_calibration_snapshot` into the sleep cycle (giving the dashboard a history series) or remove it; with `confidence_raw` now persisted, the snapshot is the natural place to re-derive `NOUS_CONFIDENCE_CALIBRATION_FACTOR` periodically instead of a frozen 2026-04 constant.

--- a/docs/reviews/cognitive-layer-audit-2026-06-09.md
+++ b/docs/reviews/cognitive-layer-audit-2026-06-09.md
@@ -1,0 +1,179 @@
+# Cognitive Layer — Deep Code Audit
+
+**Date:** 2026-06-09
+**Scope:** `nous/cognitive/*` (layer, context, critic, monitor, deliberation, intent, dedup, frames, action_gate, execution_ledger, claim_verifier, epistemic, rubric, correlation, usage_tracker, schemas). Runner (`nous/api/runner.py`) read for wiring verification only.
+**Method:** code-only — every claim verified against function bodies at HEAD. No specs/docs consulted for behavior claims.
+**Reachability config:** code defaults (`nous/config.py`) cross-checked against the prod overlay (`.env.prod-snapshot`). Verdicts: **LIVE** (fires under prod config), **LATENT** (flag-gated off or non-default config), **INERT** (computed, no consumer), **DEAD** (no caller).
+
+**Prod overlay facts that shape severity:**
+
+| Setting | Code default | Prod |
+|---|---|---|
+| `NOUS_CACHE_SPLIT_SYSTEM_PROMPT` | `True` (config.py:429) | (default) **true — split path is the live prompt path** |
+| `NOUS_ACTION_GATING_ENABLED` | `True` | **`false` — ActionGate OFF in prod** |
+| `NOUS_CLAIM_VERIFICATION_ENABLED` / `_MODE` | `True` / `enforce` (config.py:723-724) | (default) **enforce — LIVE** |
+| `NOUS_EXECUTION_LEDGER_ENABLED` | `True` | (default) true — LIVE |
+| `NOUS_CRITIC_MODE` | `shadow` (config.py:774) | **`advised`** + `NOUS_CRITIC_SKILL_INJECTION=enabled`, model haiku — critic LIVE per turn |
+| `proc_catalog_enabled` / `proc_selection_graph_primary` | `True` / `True` (config.py:156,173) | (default) — F079 catalog + F080 §14.7 LIVE |
+| `NOUS_EPISTEMIC_GATE_ENABLED` | `False` (config.py:1041) | (unset) — §2 gate LATENT |
+| `NOUS_RECENCY_RESOLVER_ENABLED` | `False` | **`true`** (+ temporal extraction true) — Gap-2 resolver LIVE |
+| `NOUS_GRAPH_HUB_AUTOSURFACE_ENABLED` | `False` (config.py:570) | **`true`** — F065 autosurface LIVE |
+| `NOUS_CONTEXT_BUDGET_OVERRIDES` | `{}` | `{"total":13000,"facts":3000,"decisions":2500,"identity":1200,"user_profile":500}` |
+| `NOUS_RUBRIC_*` | — | covered by `rubric-admission-audit-2026-06-09.md` (verified still live at HEAD, §4 below) |
+
+---
+
+## 1. How it actually works (verified spine)
+
+**pre_turn** (`layer.py:349-941`): track session metadata + transcript → bump `agents.last_active` → initiation check → `FrameEngine.select` (pure pattern match, `frames.py:63-125`) → F024 critic classify (advised mode can override frame, activate skills) → `IntentClassifier.classify/plan_retrieval` (`intent.py`) → `ContextEngine.build` → subtask-result injection → deliberation start (decision/debug frames only, `deliberation.py:25`) → episode warm/create (with 48h cosine dedup) → working-memory focus + load recalled → censor check (abort/refuse/steer, F078) → return `TurnContext`.
+
+**ContextEngine.build** (`context.py:125-997`): assembles ~14 sections (datetime, identity, anti-hallucination, F079 procedure catalog, §2 epistemic, cache hints, user profile, censors, frame, working memory, decisions, facts, §14.7/passive procedures, temporal episodes, semantic episodes). Per-type pipeline: retrieve → recency-resolve (facts) → staleness penalty → frame boost → diversity → conversation dedup → usage boost → relevance filter → collect IDs → format → truncate to per-section budget. Returns both flat `system_prompt` and `sections_by_tier` (F036).
+
+**Runner consumption** (`runner.py:1896-1970`): **when `cache_split_system_prompt` is true and `sections_by_tier` is non-empty (every successful non-initiation build), the flat `turn_context.system_prompt` string is never read** — only the tier dict plus runner extras (frame instructions, diagnostic nudges, ledger section, pending corrections, telegram format) reach the LLM. This is the load-bearing fact behind CL-1/CL-2.
+
+**post_turn** (`layer.py:943-1233`): monitor assess (structural surprise only) → monitor learn (censor auto-create, F012 error→recovery tracking, F039 correction detection) → deliberation finalize-or-delete (informational heuristics) → usage tracking (overlap of recalled content vs response) → procedure reinforcement (activate + outcome per recalled procedure) → output censor log-check → censor compliance log-check → session metadata bump → WM threads → `turn_completed` event → critic diagnostics → queue nudges for next turn.
+
+**end_session** (`layer.py:1703-1827`): end-or-discard episode (trivial filter), extract `learned:` facts from reflection, clear WM, pop per-session dicts, emit `session_ended` (no `summary` key — rubric audit R1 confirmed still true at `layer.py:1805-1812`).
+
+**F026 surfaces:** `ExecutionLedger` is in-memory per session in the runner (`runner.py:170, 2265-2270`), turn set from message count; `ClaimVerifier`/`IntentTracker` run post-response and inject corrections into the next turn's dynamic tier (`runner.py:2272-2334`); `ActionGate` checks each dispatch but is **disabled in prod**.
+
+---
+
+## 2. Findings register
+
+### P1
+
+#### CL-1 — P1 — Subtask results are injected into a discarded string and marked delivered anyway: silent, unrecoverable loss — **LIVE**
+`layer.py:642-672` + `runner.py:1914-1949` + `nous/heart/subtasks.py:295-305`
+Step 3b of pre_turn appends `_format_subtask_results(...)` ONLY to the flat `system_prompt` (`layer.py:663`) and never touches `sections_by_tier`. With `cache_split_system_prompt=true` (code default, not overridden in prod) the runner's split path (`runner.py:1915-1949`) never reads the flat string — so the "Completed/Blocked/Failed Subtask" context never reaches the LLM. Worse, the rows were already marked `delivered=true` at `layer.py:653-655` **before** rendering, so the loss is permanent: `get_undelivered` (`subtasks.py:282-293`) will never return them again. The parent agent (and DAG flows that the F061 docstring says should "react" to `blocked_reason`) silently never sees any subtask outcome. The Telegram notification (`subtask_worker.py:_notify_telegram`) is a separate human-facing channel and does not mitigate the agent-loop loss. The F078 censor-injection block immediately below (`layer.py:874-897`) documents this exact trap ("runner._build_system_prompt ignores the flat string when cache_split_system_prompt is true") and fixed itself — subtask injection was never given the same treatment.
+**Fix:** mirror the censor-injection pattern — append `subtask_context` to `sections_by_tier["dynamic"]` when it's populated; ideally also move `mark_delivered` to after successful injection.
+
+### P2
+
+#### CL-2 — P2 — F065 hub-shift notice suffers the same severed wire AND self-suppresses — **LIVE**
+`layer.py:906-918, 1292-1416` + `runner.py:1915-1949`
+With `NOUS_GRAPH_HUB_AUTOSURFACE_ENABLED=true` in prod, `_compute_hub_shift_notice` runs every pre_turn, but the returned block is appended only to the flat `system_prompt` (`layer.py:912`) — discarded by the split path. Meanwhile the method **persists new snapshots for every entered/left transition** (`layer.py:1382-1414`) precisely so the notice is emitted once. Net effect: the agent never sees a hub-shift notice, and the snapshot writes guarantee each shift is permanently consumed unseen. The feature is paying two SQL queries + snapshot writes per turn for zero delivered output.
+**Fix:** route the block into `sections_by_tier["dynamic"]` (same pattern as censors).
+
+#### CL-3 — P2 — `_apply_usage_boost` sorts by boost factor, not boosted score: usage ratio overrides relevance and breaks downstream gap detection — **LIVE**
+`context.py:1027-1044` + `usage_tracker.py:103-117`
+The method computes `wrapped = score * boost` but then sorts by `x[1]` — the bare boost factor (0.3–2.0, purely the reference-rate, no relevance component). Any item with ≥2 retrievals gets a non-1.0 boost (`usage_tracker.py:113-117`), and since every context-injected item is recorded every turn (`layer.py:1060-1094`), most recalled items acquire stats within two turns. From then on facts/episodes are ordered by historical reference-rate, not by retrieval score. Two consequences: (a) a frequently-referenced but barely-relevant memory outranks the best match; (b) `_apply_relevance_filter` (`context.py:1046-1089`) runs immediately after and its score-gap cut (`score < prev_score * drop_ratio`) assumes a descending-score list — on a boost-ordered list the "gap" is noise, so the filter cuts arbitrarily. Note `apply_frame_boost` (`heart/search.py:494-496`) deliberately sorts by boost with a comment justifying it for *discrete tiers* (1.0/1.3); usage boost is continuous, so the copied pattern becomes a full re-sort by ref-rate.
+**Fix:** sort by the wrapped (boosted) score: `boosted.sort(key=lambda x: getattr(x[0], "score", 0), reverse=True)`.
+
+#### CL-4 — P2 — Claim verification grounds claims on tool *name only*, ignoring status: any `bash` call (even `ls`, even a BLOCKED/failed call) verifies "I pushed/committed/deployed" — **LIVE**
+`claim_verifier.py:88-98` + `execution_ledger.py:140-163`
+`verify()` builds `recent_ledger_tools = {action.tool_name for action in ledger.actions[-10:]}` and passes a claim if the expected tool name appears — with no check of `action.status` (`"error"`, `"timeout"`, and `"blocked"` entries count) and no check of the action's *arguments*. The third pattern maps "I pushed/committed/deployed" → `bash`; since nearly every working session contains a bash call within the last 10 actions, push/commit/deploy claims are effectively never flagged. Similarly "I saved X file" is grounded by any `write_file` of a *different* file, and a gate-blocked `write_file` (status `"blocked"`, recorded at `runner.py:1688`) still grounds the claim it just prevented. Prod runs `claim_verification_mode=enforce`, so this is the live integrity net with a tool-name-sized hole.
+**Fix:** filter ledger lookup to `status == "success"`; for bash claims, require a write-classified or push-classified command (the ledger already stores `key_args["command"]` and `side_effect_type`).
+
+#### CL-5 — P2 — Critic confidence-drift diagnostic can raise `TypeError` inside post_turn; non-streaming path has no guard — **LIVE (conditional)**
+`layer.py:1209-1213, 1221-1227` + `critic.py:377-380` + `runner.py:544`
+post_turn builds tool-history entries with `entry["confidence"] = tr.arguments.get("confidence")` — `None` when a `record_decision` call omits confidence. `_check_confidence_drift` then does `d.get("confidence", 0.5)` — the key **exists** with value `None`, so the default doesn't apply — and evaluates `all(c < 0.4 for c in confidences)` → `TypeError: '<' not supported between 'NoneType' and 'float'` once 3+ record_decision entries are in history and one lacks confidence. `run_diagnostics` is called with no try/except (`layer.py:1221`), and the non-streaming `run_turn` calls post_turn unprotected (`runner.py:544`) — the exception propagates after the response was generated, failing the turn for REST `/chat` callers and marking subtask turns failed. (The streaming path swallows it at `runner.py:1403-1408`.) Critic is LIVE in prod (`critic_enabled=True` default, mode advised).
+**Fix:** `(d.get("confidence") or 0.5)` in `_check_confidence_drift`, or drop `None` confidences at capture time (`layer.py:1212`).
+
+#### CL-6 — P2 — Intent-plan budget overrides silently clobber the operator's env budget overrides — **LIVE**
+`context.py:164-184` + `schemas.py:114-134` + `intent.py:219-228`
+`ContextBudget.for_frame` applies `settings.context_budget_overrides` first, then `retrieval_plan.budget_overrides` are applied **on top** with REPLACE semantics (`context.py:182-183`). `plan_retrieval` unconditionally sets `{"decisions":500,"facts":500,"procedures":0,"episodes":0}` for every conversation-frame turn and `{"decisions":3500,"procedures":2000}` for decision frames (`intent.py:220-228`). Prod explicitly configures `facts=3000, decisions=2500` via `NOUS_CONTEXT_BUDGET_OVERRIDES` — on every conversation-frame turn (the default frame, i.e. the majority) those operator values are silently reverted to 500/500/0/0. The operator knob appears to work (it shows up on task/question frames) but is dead on the most common frame.
+**Fix:** apply env overrides *after* plan overrides, or have `plan_retrieval` scale rather than replace.
+
+#### CL-7 — P2 — Monitor auto-censor creation is structurally near-unreachable: the surprise threshold and the candidate source are mutually exclusive — **LIVE (no-op)**
+`monitor.py:97-116, 148-184` + `runner.py:426-431, 523-531`
+`learn()` creates censors only when `surprise_level > 0.7` AND `censor_candidates` non-empty. But `assess()` sets surprise 0.9 only on a *turn-level* error and 0.3 on tool errors — while candidates are derived exclusively from tool errors. In the non-streaming runner, a turn-level error leaves `tool_results = []` (initialized `runner.py:427`, never assigned on the exception path) → candidates empty. So: tool errors → candidates but surprise 0.3 (no creation); turn error → surprise 0.9 but no candidates. The only window is the streaming path where accumulated `all_tool_results` contain non-transient errors AND the turn itself then errors — a rare corner. The "Learn → create censors from failures" leg of the loop has effectively never fired; the `_error_to_censor_text` machinery (`monitor.py:394-403`) is consumed-but-inert in practice.
+**Fix:** decide the intended trigger — e.g. create censors at `surprise >= 0.3` with the existing per-session cap, or set surprise 0.8 when a non-transient tool error repeats.
+
+#### CL-8 — P2 — Critic skill "activation" in pre_turn + blanket per-turn reinforcement in post_turn double-count and auto-praise procedures — **LIVE**
+`layer.py:507-526` (pre_turn activate) + `layer.py:1096-1114` (post_turn activate **again** + outcome)
+In advised mode every critic-recommended skill is activated in pre_turn; then post_turn loops over **all** `recalled_procedure_ids` (which include those same skills plus §14.7/passive picks) calling `activate_procedure` a second time and `record_procedure_outcome("success"|"failure")` keyed solely on whether the *turn* had any error. Effects: activation counts inflate 2x per turn for critic skills and 1x/turn for every procedure that merely sat in context; effectiveness converges to the global turn-success rate rather than measuring the procedure (the procedure-subsystem audit's "effectiveness→telemetry" finding — this is the code path that does it). With §14.7 LIVE (graph-primary preload, `context.py:635-706`), up to 5 procedures get a success-credit every error-free turn whether or not the agent used them.
+**Fix:** reinforce only procedures whose content overlapped the response (the usage-tracker overlap already computed at `layer.py:1077-1094`), and don't re-activate critic skills in post_turn.
+
+### P3
+
+#### CL-9 — P3 — `budget.total` is never enforced; several sections bypass budgets entirely — **LIVE**
+`context.py:961-974`. The per-section truncations are the only enforcement; `total` is used only for the fill-ratio log line. Datetime, anti-hallucination, procedure catalog (`proc_catalog_max_chars`, default 4000 chars), epistemic routing, cache hints, Recent Conversations, and §14.7 first-body-always-shows (`context.py:683-688`) are all outside any `ContextBudget` field. With prod `total=13000` the real prompt can exceed it; harmless today but the knob misleads.
+
+#### CL-10 — P3 — Execution-ledger turn numbers regress after compaction — **LIVE (display) / LATENT (gate)**
+`runner.py:417, 975` computes `set_turn((len(conversation.messages)+1)//2)`. Compaction replaces history with a summary, shrinking `messages` — the next turn number jumps backward (e.g. 40 → 8) while existing `ExecutedAction.turn` values stay high. Consequences: `_build_section`'s `a.turn >= cutoff_turn` (`execution_ledger.py:235-237`) classifies all pre-compaction actions as "recent" forever (ledger prompt bloat, mitigated only by the token-budget shrink loop), and ActionGate's window check `action.turn > min_turn` (`action_gate.py:166-180`) would treat stale actions as in-window duplicates if the gate were enabled.
+**Fix:** keep a monotonic per-session turn counter instead of deriving from message count.
+
+#### CL-11 — P3 — Recalled IDs are collected before render truncation: items cut by `_truncate_to_budget` are still recorded as "shown" — **LIVE**
+`context.py:608-617` (facts; same shape for decisions 544-556, episodes 939-945). IDs/scores enter `recalled_ids` after the relevance filter but **before** `_truncate_to_budget` cuts the formatted text. A tail item that never reached the prompt is (a) penalized by the usage tracker as retrieved-but-unreferenced (`layer.py:1060-1094`), (b) excluded from `recall_deep` by F071 (`runner.py:499-501` builds the exclusion set from these IDs), and (c) loaded into working memory. The §14.7 procedure path explicitly fixed this ("B-cog-A", `context.py:673-688`); the fact/decision/episode paths still have it. Small budgets (conversation frame facts=500 tokens) make the truncation cut realistic.
+
+#### CL-12 — P3 — Monitor per-session state never cleaned up: `_last_errors`, `_error_recovery_pairs`, `_session_procedure_counts` leak — **LIVE**
+`monitor.py:63-65` vs `layer.py:1788-1801`. `end_session` pops `monitor._session_censor_counts` only. The three F012 dicts grow one entry per session with tool errors and are never removed (session IDs are unique, so this is an unbounded slow leak in a long-lived process, same class as the documented `_active_episodes` P1-8 but without the comment).
+
+#### CL-13 — P3 — Recency resolver can poison the relevance-filter gap cut; resolver also mutates shared Pydantic rows in place — **LIVE**
+`context.py:1248-1293`. `_resolve_recency` down-ranks the older fact (`*0.3`) but leaves it in its original list position; `_apply_relevance_filter` later interprets that in-place score cliff as a diminishing-returns boundary and cuts every fact after it (`context.py:1075-1087`), so one superseded fact can evict unrelated facts ranked below it. Mutating `score`/`recency_status` directly on the shared summary objects is safe only because each build constructs fresh DTOs — worth a comment, since `_ScoredWrapper` (`heart/search.py:441-452`) cannot be attribute-assigned (`__slots__`) and any reordering of the pipeline (resolver after staleness wrap) would crash.
+
+#### CL-14 — P3 — Deliberation quality gate deletes real decisions whose response happens to open with chat prefixes — **LIVE**
+`deliberation.py:33-36, 54-58` + `layer.py:1050-1056`. `finalize()` is called with `description=turn_result.response_text[:500]`; rule 3 rejects any description starting with "sure", "okay", "let me", "i'll", "here's", "done", "got it" — common openers for substantive decision/debug turns. The decision (with its captured thinking-block trace, `layer.py:1024-1038`) is then hard-deleted. The gate evaluates the *response style*, not the decision.
+
+#### CL-15 — P3 — Working-memory load threshold and procedure floor compare rank-encoded RRF scores against fixed thresholds — **LIVE**
+`layer.py:1460-1504` (0.7 floor) and `context.py:794-799` (`procedure_score_floor` 0.40 vs `search_procedures` scores). `hybrid_search` normalizes RRF by the theoretical max (`heart/search.py:171-177`), so a document at rank 0 in both legs scores 1.0 **on any query regardless of closeness** — the 0.7 WM floor therefore admits the top hit of even a hopeless query, and mid-pack genuinely-relevant items (rank 5 ≈ 0.6 at k=30) are excluded. Same threshold-space-vs-rank-space mismatch class as audit S1 / the retrieval whitepaper's central defect, on the pre-turn injection path. (The §14.7 cosine leg already migrated to raw cosine — `context.py:1429-1450` — these two consumers did not.)
+
+#### CL-16 — P3 — `run_python` ledger args contradict the spec comment; unknown-tool fallback captures code bodies — **LIVE (display) / LATENT (gate)**
+`execution_ledger.py:87, 295-307`. `_KEY_ARGS["run_python"] = []` is falsy, so `_summarize_args` falls into the unknown-tool fallback and captures the first 5 args including `code[:80]` — the comment says "spec says skip". Harmless for display; for the (disabled) gate it makes two different run_python calls with the same first-80-chars look identical.
+
+#### CL-17 — P3 — Session restore after process restart loses transcript/significance state: episodes end with empty transcript and trivial-filter misfires — **LIVE (post-restart)**
+`layer.py:1723-1752`. `_session_metadata` is process-memory; after a restart `warm_active_episode` restores the episode ID but `meta` is `None` at end_session → `transcript_text = ""` (no F067 chunking input, no F025 persistence), `is_trivial` is False by construction (meta None) so even a genuinely trivial restored session is kept. Conversations *are* DB-restored (`runner.py:2354-2356`) — the cognitive layer's session state isn't.
+
+#### CL-18 — P3 — Critic `_needs_critic` tail logic is dead: the function unconditionally invokes the critic for any message above the passthrough gate — **LIVE**
+`critic.py:135-143`. After the short-message early-return, both the sentence-endings check and the action-signals check are followed by `return True` anyway — three branches, one outcome. Combined with `critic_max_latency_ms=5000` and prod advised mode, every message longer than 5 words (or ending in "?") pays a synchronous Haiku call serial to the turn. Intent may be "err toward invoking" (docstring) — then the two checks should be deleted.
+
+#### CL-19 — P3 — Frame-selection multi-word patterns substring-match across word boundaries; overridden frames get no usage credit — **LIVE**
+`frames.py:101-103`: `pattern_lower in input_clean` matches "what if" inside "somewhat ifs"-shaped text since the cleaned input is one flat string (single-word patterns got the tokenization fix, multi-word didn't). Also when the critic overrides the frame (`layer.py:472-475`), the heuristic frame's `usage_count` was already incremented in `select()` while the actually-used frame gets none — frame usage telemetry counts the loser.
+
+#### CL-20 — P3 — Intent `topic_keywords` set-ordering makes the retrieval query non-deterministic across processes — **LIVE**
+`intent.py:134-138, 192-194`: `list(set(...))[:10]` order depends on per-process hash randomization; the joined `query_text` (used for embeddings + FTS) differs between runs/replicas for the same input, defeating cross-process reproducibility and the sha256-keyed embedding cache across restarts. `sorted(set(...))` would fix it.
+
+### INFO
+
+- **CL-21 — INFO** — Multi-level usage "strength" computed then discarded: `layer.py:1080-1088` derives 1.0/0.5/0.2 tiers but only `strength > 0` is consumed; `record_retrieval` has no strength parameter. Dead computation.
+- **CL-22 — INFO** — `Assessment.facts_extracted` is always 0 (`monitor.py:146, 246` — never incremented) and `Assessment.episode_recorded` is never set anywhere. Dead DTO fields.
+- **CL-23 — INFO** — Working-memory "Loaded context" items (loaded at ≥0.7 last turn) duplicate the same top facts re-retrieved into "Relevant Facts" this turn; conversation-dedup doesn't compare against the WM section. Token duplication on consecutive same-topic turns (`layer.py:1460-1504` + `context.py:1590-1599`).
+- **CL-24 — INFO** — Critic diagnostic cooldowns are instance-level, not session-scoped (`critic.py:77-80`, documented); `_current_turn` shared across concurrent sessions can suppress/allow nudges cross-session.
+- **CL-25 — INFO** — `pre_turn` topic-prefixed default query uses the *previous* turn's `current_task` (WM focus is updated at step 6, after the build at step 3) — first turn on a new topic retrieves under the old topic prefix (`context.py:519-525`, `layer.py:720-742`).
+- **CL-26 — INFO** — When `_is_duplicate_episode` suppresses creation (`layer.py:704-705`), the session never registers an episode, so every subsequent pre_turn re-runs warm query + embed + cosine search; and the session's facts get no `source_episode_id`.
+- **CL-27 — INFO** — `SessionMetadata.transcript` is unbounded (1000 chars/turn); a 600-turn prod session (`NOUS_MAX_TURNS=600`) holds ~600KB per session until end_session.
+- **CL-28 — INFO** — Streaming post_turn call (`runner.py:1405`) doesn't pass `is_background` — currently harmless because background turns use non-streaming `run_turn`, but the #462 invariant is one call-site change from regressing.
+- **CL-29 — INFO** — `_check_censor_compliance` (`layer.py:166-192`) counts ≥2 five-letter word hits as "compliant" — log-only, very weak signal, frequently false-positive on topic words.
+- **CL-30 — INFO** — `_classify_bash_command` (`execution_ledger.py:350-381`) inspects only the first token: `cat x | sh`, `find -delete`, `sed -i` classify as read-only "none"; chained `ls && rm -rf` is "none". Acceptable-approximate by its own docstring, but note Tier-1 gate auto-approves "none" (`action_gate.py:132-134`) — relevant only if the gate is re-enabled.
+
+---
+
+## 3. Rubric subsystem — status of 2026-06-09 audit findings at HEAD
+
+Verified against current `rubric.py` / `correlation.py` / `layer.py` bodies — **all rubric-side findings R1–R15 remain live as written**; nothing in the cognitive layer changed since the audit:
+- `session_ended` still carries no `summary` key (`layer.py:1805-1812`) → R1 (P1) live.
+- Episode outcome still hardcoded `"success"` (`layer.py:1747-1749`) → R15 live.
+- `rollback`/version-string fragility unchanged (`rubric.py:194-217`) → R7 live; `create_version` read-mark-insert race unchanged (`rubric.py:162-185`) → R8 live.
+- `suggest_weights` post-normalization cap drift unchanged (`correlation.py:157-165`) → R12 live.
+- `RubricManager.load_correction_context` still has zero callers → R6 (dead surface) live.
+No re-discovery performed; see `docs/reviews/rubric-admission-audit-2026-06-09.md` for the full register.
+
+---
+
+## 4. Dead-code inventory (cognitive layer)
+
+| Symbol | Location | Status |
+|---|---|---|
+| `ContextEngine.expand` | context.py:1624-1675 | DEAD — no callers in `nous/` |
+| `ContextEngine.refresh_needed` | context.py:1602-1622 | DEAD — no callers |
+| `ContextEngine._dedup_decisions` | context.py:1677-1709 | DEAD — superseded by `_enforce_diversity`, no callers |
+| `ExecutionLedger.has_blocked_actions_this_turn` | execution_ledger.py:170-176 | DEAD — no callers |
+| `Assessment.facts_extracted` / `episode_recorded` | schemas.py:220-221 | INERT — never set to non-default (CL-22) |
+| `critic._needs_critic` sentence/action checks | critic.py:135-142 | DEAD branches — unconditional `return True` follows (CL-18) |
+| usage "strength" tiers | layer.py:1080-1088 | INERT — computed, not consumed (CL-21) |
+| `monitor._error_to_censor_text` + censor-candidate pipeline | monitor.py:104-108, 148-184 | Effectively unreachable in non-streaming path (CL-7) |
+| `IntentTracker.check_ghost_planning` `ledger` param | claim_verifier.py:160-165 | INERT — explicitly reserved |
+| `RubricManager.load_correction_context` | rubric.py:259-275 | DEAD (rubric audit R6) |
+| `FrameSelection.match_method` consumers | schemas.py:84 | INERT — set everywhere, read nowhere outside logs/tests |
+
+---
+
+## 5. Improvement opportunities (non-bug)
+
+1. **One injection helper for pre_turn prompt additions.** Three call sites hand-append to the flat prompt; one of three remembered the dynamic tier. A `_inject_dynamic(section_text)` helper that writes both representations would have prevented CL-1/CL-2 and will prevent the next one.
+2. **Make `TurnContext.system_prompt` authoritative or delete it.** Today it is a lie under the default config — either have the runner always derive the flat string from `sections_by_tier` + extras, or build the tier dict as the only product.
+3. **Score-space discipline at the cognitive boundary.** CL-3, CL-13, CL-15 are all "a calibrated-looking threshold applied to an uncalibrated score" — the same class the storage audit fixed on the write side (S1) and §14.7 fixed for its cosine leg. A typed score (`RankScore` vs `CosineScore`) or at minimum a naming convention (`rrf_score`) would make these grep-able.
+4. **Session-state registry.** Seven per-session dicts on `CognitiveLayer` + four on `MonitorEngine` + runner-side ledgers/corrections, each individually (and inconsistently — CL-12) cleaned in end_session. A single `SessionState` object popped once would eliminate the leak class and the post-restart asymmetry (CL-17).
+5. **Procedure reinforcement should require evidence of use** (CL-8): the overlap computation already exists in the same function; gating `record_procedure_outcome` on it is a ~5-line change that would make `effectiveness` mean something before any F079/§14.5 measurement work trusts it.
+6. **Claim-verifier precision** (CL-4): the ledger already stores per-action `side_effect_type`, `status`, and the bash command — the verifier uses none of them. Matching expected-tool against *successful* actions with side-effect ∈ {write, external} would close most of the hole without new state.

--- a/docs/reviews/dag-audit-2026-06-09.md
+++ b/docs/reviews/dag-audit-2026-06-09.md
@@ -1,0 +1,565 @@
+# DAG Orchestration Subsystem Audit (F038 / F046 / F064.x / F066.1) — 2026-06-09
+
+Code-only deep audit of `nous/dag/` (orchestrator.py, store.py, schemas.py, fix_executor.py,
+_workspace.py) plus the wiring call paths in `nous/main.py`, `nous/api/tools.py`,
+`nous/api/runner.py`, `nous/heartbeat/runner.py`, `nous/heartbeat/work_queue.py`,
+`nous/heart/subtasks.py`. No code was modified.
+
+**Flag states used for reachability verdicts** (config.py defaults vs `.env.prod-snapshot`):
+
+| Flag | Default | Prod snapshot | Net |
+|---|---|---|---|
+| `NOUS_DAG_ENABLED` (`dag_enabled`, config.py:849) | `true` | unset | ON |
+| `NOUS_DAG_STALL_DETECTION_ENABLED` (config.py:854) | `false` | `true` (.env.prod-snapshot:36) | ON in prod |
+| `NOUS_DAG_FRAME_CONCURRENCY_ENABLED` (config.py:870) | `false` | `true` (:34) | ON in prod (but see DG-11: no caps reachable) |
+| `NOUS_DAG_WORKSPACE_SAFETY_ENABLED` (config.py:880) | `false` | `true` (:37) | ON in prod |
+| `NOUS_DAG_FIX_LLM_DISPATCH_ENABLED` (config.py:594) | `false` | `true` (:32) | ON in prod but severed (DG-5) |
+| `NOUS_DAG_NODE_DEFAULT_TIMEOUT` (config.py:523) | `600` | `6000` (:35) | |
+| `NOUS_WORK_QUEUE_ENABLED` (config.py:913) | `false` | `true` (:132, file_jsonl path :133) | ON in prod |
+
+The read-time workspace containment assert **is confirmed unconditional**: both consumers —
+`_run_completion_check` (orchestrator.py:548) and `_read_node_result` (orchestrator.py:691) —
+call `assert_inside_root` with no flag check; `dag_workspace_safety_enabled` gates only the
+strict insert-time `sanitize_segment` (schemas.py:237-239).
+
+---
+
+## 1. How it actually works
+
+### Components
+
+- **`DAGStore`** (store.py) — CRUD over `nous_system.execution_dags` / `dag_nodes` / `dag_edges`.
+  Enforces `MAX_ACTIVE_DAGS = 5` (store.py:19,44), resolves+clamps `timeout_seconds` and
+  `stall_timeout_seconds` at insert (store.py:72-120), assigns waves via
+  `DAGCreateRequest.compute_waves()` and sets wave-0 nodes to `ready` (fix nodes forced
+  `pending`, store.py:127-132).
+- **`DAGOrchestrator`** (orchestrator.py) — advanced by `HeartbeatRunner._loop` every
+  `heartbeat_tick_interval` (30 s) at heartbeat/runner.py:161-165. `tick()` takes an
+  `asyncio.Lock` shared with `start_dag()` (orchestrator.py:84,91,102) — but **not** with
+  `cancel_dag` / `retry_node` (see DG-7).
+- **Node execution primitives**: `subtask` → `SubtaskManager.create` row consumed by the
+  worker pool; `check` → `DynamicCheckLoader.create_check` heartbeat check named
+  `dag-{hex8}-{name}`; `gate` / `callback` → auto-completed placeholders
+  (orchestrator.py:1181-1200); `fix` (F066.1) → fired only by `_try_fix_failed_nodes`.
+- **Tool surface**: `dag_create` / `dag_manage` (tools.py:3149-3385). `dag_create` builds a
+  `DAGCreateRequest`, calls `store.create`, then `orchestrator.start_dag` inline
+  (tools.py:3220-3221).
+- **Work-queue ingress** (F064.6, prod-enabled): `WorkQueueCheck` claims items and calls
+  `dag_store.create` — never `start_dag` (work_queue.py:320, 372; see DG-6).
+
+### Tick pipeline (`_advance_dag`, orchestrator.py:220-265)
+
+1. `_sync_node_statuses` — pull running subtask/check state into node rows.
+2. 1.5 `_poll_awaiting_checks` — run `completion_check` shell commands (exit 0 = success,
+   1 = failed, 2/other = pending; 10 s hard cmd timeout, orchestrator.py:42,508-592).
+3. 1.7 `_check_stalled_nodes` (flag-gated) — fail running nodes whose `last_activity_at`
+   exceeded the effective stall timeout.
+4. Budget check — `tokens_consumed / token_budget`; ≥1.0 → `_handle_budget_exceeded` and
+   early-return (orchestrator.py:235-244). **Dead in practice — see DG-3.**
+5. 2.5 `_recover_stale_ready_nodes` — after a 300 s grace, demote orphaned `ready` nodes to
+   `pending` and promote a bypassed `pending` DAG to `running` (orchestrator.py:896-979).
+6. 2.7 `_try_fix_failed_nodes` (F066.1) — fire fix nodes for just-failed parents before the
+   cascade (orchestrator.py:981-1143).
+7. `_propagate_failures` — `cancel_cascade` targets of failed preds → `cancelled` (direct
+   only); transitive `dependency` descendants of failed/cancelled → `blocked`
+   (orchestrator.py:708-769).
+8. `_find_ready_nodes` + `_dispatch_ready_nodes` — pending nodes with all
+   `dependency`/`context_flow` preds in `_RESOLVED` ({completed, skipped}) are dispatched;
+   F064.2 per-frame caps applied when flag on **and** caps exist (orchestrator.py:791-894,
+   1144-1171).
+9. `_check_dag_completion` — all nodes terminal → final DAG status (orchestrator.py:1345-1398).
+
+### Node state machine
+
+```
+                       ┌────────────────────────────────────────────────┐
+                       │ (wave 0, non-fix)                              │
+ create ──► ready ─────┤ start_dag / _dispatch_ready_nodes              │
+        └─► pending ◄──┘   ▲       │ _launch_node                       │
+              │  ▲         │       ▼                                    │
+              │  │ (stale-ready recovery; cap deferral;                 │
+              │  │  fix retry; retry_node)                              │
+              │  └─────────┴── running ── _sync ──► completed           │
+              │                   │   │                                 │
+              │                   │   └─(has completion_check)─► awaiting_check
+              │                   │                          │ poll exit0 ──► completed
+              │                   │                          │ exit1/timeout/max ─► failed
+              │                   ▼                                     │
+              │                failed ◄── stall scan / subtask fail /   │
+              │                   │       launch error / outcome≠completed
+              │      fix node?    │
+              │   retry → pending │ skip → skipped (terminal)
+              │                   ▼
+              ├─► blocked   (dependency descendant of failure — terminal)
+              └─► cancelled (cancel_cascade target, cancel_dag, budget — terminal)
+```
+
+Terminal: `{completed, failed, blocked, cancelled, skipped}` (orchestrator.py:30).
+Dependency-resolving: `{completed, skipped}` (orchestrator.py:36).
+Only `failed` is exit-able (via `retry_node` or a fix node).
+
+### DAG state machine
+
+`pending → running → {completed | failed | cancelled | partial}`; `retry_node` can move
+`failed|partial → running` (orchestrator.py:213-214). `partial` is produced only by the
+budget path (orchestrator.py:1417-1420), which is dead (DG-3).
+
+---
+
+## 2. Findings register
+
+### P1
+
+---
+
+**DG-1 — A DAG whose nodes end `{completed, skipped}` is finalized `failed` with summary "All nodes blocked"**
+- Severity: **P1** | Reachability: **LIVE** (`dag_enabled=true` default; fix nodes authorable
+  via `dag_create` tools.py:3325; `skip_and_continue` is the rule-based dispatcher's
+  *preferred* action for timeouts and unknown errors, fix_executor.py:81-98)
+- Where: orchestrator.py:1379-1397 (`_check_dag_completion` final-status branch)
+- Evidence: the terminal classification is
+  `all(completed)` → completed; `any(failed)` → failed; `any(cancelled)` → cancelled;
+  **else → failed, "All nodes blocked"** (orchestrator.py:1394-1397). After
+  `skip_and_continue` the parent is `skipped` (orchestrator.py:1127-1134) and the fix node is
+  `completed`, so a DAG that recovered exactly as designed — every other node completed,
+  one node intentionally skipped — has status set `{completed, skipped}`, matches no branch,
+  and lands in the else: DAG `failed`, summary `"All nodes blocked"`. This is the *success*
+  path of the F066.1 skip action producing a failed DAG with a false postmortem.
+  `tests/test_f066_1_fix_stage.py:389-409` asserts only `parent.status == "skipped"`, never
+  the final DAG status, so the bug is untested.
+- Consequences: wrong terminal status persisted; dashboards/`dag_manage list` report failure;
+  `retry_node` can then "reactivate" a DAG that actually succeeded.
+- Suggested fix: treat `skipped` like `completed` in the final classification, e.g.
+  `all(n.status in ("completed", "skipped"))` → `completed` (optionally with a summary noting
+  skipped node names), before the failed/cancelled checks.
+
+### P2
+
+---
+
+**DG-2 — "Cancelling" a node never stops a RUNNING subtask: stall teardown, cancel_dag, cancel_cascade and budget-cancel all leak live work**
+- Severity: **P2** | Reachability: **LIVE** (stall detection ON in prod; `cancel_dag` reachable
+  from `dag_manage`, work-queue terminal reconciliation, and orphan cleanup)
+- Where: orchestrator.py:1327-1335 (`_cancel_node`) → heart/subtasks.py:212-232
+  (`SubtaskManager.cancel`)
+- Evidence: `_cancel_node` calls `self._subtask_mgr.cancel(...)` when
+  `subtask.status in ("pending", "running")` (orchestrator.py:1332-1333), but
+  `SubtaskManager.cancel` updates **only** rows `WHERE status = 'pending'`
+  (subtasks.py:224) and returns False otherwise — there is no mechanism anywhere in
+  `SubtaskManager`/`subtask_worker` to abort an in-flight execution by row status. The
+  stall-scan comment explicitly claims the opposite: "tear down the underlying primitive
+  BEFORE marking the node failed. Without this, the subtask keeps running (consuming tokens,
+  holding worker slots)" (orchestrator.py:660-666) — that is exactly what still happens for
+  any subtask a worker has dequeued.
+- Consequences: (a) stall-failed nodes leave a zombie subtask burning tokens and a worker
+  slot for up to its full wall-clock timeout (prod default 6000 s); (b) `cancel_dag` does not
+  actually stop work; (c) the zombie still counts `pending|running` in
+  `count_running_subtasks_by_frame_type` (store.py:321), so it consumes F064.2 cap slots;
+  (d) if a fix node then retries the parent, two subtasks for the same node run concurrently.
+- Suggested fix: add a real running-cancel path (e.g. status-poll in
+  `subtask_worker.execute_hardened` + a `cancel_requested` column, or task-handle registry
+  keyed by subtask id) or at minimum correct the comments and exclude failed/cancelled nodes'
+  subtasks from the frame-cap count.
+
+---
+
+**DG-3 — Token-budget enforcement is dead: `tokens_consumed` is never written by anyone**
+- Severity: **P2** | Reachability: **DEAD** (severed wire on an advertised live feature)
+- Where: store.py:364-373 (`update_dag_tokens` — zero callers); orchestrator.py:235-244
+  (budget check), 1400-1425 (`_handle_budget_exceeded`); tools.py:3215,3369 (`token_budget`
+  accepted from the agent)
+- Evidence: repo-wide grep for `update_dag_tokens|tokens_consumed` finds only the store
+  method definition, the ORM column (models.py:984), the orchestrator read
+  (orchestrator.py:236) and dashboard reads (dashboard_queries.py:1499,1568,1577,1596).
+  Nothing in `subtask_worker`, `runner`, or the heartbeat path ever increments it, so
+  `ratio = dag.tokens_consumed / dag.token_budget` is always `0.0` and
+  `_handle_budget_exceeded` (and with it the only producer of DAG status `partial`) is
+  unreachable.
+- Consequences: `dag_create(token_budget=...)` is a silent no-op safety control; operators
+  believe runaway DAGs are bounded by budget when only per-node wall-clock timeouts apply.
+- Suggested fix: wire `subtask_worker`'s per-run token accounting (it already computes
+  `tokens_in/tokens_out`, subtasks.py:116-117) to `store.update_dag_tokens` when
+  `subtask.dag_node_id` is set; or remove the budget parameter until implemented.
+
+---
+
+**DG-4 — `_MAX_PENDING=5` subtask-queue congestion permanently FAILS DAG nodes instead of deferring**
+- Severity: **P2** | Reachability: **LIVE**
+- Where: orchestrator.py:1216-1254 (`_launch_subtask_node` catch-all → `status="failed"`);
+  heart/subtasks.py:17,49-58 (`create` raises ValueError at 5 pending)
+- Evidence: `SubtaskManager.create` raises `ValueError("pending subtask limit (5) reached")`
+  whenever 5 subtasks are pending agent-wide (including non-DAG `spawn_task` work).
+  `_launch_subtask_node` catches **all** exceptions and marks the node `failed`
+  (orchestrator.py:1247-1251). `failed` is terminal; on the same tick
+  `_propagate_failures` blocks every dependent. A DAG wave of 4 nodes plus 2 unrelated
+  pending subtasks deterministically fails nodes purely from transient queue pressure.
+- Consequences: spurious cascading DAG failures correlated with normal background load —
+  the exact condition (multiple concurrent DAGs + subtasks) the orchestrator exists to manage.
+- Suggested fix: catch the capacity ValueError specifically and defer (demote node to
+  `pending`, mirroring the F064.2 cap-deferral at orchestrator.py:870-877) instead of failing.
+
+---
+
+**DG-5 — F066.1 Phase 1.5 LLM fix dispatch is severed: main.py never passes `llm_client`, so the prod-enabled flag does nothing**
+- Severity: **P2** | Reachability: **INERT** (flag `NOUS_DAG_FIX_LLM_DISPATCH_ENABLED=true`
+  in prod, .env.prod-snapshot:32, but the code path can never run)
+- Where: main.py:698-704 (DAGOrchestrator constructed without `llm_client`);
+  orchestrator.py:79-83, 1028-1031 (`llm_enabled = flag and self._llm_client is not None`)
+- Evidence: the only production instantiation of `DAGOrchestrator` passes
+  `store/subtask_mgr/dynamic_loader/bus/settings` — no `llm_client` kwarg — so
+  `self._llm_client` stays `None` and `_try_fix_failed_nodes` always falls through to
+  rule-based `choose_action` (orchestrator.py:1064-1070). `choose_action_llm`
+  (fix_executor.py:193-298) is reachable only from tests
+  (tests/test_f066_1_llm_dispatch.py). Note rule-based Phase 1 also cannot honor
+  `retry_with_amended_prompt` (fix_executor.py:99-105), so that action is unreachable too.
+- Consequences: operator believes Haiku-driven fix dispatch is on; every fix decision is the
+  deterministic rule table; the `dag_fix_llm_model`/`dag_fix_llm_timeout_seconds` settings are
+  inert.
+- Suggested fix: pass the existing background `api_client` (already built in main.py and
+  returned at main.py:769) into the constructor: `llm_client=api_client`.
+
+---
+
+**DG-6 — Work-queue DAGs are created but never started: each one idles 'pending' for ≥300 s until the stale-ready sweep rescues it**
+- Severity: **P2** | Reachability: **LIVE in prod** (`NOUS_WORK_QUEUE_ENABLED=true`,
+  .env.prod-snapshot:132)
+- Where: heartbeat/work_queue.py:320 (`_claim_and_dispatch`), :372 (`_reconcile_orphan`) —
+  both call `self._dag_store.create(request)` only; repo grep for `start_dag` shows the only
+  production caller is tools.py:3221 (`dag_create`)
+- Evidence: wave-0 nodes are created `ready` (store.py:129-130) and `_find_ready_nodes` only
+  considers `pending` nodes (orchestrator.py:1158), so a created-but-not-started DAG is
+  invisible to the tick loop until `_recover_stale_ready_nodes` fires — which requires
+  `dag_age >= _STALE_READY_GRACE_SECONDS = 300` (orchestrator.py:47,941-943). The recovery
+  docstring frames this path as *bypass recovery* for psql inserts (issue #430,
+  orchestrator.py:899-926), not as the intended ingress for a shipped feature.
+- Consequences: every work-queue item incurs a built-in 5-minute dispatch latency and holds
+  one of the 5 `MAX_ACTIVE_DAGS` slots while idle; the recovery log spams
+  `logger.warning("Recovered orphaned pending DAG ...")` for normal operation.
+- Suggested fix: call `await self._orchestrator.start_dag(dag.id)` after `mark_dispatched`
+  in both dispatch paths (mirroring tools.py:3221), keeping the sweep as the safety net.
+
+---
+
+**DG-7 — `cancel_dag` / `retry_node` are not serialized with `tick()`: a stale tick snapshot can resurrect cancelled nodes**
+- Severity: **P2** | Reachability: **LIVE** (race window every tick; widest when the tick lock
+  is held long — sequential 10 s completion checks per awaiting node, orchestrator.py:42,570)
+- Where: orchestrator.py:124-143 (`cancel_dag`), 145-214 (`retry_node`) — neither takes
+  `self._lock` (held by `tick` orchestrator.py:91 and `start_dag` :102); store.py:274-291
+  (`update_node` writes blindly, no expected-status guard)
+- Evidence: `tick()` operates on an eagerly-loaded snapshot from `get_active_dags()`
+  (orchestrator.py:92). A concurrent `dag_manage(action="cancel")` from the chat task sets
+  nodes `cancelled` and the DAG `cancelled` mid-tick. The in-flight tick still holds the old
+  snapshot, so `_dispatch_ready_nodes` happily runs
+  `update_node(node.id, status="ready")` then `_launch_node` (orchestrator.py:813-816) on a
+  node that is `cancelled` in the DB — last write wins, the node goes `running` and a fresh
+  subtask launches inside a DAG whose status is `cancelled`. Such a DAG is no longer in
+  `get_active_dags` (store.py:210), so the running node is never synced again → permanent
+  `running` node + orphan subtask.
+- Suggested fix: take `self._lock` in `cancel_dag` and `retry_node` (they are called from
+  tool/REST context, not from inside `tick`, so no deadlock), and/or make status updates
+  conditional (`WHERE status NOT IN (terminal)`).
+
+---
+
+**DG-8 — Running `check` nodes have no wall-clock timeout: a check that never self-disables pins the node (and an active-DAG slot) forever**
+- Severity: **P2** | Reachability: **LIVE**
+- Where: orchestrator.py:355-402 (`_sync_check_node` — the only progress mechanism is
+  "check missing or `check.active == False`"); orchestrator.py:594-600 (`_effective_timeout`
+  consulted only in `_poll_awaiting_checks` + the two launch sites)
+- Evidence: `_effective_timeout` is enforced at exactly 3 read sites — awaiting-check polling
+  (orchestrator.py:434), subtask creation (:1225), check creation (:1277, where it bounds a
+  *single run* of the dynamic check, not the node) — verified, the F046 clamp contract holds.
+  But no code path compares `now - node.started_at` against the node timeout while
+  `status == "running"`. A subtask node is indirectly bounded by the worker's timeout; a
+  check node whose prompt never self-disables (or whose check errors every run — circuit
+  state still `active=True`) stays `running` indefinitely. Stall detection cannot cover it:
+  check nodes get no `last_activity_at` baseline ping (only `_launch_subtask_node` writes
+  one, orchestrator.py:1235-1239) and NULL is treated as not-stalled (orchestrator.py:647-650).
+- Consequences: immortal DAGs that occupy `MAX_ACTIVE_DAGS=5` slots until a human runs
+  `dag_manage cancel`; with 5 such DAGs, all DAG creation is bricked (store.py:44-48).
+- Suggested fix: add a wall-clock check for running nodes in `_sync_node_statuses`
+  (fail node + `_cancel_node` when `now - started_at > _effective_timeout(node)`), or write
+  the launch baseline ping for check nodes too and document stall coverage.
+
+---
+
+**DG-9 — `DAGNodeSpec.tools` is silently ignored for subtask nodes**
+- Severity: **P2** | Reachability: **LIVE**
+- Where: orchestrator.py:1221-1228 (`_launch_subtask_node` → `subtask_mgr.create(...)` —
+  no `tools` argument); heart/subtasks.py:27-43 (`create` has no `tools` parameter);
+  contrast orchestrator.py:1275 (`_launch_check_node` passes `tools=node.tools`)
+- Evidence: the tool schema advertises `"tools": {"type": "array", ...}` for every node
+  (tools.py:3327) and the spec stores it (store.py:142), but for `subtask` nodes — the
+  primary execution type — the restriction never reaches execution; the subtask runs with
+  the full toolset of its frame.
+- Consequences: a DAG author restricting a node to e.g. `["read_file", "web_search"]`
+  gets `bash`/`write_file` anyway; the restriction works for check nodes only, which is
+  surprising and undocumented.
+- Suggested fix: thread `tools` through `SubtaskManager.create` → subtask row →
+  `subtask_worker` → `run_turn` allowed-tools, or reject `tools` on subtask specs at
+  validation time so the contract is honest.
+
+---
+
+**DG-10 — Fix-driven retry resets less state than `retry_node`: stale `check_attempts`/timestamps can insta-fail or skew the retried run**
+- Severity: **P2** | Reachability: **LATENT** today (rule-based dispatch picks `retry_as_is`
+  only for `incomplete_no_terminal`/`validation_failed` errors, fix_executor.py:73-78);
+  becomes LIVE the moment DG-5 is fixed (prod wants LLM dispatch on, which may choose retry
+  for completion-check failures)
+- Where: orchestrator.py:1110-1126 (fix retry sets only `status="pending"`, `error=None`,
+  optional `instructions`); contrast orchestrator.py:157-169 (`retry_node` resets `result`,
+  `subtask_id`, `check_name`, `started_at`, `completed_at`, `check_attempts`,
+  `last_check_at`, `awaiting_check_at`)
+- Evidence: a parent that failed via "Completion check exceeded max attempts"
+  (orchestrator.py:446-454) and is retried by a fix node re-enters `awaiting_check` after
+  its (expensive, fully re-run) subtask completes, with `check_attempts` still at the
+  exhausted value — line 446 (`node.check_attempts >= node.max_check_attempts`) fails it
+  again immediately, burning `max_fix_attempts × subtask-runtime` for guaranteed failures.
+  Stale `completed_at`/`result` also linger on the retried node until overwritten.
+- Suggested fix: in the retry branch of `_try_fix_failed_nodes`, reset the same field set
+  `retry_node` resets.
+
+### P3
+
+---
+
+**DG-11 — F064.2 frame-concurrency caps are unauthorable: `dag_create` drops `max_concurrent_by_frame_type`, env override unset → prod flag ON but feature INERT**
+- Severity: **P3** | Reachability: **INERT** (prod `NOUS_DAG_FRAME_CONCURRENCY_ENABLED=true`,
+  but `_effective_frame_caps` returns `{}` → gating skipped, orchestrator.py:784-789, 823-834)
+- Where: tools.py:3211-3218 (`DAGCreateRequest(...)` built without
+  `max_concurrent_by_frame_type`; the field also isn't in the tool's JSON schema,
+  tools.py:3309-3372); config.py:871 (`dag_global_max_concurrent_by_frame` default `{}`,
+  not set in .env.prod-snapshot)
+- Evidence: the only writers of per-DAG caps are tests; `WorkQueueCheck`'s request factory
+  doesn't set it either. With both sources empty every dispatch takes the no-caps fast path.
+- Suggested fix: expose the field in the `dag_create` schema + handler (the F066.1 comment at
+  tools.py:3163-3173 promised exactly this "thread every field" discipline), or document the
+  env override as the only knob.
+
+---
+
+**DG-12 — Missing/deleted dynamic check is interpreted as SUCCESS**
+- Severity: **P3** | Reachability: **LIVE**
+- Where: orchestrator.py:360-382 (`_sync_check_node`: `check is None` → node `completed`,
+  "Check completed (self-disabled)")
+- Evidence: registry absence conflates three cases: (a) legitimate self-disable after goal
+  met; (b) user deleting the check via `heartbeat_check_manage` (delete unregisters); (c) a
+  restart window where the orchestrator tick runs before `DynamicCheckLoader` has re-loaded
+  DB checks into the registry. Cases (b)/(c) falsely complete the node and unblock dependents.
+- Suggested fix: consult the persisted dynamic-check row (DB) rather than only the in-memory
+  registry; treat row-missing as `failed`, row-disabled as completed.
+
+---
+
+**DG-13 — `MAX_ACTIVE_DAGS` admission is a non-atomic read-then-insert**
+- Severity: **P3** | Reachability: **LATENT** (needs two concurrent creates; possible:
+  chat `dag_create` task vs heartbeat `WorkQueueCheck`)
+- Where: store.py:38-48 (count) … :171 (commit) — no lock/constraint between them
+- Evidence: two sessions can both read `active_count = 4` and commit, yielding 6 active DAGs;
+  nothing reconciles the overshoot. Work-queue's own `work_queue_max_dags_per_tick ≤ 5`
+  bounds per-tick volume but not the cross-source race.
+- Suggested fix: `pg_advisory_xact_lock` keyed on agent_id around count+insert, or tolerate
+  documented overshoot.
+
+---
+
+**DG-14 — `DAGCreateRequest.validate_dag` constructs a fresh `Settings()` from the process env**
+- Severity: **P3** | Reachability: **LIVE** (runs on every request construction)
+- Where: schemas.py:233-241
+- Evidence: `_Settings()` ignores the DI'd settings used everywhere else (store/orchestrator
+  receive `settings` explicitly); only `ImportError` is caught, so a Settings-level
+  `ValidationError` (e.g. the cross-field stall/timeout validators at config.py:1472-1498
+  failing due to env drift) surfaces as an opaque DAG-validation failure; tests that override
+  Settings get the real env instead. Also a per-call construction cost.
+- Suggested fix: move insert-time `sanitize_segment` to `DAGStore.create` (which already has
+  `self._settings` and performs the other settings-dependent validations).
+
+---
+
+**DG-15 — Cross-tick fix re-fire can retry a parent whose dependents were already terminally blocked**
+- Severity: **P3** | Reachability: **LATENT** (requires `max_fix_attempts ≥ 2` plus a
+  dispatch that switches from `mark_unrecoverable` to a retry across ticks — impossible with
+  today's deterministic rules, plausible once LLM dispatch is live)
+- Where: orchestrator.py:1016-1026 (fix re-fires while parent stays `failed` and attempts
+  remain), 763-769 (`blocked` is terminal, nothing unblocks on fix-retry; contrast
+  `retry_node`'s selective unblock at orchestrator.py:171-210)
+- Evidence: tick N: parent fails, fix chooses `mark_unrecoverable`, cascade blocks dependents.
+  Tick N+1: fix re-fires (attempts 1 < 2), chooses `retry_as_is`, parent re-runs and
+  completes — dependents remain `blocked` forever; DAG finalizes `failed: All nodes blocked`
+  despite a successful critical path.
+- Suggested fix: on fix-retry, reuse `retry_node`'s downstream-unblock logic; or stop
+  re-firing after a `mark_unrecoverable` outcome.
+
+---
+
+**DG-16 — Wave-0 parallelism validation counts fix nodes that are never dispatched**
+- Severity: **P3** | Reachability: **LIVE** (minor)
+- Where: schemas.py:363-371 (`MAX_PARALLEL_PER_WAVE` over `compute_waves()` output) +
+  392-397 (fix nodes have no inbound dependency edges → always wave 0)
+- Evidence: 4 wave-0 subtask nodes + 1 fix node = 5 in wave 0 → request rejected
+  ("Wave 0 has 5 parallel nodes, max is 4") even though fix nodes are forced `pending` and
+  excluded from dispatch (store.py:127-128, orchestrator.py:1165-1166). Caps real fan-out
+  below the documented limit whenever fix nodes are used.
+- Suggested fix: exclude `type == fix` from wave-parallelism counting (and from MAX_WAVES
+  pressure).
+
+---
+
+**DG-17 — Deterministic check-name reuse on retry can collide in the check registry**
+- Severity: **P3** | Reachability: **LATENT**
+- Where: orchestrator.py:1268 (`check_name = f"dag-{dag.id.hex[:8]}-{node.name}"`)
+- Evidence: a retried check node re-creates a check with the identical name; if the prior
+  check object still exists (disabled rows are unregistered, but a failed-then-retried node
+  whose check is still registered/active — e.g. after DG-12 case (c) — remains), the
+  `create_check` raises and the node fails. Name also isn't workspace-sanitized (node names
+  with spaces are legal when `dag_workspace_safety_enabled=false`).
+- Suggested fix: suffix an attempt counter or short random token.
+
+---
+
+**DG-18 — Duplicate edges pass schema validation and explode as raw IntegrityError at insert**
+- Severity: **P3** | Reachability: **LATENT**
+- Where: schemas.py:254-261 (validates references/self-loops only); models.py:1114-1116
+  (`uq_dag_edge`)
+- Evidence: `edges: [{a→b, dependency}, {a→b, dependency}]` passes `validate_dag` and
+  `compute_waves` (b just gets in_degree 2), then `store.create` hits the unique constraint
+  and the agent sees a database error string instead of a clean validation message.
+- Suggested fix: add a duplicate-edge check in `validate_dag`.
+
+---
+
+**DG-19 — `retry_node` does not reset the fix child's `fix_attempts_used`**
+- Severity: **P3** | Reachability: **LATENT**
+- Where: orchestrator.py:157-169 (reset list lacks fix-child state)
+- Evidence: after a fix exhausts `max_fix_attempts` and an operator manually retries the
+  parent, a subsequent failure gets no fix protection (`fix_attempts_used >= max`,
+  orchestrator.py:1024-1025) — probably surprising given the operator explicitly reset the
+  node.
+- Suggested fix: reset `fix_attempts_used` on the parent's fix child inside `retry_node`.
+
+---
+
+**DG-20 — Result-file convention is unreachable for subtask nodes: nothing tells the executing subtask its workspace path**
+- Severity: **P3** | Reachability: **LIVE** (degraded silently)
+- Where: orchestrator.py:678-706 (`_read_node_result` reads `{workspace}/result`);
+  orchestrator.py:1299-1325 (`_build_predecessor_context` — workspace path never injected
+  into instructions); only `completion_check` subprocesses get `cwd=workspace`
+  (orchestrator.py:563-567)
+- Evidence: the "status file convention" can only be satisfied by the completion_check
+  command itself writing `./result`, since the subtask agent is never told the path
+  (`compute_workspace_path` has no consumers outside the orchestrator). The graceful
+  fallback to `node.result` hides this, but the feature as designed (node publishes a rich
+  result via file) is not wired for the primary node type.
+- Suggested fix: append the resolved workspace path to subtask instructions at launch.
+
+---
+
+**DG-21 — If the heartbeat runner is disabled, DAGs are created and wave-0 launches but nothing ever advances them**
+- Severity: **P3** | Reachability: **LATENT** (`NOUS_HEARTBEAT_ENABLED=true` by default and
+  in prod)
+- Where: heartbeat/runner.py:161-165 is the **only** production caller of
+  `orchestrator.tick()`; main.py:690-718 builds the orchestrator and registers tools
+  regardless of heartbeat state (it only skips wiring at main.py:706 when
+  `heartbeat_runner is None`)
+- Evidence: with heartbeat off, `dag_create` succeeds, `start_dag` launches wave 0, then no
+  sync/dispatch/completion ever runs — subtasks complete in `heart.subtasks` but nodes stay
+  `running` forever. No warning is logged about the missing tick driver.
+- Suggested fix: when `heartbeat_runner is None`, either skip DAG tool registration or start
+  a dedicated `asyncio` tick task; at minimum log a WARN.
+
+### INFO
+
+---
+
+**DG-22 — `Any` is not imported in orchestrator.py** — orchestrator.py:1112
+(`update_kwargs: dict[str, Any] = ...`). Runtime-safe (PEP 526 local annotations are never
+evaluated), but a `NameError` under any tool that evaluates annotations, and a type-checker
+error. Add `Any` to the `typing` import.
+
+**DG-23 — Tick lock can be held for minutes** — `tick()` serially runs up to 10 s
+completion-check subprocesses per awaiting node (orchestrator.py:42,570) and (post-DG-5-fix)
+10 s LLM fix calls per failed parent, all under `self._lock`; `start_dag` (and therefore the
+agent's `dag_create` tool) blocks for the duration. Consider per-DAG locks or moving check
+subprocesses outside the lock.
+
+**DG-24 — Blocking sync I/O in async paths** — `result_file.exists()/read_text()`
+(orchestrator.py:701-702), `workspace.mkdir` (:549), `Path.resolve()` (_workspace.py:138-139)
+run on the event loop. Negligible on tmpfs, noticeable on slow volumes.
+
+**DG-25 — `_run_completion_check` re-fetches the whole DAG per awaiting node per tick**
+(orchestrator.py:540) — N+1 against `execution_dags` with two `selectinload`s; the caller
+(`_poll_awaiting_checks`) already holds the dag. Pass it in.
+
+**DG-26 — `update_dag_status(..., "running")` unconditionally overwrites `started_at`**
+(store.py:256-257) — `retry_node`'s reactivation (orchestrator.py:214) rewrites the original
+start time; age-based logic (`_recover_stale_ready_nodes` ref time, dashboards) sees a
+falsely young DAG.
+
+**DG-27 — Completion-check stderr is the only diagnostics on exit 1; stdout discarded**
+(orchestrator.py:584-586) — checks that print reasons to stdout report "exit code 1".
+
+**DG-28 — Hardcoded `interval_seconds=300` for DAG-managed dynamic checks**
+(orchestrator.py:1276) — `completion_check_interval` governs only the shell poll; the
+heartbeat check cadence is not authorable.
+
+**DG-29 — TOCTOU window in `assert_inside_root`** (_workspace.py:127-145) — the symlink
+check happens at assert time; a symlink swapped in between assert and
+`mkdir`/`read_text` could escape. Requires local attacker with write access to the temp
+root; acceptable residual risk, worth a comment.
+
+**DG-30 — `completion_check` is an arbitrary-shell surface by design**
+(orchestrator.py:563) — agent-authored commands run unsandboxed with `cwd` containment only
+(the command itself can `cd /` freely). Equivalent privilege to the `bash` tool the agent
+already has, so not an escalation — but worth stating in the feature doc.
+
+**DG-31 — `dag_create` drops `original_request`** (tools.py:3211-3218) — the request field
+exists (schemas.py:191) and is persisted (store.py:59) but the tool never threads it; always
+NULL from the tool path.
+
+**DG-32 — `fix_executor.choose_action` rationale f-string without placeholder**
+(fix_executor.py:77) — lint noise only.
+
+**DG-33 — Windows/POSIX path handling is sound** — `dag_workspace_root` defaults via
+`tempfile.gettempdir()` (config.py:881-883) matching `DAG_STATUS_BASE_DIR`'s convention;
+`Path.relative_to` on resolved paths behaves correctly on both platforms. No issue found.
+
+---
+
+## 3. Dead-code inventory
+
+| Item | Location | Note |
+|---|---|---|
+| `DAG_STATUS_BASE_DIR` | orchestrator.py:48 | Zero readers; superseded by `settings.dag_workspace_root`. Drift risk: if an operator overrides `NOUS_DAG_WORKSPACE_ROOT`, this constant silently disagrees. |
+| `DAGOrchestrator._bus` | orchestrator.py:69,77 | Constructor accepts and stores `bus`; never read. No DAG lifecycle events are ever published. |
+| `DAGStore.update_dag_tokens` | store.py:364-373 | Zero callers (see DG-3); takes the whole budget branch (orchestrator.py:235-244, 1400-1425) and DAG status `partial` with it. |
+| `count_running_subtasks_by_frame_type(dag_id=None)` legacy branch | store.py:323 | Only call site always passes `dag_id` (orchestrator.py:839-841). |
+| `DAGNode.completion_condition` / `DAGNodeSpec.completion_condition` | models.py:1057, schemas.py:104, store.py:145, tools.py:3183,3332 | Persisted and tool-exposed, consumed by nothing. Write-only column. |
+| `FixActionResult.mode` | fix_executor.py:46 | Never set, never read (Phase 2 placeholder). |
+| `DAGNodeSpec.expected_modes` / `DAGNode.expected_modes` | schemas.py:165-172, models.py:1093 | Documented Phase 2 reservation — intentional, but currently pure storage. |
+| `choose_action_llm` + `dag_fix_llm_*` settings | fix_executor.py:193-298, config.py:594-604 | Unreachable in production until DG-5 is fixed (tests-only). |
+| `schedule_continuation_default_prompt` interplay | — | Out of scope, noted in CLAUDE.md as reserved. |
+
+## 4. Improvement opportunities
+
+1. **Status-transition guard in `update_node`.** Nearly every race in this register (DG-7,
+   DG-2 aftermath) is mitigated by making writes conditional
+   (`WHERE status = :expected` or `WHERE status NOT IN terminal`) and logging rowcount-0.
+   Single change, large blast-radius reduction.
+2. **One canonical "reset node for re-run" helper.** `retry_node` (orchestrator.py:157-169)
+   and the fix-retry branch (:1110-1126) reset different field sets (DG-10, DG-19). Extract a
+   `_reset_node_for_retry()` used by both.
+3. **Wall-clock sweep for `running` nodes** (DG-8) — symmetric with `_poll_awaiting_checks`'
+   timeout; makes the F046 timeout a true upper bound for every node type and lets
+   `MAX_ACTIVE_DAGS` slots self-heal.
+4. **Real subtask cancellation** (DG-2) — a `cancel_requested` flag polled by
+   `subtask_worker` between tool-loop iterations would make stall teardown, budget exceeded
+   and `cancel_dag` actually stop spend.
+5. **Publish DAG lifecycle events on the bus** — `_bus` is already injected; emitting
+   `dag_completed`/`dag_failed`/`node_stalled` would let the existing handler/notification
+   infrastructure (Telegram, findings) surface DAG outcomes without dashboard polling.
+6. **Token accounting** (DG-3) — `subtask_worker` already tracks tokens per run and knows
+   `dag_node_id`; one call to `update_dag_tokens` closes the loop and revives the budget +
+   `partial` machinery.
+7. **Test gap:** add assertions on the final DAG status for the skip path (DG-1) and a
+   shared-corpus test where a wave saturates `_MAX_PENDING` (DG-4) — both bugs are in
+   well-tested files but in untested *combinations*.

--- a/docs/reviews/handlers-audit-2026-06-09.md
+++ b/docs/reviews/handlers-audit-2026-06-09.md
@@ -1,0 +1,186 @@
+# Event Handlers Subsystem — Deep Code Audit (2026-06-09)
+
+**Scope:** `nous/handlers/*` (all 19 modules, every line read) + `nous/events.py`, with call-path tracing into `nous/heart/*`, `nous/brain/*`, `nous/cognitive/layer.py`, `nous/main.py` (findings there reported only where the handler is the consumer/victim).
+**Method:** code-only; reachability checked against `nous/config.py` defaults AND `.env.prod-snapshot`. Prior audits cross-referenced: `docs/reviews/memory-storage-retrieval-deep-analysis-2026-06-09.md` ("DA"), `docs/reviews/rubric-admission-audit-2026-06-09.md` ("RA"), `docs/reviews/procedure-subsystem-audit-2026-06-06.md` ("PA"). Findings already shipped in PR #495 (fact_extractor / knowledge_extractor rank-score dedup, F067 chunk collision) were verified FIXED at HEAD and are not re-reported.
+
+Reachability tags: **LIVE** (fires on prod config), **LATENT** (needs an uncommon-but-real condition), **INERT** (flag-gated off), **DEAD** (no caller/emitter).
+
+---
+
+## 1. How it actually works
+
+`EventBus` (`nous/events.py`) is a single in-process asyncio queue (max 1000, overflow **drops** with a WARN — `events.py:180-184`). One background task dequeues and dispatches each event: first to the DB persister (`main.py:83-91` → `brain.emit_event`, which stamps `agent_id` from the Brain instance, not the event — `brain.py:1723-1724`), then to all subscribed handlers concurrently via `gather` with per-handler error isolation (`events.py:246-274`). `stop()` cancels the loop then drains the residual queue (`events.py:194-214`).
+
+Handlers are constructed in `main.py:244-459`; subscription happens in each handler's `__init__`. Long-running loops (session monitor, task scheduler, subtask workers, decision-review sweep) are independent asyncio tasks, not bus handlers.
+
+### Event → handler contract table
+
+| Event | Emit site(s) | Payload keys emitted | Subscribers (keys read) | Contract verdict |
+|---|---|---|---|---|
+| `turn_completed` | `cognitive/layer.py:1179-1198` | session_id, frame, surprise_level, decision_id, has_errors, **is_background** | SessionTimeoutMonitor.on_activity (session_id, is_background) | OK (#462 fix verified) |
+| `message_received` | **NONE — never emitted anywhere** (runner uses synchronous `monitor.touch()` instead, `api/runner.py:358-368,931-938`) | — | SleepHandler._on_wake; SessionTimeoutMonitor.on_activity | **SEVERED — see HD-3** |
+| `session_ended` | `cognitive/layer.py:1805-1822` | session_id, episode_id, transcript, reflection, had_reflection, facts_extracted | EpisodeSummarizer (episode_id, transcript) OK · DecisionReviewer (session_id) OK · OutcomeDetector (**summary** — absent) · SessionTimeoutMonitor (session_id) OK · tool-cache cleanup (session_id) OK | **PARTIAL — HD-9 (known RA-R1)** |
+| `episode_summarized` | `episode_summarizer.py:336-348` | episode_id, summary, candidate_facts, transcript | FactExtractor (all four) | OK |
+| `conversation_compacting` | `cognitive/layer.py:1696-1701` | message_snapshot | KnowledgeExtractor (message_snapshot) | OK |
+| `fact_learned` | `heart/heart.py:314-324` | fact_id, content, category, subject, modifies | FactGraphLinker (fact_id, content) | OK |
+| `decision_recorded` | `brain/brain.py:408-412` (emitted **before** the recording transaction commits) | decision_id, category | DecisionGraphLinker (decision_id) | OK keys / **race — HD-19** |
+| `procedure_stored` | `heart/heart.py:438-470` (store + update_body) | procedure_id, name, domain, description, tags | ProcedureGraphLinker (procedure_id, description, domain) | OK |
+| `sleep_started` | session_monitor.py:345-351 (agent_id="system") · rest.py:1017-1021 (manual) | idle_seconds / manual | SleepHandler.handle (agent_id only) | OK |
+| `sleep_completed` | `sleep_handler.py:514-525` | phases_completed, interrupted, facts_created, … | no bus subscriber; consumed from DB by `dashboard_queries.py:594` | OK (persisted under brain agent_id) |
+| `outcome_signals_detected` | `outcome_detector.py:112-122` | episode_id, signals | CorrectionExtractor (both) | OK |
+| `subtask_outcome` | `subtask_executor.py:118-123`, `subtask_worker.py:413-418` | subtask_id, final_outcome, ok, attempts, tokens, … | none on bus (DB telemetry only) | OK |
+| `subtask_completed` / `subtask_failed` | `subtask_worker.py:446-453` | subtask_id (hex, no dashes), task, result/error | none on bus (DB telemetry) | OK (ID format inconsistent with `subtask_outcome` — INFO-5) |
+
+### Sleep cycle (the previously unaudited core)
+
+`SleepHandler.handle` spawns `_run_sleep` as a detached task (`sleep_handler.py:371-381`). Phase order (`:420-513`): review(stub) → prune(stub) → compress(stub) → reflect → resolve_contradictions → stale_scan → cluster_consolidation → recover_abandoned (F060) → graph_densification (F040) → relink_open_episodes (F057) → prune_dead_edges (F053) → prune_hub_snapshots (F065) → generalize (F012 K-lines) → evolve_rubric (F024-3b). Every phase is individually try/except-wrapped (one failing phase never kills the cycle — good), returns bool for `phases_completed`, and checks `self._interrupted` between phases — which is the problem: `_interrupted` can never become True (HD-3). `sleep_completed` is emitted even when phases failed; failure is only visible as a missing entry in `phases_completed` plus `*_error` keys some (not all) phases write into `sleep_stats`.
+
+### Worker/scheduler plumbing
+
+- **Queue claiming is race-free:** `subtasks.dequeue` uses `SELECT … FOR UPDATE SKIP LOCKED` and flips status→running in the same transaction (`heart/subtasks.py:81-105`). Priority is an int map {urgent:50, normal:100, low:200} (`:16`) — ordering correct.
+- **Timeout/cancel:** `_process_subtask` wraps execution in `asyncio.wait_for`; on timeout it persists `timed_out` using the `HardenedRunState` side channel and emits the outcome event itself; `execute_hardened` deliberately skips persist+emit on CancelledError so DB and event stream can't disagree (`subtask_executor.py:263-282,410-482`). F049 cleanup (`end_conversation` under `shield(wait_for(...))`) runs in `_execute_subtask`'s `finally` on every exit path including cancellation (`subtask_worker.py:288-313`). This chain is correct.
+- **Scheduler:** `get_due` → per-schedule debounce on `metadata->>'schedule_id'` (fail-open) → create subtask → continuation state writes (each soft-failed) → advance/deactivate (`task_scheduler.py:113-265`). Missed fires don't storm: `advance` recomputes from `fired_at=now` via croniter (`heart/schedules.py:151-153`).
+- **Session monitor:** idle math is monotonic-clock based; `touch()` at run_turn start closes the close-mid-turn race; #462 background-exclusion verified end-to-end (emit site `layer.py:1187`, gate `session_monitor.py:329-343`); closures fan out via gather with CancelledError re-raise (shutdown can't hang) and an `abort_if` activity-resumed check.
+
+---
+
+## 2. Findings register
+
+### P1
+
+#### HD-1 — ProcedureLearner dedup gate compares an RRF *rank* score to 0.85 → all three auto-procedure creation pathways permanently suppressed — **LIVE**
+`nous/handlers/procedure_learner.py:550-564`; consumed at `:310,437` and by monitor pathway 3 at `nous/cognitive/monitor.py:279`.
+`_is_duplicate` runs `search_procedures(query_text, limit=1)` and treats `score > 0.85` as duplicate. But `procedures.search` returns **normalized RRF rank scores, then multiplies by the F037 utility boost** — the code's own sibling comment states it: *"search() returns normalized RRF scores that encode RANK, not closeness — the nearest procedure scores ~0.95 for ANY query"* (`nous/heart/procedures.py:502-506`, boost at `:452-467`). With 62 active procedures in prod, the top hit of any query scores ≈0.95 → `_is_duplicate` ≈ always True → decision-cluster (F012 pathway 1), episode-lesson (pathway 2), and monitor-recovery (pathway 3) procedures are silently skipped right before `store_procedure`. `procedure_learning_enabled` defaults True (`config.py:682`) and the sleep generalize phase runs it every cycle. This is the same bug class as DA-S1/S2 (fixed for facts in PR #495 via `find_similar_facts`) — unfixed here, and it mechanically explains the PA prod observation "K-line = 0" (PA attributed duplication to the skill path but did not identify this gate as always-true; PA's "phrasings slip past 0.85" model is inverted).
+**Fix:** probe with `heart.find_similar_procedures` (raw cosine, exists since §14 — `heart.py:505-513`) instead of `search_procedures`, keep 0.85 as a real cosine threshold.
+
+#### HD-2 — Sleep UPDATES-prefix supersession guard compares an RRF rank score to 0.80 → wrong-fact supersession (data corruption) — **LIVE**
+`nous/handlers/sleep_handler.py:759-805` (`_handle_updates_prefix`).
+The F031 orient loop instructs the reflection LLM to mark updated knowledge with `UPDATES: <existing content>` (`:739-744`). The handler then takes `search_facts(referenced_content, limit=3)` and supersedes `results[0]` unless `best_match.score < 0.80` — a guard added specifically "to prevent wrong-fact supersession (review fix from devil's advocate P0-1)" (`:752-753`). `facts.search` returns normalized RRF rank scores (`heart.py:357-367`, `heart/search.py:162-178`): the top hit scores ≈0.98 when it appears in both legs and ≈vector_weight (~0.7) when vector-only — in neither case does the number measure similarity to the referenced content. Consequences: (a) when the rank score ≥0.80, `supersede_fact` deactivates whatever fact happened to rank first — possibly an unrelated fact sharing keywords — and chains `superseded_by` to new content (irreversible without manual SQL); (b) when vector-only (~0.7 < 0.80), a genuinely-matching fact is *not* superseded and a duplicate is learned instead. The guard is decorative. Reachable every sleep cycle: `sleep_enabled=true` in prod, `_phase_reflect` runs with the LLM, and the orient context actively solicits the UPDATES form.
+**Fix:** same as HD-1 — probe with `find_similar_facts(referenced_content)` and threshold the raw cosine (mirror of the PR #495 S1 fix, which covered fact_extractor/knowledge_extractor but not this third site).
+
+### P2
+
+#### HD-3 — `message_received` has no emit site → sleep interruption is fully severed — **LIVE**
+Subscriptions: `sleep_handler.py:363` (`_on_wake`), `session_monitor.py:88`. Emitters: **none** (grep over `nous/`; `api/runner.py:358-368,931-938` explains the runner deliberately calls `monitor.touch()` *instead of* emitting the event). Therefore `SleepHandler._interrupted` is never set: every `if self._interrupted` check in all 14 phases (`sleep_handler.py:432-512` and per-item checks at `:628,824,1162,1607,1800`) is dead, the module docstring's "Sleep is interruptible" contract (`:14-16`) is false, and a user message arriving mid-sleep contends with reflection/contradiction/cluster/densification LLM+DB work for the full cycle duration (prod backfill caps 200+200). DA line 128 noted the densifier-flag copy is "always-False" but scoped it to F040; the root cause — no emitter at all — kills interruption for *every* phase. The monitor's `message_received` subscription is harmless dead code (touch() covers it).
+**Fix:** emit `message_received` (or call `sleep_handler.interrupt()`) from `runner.run_turn` alongside `monitor.touch()`; also propagate into `GraphDensifier.interrupt()`.
+
+#### HD-4 — DecisionReviewer Tier-1 signals systematically mislabel outcomes feeding calibration — **LIVE**
+`nous/handlers/decision_reviewer.py:51-135, 195, 255-296`. `decision_review_enabled=True` (config.py:321); handler fires on every `session_ended` AND hourly sweep over all unreviewed decisions <30 days, writing `reviewer="auto"` outcomes into Brain (which drive Brier/calibration).
+Three independent label corrupters, evaluated in order, first ≥0.7 confidence wins (`:298-311`):
+1. **ErrorSignal** (`:56-74`): any description matching `\b(error|failed|failure|broken|crashed|bug)\b` → outcome=failure at 0.9. A decision *about fixing a bug* ("decided to fix the failing test by …") is auto-labelled a failed decision.
+2. **EpisodeSignal** (`:89-110`): maps `episode.outcome` — but `cognitive/layer.py:1747-1749` hardcodes `outcome="success"` for **every** non-trivially-ended session (DA-E9 noted the vocabulary issue; the reviewer consequence is the live damage). So any decision linked to any normally-closed episode auto-reviews "success" at 0.8 regardless of what happened.
+3. **FileExistsSignal** (`:117-135`): `Path(path_str).exists()` is resolved against the **process cwd** (the container WORKDIR). Repo-relative paths like `nous/api/tools.py` exist in the image by construction → near-guaranteed "success" at 0.7 for any decision that mentions a repo path.
+Net effect: auto-review labels are dominated by lexical accidents, consistent with the F058 finding (Brier 0.252 ≈ random on 401 reviewed decisions).
+**Fix:** drop ErrorSignal keyword matching (or require failure language about the *outcome*, not the topic); stop hardcoding episode outcome success at the layer (out of this scope, but the reviewer should not trust it meanwhile); anchor FileExistsSignal to a configured workspace root or delete it.
+
+#### HD-5 — Schedule timezone token parsed then discarded; cron always runs in UTC — **LIVE**
+`nous/handlers/time_parser.py:37-39,151-159` captures the tz in `_DAILY_RE` group 3 and comments *"the scheduler layer handles tz conversion"* — but `heart/schedules.py:46-47,151-153` evaluates the cron with `croniter(expr, now_utc)` and no conversion exists anywhere (`rest.py:938-957`, `api/tools.py:2300+` call `parse_every` directly). "daily at 9am EST" fires at 09:00 **UTC** (04:00 EST). Wrong-by-hours behavior on the live `schedule_task` tool; the misleading comment guarantees the next reader assumes it works.
+**Fix:** convert h24 to UTC using the captured tz (or reject tz tokens loudly).
+
+#### HD-6 — `parse_when("tomorrow 9am")` schedules **today** 9am (or errors), despite being a documented format — **LIVE**
+`nous/handlers/time_parser.py:65-106`. The docstring advertises `"tomorrow 9am"` via "dateutil fallback", but `dateutil_parser.parse(..., fuzzy=True)` *ignores* unknown tokens: "tomorrow" is dropped and "9am" resolves against today's default date. Before 09:00 local: returns today 09:00 → one-shot fires the same day, a day early. After 09:00: `dt <= now` → ValueError "Time is in the past" — confusing but safe. Same fuzzy-token hazard applies to "next monday …" ("next" is dropped; dateutil's bare-weekday resolution is week-relative, not strictly-future).
+**Fix:** handle `tomorrow`/`next <weekday>` explicitly before the dateutil fallback.
+
+#### HD-7 — Crash-orphaned `running` subtasks are only reclaimed at startup, and only if already timeout-expired → stuck rows can block their schedule — **LATENT**
+`subtask_worker.py:64-68` calls `reclaim_stale()` exactly once at pool start; `heart/subtasks.py:307-324` reclaims only rows where `started_at + timeout < now`. A crash with an in-flight subtask followed by a quick restart (the normal case — prod timeout is 2000s, `.env.prod-snapshot:109`) leaves the row `running` with no live worker, and nothing ever re-checks until the *next* process restart. Until then: (a) the dashboard shows a phantom running task; (b) if the subtask was schedule-fired, `_has_active_subtask_for_schedule` (`task_scheduler.py:79-111`, status in pending/running) returns True every tick → **that schedule silently never fires again** until another restart happens ≥timeout later.
+**Fix:** run `reclaim_stale()` periodically (e.g., in the scheduler/worker poll loop), not only at boot.
+
+#### HD-8 — F060 recovery is half-wired: recovered episodes keep `ended_at/outcome` NULL, their candidate_facts are discarded, and summary-fallback text is chunked as dialogue — **LIVE** *(confirms DA lines 96/107/E9 — still true at HEAD)*
+`sleep_handler.py:1516-1708` + `episode_summarizer.py:150-202`. `_phase_recover_abandoned_episodes` calls `summarize_episode` which persists `structured_summary` only (`episodes.update_summary` backfills title/summary/lessons but never `ended_at`/`outcome`/`active` — `heart/episodes.py:134-161`), and deliberately does not emit `episode_summarized` (`episode_summarizer.py:163-168`) while the sleep phase doesn't invoke FactExtractor either — so the LLM spend extracts zero facts and the episode stays an open-looking row excluded from `list_recent` (`ended_at IS NOT NULL` filter). The F060.1 summary-fallback additionally pushes the ≤500-char plain summary through `_chunk_and_store_transcript` as `source_kind='dialogue'` when chunks are enabled (prod: `NOUS_EPISODE_CHUNKS_ENABLED=true`).
+**Fix:** after successful recovery, set `ended_at`/`outcome` and either emit `episode_summarized` or call the extractor directly; skip chunking for `source_kind == "summary"` inputs.
+
+#### HD-9 — `session_ended` carries no `summary` → OutcomeDetector's scores channel permanently NULL — **LIVE** *(known: RA-R1; verified unchanged at HEAD)*
+Emit: `cognitive/layer.py:1805-1812`. Read: `outcome_detector.py:79-81,101`. `self_improvement_scores` is NULL on every `heart.outcome_signals` row; downstream RubricEvolver runs on uniform proxy scores (RA-R2) — and prod has `NOUS_RUBRIC_EVOLUTION_ENABLED=true` (`.env.prod-snapshot:97`), so the sleep evolve_rubric phase burns a weekly cycle that can only drift weights toward uniform. Listed for completeness; remediation owned by the rubric-audit follow-up.
+
+#### HD-10 — `_review_weak_procedures` queries `search_procedures("auto:")` which matches nothing → weak-procedure retirement dead — **LIVE / DEAD-path** *(known: PA bug 1; verified unchanged at HEAD)*
+`procedure_learner.py:469-544`. `tags` are in neither `search_tsv` nor the embedding text, so the candidate list is empty every cycle; `stats["weak_reviewed"]` is structurally 0. Note interaction with HD-1: even if retirement worked, nothing auto-learned exists to retire.
+
+#### HD-11 — TaskScheduler can double-fire when post-enqueue lifecycle writes fail — **LATENT**
+`task_scheduler.py:182-263`. Failure order is: subtask **created** → continuation writes (soft-failed, OK) → `deactivate()` (once) / `advance()` (recurring). If `deactivate`/`advance` raises (transient DB error), the outer `except Exception` logs and the schedule's `next_fire_at` stays in the past → next tick re-fires. The debounce guard (`:132`) suppresses the duplicate only while the first subtask is still pending/running; a fast subtask (or a `once` schedule whose work finished) gets executed twice. Bounded (one extra fire per failure) but a real at-least-once → at-least-twice hazard for `once` schedules.
+**Fix:** for `once`, deactivate *before* enqueue (compensate on enqueue failure), or stamp `last_fired_at` first and add it to the debounce predicate.
+
+#### HD-12 — `actionability_backfill` has no forward-progress guard: persistent per-row failure = infinite loop on one connection held idle-in-transaction — **LATENT**
+`actionability_backfill.py:117-152` loops `while True` re-fetching `actionable IS NULL` rows; rows that fail `classify`/`_update_actionable` stay NULL and are re-fetched forever (same LIMIT batch, no ordering/offset/attempt cap) at 0.5 s cadence. Meanwhile the advisory-lock session opened at `:76-90` executed a SELECT (autobegin) and never commits — that pooled connection sits "idle in transaction" for the entire backfill (normally fine for minutes; pathological under the infinite loop: blocks vacuum xmin + burns a pool slot indefinitely). Triggered at every startup (`actionability_backfill_on_startup=True`, `main.py:224-239`).
+**Fix:** break after N consecutive all-error batches (or exclude failed IDs in-session); commit/close the lock session's implicit transaction (`pg_advisory_lock` survives commit).
+
+### P3
+
+#### HD-13 — Sleep phases mutate facts in two transactions; crash between leaves inconsistent state — **LATENT**
+F031 MERGE (`sleep_handler.py:929-1008`) and F027 cluster merge (`:1259-1314`) first `heart.learn()` the merged fact (own transaction), then deactivate+supersede originals in a second session. A crash/exception between the two leaves the merged fact live **alongside** all originals (duplicate content, no chain). Inner excepts log at WARNING and continue. Low frequency, self-correcting only via future contradiction scans.
+
+#### HD-14 — F031 resolution-event task not GC-protected — **LIVE (cosmetic loss)**
+`sleep_handler.py:889-906` uses bare `asyncio.create_task(self._brain.emit_event(...))` for `f031_contradiction_resolution`, unlike `_emit_action_event` (`:387-409`) which retains strong refs in `_pending_emits` precisely to avoid mid-flight GC. Occasional silent loss of audit events; the eval that consumes them under-counts.
+
+#### HD-15 — `_phase_relink_open_episodes`: one DB error inside the shared session aborts the rest of the phase — **LATENT**
+`sleep_handler.py:1759-1832`. The per-episode `try` wraps only `link_episode_deterministic`; if that fails with a *database* error the transaction is poisoned, and the next iteration's anchor SELECT (`:1804`, outside the try) raises `PendingRollbackError` → outer except → phase aborts, edges built so far in this session are rolled back. Errors counter under-reports.
+**Fix:** per-episode savepoint (`session.begin_nested()`), or rollback+continue on failure.
+
+#### HD-16 — Sleep stale-scan loads and deactivates an unbounded row set in one transaction — **LIVE** *(DA-G9 noted the asymmetry; restated for the fix list)*
+`sleep_handler.py:1068-1115`: no LIMIT; a first run on an old corpus can deactivate thousands of facts in one commit while F053 edge pruning is capped at 1000/cycle — orphaned dead edges then take many cycles to drain. Add a per-cycle cap mirroring `dead_edge_pruning_max_per_cycle`.
+
+#### HD-17 — Double-sleep spawn race + `_sleep_task` clobber — **LATENT** *(DA-G9)*
+`sleep_handler.py:371-381`: `_sleeping` is set inside the spawned task, not before `create_task`; two `sleep_started` events dispatched in the same tick window can both pass the guard. Second task also overwrites `self._sleep_task`, and the first task's `finally` (`:537`) later nulls the reference to the *second* task. Practically rare (REST trigger + monitor coinciding).
+
+#### HD-18 — Knowledge extractor residual gaps after PR #495 — **LIVE**
+`knowledge_extractor.py:117-139`: (a) hardcoded cosine 0.85 instead of `settings.fact_dedup_threshold` (0.92) — the two write paths now disagree on what "duplicate" means; (b) no F377 tiebreaker and no F075 distinct-date bypass (`_resolve_dedup` was not adopted — DA-S2's fix suggestion remains open); (c) stores facts with no `source_episode_id`/`source_text` → ungrounded for admission, orphaned in the graph.
+
+#### HD-19 — `decision_recorded` is emitted before the recording transaction commits → linker can read-miss and silently skip — **LIVE (small window)**
+`brain/brain.py:406-412` emits mid-transaction; `DecisionGraphLinker.handle` fetches via a **new** session (`decision_graph_linker.py:72-74`) and returns silently on None. Window opens whenever the bus task runs while `record()` is still doing auto-link/commit work. No retry; the decision stays orphaned until F040 sleep backfill. Same-pattern check: `fact_learned`/`procedure_stored` are emitted post-commit (heart facade) — only the decision path has this ordering.
+
+#### HD-20 — Reverse/procedure linkers skipped the F022 content-length guard and hide failures at DEBUG — **LIVE**
+`decision_graph_linker.py:71-182`, `procedure_graph_linker.py:64-150`: neither applies `cross_type_link_min_content_chars` (the 2026-04-30 F022 audit fix landed only in `GraphLinker.link_fact_to_*`, `brain/graph_linker.py:162-168,250-255`) — short/empty descriptions still generate the exact low-precision edges that fix targeted. Both handlers also log total failure at `logger.debug` (`:182`, `:150`), invisible at prod log level — a broken embedder or SQL regression would zero out live linking with no signal (same class as DA-S13 `_create_graph_edge`).
+
+#### HD-21 — Sleep reflection lessons stored as category="rule" — **LIVE**
+`sleep_handler.py:671-685`: fallback lessons go in with `category="rule"`, which the system defines as user-directives-only and loads **every turn**. LLM-authored generalizations escalate themselves into always-on context (same class as DA's `layer.py:1777-1783` finding; different site).
+
+#### HD-22 — Correction extractor logs success on rejected facts — **LIVE**
+`correction_extractor.py:126-127`: `heart.learn` result not checked for `FactRejected`; "F039: Stored correction fact" logs regardless, and a (provenance-capped) censor can still be created at `:130-139` for a principle whose fact was rejected.
+
+#### HD-23 — Event-bus shutdown can drop in-flight handler work; queue overflow drops events silently for handlers with persistence side effects — **LATENT** *(overflow half is DA-S13)*
+`events.py:194-227`: `stop()` cancels the loop task mid-`_dispatch` (the gather is cancelled; that event's remaining handlers never run) before draining the rest; events emitted *during* drain dispatch are processed, but anything a cancelled handler half-did is lost. Acceptable for telemetry, less so for `episode_summarized`→fact extraction at shutdown.
+
+#### HD-24 — Backfill budget gate mutates a shared classifier — **LATENT**
+`actionability_backfill.py:56-61,104`: `classifier._budget_check` is swapped at construction and restored only in `run_once`'s finally — between handler construction (`main.py:231`) and the backfill's completion, *live-path* `classify()` calls are also subject to the backfill's call cap; two concurrent backfills (multi-agent) would clobber each other's gate.
+
+### INFO
+
+- **INFO-1 — Stub phases report success:** `_phase_review_decisions`, `_phase_prune`, `_phase_compress` (`sleep_handler.py:546-584`) do nothing but appear in `phases_completed` ("review", "prune", "compress"), inflating dashboard/telemetry. *(DA-G9.)*
+- **INFO-2 — DecisionReviewer `CONFIDENCE_THRESHOLD=0.7` is inert:** every signal's hardcoded confidence is ≥0.7 (`decision_reviewer.py:64,71,107,131,175,183`).
+- **INFO-3 — `handle()` runs a full 30-day sweep on every `session_ended`** (`decision_reviewer.py:277-280`) *in addition to* the hourly sweep — O(unreviewed) GitHub/file checks per session end.
+- **INFO-4 — `episode_summarizer.py` uses `datetime` in annotations without importing it** (`:450,492`) — safe only because of `from __future__ import annotations`; same for `FactSummary`/`date` strings in `fact_extractor.py:142,201`.
+- **INFO-5 — Subtask event ID formats differ:** `subtask_id` is `uuid.hex` in `subtask_completed/failed` (`subtask_worker.py:438`) but `str(uuid)` (dashed) in `subtask_outcome` (`subtask_executor.py:99`) — joins on the events table need to normalize.
+- **INFO-6 — `call_background_llm*` only accept dict content blocks** (`handlers/__init__.py:77-79,144-146`); a typed-object client response would silently return None for every background LLM consumer.
+- **INFO-7 — `_repair_json` strips trailing commas inside string literals too** (`handlers/__init__.py:196` — regex is not string-aware, unlike `_extract_braces`); can corrupt a candidate that would otherwise fail loudly. Low impact since it's a last-resort path.
+- **INFO-8 — `procedure_learner.py:390` `except (ValueError, Exception)`** — redundant tuple; and `_learn_from_episodes` filters on outcomes ("success","partial") that only exist because `layer.py` hardcodes "success" (see HD-4.2) — the filter is effectively "any non-abandoned episode".
+- **INFO-9 — KnowledgeExtractor stores `self._bus` it never uses** (`knowledge_extractor.py:82`).
+- **INFO-10 — Monitor pathway 3 reaches into `_procedure_learner._call_llm/_is_duplicate/_heart` privates** (`cognitive/monitor.py:262-295`) — wiring coupling that made HD-1 spread to a third pathway invisibly.
+
+---
+
+## 3. Dead-code inventory
+
+| Item | Location | Note |
+|---|---|---|
+| `SleepHandler._on_wake` + all `_interrupted` checks | `sleep_handler.py:363-369` and 14 phase sites | No `message_received` emitter (HD-3) |
+| SessionTimeoutMonitor `message_received` subscription | `session_monitor.py:88` | Superseded by synchronous `touch()` |
+| `_phase_review_decisions` / `_phase_prune` / `_phase_compress` bodies | `sleep_handler.py:546-584` | Stubs since 006; still listed as phases |
+| `_review_weak_procedures` (entire branch incl. `_WEAK_REVIEW_PROMPT`) | `procedure_learner.py:70-87,469-544` | Candidate query matches nothing (HD-10) |
+| `_is_duplicate`-guarded store paths (effectively) | `procedure_learner.py:310-331,437-457`; `monitor.py:279` | Unreachable in practice while HD-1 stands |
+| `OutcomeSignal.self_improvement_scores` real-scores branch | `outcome_detector.py:101`; `rubric_evolver.py:190-191` | Severed payload (HD-9 / RA-R1) |
+| `CONFIDENCE_THRESHOLD` filtering effect | `decision_reviewer.py:195,303` | All signals ≥0.7 (INFO-2) |
+| tz capture group in `_DAILY_RE` | `time_parser.py:39,156-157` | Captured, never used (HD-5) |
+| `_build_retry_message` `task` param | `subtask_executor.py:531` | Explicitly reserved/`del`-ed |
+| `EventBus._queue.task_done` discipline | `events.py:220` | `get()` without `task_done()`; `join()` unused — harmless |
+
+---
+
+## 4. Improvement opportunities
+
+1. **One shared "similar-by-cosine" probe for every dedup/supersede gate.** PR #495 fixed two of five rank-score sites; HD-1 and HD-2 are the remaining write-path gates, HD-18(a) the remaining threshold drift. A single helper (`find_similar_facts` / `find_similar_procedures` + settings threshold) used by all five removes the class.
+2. **Make sleep interruptible for real (HD-3) and add a watchdog:** a `max_sleep_duration` guard would also bound the uninterruptible worst case until the wire is restored.
+3. **Auto-review quality gate (HD-4):** before any new signal work, persist the signal_type with each auto review (it's already in `ReviewResult`) and run a one-off accuracy eval against hand labels — the F058 calibration data suggests today's labels are worse than no labels.
+4. **Promote linker failures from DEBUG to WARNING with a counter in bus stats** (HD-20); the EventBusStats handler table already exists — failures there are visible, but in-handler swallowed exceptions are not.
+5. **Periodic `reclaim_stale` + scheduler-debounce TTL** (HD-7, HD-11): both are one-line policy changes in existing loops.
+6. **Emit `episode_summarized` from the F060 recovery path** (HD-8): converts already-spent LLM calls into facts and unifies the two summarize entry points' side effects.
+7. **Sleep-phase savepoints** (HD-13, HD-15): wrap per-item mutations in `begin_nested()` so one bad item can't roll back or poison a phase.
+8. **Contract tests for event payloads:** a tiny test asserting emitted-key ⊇ read-key per (event, handler) pair would have caught HD-3 and HD-9 at introduction time; the table in §1 is the spec.

--- a/docs/reviews/heart-audit-2026-06-09.md
+++ b/docs/reviews/heart-audit-2026-06-09.md
@@ -1,0 +1,207 @@
+# Heart Organ (Memory System) — Deep Code Audit
+
+**Date:** 2026-06-09 · **HEAD:** `2f6a193` (post-PR #495 — the storage/retrieval integrity fixes are merged)
+**Scope:** `nous/heart/*` (all 25 files read fully) + `nous/api/retrieval_pipeline.py`. Boundaries: `nous/handlers/*`, `nous/api/tools.py`, `nous/brain/*`, `nous/cognitive/*` covered by other agents (touched here only to close wires).
+**Method:** code only; every claim carries `path:line`. Reachability verdicts use `config.py` defaults overlaid with `.env.prod-snapshot` (LIVE / LATENT / INERT / DEAD). Numeric-space checks on every score-vs-threshold comparison; closed-loop tracing on admission, censors, working memory, residual activation, subtasks/schedules.
+**Job:** (a) verify prior-audit P1/P2 status at HEAD, (b) net-new findings in under-audited corners.
+
+---
+
+## (a) Current-state overview
+
+PR #495 (commit `2f6a193`) genuinely fixed the write-path headline pair: both fact-dedup gates now threshold **raw cosine** (`facts.py:1400-1485` `find_similar_for_dedup`; `facts.py:1019-1108` `_find_duplicate`, HNSW-served), in-band dupes are F027-classified before confirming (`facts.py:896-997`), `event_date` merges onto undated dupes (`facts.py:999-1017`), dedup probes no longer mutate recall stats, `exclude_ids` reaches `_supersede_by_subject` (`facts.py:585-590, 837-851`), the F067/F069 chunk-index collision is closed under the shared advisory lock (`episode_summarizer.py:259-300`), F055 working-memory writes merge instead of clobber (`working_memory.py:430-547`), decision deletes remove their graph edges + migration 060 cleanup, an embedding LRU kills the 4–10× repeat-embed tax, and the §14 cosine leg gained the procedure score floor (`context.py:1445-1449`).
+
+What did **not** change: the transaction-spans-LLM-calls pattern in `_learn` (now with one *more* potential Haiku call — the band classifier — inside the transaction), NULL-embedding facts with no repair path, the pre-commit `fact_learned` emission, every graph-writer defect (G1–G9), the episode/WM lifecycle items E3–E9, and the read-side score-space residue (B3/B4/B5/B6/B7).
+
+The headline **net-new** finding of this audit: the episode semantic-search leg is structurally dead in the production lifecycle — every episode closed since PR #79 (2026-02-28) is `active=false` and therefore filtered out of hybrid search, while ongoing episodes are filtered out by `outcome != 'abandoned'` NULL semantics. No episode state produced by the live lifecycle can be retrieved by `search_episodes`, `Heart.recall`'s episode leg, the cognitive Episodes section, or `search_recent_episodes_by_embedding` (HT-1). Eval corpora insert episodes directly (`active=true` + outcome set), which is why this never showed up in LME/BEAM numbers — the exact "eval fixtures must match prod input thinness" trap.
+
+---
+
+## (b) Known-findings status at HEAD
+
+### Deep analysis 2026-06-09 (`memory-storage-retrieval-deep-analysis-2026-06-09.md`)
+
+| ID | Was | Verdict at `2f6a193` | Evidence |
+|---|---|---|---|
+| S1 Leg-1 RRF-vs-similarity dedup | P1 | **FIXED** | `facts.py:1400-1485` raw-cosine probe; `heart.py:369-380` `find_similar_facts`; fact_extractor rewired (PR #495) |
+| S2 knowledge_extractor 0.85 rank-score | P1 | **PARTIALLY-FIXED** | dedup math fixed (`knowledge_extractor.py:117-130` raw cosine); still passes **no** `source_episode_id`/`source_text` (`:133-139`) → survivors remain ungrounded for admission |
+| S3 0.80 threshold swallows contradiction band | P1 | **FIXED** | `_classify_dupe_in_band` (`facts.py:896-954`) + `_apply_band_action` (`:956-997`) + `_confirm_duplicate` date merge (`:999-1017`) — but see net-new **HT-2** (the date-bypass branch re-opens a sibling hole) |
+| S4 NULL-embedding facts, no backfill | P2 | **STILL-LIVE** | `facts.py:439-443` swallow → `:549` insert; no `embedding IS NULL` repair consumer for facts |
+| S5 transaction spans ≤4 LLM calls + dup race | P2 | **STILL-LIVE (slightly worse)** | `facts.py:480` (band classifier — new), `:499` (admission utility), `:528` (actionability), `:686` (contradiction), `:856-858` (supersession) all inside `_learn`'s session |
+| S6 `fact_learned` emitted pre-commit | P2 | **STILL-LIVE** | `heart.py:313-324` |
+| S7 ~10 embeds per stored fact | P2 | **FIXED (cache)** | `embeddings.py` bounded LRU (`NOUS_EMBEDDING_CACHE_SIZE=1024`, packed float32) |
+| S8 sleep MERGE learn() without exclude_ids | P2 | **STILL-LIVE** | `sleep_handler.py:930-938` (`contradiction_resolution` learn has no `exclude_ids`); same for F031 merge |
+| S9 dedup probes inflate recall stats | P2 | **FIXED** | `facts.py:1414-1418` (no `_fire_track_access` in dedup probe) |
+| S10 `_find_duplicate` seq scan | P2 | **FIXED** | `facts.py:1078-1090` plain distance ORDER BY LIMIT 20 + `set_local_ef_search` |
+| S11 exclude_ids not in `_supersede_by_subject` | P2 | **FIXED** | `facts.py:585-590, 837-851` |
+| S12 reflection facts as `category="rule"` | P2 | **STILL-LIVE** | `layer.py:1777-1783` (boundary; spot-verified) |
+| S13 batch (P3) | P3 | **MOSTLY STILL-LIVE** | `learn_fact` source discard, `track_access` not agent-scoped (`facts.py:238-247`), `_create_graph_edge` DEBUG swallow (`:216-217`), stale `FactDetail` when contradiction handling deactivates the new fact (`:602` vs `:734-737`), unlocked confidence decrements (`:755, :987, :1316`), event-bus overflow drop. **FIXED:** Settings re-instantiation (`search.py:71-99` env-fingerprint cache). **PARTIALLY-FIXED:** F075 top-1 date bypass (date preference now scans top-20, `facts.py:1096-1101`) |
+| E1 F067↔F069 chunk-index collision | P1 | **FIXED** | `episode_summarizer.py:259-300` — MAX+1 under the same `ingest_document:{episode_id}` advisory lock + per-kind idempotency check |
+| E2 F055 WM wholesale clobber | P1 | **FIXED** | `working_memory.py:430-547` merge-by-ref_id, curated-wins, combined-cap; real snippets threaded (`residual_activation.py:254-265`, `tools.py:789-797`) |
+| E3 500-char/turn transcript truncation | P2 | **STILL-LIVE** | `layer.py:390`, `:1159` |
+| E4 end_session pops state pre-persist | P2 | **STILL-LIVE** | `layer.py:1723-1724`, swallow at `:1754-1755` |
+| E5 F060-recovered episodes invisible | P2 | **STILL-LIVE** | recovery loop A never sets `ended_at`/`outcome`; `episodes.py:373, 383, 516, 526` — and now subsumed by net-new **HT-1** (the whole leg is dead, not just recovered rows) |
+| E6 episode dedup shares episode across sessions | P2 | **STILL-LIVE** | `episodes.py:71-85` (no session_id scope), `_end` overwrites unconditionally `:229-239` |
+| E7 chunk persistence one-shot/unretryable | P2 | **PARTIALLY-FIXED** | manual `scripts/backfill_episode_chunks.py` (+`--repair-dialogue`) shipped in #495; still no automatic retry on the live path (`episode_summarizer.py` guard) |
+| E8 WM load_item no ref_id dedup | P2 | **STILL-LIVE** | `working_memory.py:133-145` appends unconditionally (residual path got dedup; curated path didn't) |
+| E9 batch (P3) | P3 | **MOSTLY STILL-LIVE** | `cleanup_stale` one-transaction batching (`working_memory.py:364-386` — single commit at `:386` defeats the stated lock-avoidance); outcome always `'success'` (`layer.py:1749`); chunk recall surfaces deactivated episodes (`retrieval_pipeline.py:913-922`); `record_surfaced` bare `create_task` GC-eligible (`tools.py:798`); WM row resurrected after end_session (`working_memory.py:530-544` creates if missing); ORM/DB constraint-name coupling on WM upsert (`working_memory.py:58`). **PARTIALLY-FIXED:** concurrent double-summarize for chunks only (per-kind existence check under lock) |
+| G1–G9 graph writer defects | P2/P3 | **STILL-LIVE (carried)** | PR #495's `graph_densifier.py` delta is embed-cache plumbing only; reverse-duplicate edges, inverted relations, four weight spaces, co_occurrence orphan mask, dead interrupt, no failed-orphan memory, CE-mode threshold trap, dead F070.1 cycle hook — all unchanged |
+| D1 decision delete dangles edges | P1 | **FIXED** | `brain.py:565-600` explicit edge DELETE; `sql/migrations/060_memory_integrity.sql` cleanup |
+| D2 query embedded 4–7× | P2 | **FIXED (cache)** | embedding LRU; calls still issued, served from cache |
+| D3 sessions across LLM/embeds | P2 | **STILL-LIVE** | same sites as S5 + `heart._recall` embeds in-session |
+| D4 missing lower(subject) index | P2 | **FIXED** | migration 060 `idx_facts_agent_subject_lower` |
+| D5 chunk recall ignores episode soft-delete | P2 | **STILL-LIVE** | `retrieval_pipeline.py:913-922` (no JOIN on `episodes.active`) |
+| D6 embedding-space mixing unguarded | P2 | **STILL-LIVE** | no boot assert/model marker; prod runs `text-embedding-3-large` against code default small |
+| D7 migrator concurrency/checksum | P2 | **STILL-LIVE** | `migrator.py` unchanged |
+| D8 SA CTE no visited-set | P2 | **STILL-LIVE / UNREACHABLE-today** | `spreading_activation.py` unchanged |
+| D9 censor vector scan shape | P2 | **PARTIALLY-FIXED (by design)** | read-only `_semantic_search` index-served (`censors.py:403-420`); enforcement `_semantic_match` deliberately exact (`:272-289`, codex P1 — accepted trade) |
+| D10 batch | P3 | Settings re-instantiation **FIXED**; rest **STILL-LIVE** |
+| R1 §14 floorless body preload | P2 | **FIXED** | `context.py:1445-1449` applies `procedure_score_floor` to raw-cosine scores (`procedures.py:493-570` provides the cosine probe) |
+| R2 recall_deep contract lie | P2 | **FIXED** | docstring + schema updated in `tools.py` (PR #495) |
+| R3 conversation-frame procedure hole | P2 | **STILL-LIVE** | `schemas.py` frame budgets unchanged |
+| R4 batch | P3 | **STILL-LIVE** (F081 char-based embed cap `procedures.py:60-61`; §14 N+1 etc.) |
+
+### Retrieval whitepaper 2026-06-08 (register at HEAD)
+
+| ID | Verdict | Evidence |
+|---|---|---|
+| B1 censor floor ≥0.7 in pool | FIXED on recall_deep default path (F080, `retrieval_pipeline.py:363-365`); **STILL-LIVE on Heart.recall direct surfaces** — see net-new **HT-3**; floor unchanged `censors.py:266, 396` + keyword matches hardcoded **1.0** (`censors.py:486`) |
+| B2 procedure boost >1.0 | same shape as B1 (`procedures.py:452-467`); LATENT on default path, LIVE on direct surfaces |
+| B3 embed-fail leg raw ts_rank | **STILL-LIVE** (`search.py:281-283`; mirror `facts.py:1668-1669`) |
+| B4 mixed-scale rerank sort | **STILL-LIVE (residual mix)** (`retrieval_pipeline.py:282-283`: RRF facts vs raw-cosine chunks vs graph-composed scores) |
+| B5 stats hardcoded False | **STILL-LIVE** (`retrieval_pipeline.py:301-302`) |
+| B6 contradiction ids exclude facts/chunks | **STILL-LIVE** (`:679-686`) |
+| B7 no global top-K | **STILL-LIVE** (`:224-315`) |
+| B8 one-directional contradiction attach | **STILL-LIVE** (`:1211-1224`) |
+| B9 dead recency_date arg | **STILL-LIVE** (harmless; `:1171, :1187`) |
+| B-cog-A…G | **STILL-LIVE (carried — cognitive boundary)** |
+| B-graph-5 | changed by prod overlay (`NOUS_GRAPH_NEIGHBOR_SEED_SCORE_ENABLED=true`); seed-score scoring live (`:976-993`) |
+| B-graph-6 boost before graph_expanded append | **STILL-LIVE** (`:249-254`) |
+| B-graph-8 density recompute per recall | **STILL-LIVE** (`:586-600`) |
+| B-graph-9 dup decisions Stage 2/4 | **STILL-LIVE** (`:430` vs `:578`) |
+| B-hs-8 query embedded 3–4× | **FIXED (cache)** |
+| B-hs-4 Tier-1 score=1.0 | **STILL-LIVE** (`facts.py:1387`) |
+| B-hs-10 `_search_all` fork | **STILL-LIVE** (`facts.py:1609-1704`) |
+| B-rm-1 date-aware boost dead | **STILL-DEAD** (config-only; zero consumers outside `config.py`) |
+| B-rm-3 CE head/tail scales | **LATENT** (`reranker.py:103-167`; CE off in prod) |
+| B-rm-7 cache-write desync / B-rm-8 monotonic budget | **STILL-LIVE** (`query_expansion.py:498-526`, `:447`) |
+
+### Procedure subsystem audit 2026-06-06 (§2 bugs)
+
+| Bug | Verdict | Evidence |
+|---|---|---|
+| 1 dead auto-retirement (`search_procedures("auto:")`) | **STILL-LIVE** | `procedure_learner.py:476` unchanged; tags still not in `search_tsv` or embed text (`procedures.py:31-61`) |
+| 2 `get_evolution_candidates` no prod consumer | **STILL-LIVE** | zero callers outside `nous/heart/` |
+| 3 coarse turn-blanket reinforcement | **STILL-LIVE** (boundary) |
+| 4 conversation frame 0 procedure budget | **STILL-LIVE** (= R3) |
+| 5 recall_deep procedures unreinforced | **MOOT-SHIFTED** — F080 removed procedures from the default recall pool entirely; reinforcement gap remains for explicit-type calls |
+| 6 `neutral_count` dead | **STILL-LIVE** | written only on explicit `record_outcome("neutral")` (`procedures.py:313-314`); ignored by `_compute_effectiveness` (`:958-968`) |
+| 7 vestigial columns | **STILL-LIVE** | `related_procedures`/`censor_ids` "reserved" (`schemas.py:263-264`) |
+| 8 embedding failure → silent NULL | **PARTIALLY-FIXED** | `_embed_with_retry` (`procedures.py:112-132`): retry + ERROR log; still stores NULL |
+| 9 learn_skill count reset | **FIXED** | `update_body` in-place refresh (`procedures.py:181-232`) + F081 |
+| 10 no REST retire endpoint | **STILL-LIVE** | no `retire` route in `rest.py` |
+| §6-B1 resurrection loop | **FIXED** | `superseded_by`/`archived_at` guards (`procedures.py:884-892, 896-916`); reactivate name-collision precheck (`:802-819`); migrations 057/058 |
+
+---
+
+## (c) NET-NEW findings register
+
+### P1
+
+**HT-1 — Episode semantic search is structurally dead for the production lifecycle. [P1, LIVE]**
+`EpisodeManager._end` sets `active = False` on every closed episode (`episodes.py:235`, shipped PR #79, 2026-02-28). Every episode hybrid search runs through `hybrid_search` with the default `active_filter=True` → `AND t.active = true` (`episodes.py:519-527` → `search.py:241-242`), plus `extra_where="AND t.outcome != 'abandoned'"` (`episodes.py:516, 526`). SQL three-valued logic excludes NULL-outcome rows from `!= 'abandoned'`. State space:
+- **Closed** episodes (the searchable corpus): `active=false` → excluded.
+- **Ongoing / F060-recovered / stuck-open** episodes: `outcome IS NULL` → excluded.
+- **Marked-abandoned** (F060.2): `active=false AND outcome='abandoned'` → doubly excluded.
+- Only `active=true AND outcome NOT NULL` rows match — produced by no live writer; only bulk eval ingest and pre-PR-#79 rows qualify.
+
+Affected consumers (all return ~nothing in prod shape): `Heart.recall` episode leg (`heart.py:951`), recall_deep Stage 1 episodes, ContextEngine "Related Episodes" section (`context.py:918`), heartbeat checks (`heartbeat/checks.py:282, 888`), censor actions (`censor_actions.py:123`), and `search_recent_by_embedding` (`episodes.py:607-616`: `active = true AND outcome != 'abandoned'`) — which kills the cognitive pre-turn episode-dedup probe (`layer.py:1649`, always returns no match → its >0.85 skip never fires) and the summarizer's similar-episode (ep↔ep `related_to`) linking. Eval corpora (LME/BEAM loaders) insert episodes directly with `active=true` + outcome set, masking this completely — the documented "eval fixtures must match prod input thinness" trap.
+*Why prior audits missed it:* E5/E9 analyzed the `outcome != 'abandoned'` NULL semantics for recovered rows and the always-`'success'` outcome but treated normally-closed episodes as searchable; the `active=False`-on-close × `active_filter=True` interaction was never composed.
+*Fix:* episodes' `active` is overloaded (ongoing-flag AND soft-delete). Either pass `active_filter=False` + `AND (t.outcome IS NULL OR t.outcome != 'abandoned')` from `EpisodeManager._search`/`_search_recent_by_embedding`, or stop setting `active=False` in `_end` and keep `active` strictly as the soft-delete bit (one-time backfill `UPDATE heart.episodes SET active=true WHERE ended_at IS NOT NULL AND outcome != 'abandoned'`).
+
+**HT-2 — F075 date-bypass survivors are immediately re-collided by `_find_contradiction`, which has no event-date guard; an UPDATE verdict deactivates the older dated event. [P1, LIVE]**
+When `_find_duplicate` returns a hit whose `event_date` differs from the candidate's, `_learn` bypasses dedup (`facts.py:473-478`, `pass # treat as new event`) — but unlike the S3 band path (`:491` appends `dupe.id` to `exclude_ids`), the bypass branch leaves `exclude_ids` unchanged. The post-insert contradiction scan then runs with `safe_excludes = exclude_ids + [fact.id]` (`:608-613`) and finds the same dated sibling (similarity was above the prod 0.80 dedup threshold, so typically inside the 0.85–0.95 contradiction band). The F027 routing in `_find_contradiction` has **no event-date check**: `UPDATE`/`current=new`/conf ≥0.8 sets `old_fact.superseded_by`, `active=False`, confidence ×0.3 (`facts.py:719-731`). Two same-shape dated events ("API key obtained March 10" vs "rotated March 12") are exactly the pairs the classifier's own prompt examples route to UPDATE (`facts.py:64-68`). Net: the distinct-event preservation F075 exists for is undone one statement later — the older event is silently deactivated. `_supersede_by_subject` got the date-disagreement skip (`:845-851`); `_find_contradiction` never did. Prod: `NOUS_TEMPORAL_EXTRACTION_ENABLED=true`, threshold 0.80, LLM wired → LIVE.
+*Fix:* in the date-bypass branch, append `dupe.id` to `exclude_ids` (mirroring `:491`); additionally skip the UPDATE/supersede routing in `_find_contradiction` when both facts carry differing non-null `event_date`.
+
+### P2
+
+**HT-3 — F080 coherent ranking exists only in `run_recall_pipeline`; `Heart.recall` direct surfaces still merge censors and boosted procedures into the knowledge pool. [P2, LIVE]**
+The censor/procedure exclusion is applied in the pipeline only (`retrieval_pipeline.py:363-365`). Direct callers of `heart.recall` with default types get all four legs: the MCP server's recall (`mcp.py:263` for `"all"`, `:278` for typed) and censor trigger-actions (`censor_actions.py:90`). There the whitepaper's B1/B2 remain fully live: censors enter at raw cosine ≥0.7 (`censors.py:266, 396`) — or at a hardcoded **1.0** when the regex/substring keyword path matches (`censors.py:486`, also the fallback when query embedding fails) — and procedures at boosted RRF >1.0 (`procedures.py:452-467`), displacing facts at the `[:limit]` cut inside `heart._recall` (`heart.py:1133-1135`). Prod: `NOUS_MCP_ENABLED=true`.
+*Fix:* move the knowledge-only default (or score normalization) into `Heart._recall` so every consumer inherits it; keep explicit `types=` honored.
+
+**HT-4 — Subtask `complete()`/`fail()` are unconditional, unguarded UPDATEs: a stale worker can overwrite a reclaimed/re-run/cancelled task's state; no agent scoping. [P2, LIVE]**
+`complete` (`subtasks.py:143-149`) and `fail` (`:197-203`) update `WHERE Subtask.id == :id` with no `status` precondition and no `agent_id` filter. `reclaim_stale` (`:307-324`) flips timed-out `running` rows back to `pending`; if the original worker's coroutine is still alive (event-loop stall, generous `wait_for`, prod `NOUS_SUBTASK_DEFAULT_TIMEOUT=2000`s), its terminal write lands on a row another worker has since re-dequeued — marking the in-flight re-run `completed`/`failed` with the stale attempt's result, corrupting `final_outcome`/`report_jsonb` and the F061 dashboard. Same class: `mark_delivered` (`:299-305`), `get` (`:234-237`) are id-only.
+*Fix:* add `WHERE status='running' AND worker_id=:worker AND agent_id=:agent` preconditions to the terminal transitions; log when rowcount==0.
+
+### P3
+
+**HT-5 — `_update_summary` / `_bump_compaction_count` not agent-scoped. [P3, LIVE]**
+`episodes.py:137` and `:187-188` fetch by `Episode.id` only — the only two Heart write paths without the `agent_id` filter every sibling `_get_*_orm` applies (recurring-miss class). UUID guessing is impractical, but multi-agent readiness is violated; `schedules.advance/deactivate/get` (`schedules.py:140, 174, 183`) share the pattern.
+
+**HT-6 — `schedules.create(schedule_type="once", fire_at=None)` creates a permanently dormant active schedule. [P3, LIVE]**
+`schedules.py:43-44` sets `next_fire = None` for `once` without validating `fire_at`; `get_due` filters `next_fire_at <= now` (`:88`) → the row never fires and never deactivates, but shows as active in `list()`. The recurring branch raises on missing timing (`:51`); the once branch doesn't.
+
+**HT-7 — `resolve_thread` removes every containing-match, not the documented first match. [P3, LIVE]**
+Docstring says "remove first match" (`working_memory.py:246, 267`); the comprehension at `:268` drops **all** threads whose description contains the (possibly very short) needle — `resolve_thread("fix")` wipes every thread mentioning "fix".
+
+**HT-8 — `upsert_residual_items` cold-start insert race loses the write. [P3, LIVE]**
+Two concurrent `record_surfaced` tasks on a fresh session both see `existing is None` (`working_memory.py:470-471`) and both `session.add` (`:530-544`); the loser's commit raises on the unique constraint and is swallowed at WARN by `record_surfaced` (`residual_activation.py:278-283`) — one recall's residual set is silently dropped. Bounded impact (next recall rewrites).
+
+**HT-9 — Residual SA seeds are all typed `"fact"`. [P3, INERT]**
+`seed_for_spreading` hardcodes `node_type="fact"` (`residual_activation.py:182`); a residual episode/chunk/decision id seeded into the spreading-activation CTE matches no edges under `(source_id, source_type)` polymorphic keys — those seeds are no-ops. Inert today only because SA is density-gated unreachable.
+
+**HT-10 — Residual boost clamp `min(1.0, …)` can *demote* boosted procedures. [P3, LIVE prod-TODAY]**
+`boost_scores` assumes scores ≤1.0 (`residual_activation.py:209`); a residually-activated procedure carrying the F037 boosted score (e.g. 1.26) is reset to 1.0 — receiving a "boost" lowers it below an unboosted 1.2 sibling. Numeric-space mismatch of the recurring class. Narrow: requires procedures in the pool (prod-TODAY default; explicit-type / MCP at HEAD-deploy) + `NOUS_RESIDUAL_ACTIVATION_ENABLED=true` (prod).
+
+**HT-11 — Subtask pending-limit check is TOCTOU. [P3, LIVE]**
+`subtasks.py:49-58` SELECT-count-then-INSERT with no lock/constraint — concurrent creates exceed `_MAX_PENDING=5`. Advisory only; harmless overshoot.
+
+**HT-12 — Censor enforcement side-effects ride the caller's injected transaction. [P3, LIVE]**
+`check()` increments `activation_count`/`last_activated` and emits `censor_triggered` in the caller's session (`censors.py:188, 220-250`); the pre-turn caller (`layer.py:777`) commits much later — a failed turn rolls censor telemetry back, undercounting activations the F078 UI relies on.
+
+**HT-13 — `heart._recall` with an injected session cascades sub-search failures. [P3, LIVE-edge]**
+Documented choice (`heart.py:849-855, 977-989`): no rollback on caller-owned sessions, so one failed leg aborts the transaction and every later leg fails with `InFailedSQLTransaction`. The only prod injected-session caller is censor trigger-actions (`censor_actions.py:90`) — a single bad leg silently empties a censor's prescribed recall *and* poisons the surrounding pre-turn transaction.
+
+### INFO
+
+- **`heart.py:822-824, 991-994`** — `recall()` doc/comment still claims per-type scores "are directly comparable"; the 2026-06-08 whitepaper establishes the opposite. Doc drift that keeps inviting B1-class regressions.
+- **`heart.py:905-913, 948`** — `search_map` values `("episodes", {"limit": …})` are dead; the loop dispatches via if/elif.
+- **`procedures.py:392`** — `extra_where = " AND t.active = true"` duplicates `hybrid_search`'s own active clause (harmless double filter).
+- **`censors.py` `escalation_threshold`** — F078 removed auto-escalation; the column/DTO field (`censors.py:788`, `schemas.py:334`) is consulted by nothing.
+- **`content_date_extractor.py:60`** — comment says "or 01/05/24" but the regex requires a 4-digit year.
+- **`retrieval_pipeline.py:912`** — chunk query vector serialized at `%.6f` (other sites use full `str(float(v))`); negligible precision asymmetry.
+- **`.env.prod-snapshot`** — `NOUS_WORK_QUEUE_FILE_JSONL_PATH=/tmp/nous_workspace/...` vs `NOUS_WORKSPACE_DIR=/tmp/nous-workspace` (underscore vs hyphen). If the queue file is written under the workspace dir, the poller watches a path nothing writes. Deployment config, not code — flagging for operator verification.
+- **`admission.py:153`** — utility-scoring payload sets `cache_control` on all three tiny blocks; harmless but pointless cache writes per fact.
+
+---
+
+## (d) Dead-code inventory
+
+| Item | Location | Status |
+|---|---|---|
+| `content_date_extractor.py` — entire module (324 lines, regex+dateparser extraction, `format_dates_inline`) | `nous/heart/content_date_extractor.py` | **DEAD** — zero imports anywhere in `nous/` (F075 went the LLM-extraction route instead) |
+| `has_cjk()` | `cjk.py:41-43` | no callers (`count_cjk_aware_words` is the only consumed symbol) |
+| `get_evolution_candidates` | `procedures.py:576-647` | computed, no prod consumer (procedure-audit bug 2, unchanged) |
+| `neutral_count` | `procedures.py:313-314`, ignored at `:958-968` | written by no auto path, read by nothing |
+| `related_procedures` / `censor_ids` on procedures | `schemas.py:263-264` | reserved columns, never written |
+| `escalation_threshold` on censors | `schemas.py:334`, `censors.py:788` | orphaned by F078 |
+| Date-aware boost settings (F075 L3) | `config.py` only | flags with no consumer (whitepaper B-rm-1, unchanged) |
+| `search_map` tuple values | `heart.py:905-913` | dead data |
+| `_dedup_decisions` | `context.py` (boundary) | still defined, never called (B-cog-C) |
+
+---
+
+## (e) Improvement opportunities
+
+1. **Disambiguate episode `active`** (HT-1 root cause): split "ongoing" from "soft-deleted" — either a dedicated state column or stop flipping `active` in `_end`. Add a prod-shape retrieval probe to the eval harness that exercises the real lifecycle writers (start→end→summarize) instead of bulk-ingested rows, so filter-composition kills can't hide again.
+2. **Make `Heart._recall` own the pool policy** (HT-3): F080's exclusion (and any future normalization) belongs at the merge site, not in one caller. The MCP surface should not be a time capsule of pre-F080 ranking.
+3. **One event-date contract across all three write-time passes** (HT-2): `_find_duplicate` (has it), `_supersede_by_subject` (has it), `_find_contradiction` (missing). A small shared `dates_disagree(a, b)` helper applied at all routing sites prevents the next drift.
+4. **Status-guarded subtask state machine** (HT-4): terminal transitions conditioned on `(status, worker_id, agent_id)` with rowcount checks; this also gives observability on stale-worker writes.
+5. **NULL-embedding repair sweep for facts** (S4): the F081 skill backfill and `reembed_all` for procedures exist; facts — the highest-volume table — still have no `embedding IS NULL` consumer. A bounded sleep-phase pass closes the last silent-invisibility hole.
+6. **Move LLM verdicts out of `_learn`'s transaction** (S5/D3): compute admission-utility, actionability, band/supersession/contradiction classifications against snapshots, then apply in a short write transaction. The band classifier added by #495 made the in-transaction LLM ceiling 5 calls.
+7. **Retire or wire the dead surface area** (§d): especially `content_date_extractor.py` and the auto-retirement FTS bug (procedure bug 1) — the latter is a two-line fix (`WHERE tags && ARRAY['auto:...']`) that has been known since 2026-06-06.
+8. **Censor keyword-match score**: if censors ever re-enter a ranked pool, the hardcoded 1.0 (`censors.py:486`) must carry a calibrated score or a non-score marker; today it is the single largest score-space outlier left in the codebase.
+
+---
+
+*Files of record:* all of `nous/heart/` (heart, facts, episodes, procedures, censors, censor_actions, working_memory, residual_activation, search, query_expansion, admission, actionability, content_date_extractor, subtasks, subtask_validator, subtask_report, schedules, schemas, chunking, document_chunker, reranker, cjk, hashing, work_queue, `__init__`), `nous/api/retrieval_pipeline.py`; spot-verified wires into `nous/api/{tools,mcp}.py`, `nous/cognitive/layer.py`, `nous/handlers/{episode_summarizer,knowledge_extractor,sleep_handler,procedure_learner}.py`, `nous/brain/brain.py`, `nous/main.py`, `sql/init.sql`, `sql/migrations/060_memory_integrity.sql`, `.env.prod-snapshot` (deployment overlay only).

--- a/docs/reviews/heartbeat-audit-2026-06-09.md
+++ b/docs/reviews/heartbeat-audit-2026-06-09.md
@@ -1,0 +1,240 @@
+# Heartbeat Subsystem Audit (F034.x) — 2026-06-09
+
+Code-only deep audit of `nous/heartbeat/` (runner, registry, checks, dynamic, finding_store, tuner, work_queue, schemas) plus the wiring in `nous/main.py`, the REST surface in `nous/api/rest.py`, and the work-queue handoff in `nous/heart/work_queue.py`. Reachability verdicts are evaluated against `nous/config.py` defaults **and** `.env.prod-snapshot`.
+
+Verdict legend: **LIVE** = reachable with prod config; **LATENT** = reachable only via manual/non-default trigger; **INERT** = code exists but disabled/unwired in prod; **DEAD** = unreachable from any path.
+
+---
+
+## 1. How it actually works
+
+**Construction (main.py:614-748).** When `heartbeat_enabled` (default true, prod true), main.py builds an `EscalationConfig` from settings (main.py:627-632), an in-memory `FindingStore`, and a `CheckRegistry`. It registers:
+
+| Check | Registered when | Prod status |
+|---|---|---|
+| `HealthCheck` (interval 3600s) | always, permanent | **LIVE** |
+| `SelfInitiatedCheck` (1800s) | always, permanent, with embeddings | **LIVE** |
+| `EmailCheck` (180s, urgent_override) | `heartbeat_email_enabled` + `email_user` (main.py:642) | **LIVE** (prod `NOUS_HEARTBEAT_EMAIL_ENABLED=true`, creds set) — but constructed **without** `llm_callable` (HB-4) |
+| `DriveCheck` (600s) | `heartbeat_drive_enabled` + `GOOGLE_SERVICE_ACCOUNT_JSON` (main.py:645) | **INERT** (no service-account JSON in prod env) |
+| `BehaviorDriftCheck` (3600s) | `drift_detection_enabled` (default true) + bus (main.py:649-657) | **LIVE** (but its findings are dropped — HB-1) |
+| `DynamicCheckLoader` + DB-backed dynamic checks | always | **LIVE** |
+| `WorkQueueCheck` (300s) | `work_queue_enabled` + DAG enabled (main.py:723-748) | **LIVE** (prod `NOUS_WORK_QUEUE_ENABLED=true`, `file_jsonl`) |
+
+**Tick loop (runner.py:147-187).** Sleeps `heartbeat_tick_interval` (30s default; not overridden in prod), resets the daily budget on local-date change, then runs `_tick()` — or `_tick(urgent_only=True)` during quiet hours (prod 03:00–12:00 UTC; only `EmailCheck` has `urgent_override`). The same loop then ticks the DAG orchestrator, periodically re-syncs dynamic checks (every 60 ticks ≈ 30 min), sends the daily digest at hardcoded UTC hour 9, and prunes/sweeps the FindingStore every 24h. Everything — checks, cognitive triage, callbacks dispatch, DAG ticks — runs **sequentially in this one task**.
+
+**Per tick (runner.py:189-331).** Due checks (interval elapsed, circuit breaker closed: `consecutive_failures < 3`, registry.py:33-43) run one at a time under `asyncio.wait_for(check.run(), timeout=check.timeout)`. Findings from results with `has_updates=True` are stamped with `check_name`, fingerprinted (`sha256(check:source:digits→N(summary))`, schemas.py:33-37), auto-resolve bookkeeping runs (ACKNOWLEDGED findings absent from 2 consecutive successful runs get resolved), then `_triage` routes each finding through `FindingStore.ingest` → TRIAGE / SUPPRESS / ESCALATE. High-urgency findings go straight to Telegram; `needs_action` findings go to a cognitive session (`run_turn` on a dedicated forked AgentRunner with an isolated API client) if the daily token budget (prod 500K) has headroom. Usage from `run_turn` is the full tool-loop aggregate (api/runner.py:1499-1614), so budget accounting per session is correct.
+
+**Dynamic checks (dynamic.py).** DB rows (`nous_system.dynamic_checks`, UNIQUE(agent_id, name)) become `DynamicCheck` instances whose `run()` sends a JSON-instruction prompt through `run_turn` with a tool allowlist (`ALLOWED_TOOLS`, dynamic.py:32-35) and parses the response with the tolerant `parse_llm_json`. A check can self-disable via `heartbeat_check_manage` mid-run; the runner then fires its `on_complete` callback as a background task with 3-layer failure handling (retry → Telegram → warning Finding).
+
+**Tuner (tuner.py).** Reads outcome signals from the FindingStore per check, relaxes (>60% negative) or tightens (>80% positive) one tunable param per check per pass, with snapshot-based cross-cycle rollback. Only invoked from `POST /heartbeat/tune` (rest.py:2092). Nothing schedules it (HB-3).
+
+**Work queue (work_queue.py + heart/work_queue.py).** `WorkQueueCheck` polls the `FileJsonlAdapter`, claims each new item via `INSERT … ON CONFLICT DO NOTHING RETURNING` on `nous_system.work_queue_items` (race-safe), creates a single-subtask DAG (`frame_type="research"`), and links it via `mark_dispatched`. Terminal items cancel their DAG before `mark_terminal`. A reconciler re-dispatches rows claimed >5 min ago that never got linked. Per-tick admission cap = `work_queue_max_dags_per_tick` (5); terminal handling is exempt from the cap.
+
+---
+
+## 2. Findings register
+
+### P1
+
+---
+
+**HB-1 — BehaviorDriftCheck findings are silently dropped (drift alerting is a no-op)**
+- Severity: P1 · Reachability: **LIVE**
+- Where: `nous/heartbeat/checks.py:957` vs `nous/heartbeat/runner.py:244`
+- Description: `BehaviorDriftCheck.run` returns `CheckResult(findings=findings)` without setting `has_updates`. `CheckResult.has_updates` defaults to `False` (schemas.py:44), and `_tick` only collects findings when `if result.has_updates:` (runner.py:244). Every other check sets `has_updates=bool(findings)` (checks.py:126, 467, 600, 849); drift is the lone omission.
+- Evidence: drift anomalies (including `severity == "alert"` with `urgency="high"`, checks.py:946-952) never reach `all_findings`, so they are never triaged, never Telegram-alerted, never tracked in the FindingStore. The check still persists snapshots to `nous_system.behavior_snapshots`, so the DB side looks healthy while the alerting half of F035.3 is dead. Registered in prod (main.py:649-657; `drift_detection_enabled` default true, event bus on).
+- Fix: `return CheckResult(has_updates=bool(findings), findings=findings)`.
+
+---
+
+**HB-2 — Startup suppression permanently captures first-run findings; SUPPRESSED has no exit to triage**
+- Severity: P1 · Reachability: **LIVE**
+- Where: `nous/heartbeat/finding_store.py:51-62` (capture), `:64-89` (no SUPPRESSED→NEW transition), `:311-313` (window), `nous/heartbeat/registry.py:39-40` (first-run due immediately)
+- Description: For 5 minutes after process start, every new finding is stored with `state=SUPPRESSED` (finding_store.py:53-62). There is no code path that moves a SUPPRESSED finding back to NEW/TRIAGE: on every subsequent ingest of the same fingerprint the store updates `last_seen`, bumps `seen_count`, and returns SUPPRESS again (finding_store.py:64-89) until the *time-based escalation* threshold fires (24h for normal, 72h for low).
+- Evidence: all permanent checks have `last_run=None` at boot, so `is_due` is true on the **first tick (~30s after start)** — deterministically inside the 5-minute window. Therefore the steady-state recurring findings (e.g. HealthCheck's "N decisions pending review", whose fingerprint is stable because digits are normalized, schemas.py:35) are captured as SUPPRESSED on every restart, skip cognitive triage entirely, and only surface 24–72h later as **escalated-to-high Telegram alerts** (runner.py:394-396). If the process restarts more often than the escalation threshold, these findings never surface at all (the in-memory store resets `first_seen` on every restart). `heartbeat_suppression_ttl_hours` (config.py:822) was presumably meant to bound this and is consumed nowhere.
+- Fix: when the startup window has passed, transition SUPPRESSED findings ingested during the window to NEW (return TRIAGE on next sighting), or stamp suppressed-at and expire suppression after `heartbeat_suppression_ttl_hours`.
+
+---
+
+### P2
+
+---
+
+**HB-3 — Scheduled self-tuning never implemented; four tuning settings are severed wires**
+- Severity: P2 · Reachability: **LATENT** (manual REST only; prod `NOUS_HEARTBEAT_TUNING_ENABLED=true` expects it to run)
+- Where: `nous/heartbeat/runner.py:78-79` (tuner + `_last_tune` created, never used in the loop), `nous/api/rest.py:2084-2092` (only call site of `tuner.tune`), `nous/config.py:826-829`
+- Description: `HeartbeatRunner._loop` never calls `tuner.tune`. `heartbeat_tuning_interval_hours` (weekly), `heartbeat_tuning_min_samples`, `heartbeat_tuning_learning_rate`, and `heartbeat_tuning_rollback_threshold` are consumed by no code — `HeartbeatTuner` hardcodes `MIN_SAMPLES=10`, `LEARNING_RATE=0.1` (tuner.py:39-41) and a rollback trigger of `neg_rate > 0.8` (tuner.py:169), which doesn't even match the documented semantics of the setting ("negative rate **increase** of 0.2").
+- Evidence: grep over the tree shows `heartbeat_tuning_enabled` read only by rest.py (gate on the manual endpoint + dashboards); the other four fields have zero readers. Operator turned tuning on in prod 2026-x believing F034.3's "weekly pass" runs; it does not.
+- Fix: add an interval gate in `_loop` analogous to `_maybe_prune_and_sweep`, and thread the four settings into `HeartbeatTuner`.
+
+---
+
+**HB-4 — EmailCheck LLM classification tier is unreachable (never wired)**
+- Severity: P2 · Reachability: tier **DEAD** on a **LIVE** check
+- Where: `nous/main.py:643` (`registry.register(EmailCheck(settings))`), `nous/heartbeat/checks.py:543-555, 615`
+- Description: `EmailCheck.__init__` accepts `llm_callable` and `budget_check` for F034.2's tiered classification (reputation → LLM → keywords), but main.py constructs it with neither. `self._llm_callable` is always `None`, so the Tier-1 branch (checks.py:615) never executes; every email is classified by the 4-keyword heuristic (checks.py:694-701), and the sender-reputation cache (checks.py:628-666) learns from keyword output only.
+- Evidence: only construction site in the tree is main.py:643. CLAUDE.md/F034.2 advertise "LLM email classification"; in prod (email check live, 180s interval) it has never run.
+- Fix: pass a Haiku-backed callable + `heartbeat_runner._has_budget` at wiring time (the constructor was designed for exactly this).
+
+---
+
+**HB-5 — Dynamic-check execution is not gated on the daily token budget**
+- Severity: P2 · Reachability: **LIVE**
+- Where: `nous/heartbeat/runner.py:214-225` (checks run unconditionally; tokens added post-hoc), `:744-746` (`_has_budget` checked only for triage at :450 and callbacks at :276/:562)
+- Description: `_tick` runs every due check regardless of `_tokens_used_today`. Dynamic checks each open a full `run_turn` cognitive session (dynamic.py:123-131); their tokens are *counted* after the fact (runner.py:224-225) but exhaustion never stops the next check from running. The budget therefore only suppresses triage and callbacks — the largest spenders (agentic dynamic checks with tools, prod model Sonnet, up to 10 checks) bypass it entirely and can overrun the 500K/day cap without bound.
+- Evidence: contrast with `_triage` (runner.py:450-457) and callback dispatch (:276-285), which both check `_has_budget()` first. There is no analogous gate in the `for check in due_checks` loop. Additionally, tokens consumed by a check that *times out* are never counted at all (the usage dict is lost when `wait_for` cancels, runner.py:251-261), so the counter also under-reports.
+- Fix: skip (or defer) `DynamicCheck` instances when `not self._has_budget()`, mirroring the triage gate.
+
+---
+
+**HB-6 — Cognitive triage and check execution block the entire heartbeat loop (including DAG orchestration) with no outer timeout**
+- Severity: P2 · Reachability: **LIVE**
+- Where: `nous/heartbeat/runner.py:147-187` (single sequential loop), `:476-533` (`_cognitive_triage` — no `asyncio.wait_for`)
+- Description: `_tick` → `_triage` → `_cognitive_triage` runs `run_turn` inline with no timeout. Prod runs `NOUS_MAX_TURNS=600` and `NOUS_TOOL_TIMEOUT=2000`; a single pathological triage session can stall the loop for tens of minutes. While stalled: no checks run (email check misses its 180s cadence), the **DAG orchestrator does not tick** (runner.py:161-165 — DAG advancement is piggybacked on this same loop), dynamic-check sync stops, and the daily digest can be skipped if the stall spans UTC hour 9 (`now.hour == 9` check at :646 evaluates after the stall).
+- Evidence: the only timeouts in the path are per-API-call read timeouts inside the runner; there is no bound on the tool loop for `platform="heartbeat"` sessions. F048 keep-alives make long generations *more* likely to run to completion, not less.
+- Fix: wrap `_cognitive_triage` in `asyncio.wait_for` with a settings-derived cap, and/or move DAG orchestrator ticking to its own task.
+
+---
+
+**HB-7 — Work-queue dispatch is not cancellation-safe: check timeout between `dag_store.create` and `mark_dispatched` yields a duplicate DAG**
+- Severity: P2 · Reachability: **LIVE**
+- Where: `nous/heartbeat/work_queue.py:293-355` (`_claim_and_dispatch`), `:357-403` (`_reconcile_orphan` — re-**creates**), `nous/heartbeat/runner.py:216-219` (`wait_for(check.run(), timeout=30)`)
+- Description: `WorkQueueCheck` inherits `timeout=30` (registry.py:23). `asyncio.wait_for` *cancels* `run()` on timeout. If cancellation lands after `dag = await self._dag_store.create(request)` but before `mark_dispatched`, the cleanup branch does **not** run — `except Exception` (work_queue.py:322) does not catch `CancelledError` — so the orphan DAG is never cancelled. Five minutes later `list_undispatched` returns the row and `_reconcile_orphan` calls `self._dag_store.create(request)` **again** (work_queue.py:372), producing a second DAG executing the same work item. The comment at work_queue.py:303-307 claims "the reconciler will retry the link (not re-create)" — the code contradicts it: `_reconcile_orphan` has no path that re-links an existing DAG.
+- Evidence: prod has work_queue LIVE with a default request factory that spawns subtasks (side-effectful agent work). DAG creation is multiple DB roundtrips; under DB load with up to 5 dispatches + reconciler inside one 30s window, mid-flight cancellation is realistic. The same gap applies to ordinary exceptions thrown by `mark_dispatched` *when the compensating `cancel_dag` also fails* (acknowledged "we just leak the DAG" at :328-331 — but the next reconciler pass then duplicates it, which the comment misses).
+- Fix: persist the created `dag_id` on the row *before* the DAG becomes runnable, or have the reconciler first look for an existing non-terminal DAG named `work_queue:{safe_ext}` and re-link instead of re-creating; shield the create+link section from cancellation (`asyncio.shield`) or catch `BaseException` for cleanup.
+
+---
+
+**HB-8 — Circuit breaker never auto-recovers and opening it is invisible**
+- Severity: P2 · Reachability: **LIVE**
+- Where: `nous/heartbeat/registry.py:36-38` (`is_due` returns False forever once `consecutive_failures >= 3`), `:50-58` (open = log.warning only)
+- Description: Three consecutive failures permanently disable a check until someone calls `POST /heartbeat/check/{name}/reset` or restarts the process. There is no half-open/retry-after-cooldown state, and the only signal that a breaker opened is a log line — no Finding, no Telegram, no event-bus emission.
+- Evidence: `EmailCheck` raises on any IMAP failure (checks.py:572-575) and runs every 180s, so a ~9-minute Gmail/IMAP blip silently kills email monitoring (the subsystem's flagship prod feature) indefinitely. `WorkQueueCheck` similarly re-raises adapter/DB failures by design (work_queue.py:233-239) — three DB hiccups and work ingestion stops forever. The `/heartbeat/checks/dynamic` listing and dashboard expose `circuit_breaker_open`, but only if someone looks.
+- Fix: add a cooldown-based half-open (e.g. retry once after `interval * 2^failures`, capped), and emit a Finding/Telegram when a breaker opens.
+
+---
+
+**HB-9 — Escalation skips the documented ladder: low findings jump straight to high (immediate Telegram)**
+- Severity: P2 · Reachability: **LIVE**
+- Where: `nous/heartbeat/runner.py:393-396` (`f.urgency = "high"` for every ESCALATE), `nous/heartbeat/finding_store.py:291-309`, `nous/heartbeat/schemas.py:92-98`
+- Description: `EscalationConfig` defines a low→normal (72h) and normal→high (24h) ladder, and the settings/REST surface advertise it (`low_to_normal_hours`). But `_triage` upgrades **every** ESCALATE action to `"high"`, so a low-urgency finding that ages 72h goes directly to an urgent Telegram page rather than entering the normal-triage pool. The store also marks `escalated=True` on the original tracked finding (finding_store.py:85-87), so low/normal findings escalate exactly once — there is no second-stage normal→high progression at all.
+- Evidence: `low_to_normal_hours` is used only as a time gate (finding_store.py:299-300); nothing ever produces `urgency="normal"` from an escalation. Combined with HB-2 this means restart-suppressed low findings reappear *only* as urgent pages.
+- Fix: map the escalation step to the next rung (`low→normal` re-enters triage; `normal→high` pages), keeping high re-alert as is.
+
+---
+
+### P3
+
+---
+
+**HB-10 — Digest hour hardcoded; `heartbeat_digest_hour_utc` is a severed setting**
+- P3 · LIVE (coincidence: prod uses default 9) · `runner.py:646` (`if now.hour == 9`), `config.py:821`. Changing the env var does nothing. Fix: read the setting.
+
+**HB-11 — `heartbeat_suppression_ttl_hours` consumed nowhere**
+- P3 · DEAD setting · `config.py:822`; `FindingStore._startup_suppression_seconds` hardcoded 300 (finding_store.py:35). Companion to HB-2.
+
+**HB-12 — Tuner step math has a units bug**
+- P3 · LATENT · `tuner.py:134-137`: `step = param.step * LEARNING_RATE * param_range` multiplies the param's natural step by the *range*, then clamps to 10% of range. For `stale_fact_days` (step 5, range 83) the raw step is 41.5 → always clamped to 8.3; for `similarity_threshold` (step 0.02, range 0.3) the step is 0.0006 — 1000× smaller than its declared step. Adjustments are either "always max" or "effectively zero" depending on units. Fix: `step = param.step` or `LEARNING_RATE * param_range`, not both.
+
+**HB-13 — Tuner relax/tighten direction is wrong for count/lookback params**
+- P3 · LATENT · `tuner.py:139-142` assumes increase = less sensitive ("relax = increase threshold"). For `max_findings_per_run`, `max_pending_items`, `lookback_days`, `cross_reference_lookback_hours` (checks.py:55, 175, 174, 781), increasing produces *more* findings — i.e. the tuner would respond to noise by amplifying it. Fix: per-param direction metadata on `TunableParam`.
+
+**HB-14 — Rollback evaluation window includes pre-adjustment outcomes**
+- P3 · LATENT · `tuner.py:163`: `_check_and_rollback` uses `get_outcomes_for_check` with the default 30-day window, despite the docstring claiming "outcomes accumulated AFTER the previous adjustment". A check with chronically bad outcomes gets rolled back regardless of whether the adjustment helped. Fix: pass `since_seconds` = time since `_last_tune`.
+
+**HB-15 — Outcome-signal economy makes the tuner effectively inert**
+- P3 · LATENT · Emitters: REST resolve → POSITIVE (rest.py:2004), REST dismiss → STRONG_NEGATIVE (finding_store.py:125), 72h sweep → WEAK_NEGATIVE (finding_store.py:235). `NEGATIVE`, `STRONG_POSITIVE`, `NEUTRAL` are never emitted anywhere (grep-verified). But `_negative_rate` counts only STRONG_NEGATIVE+NEGATIVE and `_positive_rate` only STRONG_POSITIVE+POSITIVE (tuner.py:186-204) — so WEAK_NEGATIVE (the *dominant* signal, generated automatically) dilutes both rates toward zero and the >60%/>80% triggers essentially require the operator to manually dismiss/resolve via REST. Auto-resolve (runner.py:367) records **no** outcome at all. Fix: count WEAK_NEGATIVE at fractional weight; emit POSITIVE on auto-resolve-after-action or NEUTRAL on auto-resolve.
+
+**HB-16 — "Embedding search" never uses the embeddings; threshold compares the wrong score space**
+- P3 · LIVE · `checks.py:178-189` embeds the 5 `PENDING_PROTOTYPES` into `_prototype_cache`, which is then used **only as a truthiness gate** (:196-198); the actual matching is `heart.facts.search(proto_text)` — text/hybrid search with the prototype *string* as query. The cached vectors are never compared to anything. Worse, the fallback branch `is_pending = score >= threshold` (:247) compares a hybrid/RRF score (≪0.1 typical — cf. memory-retrieval whitepaper) against `similarity_threshold=0.75`, so it is constant-false; unclassified facts are detected solely by substring patterns. Fix: either do real cosine scoring against the prototypes or delete the cache and rename.
+
+**HB-17 — `lookback_days` tunable read but never applied**
+- P3 · LIVE (no-op) · `checks.py:202, 328`: fetched in `_embedding_search` and `_temporal_scan` but no query uses it — fact searches have no recency filter. The tuner could "adjust" it forever with zero effect. Fix: thread into `facts.search` or remove the param.
+
+**HB-18 — Layer-3 callback failure Finding is write-only: never triaged, never expires**
+- P3 · LIVE (when callbacks fail) · `runner.py:613-628`: the warning Finding is `ingest()`ed directly; the returned action is ignored, no triage/Telegram/acknowledge happens (Layer 2's Telegram is the only notification), and the entry sits in state NEW forever — escalation requires re-ingest of the same fingerprint (never happens for one-shot callbacks), auto-resolve requires ACKNOWLEDGED, and `prune()` removes only RESOLVED (finding_store.py:240-250). It is visible only via `GET /heartbeat/findings`. Fix: route it through `_triage([failure_finding])` instead.
+
+**HB-19 — `heartbeat_triage` event lineage points at the *previous* tick**
+- P3 · LIVE · `runner.py:298-303` runs `_triage` (which reads `getattr(self, "_current_tick_event", None)` at :511) **before** the tick event is created and assigned at :307-329. The triage event's `trace_id`/`caused_by` therefore reference the prior tick's event (or None on the first findings-bearing tick). F035 causal traces for heartbeat are systematically off-by-one. Fix: build/emit the tick event before triage.
+
+**HB-20 — Fire-and-forget `create_task` without reference retention**
+- P3 · LIVE · `runner.py:277-280, 863-866`: callback tasks are not stored; per asyncio docs the loop holds only a weak reference, so a mid-flight GC can drop a running callback. Fix: keep a `set` of tasks with `add_done_callback(discard)`.
+
+**HB-21 — REST `trigger_tick`/`trigger_check` race the background loop**
+- P3 · LIVE · `runner.py:835-846`: a forced tick runs concurrently with `_loop`'s `_tick`; both see the same checks as due (`last_run` updates only after completion), so the same check can run twice concurrently (double IMAP fetch → duplicate findings pre-dedup; double work-queue poll → benign thanks to DB claim, but doubled DAG-create attempts). Fix: an `asyncio.Lock` around `_tick`.
+
+**HB-22 — Telegram delivery failure is swallowed; one-shot urgent alerts are lost permanently**
+- P3 · LIVE · `runner.py:705-725`: any exception → `logger.warning`, no retry, no fallback. The findings were already `acknowledge()`d in `_triage` (:402) before the send, and low/normal escalations fire only once (`escalated=True`), so a transient Telegram outage permanently eats those pages; only high-urgency re-alert (12h) retries. Fix: don't mark escalated until send succeeds, or add a bounded retry.
+
+**HB-23 — IMAP fetch marks messages `\Seen` (no `BODY.PEEK`)**
+- P3 · LIVE · `checks.py:716`: `fetch(mid, "(BODY[HEADER.FIELDS (...)])")` implicitly sets `\Seen` on the message. The agent silently marks inbox mail as read on every poll; if the account is ever a shared/human inbox this destroys unread state, and it makes the `UNSEEN` search + `_seen_ids` cache double-dedup (the cache is mostly redundant). Fix: `BODY.PEEK[HEADER.FIELDS (...)]`.
+
+**HB-24 — Cron dynamic checks: immediate first fire, `MIN_INTERVAL` bypass, unbounded timeout**
+- P3 · LIVE · `dynamic.py:85-88`: with no `last_run`, the croniter anchor is 2000-01-01 so any cron check fires on the first tick after registration regardless of schedule. `create_check` skips the 300s minimum when `cron_expr` is set (:357), so `* * * * *` (every minute) is accepted. Neither `create_check` nor `manage_check("update")` bounds `timeout_seconds` (:347, :503), so a huge value lets one check monopolize the (single-threaded) tick loop, and a non-positive value makes it instantly time out into the circuit breaker. Fix: anchor first cron fire at registration time; enforce a cron floor; clamp timeout to e.g. [5, heartbeat_default_check_timeout*4].
+
+**HB-25 — Terminal work-queue items are re-processed every tick forever**
+- P3 · LIVE · `work_queue.py:405-456`: `_handle_terminal` never checks `existing.terminal_state` — as long as the terminal line stays in the JSONL file (operators don't truncate it), every 300s tick re-calls `cancel_dag` (idempotent early-return at orchestrator.py:130-132) and re-runs `mark_terminal`, and re-appends a "Cancelled DAG …" finding (deduped downstream). If the DAG row was deleted, `cancel_dag` raises `ValueError` (orchestrator.py:128) → an `urgency="high"` finding loops every tick. Fix: short-circuit when `existing.terminal_state is not None`.
+
+**HB-26 — FileJsonlAdapter body-hash IDs collide for identical bodies**
+- P3 · LIVE · `work_queue.py:119-125`: when `external_id` is omitted, it is derived from `sha256(body)`. Two distinct items with identical bodies (e.g. templated "run the nightly report" entries) collapse to one row; the second is never dispatched, silently. Fix: include title/line-number in the hash or require external_id.
+
+**HB-27 — Work-queue ingestion and all dynamic checks pause 9h/day in prod quiet hours**
+- P3 · LIVE · `runner.py:154-158`: quiet hours (prod 03–12 UTC) restrict ticks to `urgent_override` checks — only EmailCheck qualifies. `WorkQueueCheck` and every dynamic check (unless created `urgent=True`) stop polling for 9 hours; queued work items wait until 12:00 UTC. Probably unintended for a machine-facing ingestion path. Fix: set `urgent_override=True` on WorkQueueCheck (it pages nothing by itself) or exempt non-notifying checks from quiet hours.
+
+**HB-28 — Budget resets on *local* midnight; everything else is UTC**
+- P3 · LIVE · `runner.py:748-754` uses `date.today()` (local tz) while quiet hours/digest/escalations use UTC. In a non-UTC container the 500K budget window is offset from the digest/quiet windows. Fix: `datetime.now(UTC).date()`.
+
+**HB-29 — DriveCheck loses the modification window on failure; timestamp has no timezone**
+- P3 · **INERT** in prod (no service-account JSON) · `checks.py:796-801`: `_last_check_time` is advanced *before* the fetch; if `list_files` raises, the next run's cutoff is the failed run's start, so files modified in the window preceding the failure are permanently skipped. The Drive query also formats the cutoff without `Z`/offset. Fix: advance the watermark only on success; use RFC3339 with `Z`.
+
+**HB-30 — Renaming a dynamic check in the DB orphans the old registry entry**
+- P3 · LATENT (rename impossible via API — `name` not in `allowed_fields`, dynamic.py:494-498 — but possible via direct DB edit) · `sync()` keys unregistration on removed *ids* (:227-232); a same-id name change registers the new name and overwrites `_id_to_name`, leaving the old-name `DynamicCheck` registered and running forever. Fix: detect name changes per id during sync.
+
+**HB-31 — Mid-run sync replacement can double-run a dynamic check**
+- P3 · LATENT · `dynamic.py:269-277`: if a check's signature changed while an instance is mid-`run()`, sync registers a fresh instance copying the *pre-run* `last_run`; the in-flight instance's eventual `mark_success` lands on the orphaned object, so the new instance is immediately due again → back-to-back duplicate run. Narrow window (sync every 60 ticks), no corruption. Fix: copy state at completion or look up the live instance in `mark_*`.
+
+---
+
+### INFO
+
+- **HB-I1** — Quiet hours documented as "user timezone" (CLAUDE.md, config comments) but computed in UTC (`runner.py:733`). Prod values (3–12) appear pre-compensated; document it.
+- **HB-I2** — Tokens consumed by a check that times out are never added to the budget counter (usage lost on cancellation, `runner.py:251-261`); daily spend is under-reported.
+- **HB-I3** — Findings are `acknowledge()`d in `_triage` (runner.py:402) *before* Telegram/cognitive triage occur; a triage crash or budget-skip still leaves them ACKNOWLEDGED (later swept WEAK_NEGATIVE) — "acknowledged" does not mean "seen".
+- **HB-I4** — `BehaviorDriftCheck.run` swallows all exceptions (`checks.py:955-957`), so its circuit breaker can never trip and persistent DB failures are invisible (debug-level logs in `_store_snapshot`/`_load_baseline`).
+- **HB-I5** — Email header parsing is line-naive: RFC2822 folded headers are truncated to their first line and MIME-encoded-word subjects (`=?UTF-8?...?=`) are not decoded (`checks.py:724-731`); only the last 5 unseen messages are examined per poll (`:714`).
+- **HB-I6** — `heartbeat_default_check_timeout` (prod 120) applies only to *dynamic* checks (dynamic loader default, main.py:666); built-ins hardcode `timeout` 30/20/30 (checks.py:44, 157, 537, 764) and ignore the setting.
+- **HB-I7** — `dynamic.py:242, 382` and `rest.py:2028` reach into private attributes (`registry._permanent`, `store._escalation`) across module boundaries.
+- **HB-I8** — Every already-dispatched JSONL item costs one INSERT-conflict roundtrip per item per tick (`work_queue.py:308`, heart/work_queue.py:59-83); fine at small scale, quadratic-ish as the file grows since dispatched lines are never removed.
+- **HB-I9** — Prod path suspicion: `NOUS_WORK_QUEUE_FILE_JSONL_PATH=/tmp/nous_workspace/task_queue/tasks.jsonl` (underscore) vs `NOUS_WORKSPACE_DIR=/tmp/nous-workspace` (hyphen). If the underscore directory is wrong, the adapter logs "path does not exist" every 300s and ingests nothing (`work_queue.py:92-96`) — worth a one-line prod check.
+- **HB-I10** — `PUT /heartbeat/escalation-policy` and `PUT /heartbeat/config` mutate in-memory state only; changes are lost on restart (no persistence).
+- **HB-I11** — `Finding.needs_action` from dynamic-check LLM output is taken as-is (`dynamic.py:176`) — a truthy string like `"false"` becomes `True`. `parse_llm_json` is otherwise robustly fenced.
+
+---
+
+## 3. Dead-code inventory
+
+| Item | Location | Note |
+|---|---|---|
+| `HeartbeatRunner._last_tune` | runner.py:79 | assigned `None`, never read/written again (the tuner keeps its own) |
+| `SelfInitiatedCheck._prototype_cache` vectors | checks.py:171, 178-189 | embedded, cached, never compared (HB-16) |
+| `lookback_days` tunable | checks.py:174, 202, 328 | read into locals, never used in any query (HB-17) |
+| `EmailCheck` params `sender_reputation_weight`, `llm_classification_budget` | checks.py:560-563 | declared (and tuner-adjustable) but never read |
+| `DriveCheck` param `cross_reference_lookback_hours` | checks.py:781 | declared, never read (`_contextualize` has no lookback) |
+| `DEFAULT_FOLDER_MAP` | checks.py:753 | defined, zero references |
+| Settings: `heartbeat_digest_hour_utc`, `heartbeat_suppression_ttl_hours`, `heartbeat_tuning_interval_hours`, `heartbeat_tuning_min_samples`, `heartbeat_tuning_learning_rate`, `heartbeat_tuning_rollback_threshold` | config.py:821-829 | no readers (HB-3/10/11) |
+| `EmailCheck` LLM tier (`_llm_classify`, `llm_callable` plumbing) | checks.py:543-555, 668-691 | unreachable in any wiring (HB-4) |
+| `OutcomeSignal.NEGATIVE`, `STRONG_POSITIVE`, `NEUTRAL` | schemas.py:80-88 | never emitted anywhere (HB-15) |
+| `_OBSERVATION_PATTERNS` re-export | checks.py:138 | declared back-compat shim; no external importers found in-tree |
+| `GithubIssuesAdapter`, `LinearAdapter` | work_queue.py:137-158 | declared v2 stubs (intentional) |
+| `WorkQueueAdapter.get_state` mention | work_queue.py:56-58 | docstring promises an optional method that exists nowhere |
+
+---
+
+## 4. Improvement opportunities
+
+1. **Persist the FindingStore.** Everything F034.1 tracks (states, outcomes, escalation timers, reputation in EmailCheck, `_seen_ids`) is in-memory and resets on every deploy — which is the root enabler of HB-2 and makes outcome history (HB-15) too sparse for the tuner to ever act. A small `nous_system.heartbeat_findings` table would fix the restart pathology, give the tuner real sample sizes, and let the digest survive restarts.
+2. **Decouple the loop.** One task currently serializes checks, triage, callbacks budget-decisions, DAG orchestration, digest, and prune (HB-6). Run checks with `asyncio.gather` under per-check timeouts, and give the DAG orchestrator its own ticker.
+3. **Make budget a first-class gate** (HB-5): one `_charge(tokens)`/`_reserve()` helper used by triage, callbacks, *and* dynamic checks, counting timed-out sessions (HB-I2), reset on UTC midnight (HB-28).
+4. **Close the outcome loop end-to-end** (HB-15): auto-resolve → NEUTRAL/POSITIVE, sweep → counted negative, cognitive triage result ("acted" vs "ignored") → signal. Then schedule the tuner (HB-3) — today F034.3 is advertising, not behavior.
+5. **Half-open circuit breakers + breaker-open Findings** (HB-8) — the email check is the prod feature most likely to die silently today.
+6. **Work-queue hardening**: raise `WorkQueueCheck.timeout`, make dispatch cancellation-safe (HB-7), short-circuit recorded terminals (HB-25), and emit a startup Finding if the configured JSONL path doesn't exist (HB-I9) instead of a 300s log loop.

--- a/docs/reviews/nous-complete-audit-2026-06-09.md
+++ b/docs/reviews/nous-complete-audit-2026-06-09.md
@@ -1,0 +1,109 @@
+# Nous Complete Code Audit — Master Synthesis (2026-06-09)
+
+Code-only audit of every major subsystem, driven by actual source at HEAD `2f6a193`
+(post PR #495). Eleven subsystem reviews were produced by parallel agents; every P1
+below was **personally re-verified against the source** by the synthesizing session
+(file:line evidence inline). Reachability is judged against `nous/config.py` defaults
+**and** the prod overlay `.env.prod-snapshot`.
+
+Per-subsystem detail lives in the sibling docs:
+`brain-`, `cognitive-layer-`, `runtime-core-`, `agent-tools-`, `handlers-`,
+`rest-mcp-dashboard-`, `heart-`, `heartbeat-`, `dag-`, `storage-config-`,
+`skills-identity-observability-audit-2026-06-09.md`.
+
+---
+
+## 1. The three dominant defect patterns
+
+Almost every confirmed P1 is an instance of one of three recurring structural bugs.
+This is the most important takeaway: the bugs are not random, they are **the same
+three mistakes repeated at sites the earlier targeted audits/PRs did not reach.**
+
+### Pattern A — RRF *rank* score compared to a *similarity* threshold
+`heart` hybrid search returns RRF-fused scores that encode **rank**, not closeness:
+the top hit scores ≈0.95 for *any* query (documented at `heart/procedures.py:502-506`).
+PR #495 fixed this at the fact-dedup sites. It survives at:
+- **HD-1 (P1)** `procedure_learner.py:561` — `_is_duplicate` thresholds the RRF score `>0.85` → top procedure always "duplicate" → **all** auto-procedure creation suppressed (the prod "K-line = 0").
+- **HD-2 (P1)** `sleep_handler.py:777` — UPDATES-prefix supersession compares RRF score to `0.80` → can deactivate an unrelated fact.
+- **CL-3 (P2)** `context.py:1027-1044` — usage boost sorts by RRF-derived factor, destroying relevance order.
+- **CL-15 / HT-3 (P2)** WM floor `0.7` and procedure floor `0.40` and censor keyword score hardcoded `1.0` are all compared against RRF facts in the cross-type merge.
+
+**Fix shape:** use a raw-cosine probe (`find_similar_*`) with a cosine-calibrated
+threshold wherever a *closeness* decision is made; never threshold the RRF rank score.
+
+### Pattern B — F036 cache-split ignores the flat `system_prompt`
+When `cache_split_system_prompt` is on (prod default), `runner._build_system_prompt`
+reads only `turn_context.sections_by_tier` and **ignores the flat `system_prompt`
+string** (`runner.py:1916-1952`). F078 fixed censors by writing to *both*
+(`layer.py:874-893`). Two producers still write only the ignored flat string:
+- **CL-1 (P1)** `layer.py:642-672` — subtask results appended to the flat string **and rows marked `delivered` first** → the parent agent permanently never sees subtask outcomes.
+- **CL-2 (P2)** `layer.py:906-918` — F065 hub-shift notice, same discarded string; snapshot still persisted so the shift is consumed unseen.
+
+**Fix shape:** route these into `sections_by_tier["dynamic"]` (as F078 does), and only
+mark subtask rows delivered once the content is actually placed in a read surface.
+
+### Pattern C — severed self-improvement / telemetry wires (built, flag-ON, no consumer)
+Features are fully built and enabled in prod but nothing reads their output:
+- **BR-7** `brain/guardrails.py` — `Brain.check`/GuardrailEngine has zero runtime callers.
+- **HB-3** scheduled heartbeat tuning never invoked (`tuner.tune` is REST-only) despite `NOUS_HEARTBEAT_TUNING_ENABLED=true`.
+- **HB-4** EmailCheck built without `llm_callable` → F034.2 LLM classification tier dead.
+- **DG-5** DAG LLM fix dispatch: `llm_client` never passed; `NOUS_DAG_FIX_LLM_DISPATCH_ENABLED=true` is inert.
+- **DG-3** DAG token budget: `update_dag_tokens` has zero callers, `partial` status unreachable.
+- **CL-6 (P2)** operator budget overrides (`facts=3000/decisions=2500`) silently REPLACED back to 500/500 every conversation-frame turn.
+- **HD-9** rubric loop: `session_ended` carries no `summary` → `self_improvement_scores` always NULL (known RA-R1, still live).
+- **OB-1/OB-3** `nous_system.context_log` grows unbounded (no retention consumer) and its token/latency columns are never written.
+
+---
+
+## 2. Confirmed P1 register (personally verified)
+
+| ID | File:line | Bug | Verdict |
+|----|-----------|-----|---------|
+| **CL-1** | `cognitive/layer.py:663` vs `api/runner.py:1916-1952` | Subtask results to flat prompt the split path ignores; rows marked delivered → permanent loss | LIVE |
+| **HD-1** | `handlers/procedure_learner.py:561` | RRF rank vs 0.85 → all auto-procedure creation suppressed (K-line=0) | LIVE |
+| **HD-2** | `handlers/sleep_handler.py:777` | RRF rank vs 0.80 → can supersede/deactivate an unrelated fact | LIVE |
+| **BR-1** | `brain/brain.py:1316-1342` | fact/episode/chunk neighbor queries lack `active` filter (only procedures got F080) → superseded facts resurface in recall | LIVE |
+| **HT-1** | `heart/search.py:191,241` + `heart/episodes.py:235,519-527` | episode hybrid search filters `active=true AND outcome!='abandoned'` → excludes both closed and ongoing episodes → episode semantic recall structurally dead | LIVE |
+| **HT-2** | `heart/facts.py:473-478` vs `608-613,719-731` | F075 date-distinct dupe not added to `exclude_ids`; `_find_contradiction` re-collides and supersedes the older dated event the bypass preserved | LIVE |
+| **HB-1** | `heartbeat/checks.py:957` vs `runner.py:244` | BehaviorDriftCheck returns findings without `has_updates=True` → all drift alerts silently dropped | LIVE |
+| **DG-1** | `dag/orchestrator.py:1379-1397` | DAG finishing via skip-and-continue success path finalized as `failed` | LIVE |
+| **RM-1** | `docker-compose.yml:5-6,116-117` + `config.py:299` | REST+MCP+dashboard zero-auth on 0.0.0.0; Postgres also published with default password | LIVE |
+| **ST-1** | `docker-compose.yml:70` + `config.py:195` | `NOUS_CONTEXT_BUDGET_OVERRIDES=${...:-}` passes empty string to JSON dict field → fresh `docker compose up` without host `.env` crash-loops | LIVE (clean-install) |
+| **SK-1** | `api/tools.py:975-986` | `learn_skill` dedup misses superseded rows → re-learn resurrects archived duplicate (reopens F081 loop on agent path) | LIVE |
+
+(Rubric P1 chain RA-R1..R3 from the 2026-06-09 rubric audit remains live at HEAD; not
+re-listed here.)
+
+## 3. High-value P2 register (selected; full lists in subsystem docs)
+
+- **CL-4** `claim_verifier.py:88-98` — claim grounding checks tool *name only*, ignoring status/args → any `bash` "verifies" "I deployed"; enforce-mode net is hollow.
+- **CL-5** `critic.py:377-380` + `layer.py:1209` — `record_decision` without confidence stores `None`; `None < 0.4` → TypeError in post_turn on the non-streaming (REST/subtask) path.
+- **HD-4** `decision_reviewer.py:51-135` — auto-review corrupts Brain calibration three ways (error-keyword in description → fail; any existing referenced file → success; hardcoded episode "success").
+- **HD-5** `time_parser.py:151-159` + `heart/schedules.py:152` — timezone token captured then discarded → "daily 9am EST" fires 9am UTC.
+- **HT-4** `heart/subtasks.py:143-203` — `complete()`/`fail()` unconditional UPDATE with no precondition → stale worker overwrites a re-run.
+- **RT-1** `anthropic_client.py:1167` + `runner.py:1196` — streamed `input_tokens` double-counted; `None` injection → TypeError kills a successful streamed turn.
+- **RT-3** `config.py:452-460` + `compaction.py:593` — `tool_metadata_degrade_after`/`tool_hard_clear_after` severed (prod 60/90 ignored; hardcoded profile used).
+- **RT-8/RT-9** telegram overflow duplicates messages; sequential bot loop blocks all chats on one hung turn.
+- **HB-5..HB-9** dynamic-check budget not gated; triage no timeout (stalls tick + DAG); work-queue cancel → duplicate DAG; circuit breaker never auto-recovers; every escalation forced `urgency=high`.
+- **DG-2/DG-4/DG-6/DG-7** can't cancel RUNNING subtasks; `_MAX_PENDING=5` permanently fails nodes instead of deferring; work-queue DAGs never `start_dag`; cancel/retry not serialized with tick.
+- **RM-3/RM-4** MCP constant session ids collide concurrent callers; unbounded/negative `limit` on list endpoints.
+- **ID-2** `identity/manager.py:92-125` — concurrent `update_section` → two `is_current=true` → `MultipleResultsFound` permanently bricks that section.
+- **OB-2** 5 of 11 drift metrics never populated → constant zero → skipped forever.
+
+## 4. Dead code (headline items)
+`heart/content_date_extractor.py` (324 lines, zero consumers) · `brain` calibration
+snapshot (`generate_calibration_snapshot`/`CalibrationSnapshot` never written or read) ·
+`Brain.link` unused · `ContextEngine.expand`/`refresh_needed`/`_dedup_decisions` zero
+callers · `ExecutionLedger.has_blocked_actions_this_turn` zero callers · `web_tools`
+direct-Brave fallback unreachable · 9 dead config fields (`quality_block_threshold`,
+`agent_description`, `subtask_bootstrap_timeout`, …).
+
+## 5. Recommended fix order
+1. **Security (RM-1)** — bind ports to 127.0.0.1, rotate DB password. Deploy/compose change.
+2. **Pattern A cluster (HD-1, HD-2)** — swap RRF probe → raw cosine. Unblocks procedure learning, stops wrong supersession.
+3. **BR-1 / HT-1 (active-filter correctness)** — restore episode + neighbor retrievability.
+4. **HB-1** — one-line `has_updates=True`; restores drift alerting.
+5. **CL-1 + CL-2** — route into `sections_by_tier`; stop silent subtask/hub-shift loss.
+6. **DG-1** — correct skip-and-continue terminal status.
+7. **ST-1** — guard empty-string JSON env default for clean installs.
+8. Telemetry/loop re-wiring (Pattern C) — larger, schedule as follow-up features.

--- a/docs/reviews/rest-mcp-dashboard-audit-2026-06-09.md
+++ b/docs/reviews/rest-mcp-dashboard-audit-2026-06-09.md
@@ -1,0 +1,155 @@
+# REST / MCP / Dashboard Code-Only Audit — 2026-06-09
+
+Scope: `nous/api/rest.py` (2619 lines), `nous/api/mcp.py` (356), `nous/api/dashboard_queries.py` (2036), `nous/api/models.py` (97). Call paths into `runner.py`, `tools.py`, `heart/*`, `brain/*` traced but **not** reported (other agents own them).
+
+Reachability tags use `nous/config.py` defaults + `.env.prod-snapshot` (133 lines, agent `nous-default`, single-agent prod).
+
+---
+
+## A. How it actually works
+
+`create_app()` (rest.py:63) is a closure factory: every route handler is a nested `async def` over the injected component set (`runner`, `brain`, `heart`, `cognitive`, `database`, `settings`, plus optional `identity_manager`, `bus`, `sleep_handler`, `rubric_manager`, `rubric_evolver`, `heartbeat_runner`, `session_monitor`, `context_logger`). Optional components arrive as `_LazyProxy` (main.py:925) that raises `RuntimeError` until lifespan populates them; handlers probe with `try: _ = proxy.attr` and return 503 when unresolved.
+
+Routes are a flat `Route(...)` list (rest.py:2487-2589). Ordering is deliberate: `/decisions/unreviewed` before `/decisions/{id}`, `/dashboard/admission/rejected` before `/dashboard/admission`, and the static `Mount("/dashboard", ...)` (html=True, no-cache wrapper) appended **last** as the catch-all. MCP is mounted separately at `/mcp` in `main.py:918` (lazy ASGI, stateless StreamableHTTP, single shared transport) only when `settings.mcp_enabled` (default True, prod=true).
+
+Persistence model: most handlers open `async with database.session()` per request; dashboard handlers delegate to `dashboard_queries.py` functions that take `(session, agent_id)` and never manage their own session. SSE `/chat/stream` races `aiter.__anext__()` against `settings.sse_ping_interval` (default 15s, prod unset→15) via `asyncio.wait` (no cancel-on-timeout), emits `: keepalive` comments, and `finally`-closes the underlying generator on disconnect.
+
+`docker-compose.yml:5-6` publishes the agent as `"${NOUS_PORT:-8000}:8000"` — host-side bind defaults to **all interfaces** (contrast `nous-eval-db` which is explicitly `127.0.0.1:5433`). `settings.host` default is `0.0.0.0`. There is **no authentication middleware anywhere** in `create_app`.
+
+### Route inventory (REST)
+
+| Method | Path | Handler | Notes |
+|---|---|---|---|
+| POST | /chat | chat | |
+| POST | /chat/stream | chat_stream | SSE |
+| DELETE | /chat/{session_id} | end_chat | |
+| GET | /status | status | `?dashboard=true` extends |
+| GET | /decisions | list_decisions | |
+| GET | /decisions/unreviewed | list_unreviewed | no error guard |
+| POST | /decisions/{id}/review | review_decision | no error guard |
+| GET | /decisions/{id} | get_decision | |
+| GET | /episodes | list_episodes | |
+| GET | /facts | search_facts | search + browse |
+| GET | /chunks | list_chunks | direct SQL |
+| PUT | /censors/{id} | update_censor | |
+| GET | /censors | list_censors | |
+| GET | /procedures | list_procedures | |
+| GET | /frames | list_frames | |
+| GET | /calibration | calibration | |
+| GET | /identity | get_identity | |
+| PUT | /identity/{section} | update_identity_section | mutating, no auth |
+| POST | /reinitiate | reinitiate | destructive, no auth |
+| GET/DELETE | /subtasks, /subtasks/{id} | list/get/cancel_subtask | |
+| GET/POST/DELETE | /schedules, /schedules/{id} | list/create/deactivate | |
+| GET | /health | health | |
+| GET | /events/stats, /events/recent | events_stats/recent | |
+| GET | /events/trace/{trace_id} | events_trace | **no agent_id scope** |
+| GET | /events/recent-traces | events_recent_traces | **no agent_id scope** |
+| GET | /events/modifications | events_modifications | **no agent_id scope** |
+| GET/POST/PUT | /heartbeat/* (status, trigger, config) | heartbeat_* | config mutates Settings |
+| POST | /heartbeat/findings/{fp}/{ack,resolve,dismiss} | | |
+| GET/PUT | /heartbeat/findings, /escalation-policy | | |
+| GET/POST | /heartbeat/tuning-report, /tune | | |
+| POST | /heartbeat/check/{name}/{trigger,reset} | | |
+| GET/POST/PATCH/DELETE | /heartbeat/checks/dynamic[/{name}[/trigger]] | | |
+| POST | /sleep/trigger | trigger_sleep | |
+| GET/POST | /admin/search-weights | get/set_search_weights | mutating, no auth |
+| POST/GET | /rubric/* (propose, approve, rollback, history, signals, evolve, root) | | mutating, no auth |
+| GET | /dashboard/{graph,calibration,activity,health,rubric,admission[/rejected],ledger,heartbeat,observability,cache,dag,density,subtasks} | dashboard_* | |
+| GET | /context/log[/{id}[/payload|/sections]], /context/diff | context_log_* | |
+| GET | /behavior/{snapshot/latest,trends,anomalies,drift-report} | behavior_* | |
+| (mount) | /dashboard/* | static SPA | html=True catch-all, no auth |
+
+### MCP tool surface (`/mcp`)
+
+5 tools: `nous_chat`, `nous_recall`, `nous_status`, `nous_teach`, `nous_decide`. `nous_chat`/`nous_decide` accept an optional/none session id; **`nous_recall` has no session, `nous_decide` hardcodes `"mcp-decision"`, `_handle_chat` defaults `"mcp-session"`** (mcp.py:224, 345). No auth on the MCP mount either.
+
+---
+
+## B. Findings register
+
+### P1
+
+**RM-1 — REST API + dashboard + MCP exposed with zero authentication on a publicly-bound port. (LIVE)**
+
+> Main-session verification addendum (2026-06-09): CONFIRMED, and it compounds —
+> `docker-compose.yml:116-117` also publishes the **main Postgres** on an
+> all-interface bind (`"${DB_PORT:-5432}:5432"`), and the prod env snapshot
+> shows prod still runs the default `DB_PASSWORD=nous_dev_password`. Anyone who
+> can reach the host gets not just the unauthenticated REST/MCP surface but the
+> database itself with a guessable password. Mitigation order: bind both ports
+> to 127.0.0.1 (or an internal network), rotate the DB password, then add an
+> auth layer to REST/MCP if remote access is required.
+
+`docker-compose.yml:5-6` `"${NOUS_PORT:-8000}:8000"` binds the host port on all interfaces (no `127.0.0.1:` prefix, unlike the eval DB at line 131); `settings.host` defaults to `0.0.0.0` (config.py:299). `create_app` (rest.py:63-2618) registers **no auth middleware**. Anyone who can reach the port can: read all memory (`/facts`, `/decisions`, `/episodes`, `/chunks`, every `/dashboard/*`, the static SPA), wipe agent identity (`POST /reinitiate`, rest.py:742), rewrite identity sections (`PUT /identity/{section}`), mutate retrieval weights persisted to DB (`POST /admin/search-weights`, rest.py:1042), force sleep cycles, cancel subtasks/schedules, evolve/rollback the rubric, and drive arbitrary LLM turns with tool access via `POST /chat` and the unauthenticated MCP mount (`nous_chat`/`nous_decide` run the full tool loop → `bash`, `write_file`, `web_fetch`, etc.). Evidence: no `Middleware`/`AuthenticationMiddleware` in the `Starlette(**kwargs)` build (rest.py:2615-2618); telegram is the only "trusted" client and it talks plain HTTP to `http://nous:8000`. Fix: bind the published port to `127.0.0.1` in compose (matching the eval-DB pattern) and/or add a shared-secret/Bearer auth middleware gating all non-`/health` routes; at minimum gate the mutating/destructive set and `/mcp`.
+
+### P2
+
+**RM-2 — `/events/recent-traces`, `/events/modifications`, `/events/trace/{trace_id}` query `nous_system.events` with no `agent_id` filter. (LATENT)**
+rest.py:2283-2303 (recent-traces) and 2317-2323 (modifications) scan the entire events table across all agents; `events_trace` (rest.py:2249-2254) filters only by `trace_id`. By contrast the in-handler `dashboard_observability` version of the same query *does* scope `AND agent_id = :aid` (rest.py:1425, 1459, 1479) — so the standalone endpoints are inconsistent with the dashboard ones. Latent today (single agent `nous-default`) but a direct cross-agent data leak the moment a second agent shares the DB, which the schema is explicitly designed for ("All tables are agent-scoped for multi-agent readiness"). Fix: add `AND agent_id = :aid` and bind `settings.agent_id`.
+
+**RM-3 — MCP `nous_recall`/`nous_chat`/`nous_decide` share fixed session IDs across all external callers. (LIVE if MCP used)**
+mcp.py:224 (`"mcp-session"`), 345 (`"mcp-decision"`). Two external agents (or two concurrent calls from one) calling `nous_chat`/`nous_decide` land in the **same** conversation/working-memory/ledger session, interleaving history and context. `nous_recall` is stateless so safe, but `nous_chat` defaulting to a single constant means multi-client MCP is effectively a shared mutable conversation. prod `NOUS_MCP_ENABLED=true`. Fix: generate a per-connection session id (or require the caller to pass one) instead of a module constant.
+
+**RM-4 — Core list endpoints accept an unbounded, unvalidated-sign `limit`. (LIVE)**
+`list_decisions` (rest.py:352), `list_episodes` (406), `search_facts` (438), `list_censors` (561), `list_procedures` (645), `list_subtasks` (804), `list_schedules` (888) parse `int(limit)` with **no upper cap** and **no `>= 0` check** — unlike `dashboard_graph` (min(...,2000)) and `dashboard_admission_rejected` (min(...,200)). `?limit=100000000` forces a giant result set + `model_dump` loop (memory/latency DoS); a **negative** limit reaches Postgres `LIMIT -5`, which errors → swallowed into a generic 500. Fix: clamp to a sane max and reject negatives, mirroring the dashboard handlers.
+
+### P3
+
+**RM-5 — `confidence_min`/`float` parsing sits outside the try/except in `list_decisions`. (LATENT)**
+rest.py:361 `confidence_min = float(confidence_min_str)` is between the int-guard try (ends 355) and the brain-call try (starts 369). `?confidence_min=abc` raises an unguarded `ValueError` → generic Starlette 500 instead of a 400. Same shape exists implicitly anywhere a raw `float(...)`/`int(...)` runs outside a guard.
+
+**RM-6 — `list_unreviewed` and `review_decision` have no input guards at all. (LATENT)**
+`list_unreviewed` (rest.py:780-794): `int(max_age_days)` / `int(limit)` and the brain call are unwrapped → 500 on non-int params. `review_decision` (757-778): `await request.json()` unwrapped (500 on bad body), `UUID(decision_id)` unwrapped (500 on malformed id), and only `ValueError→404` is caught so any other brain exception is a raw 500. Both should mirror the `try/except ValueError → 400/404` pattern used elsewhere.
+
+**RM-7 — Many observability/behavior endpoints parse `int(limit|hours)` ungaurded. (LATENT)**
+`events_recent` (2231), `events_recent_traces` (2280), `events_modifications` (2314), `behavior_trends` (2424), `behavior_anomalies` (2449), `context_log_list` (2339), `get_rubric_history` (1698), `list_unreviewed` (783) all do bare `int(query_params.get(...))` → 500 on garbage input. Low severity (operator-facing) but inconsistent with the guarded list handlers.
+
+**RM-8 — `heartbeat_config` mutates a live `Settings` via `object.__setattr__` with weak validation and no persistence. (LATENT)**
+rest.py:1915 writes `heartbeat_quiet_start`/`quiet_end`/`tick_interval`/`daily_token_budget` onto the shared settings object. Validation is only `isinstance(val, int) and val >= 0` — `quiet_start=99` or `tick_interval=0` are accepted. Changes are lost on restart (not persisted), and mutating a process-global settings object that other components read concurrently is a latent consistency hazard. Fix: range-validate (0–23 for hours, ≥1 for intervals) and document the non-persistence.
+
+**RM-9 — Error responses leak raw internal exception strings to clients. (LIVE)**
+Pervasive `return JSONResponse({"error": str(e)}, status_code=500)` (e.g. rest.py:132, 231, 347, 384, 401, ...). `str(e)` on SQLAlchemy/asyncpg errors can include SQL fragments, table/column names, and connection detail. Combined with RM-1 (no auth) this is real reconnaissance surface. Fix: log full detail, return a generic message + request id to the client.
+
+**RM-10 — `set_search_weights` swallows DB-persist failures but returns 200. (LIVE)**
+rest.py:1068-1072 / 1088-1092: `persist_to_db` failures are caught and logged only; the response still reports success with the new in-memory weight. The runtime value *is* applied (so behavior changes), but the operator believes it was persisted when it was not — silent divergence after restart. Fix: surface a `persisted: false` flag or non-2xx when persistence fails.
+
+**RM-11 — `chat_stream` returns a `JSONResponse` 400 from a handler typed/clients-expecting SSE. (LATENT)**
+rest.py:137-143: on bad JSON / missing message the SSE endpoint returns a JSON body, not an `text/event-stream` error event. SSE clients parsing the stream may mishandle the 400. Cosmetic but a contract wrinkle.
+
+### INFO
+
+**RM-12** — `get_admission_data` interpolates `{dim}` into SQL via f-string (dashboard_queries.py:964-969). Safe today: `dim` iterates a hardcoded `["utility","confidence","novelty","recency","type_prior"]` list, never user input. Same for `base_where`/`filter_clause` ("1=1", `active = true`) in `get_density_data` (1689-1695) and the `{table}`/`{cols}` map in `get_graph_data` (181-206) — all hardcoded. Sort/order in `get_admission_rejected` go through an allowlist (1125-1131). No injection reachable, but the f-string-into-`text()` pattern is fragile if a future edit makes any token user-derived.
+
+**RM-13** — `get_unreviewed` fetches all unreviewed rows then slices `[:limit]` in Python (rest.py:786-790) — works but does redundant DB work; push the limit into SQL.
+
+**RM-14** — Dashboard orphan/degree/density queries (`get_graph_data` orphan `NOT EXISTS`, `get_health_data` degree-distribution UNION-ALL, `get_density_data` per-type orphan scans) are full sequential scans joined against `brain.graph_edges` on every dashboard load, repeated per node type (5×). On a large graph these are hot-path table scans; verify indexes on `graph_edges(agent_id, source_id)` / `(agent_id, target_id)` exist, else dashboard latency scales with corpus size.
+
+**RM-15** — `get_activity_data` (dashboard_queries.py:474) and `events_*` return raw `data` JSONB blobs verbatim to the client; event payloads can embed conversation/tool content. Under RM-1 this widens the read surface. Consider field-whitelisting.
+
+**RM-16** — `_handle_teach` (mcp.py:308-336) maps `domain`→`category` for facts with no category validation, and bypasses admission/dedup paths the REST `/facts` write would use; benign but an inconsistency between the two write surfaces.
+
+---
+
+## C. Dead-code / no-consumer inventory
+
+Verified consumers: dashboard JS (`static/dashboard/js/*`) fetches `/status?dashboard=true`, `/decisions`, `/episodes`, `/facts`, `/chunks`, `/procedures`, `/censors`, `/context/log/*`, and every `/dashboard/*`. Telegram bot uses only `/chat`, `/chat/stream`, `/chat/{id}` (DELETE), `/identity`. No test references found for the events/behavior/admin families.
+
+- **No frontend or test consumer found** for: `/events/trace/{trace_id}`, `/events/recent-traces`, `/events/modifications`, `/events/stats`, `/events/recent`, `/behavior/snapshot/latest`, `/behavior/trends`, `/behavior/anomalies`, `/behavior/drift-report`, `/context/diff`, `/admin/search-weights` (GET/POST), `/rubric/*` REST family, `/decisions/unreviewed`, `/decisions/{id}/review`. These are external-API/manual-curl surfaces — not strictly dead (intentional external endpoints) but unexercised by any in-repo client, so field-shape drift here is invisible until an external caller hits it. RM-2/RM-6/RM-7 cluster in exactly this unexercised set.
+- `_get_last_bot_message_id` (telegram_bot.py:808) is a `return None` stub (out of scope, noted in passing).
+- `events_trace` computes `"duration_ms": None` with a comment "Could compute" (rest.py:2275) — placeholder field always null.
+
+No endpoints mutate state via GET (all writes are POST/PUT/DELETE) — clean.
+
+## D. FE/BE field-shape spot check
+
+Cross-checked dashboard JS field access against handler dicts: `overview.js` (`data.memory/calibration/execution_integrity/dashboard`), `graph.js` (`nodes/edges/stats`), `admission.js` (`summary/score_distribution/dimension_stats/by_source/by_category/daily_trend/bypass_breakdown/config/facts/total`), `health.js` (`daily_edges/degree_distribution/density_history/orphan_trend/total_edges`), `heartbeat.js` (`status/checks/budget/quiet_hours/totals/findings_by_day/findings_timeline/cognitive_sessions/finding_lifecycle/tuning`) — **all present** in the corresponding response builders. No drift detected on the exercised surface. (The unexercised endpoints in section C are where drift would hide.)
+
+## E. Improvement opportunities
+
+1. Add an auth middleware + bind `127.0.0.1` (RM-1) — single highest-value change.
+2. Factor a `_parse_int(param, default, *, min, max)` helper and route all list/observability handlers through it (fixes RM-4, RM-5, RM-6, RM-7 uniformly).
+3. Add `AND agent_id = :aid` to the three standalone events endpoints (RM-2) to match the dashboard variants.
+4. Per-connection MCP session ids (RM-3).
+5. Generic client error bodies + structured server logs (RM-9).
+6. Confirm/add `graph_edges(agent_id, source_id)` and `(agent_id, target_id)` indexes for dashboard scans (RM-14).

--- a/docs/reviews/runtime-core-audit-2026-06-09.md
+++ b/docs/reviews/runtime-core-audit-2026-06-09.md
@@ -1,0 +1,395 @@
+# Runtime Core Audit — 2026-06-09
+
+**Scope:** `nous/api/runner.py`, `nous/api/anthropic_client.py`, `nous/api/compaction.py`,
+`nous/api/smart_compress.py`, `nous/api/tool_cache.py`, `nous/api/cache_optimizer.py`,
+`nous/api/models.py`, `nous/main.py`, `nous/telegram_bot.py`, `nous/events.py`.
+
+**Method:** code-only; every claim verified against function bodies. Reachability checked against
+`nous/config.py` defaults AND the prod overlay `.env.prod-snapshot`. Prod-relevant facts used below:
+API backend = **SDK** (default `sdk`, not overridden in prod), `NOUS_MODEL=claude-opus-4-8`,
+`NOUS_CONTEXT_WINDOW=700000`, `NOUS_MAX_TURNS=600`, `NOUS_TOOL_TIMEOUT=2000`,
+`NOUS_KEEP_LAST_TOOL_RESULTS=50`, `NOUS_TOOL_METADATA_DEGRADE_AFTER=60`, `NOUS_TOOL_HARD_CLEAR_AFTER=90`,
+`NOUS_ACTION_GATING_ENABLED=false`, compaction + pruning + smart-compress + F048 streaming all on,
+thinking adaptive, `NOUS_SUBTASK_WORKERS=6` (concurrent background turns on the **same** AgentRunner
+instance as chat).
+
+Verdicts: **LIVE** (reachable in prod config), **LATENT** (reachable under non-default but supported
+config), **INERT** (flag-gated off everywhere), **DEAD** (no caller).
+
+---
+
+## 1. How it actually works (brief)
+
+**Turn flow (non-streaming).** `AgentRunner.run_turn` (runner.py:312) touches the session monitor
+synchronously, takes a per-session `asyncio.Lock` (runner.py:381), runs `cognitive.pre_turn`,
+appends the user message to the in-memory `Conversation` (plain-text `Message` objects only),
+optionally compacts history (Layer 2) under a per-session compaction lock, then enters `_tool_loop`
+(runner.py:1427). The loop builds messages fresh from `conversation.messages` each turn
+(`_format_messages`, runner.py:2498 — ALL messages when compaction enabled), calls the API via
+`_call_api` → backend client, dispatches every `tool_use` block via `ToolDispatcher.dispatch`,
+appends results as a single user message, smart-compresses (`smart_compress`, runner.py:1745) and
+caches non-refetchable originals (`tool_cache`), prunes old tool results in-turn
+(`prune_tool_results`, runner.py:1828), and repeats until no `tool_use` blocks or `max_turns`.
+**Only the final response text is persisted to `conversation.messages`** — intermediate tool
+exchange is in-turn-local by design. `post_turn` always runs, then a caught exception is re-raised
+after cleanup (runner.py:556).
+
+**Streaming.** `stream_chat` (runner.py:911) mirrors run_turn but reconstructs blocks from SSE
+events, yields `StreamEvent`s, holds the session lock across yields, shields `post_turn` in its
+`finally`. rest.py pumps it via fresh `create_task(aiter.__anext__())` per chunk, racing a 15s SSE
+comment-ping (rest.py:151-221).
+
+**API clients.** `create_client` (anthropic_client.py:1190) picks `SdkAnthropicClient` (prod) or
+`HttpxAnthropicClient`. Both set the "You are Claude Code…" preamble as system block 0 with
+`cache_control` (runner.py:720, 777) — the OAT 429 requirement is met on both the 3-tier and legacy
+paths. Max cache breakpoints = preamble + static + semi_stable + last-user-message = 4 (exactly the
+API limit). F048 background turns (`is_background=True`) route through `call_streaming_aggregated`
+with truncated-stream detection (httpx: anthropic_client.py:736-744; SDK: `messages.stream()` +
+`get_final_message()`), and both transports get TCP keep-alive socket options + env-proxy mounts.
+
+**Lifecycle.** `main.create_components` wires everything in dependency order on the uvicorn loop via
+Starlette lifespan; `shutdown_components` (main.py:779) stops heartbeat → subtask pool → scheduler →
+decision reviewer → session monitor → bus (drains queue after cancelling the loop task) → HTTP
+clients → runner → API client → heart/brain → DB. Heartbeat's dedicated API client is closed inside
+`HeartbeatRunner.stop()` (heartbeat/runner.py:133-139).
+
+**Event bus.** Bounded queue (1000), `put_nowait` with drop-on-full, single consumer task, handlers
+run concurrently via `gather` with per-handler exception isolation (`_safe_handle`), DB persister
+awaited inline before handlers.
+
+**Telegram bot.** Separate container (`python -m nous.telegram_bot`, compose `telegram` service,
+distinct `TELEGRAM_BOT_TOKEN` env). Long-polls `getUpdates`, handles updates **sequentially**, and
+proxies to `/chat/stream` with `read=None` timeout (server SSE pings keep the socket warm).
+`StreamingMessage` throttles edits to 1.2s, splits >4000-char messages, converts markdown → HTML
+with a plain-text fallback retry when Telegram rejects parse_mode.
+
+---
+
+## 2. Findings register
+
+### P1 — none found
+
+No live-path data-loss/corruption bug was confirmed at P1 severity. The closest candidates are
+RT-1 (telemetry corruption + crash variant) and RT-2 (guard evidence poisoning), both classified P2
+for the reasons given inline.
+
+### P2
+
+---
+
+**RT-1 — Streaming usage: `message_delta` input_tokens double-counted; SDK conversion can inject
+`None` and TypeError the turn.**
+**Severity:** P2 · **Reachability:** LIVE (prod = SDK backend + Telegram streaming)
+**Where:** nous/api/anthropic_client.py:1163-1176 (`_convert_sdk_event`, `message_delta` branch);
+nous/api/runner.py:1193-1199 (`stream_chat` `done` handler); runner.py:1118-1122 (`message_start`).
+**Evidence:** `stream_chat` adds `input_tokens` to `total_usage` at **both** `message_start`
+(runner.py:1120) and `done` (runner.py:1196). The installed SDK (anthropic 0.85.0, verified) defines
+`MessageDeltaUsage.input_tokens: Optional[int] = None`; `_convert_sdk_event` builds
+`{"input_tokens": getattr(event.usage, "input_tokens", 0), ...}` — when the server populates it
+(current API sends cumulative usage on `message_delta`), the same input tokens are summed twice →
+inflated usage in the Telegram footer and `/chat/stream` `done` event. When the server omits it, the
+dict value is `None` (the key exists, so `.get("input_tokens", 0)` returns `None`) and
+`total_usage["input_tokens"] += None` raises TypeError, which the broad handler at runner.py:1370
+converts into "I encountered an error…" — discarding an otherwise-successful streamed turn.
+**Fix:** in `_convert_sdk_event`, coerce `None → 0` (`getattr(...) or 0`); in `stream_chat`'s `done`
+branch, stop adding `input_tokens` (it is already captured at `message_start`) or replace instead of
+add.
+
+---
+
+**RT-2 — F059 hallucination guard compares the new summary against input that EXCLUDES the prior
+summary → systematic false suspects from the 2nd compaction onward.**
+**Severity:** P2 · **Reachability:** LIVE (guard on by default; fires whenever compaction runs more
+than once per session — rare in prod due to the 420K threshold, but every fire is wrong)
+**Where:** nous/api/compaction.py:745-749 vs. 717-719 and 858-864.
+**Evidence:** `_summarize` feeds the model `existing_summary + new messages` and instructs
+"PRESERVE existing info" (UPDATE_SYSTEM_PROMPT, compaction.py:96). The guard's reference text is
+`self._serialize_for_summary(old_messages[serialize_start:])` (compaction.py:746-748) where
+`serialize_start=2` deliberately skips the synthetic `[Previous conversation summary]` prefix pair —
+i.e. it excludes exactly the text the carried-over entities come from. Every entity correctly
+preserved from the previous summary that doesn't reappear in the new message window is reported as a
+hallucination suspect. Consequences: (a) noisy `f059_hallucination_guard` events poison the audit
+data meant to justify flipping `compaction_hallucination_fallback_enabled`; (b) if that flag is ever
+flipped, legitimate summaries get destroyed (fallback truncation drops `conversation.summary`
+entirely, compaction.py:783-788).
+**Fix:** include `existing_summary` in `input_text` when present
+(`input_text = (existing_summary or "") + serialized`).
+
+---
+
+**RT-3 — `NOUS_TOOL_METADATA_DEGRADE_AFTER` / `NOUS_TOOL_HARD_CLEAR_AFTER` are severed wires:
+validated in Settings, never consumed; pruning uses hardcoded per-profile ages.**
+**Severity:** P2 · **Reachability:** LIVE (prod sets 60/90 expecting late clearing)
+**Where:** nous/config.py:452-460, 1452-1456 (definition + cross-validation only — grep confirms no
+other consumer); nous/api/compaction.py:593-595 uses `DECAY_PROFILE_AGES` from
+nous/cognitive/schemas.py:40-45 (`preserve (8,999,20)`, `aggressive (2,4,8)`, `standard (3,8,12)`,
+`conservative (5,10,15)`).
+**Evidence:** `prune_tool_results` derives degrade/clear ages exclusively from the profile table.
+With prod's `keep_last_tool_results=50`, every tool result older than the last 50 has
+age ≥ 51 ≥ all profile clear ages → **immediately hard-cleared** (content replaced with
+"[Tool output cleared…]", compaction.py:599-610), skipping the soft-trim and metadata tiers. The
+operator's explicit 60/90 settings — documented as functional in CLAUDE.md — are silently ignored.
+In a 600-max-turn agentic session this clears context the operator paid to keep.
+**Fix:** either thread `settings.tool_metadata_degrade_after/_hard_clear_after` into
+`DECAY_PROFILE_AGES` lookup as the "standard" tuple (scaling the profiles), or delete the settings
+and the CLAUDE.md rows so the knob isn't a lie.
+
+---
+
+**RT-4 — Context-logger attribution state is shared mutable instance state across concurrent turns.**
+**Severity:** P2 · **Reachability:** LIVE (prod runs 6 subtask workers + chat + DAG turns on the
+same `AgentRunner`; `context_log_enabled=true` and `NOUS_CONTEXT_LOG_FULL_PAYLOAD=true` in prod)
+**Where:** nous/api/runner.py:163-167 (`_current_session_id/_current_turn_number/_current_frame_id/
+_current_call_type/_last_context_entry_id`), written at runner.py:420-423 and 977-981, read inside
+`_build_api_payload` (runner.py:828-847), consumed at runner.py:1601-1610 and 1202-1211.
+**Evidence:** Two concurrent turns (e.g. a chat turn and a subtask turn — different sessions, so the
+per-session lock does not serialize them) interleave on `await` points: turn B overwrites
+`_current_session_id` before turn A's `_call_api` logs, so A's context_log row is attributed to B's
+session/frame/call_type; `_last_context_entry_id` is a single slot, so usage/stop_reason updates can
+be attached to the wrong entry or lost (`= None  # Consumed`). Telemetry-only corruption (the
+payload itself is passed explicitly), hence P2 not P1.
+**Fix:** pass a per-call context object (session_id, turn, frame, call_type) down into
+`_build_api_payload` and return the entry id to the call site, or use a ContextVar like F071 does.
+
+---
+
+**RT-5 — `HttpxAnthropicClient.call`: non-retryable errors (4xx) are retried `_MAX_RETRIES+1` times
+with NO backoff (missing `break`).**
+**Severity:** P2 · **Reachability:** LATENT (httpx backend only; prod uses SDK)
+**Where:** nous/api/anthropic_client.py:506-509.
+**Evidence:** after `last_error = RuntimeError(...)` there is no `break`/`raise`; the `for attempt`
+loop falls through to the next iteration, immediately re-POSTing the full payload. A 400
+(invalid_request / context-too-long), 401, or 403 is sent 6 times back-to-back before the final
+raise. Only `httpx.HTTPError` (anthropic_client.py:518-520) breaks.
+**Fix:** add `break` after assigning `last_error` in the non-retryable branch.
+
+---
+
+**RT-6 — `HttpxAnthropicClient.stream`: mid-stream `TimeoutException` retries the whole request
+AFTER events were already yielded → duplicated deltas to the consumer.**
+**Severity:** P2 · **Reachability:** LATENT (httpx backend only)
+**Where:** nous/api/anthropic_client.py:597-602 (retry `continue` inside the attempt loop wraps the
+`aiter_lines()` consumption at 585-595).
+**Evidence:** a `ReadTimeout` raised while iterating SSE lines (after N events have already been
+yielded to `stream_chat` / `call_streaming_aggregated`) is caught and the request is re-sent from
+scratch; the new stream re-yields the response from the beginning. In `stream_chat` the flat
+`text_parts` list (runner.py:1101, 1160) is appended without reset → duplicated text shown to the
+user and stored in history. In `call_streaming_aggregated`, `text_parts[idx]` is reset on
+`text_block_start` so duplication is partial, but `message_start` usage is `update()`-merged twice.
+Also: a `json.JSONDecodeError` from a truncated SSE line (anthropic_client.py:588) is not caught by
+any handler in `stream()` and propagates raw.
+**Fix:** track "first event yielded" and disable retry after it (raise/yield error instead);
+tolerate malformed SSE lines.
+
+---
+
+**RT-7 — `create_components` raises NameError at the return statement when
+`NOUS_EVENT_BUS_ENABLED=false`.**
+**Severity:** P2 · **Reachability:** LATENT (default true, prod true; any operator disabling the bus
+gets a startup crash)
+**Where:** nous/main.py:386 (`sleep_handler`), main.py:428-436 (`decision_reviewer`) — both defined
+only inside `if bus is not None:` (main.py:244) but referenced unconditionally in the return dict at
+main.py:768 and 770.
+**Evidence:** with the bus disabled, neither local exists; `return {... "decision_reviewer":
+decision_reviewer, "sleep_handler": sleep_handler ...}` raises `NameError` and the lifespan never
+yields. (`rubric_evolver` is correctly pre-initialized at main.py:241; these two are not.)
+**Fix:** initialize `sleep_handler = None` and `decision_reviewer = None` before the bus guard.
+
+---
+
+**RT-8 — Telegram `StreamingMessage` overflow: once a streamed reply crosses 4000 chars, EVERY
+subsequent edit spawns a new Telegram message duplicating the head.**
+**Severity:** P2 · **Reachability:** LIVE
+**Where:** nous/telegram_bot.py:429-446 (`_send_or_edit` overflow branch) + 332-344 (`update`
+rebuilds the FULL display text from `_base_text` every delta).
+**Evidence:** after the first overflow, `message_id` points at the overflow message and
+`self.text = overflow`, but the next `append_text` calls
+`update(self._base_text + text)` → `_build_display_text()` reconstructs the **entire** text
+(`_base_text` was never truncated). `len > 4000` is true again, so the code edits the current
+(overflow) message back to the truncated **head** and sends the tail as yet another new message.
+Each throttled edit cycle (~1.2s) emits one more duplicate message until the stream ends; the
+visible chat fills with repeated 4000-char heads.
+**Fix:** track a per-message base offset (only render `_base_text[sent_offset:]` into the active
+message) instead of re-rendering the full text.
+
+---
+
+**RT-9 — Telegram bot processes updates strictly sequentially with an unbounded stream read — one
+hung/long turn blocks ALL commands including `/new`.**
+**Severity:** P2 · **Reachability:** LIVE
+**Where:** nous/telegram_bot.py:492-505 (`for update in updates: await self._handle_update(update)`),
+724-732 (`read=None` stream timeout in `_chat_streaming`).
+**Evidence:** `_handle_update` awaits the full streaming turn inline; there is no per-chat task
+spawn and no overall deadline on the SSE read (`read=None`, justified by server pings — but if the
+server keeps the socket open while wedged, e.g. a stuck tool with prod `NOUS_TOOL_TIMEOUT=2000` ≈ 33
+min, the poll loop is blocked for the duration). During that window `/new` — the user's only
+recovery lever — is queued behind the hung turn, as is every other message.
+**Fix:** dispatch `_handle_update` as a task (per-chat serialization if desired) and/or add a
+generous absolute deadline around the stream.
+
+---
+
+### P3
+
+**RT-10 — Tool timeout (`NOUS_TOOL_TIMEOUT`) is only enforced on the streaming path.**
+LIVE · runner.py:1727-1730 awaits `self._dispatcher.dispatch(...)` directly (no `wait_for`);
+`_dispatch_with_keepalive` (runner.py:2444-2461, streaming only) is the sole place the timeout is
+applied. `ToolDispatcher.dispatch` (tools.py:61-95) has no timeout either. Non-streaming `/chat` and
+heartbeat triage rely entirely on per-tool internal timeouts; a tool without one hangs the turn
+indefinitely (subtasks are saved by the outer `wait_for`).
+
+**RT-11 — Session-lock entry pop allows brief double-turn concurrency after close.**
+LIVE (edge) · runner.py:655 pops `_session_locks[sid]` after releasing; a coroutine still queued on
+the OLD lock object proceeds while a newer arrival gets a NEW lock via `_get_session_lock`
+(runner.py:241-249) → two turns for the same (resurrected) session can run concurrently. Also,
+LRU eviction (runner.py:2348-2352) pops compaction locks/ledgers/corrections but NOT
+`_session_locks` — slow leak for evicted-but-never-closed sessions.
+
+**RT-12 — LRU eviction orphans an in-flight session without `end_session`.**
+LIVE (requires >100 concurrent sessions) · runner.py:2348-2352 silently drops the `Conversation` of
+the least-recently-used session; an in-flight turn keeps appending to the orphaned object and its
+episode is never closed at eviction time (F060 sleep recovery is the backstop). No log line is
+emitted for the eviction.
+
+**RT-13 — EventBus: in-flight event lost on stop; queue-full drops are the only delivery guarantee.**
+LIVE (shutdown window) · events.py:199-206 cancels the consumer task first; an event mid-`_dispatch`
+is abandoned (handlers partially run, event not re-queued) before the drain loop at 208-213 runs.
+`emit` (events.py:175-184) drops on full queue by design. Acceptable, but worth knowing: events are
+at-most-once.
+
+**RT-14 — Fire-and-forget `asyncio.create_task` without strong references (GC risk).**
+LIVE · runner.py:206/222 (`_log_f026_decision`, `_log_compaction_guard`), runner.py:2229 (`_ping`),
+main.py:239 (actionability backfill). The event loop holds only weak refs to tasks; a pending task
+with no external reference can be collected mid-flight (documented CPython footgun). Low observed
+probability, silent when it happens (telemetry/backfill loss only).
+
+**RT-15 — `CacheBreakDetector` is global across sessions and call types.**
+LIVE · cache_optimizer.py:44-110 holds a single `_previous` state; runner.py:184-186 creates one per
+runner. Interleaved sessions (chat ↔ subtask) have different semi-stable tiers, so in
+single-breakpoint mode (`cache_single_breakpoint=true`, runner.py:737-749) the semi-stable
+`cache_control` is suppressed for nearly every interleaved call, and cache-break telemetry reports
+phantom breaks. `reset()` on ANY session end (runner.py:648-649) clears global state. Cost/telemetry
+impact only.
+
+**RT-16 — Heartbeat fork never gets `_session_monitor` (and intentionally no context logger), so
+triage turns skip the synchronous activity touch.**
+LIVE · runner.py:283-304 (`fork` copies api/dispatcher/ledgers only); main.py:526-533 wires
+`_session_monitor` onto the main runner only. The mid-turn-close race that `touch()` exists to fix
+(runner.py:369-373) remains open for multi-turn heartbeat triage sessions; classification still
+arrives via the `turn_completed` bus event (`is_background` in event data, layer.py:1187,
+session_monitor.py:102-111), so #462 sleep-gating itself is intact.
+
+**RT-17 — In-turn cache key never surfaced to the model.**
+LIVE · runner.py:1755 assigns `hash_key = await cache_compressed_result(...)` and never uses it; the
+SmartCompressed marker (smart_compress.py:208-210) contains no retrieval key. The model can only
+discover `cache_retrieve` keys from next-turn context hints (cognitive/context.py:411-412) — within
+the turn that produced the compressed result, retrieval is impossible.
+
+**RT-18 — Telegram: `append_tool_indicator`/`append_thinking` bypass the 1.2s edit throttle; no
+Telegram 429 `retry_after` handling anywhere.**
+LIVE · telegram_bot.py:346-350 and 323-330 call `_send_or_edit()` unconditionally (only `update()`
+checks `_min_interval`, telegram_bot.py:340-343). A burst of tool starts produces unthrottled
+`editMessageText` calls; on 429 `_tg` (telegram_bot.py:813-839) misdiagnoses the failure as a
+parse_mode problem, retries once stripped, then gives up (returning a `list` where callers expect a
+`dict`).
+
+**RT-19 — Telegram session TTL race + URL-transported payloads.**
+LIVE (edge) · telegram_bot.py:34 hardcodes `SESSION_TTL_SECONDS=1800` equal to prod
+`NOUS_SESSION_TIMEOUT` — at the boundary the bot reuses a session id the server just closed
+(conversation state deleted → silent context reset mid-conversation). `_tg` sends all calls as
+**GET** with the message text in query params (telegram_bot.py:819-821) — ~4000-char texts ride in
+the URL; works today but is fragile (proxy/URL limits) and leaks message text into any intermediary
+logs. `_LINK_RE` href substitution (telegram_bot.py:154) doesn't escape `"` in URLs → broken HTML →
+plain-text fallback fires.
+
+**RT-20 — `stream_chat` swallows `CancelledError` and then yields `done`.**
+LIVE (edge) · runner.py:1376-1380 converts client-disconnect cancellation into `error="cancelled"`,
+then control reaches `yield StreamEvent(type="done", ...)` (runner.py:1421) — yielding again after
+cancellation only works because rest.py suppresses everything in its finally (rest.py:206-212);
+under a different consumer this is a `RuntimeError` waiting to happen. Partial streamed text is also
+not appended to history on cancel (user saw words; history has nothing).
+
+**RT-21 — Token-estimate `else`-branch and compaction health log inaccuracies.**
+LIVE (cosmetic) · runner.py:481-485 / 1049-1053 estimate `len(content)//4` only when the compactor
+is disabled — but in run_turn the "Context health" log after a compaction (runner.py:487-492) prints
+pre-compaction token counts (messages rebuilt only inside `_tool_loop`). `TokenEstimator.calibrate`
+(compaction.py:418-424) divides API `input_tokens` (which include system prompt + tools) by message
+chars only — ratio systematically overestimates (acknowledged in docstring; safety margin absorbs).
+
+**RT-22 — `MODEL_CONTEXT_WINDOWS` has no entry for prod's model.**
+LIVE (masked) · cognitive/schemas.py:15-23 lacks `claude-opus-4-8` (and any 4-8 family) → fallback
+200K. Prod masks this with `NOUS_CONTEXT_WINDOW=700000`; if that override is ever removed, the
+compaction threshold drops to 120K and budget scaling shrinks silently. Worth adding the entry.
+
+**RT-23 — SmartCompress + tool-cache run ONLY on the non-streaming loop.**
+LIVE · `stream_chat`'s dispatch path (runner.py:1300-1338) appends raw `result_text` — no
+`smart_compress`, no `cache_compressed_result`. Telegram turns (the primary chat surface in prod)
+never compress web_search/web_fetch results at ingestion; only the pruning tiers apply. Divergence
+between the two loops is undocumented.
+
+### INFO
+
+- **I-1** runner.py:1493/2362 `_stream_with_keepalive` annotates `system_prompt: str` but receives
+  the F036 dict; works only because it's passed through opaquely.
+- **I-2** `_build_api_payload` adds `cache_control` to the last user message every call
+  (runner.py:684-705) — moving breakpoint across tool-loop iterations is correct usage; total
+  breakpoints sit exactly at the API max of 4.
+- **I-3** events.py `_dispatch` awaits the DB persister inline before handlers — a slow DB write
+  delays all handler fan-out for that event (single consumer task). Acceptable at current volume.
+- **I-4** main.py:670-672 heartbeat API client is created inside the `try:` — a non-ImportError
+  failure between creation and `HeartbeatRunner.start()` leaks the client (startup aborts anyway).
+- **I-5** Compose `telegram` service reads `TELEGRAM_BOT_TOKEN` (docker-compose.yml:97), a different
+  variable from the app's `NOUS_TELEGRAM_BOT_TOKEN`; `.env.prod-snapshot` contains only the latter —
+  if the host `.env` matches the snapshot, the bot container exits at startup ("TELEGRAM_BOT_TOKEN
+  not set", telegram_bot.py:853-856). Unverifiable from the repo; flagging for operator check.
+- **I-6** `fork()` shares the `_ledgers` dict across runners without locking — safe under GIL
+  dict-op atomicity for current usage, but `ExecutionLedger` itself is not designed for cross-task
+  mutation.
+- **I-7** prod `NOUS_MAX_TURNS=600` + no tool-call cap on chat turns means a runaway chat tool loop
+  is bounded only by tokens/cost; combined with RT-3's early hard-clearing, very long loops silently
+  degrade their own context.
+
+---
+
+## 3. Dead-code inventory
+
+| Item | Location | Note |
+|---|---|---|
+| `format_event_bus_status`, `format_trace_summary`, `format_context_summary` | telegram_bot.py:205, 230, 248 | No `/status`, `/trace`, `/context` command handlers exist in `_handle_update` (telegram_bot.py:507-557). Planned F035 integration (docs/superpowers/plans/2026-04-04-f035-observability.md:874) never wired. DEAD. |
+| `has_cache_entries` | tool_cache.py:141-147 | No production caller (only docs/tests reference it). DEAD. |
+| `StreamEvent.tool_input` field | anthropic_client.py:52 | Never populated by either parser; tool inputs travel via `tool_input_delta` fragments. DEAD field. |
+| `_get_last_bot_message_id` | telegram_bot.py:809-811 | Always returns None → the `setMessageReaction` call at telegram_bot.py:657-665 always fires with `message_id=None` and fails silently. Broken vestigial feature (non-streaming `/debug` path only). |
+| `settings.tool_metadata_degrade_after` / `tool_hard_clear_after` | config.py:452-460 | Validated, documented, never consumed (see RT-3). |
+| `hash_key` local | runner.py:1755 | Assigned, never used (see RT-17). |
+| `_parse_sse_event` / `ApiResponse`/`Conversation`/`Message` re-exports | runner.py:23, 29 | Backward-compat re-exports for tests; intentional. |
+| ActionGate machinery (`_call_gate_model`, gate branches) | runner.py:228-239, 1663-1693, 1267-1298 | INERT in prod (`NOUS_ACTION_GATING_ENABLED=false`); live code path elsewhere. |
+| F071 exclusion wiring on the streaming path | runner.py:1068-1095 | INERT (flag default false, unset in prod) and documented as non-functional under SSE even when on. |
+
+---
+
+## 4. Improvement opportunities
+
+1. **Unify the two tool loops.** `_tool_loop` and `stream_chat` duplicate ~200 lines (gating,
+   ledger, episode-id injection, pruning) with already-diverged behavior (smart-compress, tool
+   timeout, F064.1 pings, F071). Extract a shared per-tool-call pipeline; the streaming loop should
+   differ only in transport.
+2. **Per-call attribution object for the context logger** (fixes RT-4 structurally) — thread an
+   immutable `CallMeta` through `_call_api`/`_build_api_payload` instead of instance fields.
+3. **Usage accounting normalization layer.** Define one place that merges
+   `message_start`/`message_delta` usage with explicit None-coercion and replace-not-add semantics
+   (fixes RT-1 for both backends and future API shape drift).
+4. **Bring the httpx client to parity or delete it.** RT-5/RT-6 plus the SDK's native retry handling
+   suggest the httpx backend is under-maintained; if it exists only as a fallback, gate it with a
+   startup warning and a test matrix, or remove it.
+5. **Telegram bot hardening:** per-chat task dispatch with an absolute turn deadline (RT-9), offset-
+   based message continuation (RT-8), honor `retry_after` from Telegram 429 payloads (RT-18), POST
+   with JSON body instead of GET query params (RT-19).
+6. **Make pruning settings real** (RT-3): scale `DECAY_PROFILE_AGES` from the two settings, keeping
+   profile ratios.
+7. **Event-bus graceful stop:** set `_running=False`, `await queue.join()`-style drain (or sentinel)
+   BEFORE cancelling, so the in-flight event finishes (RT-13).
+8. **Persist conversation state on every turn** (not only post-compaction) if restart amnesia for
+   active sessions matters — `_restore_conversation` already supports it; today it only ever sees
+   compacted sessions.
+9. **Add `claude-opus-4-8` (and 4-7/4-8 family) to `MODEL_CONTEXT_WINDOWS`** so prod doesn't depend
+   on the manual `NOUS_CONTEXT_WINDOW` override (RT-22).

--- a/docs/reviews/skills-identity-observability-audit-2026-06-09.md
+++ b/docs/reviews/skills-identity-observability-audit-2026-06-09.md
@@ -1,0 +1,211 @@
+# Skills / Identity / Observability / Integrations — Deep Code Audit
+
+**Date:** 2026-06-09
+**Scope:** `nous/skills/`, `nous/identity/`, `nous/observability/`, `nous/integrations/` (every file read fully), with call-path tracing into `nous/main.py`, `nous/api/tools.py`, `nous/api/runner.py`, `nous/api/rest.py`, `nous/heart/heart.py`, `nous/heart/procedures.py`, `nous/cognitive/layer.py`, `nous/cognitive/context.py`, `nous/heartbeat/checks.py`, `sql/migrations/026_observability.sql`.
+**Method:** Code-only. Reachability verdicts against `nous/config.py` defaults AND `.env.prod-snapshot`. F081 (PR #494) fixes verified at HEAD and NOT re-reported; residual gaps around them are.
+
+Reachability legend:
+- **LIVE** — executes on the default + prod-configured path.
+- **LATENT** — reachable but requires a state/config precondition not currently true in prod.
+- **INERT** — code wired but a flag/credential gate means it never runs in prod as configured.
+- **DEAD** — no caller / unreachable branch.
+
+---
+
+## 1. How it actually works
+
+### 1.1 Skills (`nous/skills/`)
+
+Two ingestion paths converge on `heart.procedures`:
+
+1. **Startup bootstrap** (`bootstrap.py::bootstrap_local_skills`, called from `main.py:466-472` every startup): scans `{workspace_dir}/skills/*/SKILL.md`, parses each with `SkillParser`, dedups by exact (case-insensitive) active name (`heart.get_procedure_by_name` → `procedures.py:925-945`), then checks the F081 Phase-0 supersession guard (`is_procedure_name_superseded`, `bootstrap.py:56`) before `store_procedure`. Per-skill failures are caught and warned (`bootstrap.py:65-66`); the whole call is wrapped in a `try/except` at `main.py:471-472` that logs only at DEBUG.
+2. **`learn_skill` tool** (`api/tools.py:930-1017`, frames conversation/question/task → LIVE): fetches markdown from URL (`httpx` GET, `tools.py:949-955`), local path (`tools.py:956-964`), or inline; parses; gates `active` on `requires` env vars (`tools.py:969-972`); on name collision updates in place via `update_procedure_body` (preserves stats — audit bug 9 fix), else `store_procedure`.
+
+`SkillParser.parse` (`parser.py:222-396`) does strict `---` frontmatter, then three lenient fallbacks (leading whitespace, fenced ```` ```yaml ````, missing closing `---`). The hand-rolled YAML subset (`parser.py:73-177`) handles scalars, inline lists, block lists, block dicts (F064.4 `hooks:`), and block scalars (`|`/`>`). F064.4 runtime fields (`concurrency_cap`, `timeout_override_seconds`, `hooks`, `requires_human_review`) are always parsed with fail-loud validation and always persisted to `procedures.runtime_metadata` (`parser.py:428-446`, `procedures.py:161,226`); the `NOUS_SKILL_RUNTIME_METADATA_ENABLED` flag (default `False`, `config.py:892`) gates only a v2 consumer that does not exist yet — `runtime_metadata` currently has **zero readers** (INERT by documented design).
+
+**F081 verification at HEAD:** `to_procedure_input` persists the full `raw_content` body into `implementation_notes` with `first_section` only as empty-body fallback (`parser.py:409-416`) — the first-H2-only truncation is fixed on BOTH ingestion paths (bootstrap and learn_skill share `to_procedure_input`). NULL-embed is fail-loud with retry (`procedures.py:112-132`). Resurrection guards exist in bootstrap (`bootstrap.py:52-58`) and in `list_inactive_skills` (`superseded_by IS NULL AND archived_at IS NULL`, `procedures.py:884-892`). Residual gap: the supersession guard is bootstrap-only — see SK-1.
+
+`reactivate_skills` (`bootstrap.py:74-104`, startup): re-activates inactive skill procedures whose `requires:*` env vars are now set; protected from unique-index aborts by the B6 clash guard (`procedures.py:802-819`).
+
+### 1.2 Identity (`nous/identity/`)
+
+`IdentityManager` (`manager.py`) versions six sections (`character`, `values`, `protocols`, `preferences`, `boundaries`, `environment`) in `agent_identity` with an `is_current` flag and a 60 s in-process TTL cache. `CognitiveLayer.pre_turn` loads sections each turn (`layer.py:601-605`), assembles them via `assemble_prompt` (`manager.py:273-283`) and passes the string as `identity_override` into `ContextEngine.build` (`layer.py:622`), where it becomes the `## Identity` section verbatim (`context.py:214-221`).
+
+Initiation: tri-state `agents.is_initiated` (False → NULL=in-progress → True). `pre_turn` claims via atomic `UPDATE ... WHERE is_initiated = FALSE → NULL` (`manager.py:201-216`, `layer.py:402-417`); the winner gets the `initiation` frame whose tool set is hard-restricted to `store_identity` + `complete_initiation` (`runner.py:99`). `complete_initiation` requires `character` + `preferences` sections before `mark_initiated` (`tools.py:54-73`). `POST /reinitiate` resets everything (`rest.py:742-751`). An upgrade path auto-seeds identity from existing preference/person/rule facts at startup (`manager.py:218-271`, `main.py:98-106`). Prod is initiated, so the initiation path is LATENT; section CRUD + prompt injection are LIVE.
+
+### 1.3 Observability (`nous/observability/`)
+
+- **`ContextLogger`** (F035.4, LIVE — `context_log_enabled` default `True`, prod sets `NOUS_CONTEXT_LOG_FULL_PAYLOAD=true`): `AgentRunner._build_payload` logs every Anthropic API call (`runner.py:828-849`) — section split by marker (`context_logger.py:16-67`), len/4 token estimates, item-count heuristics, in-memory deque of 200 + per-session full-payload ring buffer (10/session, 50 total), and a fire-and-forget DB insert into `nous_system.context_log` (`main.py:540-569`). `update_response` back-fills actual usage **in memory only** (`context_logger.py:386-402`). REST exposes `/context/log*` (`rest.py:2579-2582`).
+- **`BehaviorSnapshot` + `DriftDetector`** (F035.3, LIVE — `drift_detection_enabled` default `True`, registered at `main.py:649-656`): `BehaviorDriftCheck` (`heartbeat/checks.py:907-1044`) captures counts hourly, loads a 168 h baseline from `nous_system.behavior_snapshots`, runs z-score detection (`drift.py:40-63`, warn at |z|>k, alert at |z|≥3), emits heartbeat Findings, then stores the snapshot. Dashboard endpoints read the table (`rest.py:1478,2412-2470`). The wire is **not** fully severed — findings flow into the heartbeat triage pipeline — but half the monitored metrics are constant zero (OB-2).
+
+### 1.4 Integrations (`nous/integrations/gdrive.py`)
+
+Synchronous Google Drive v3 wrapper. OAuth (env `GDRIVE_CLIENT_ID/SECRET/REFRESH_TOKEN`, read straight from `os.environ`, not Settings) preferred over service account (`GOOGLE_SERVICE_ACCOUNT_JSON` base64 or `GOOGLE_SERVICE_ACCOUNT_PATH`). Lock-guarded token refresh before each call (`_ensure_valid_token`, `gdrive.py:168-190`); list/search/download/upload/update/delete/folder/health methods. Sole consumer is `DriveCheck` (`heartbeat/checks.py:756-899`), which is only registered when `settings.heartbeat_drive_enabled AND settings.google_service_account_json` (`main.py:645-646`). `.env.prod-snapshot` contains no `GDRIVE_*` or `GOOGLE_*` keys → the entire module is **INERT in prod**.
+
+---
+
+## 2. Findings register
+
+### P1
+
+#### SK-1 — `learn_skill` bypasses the Phase-0 supersession guard: re-learning a consolidated skill resurrects the archived duplicate
+- **Severity:** P1 · **Reachability:** LIVE (tool registered for conversation/question/task frames)
+- **Where:** `nous/api/tools.py:975-986` vs `nous/skills/bootstrap.py:52-58`; `nous/heart/procedures.py:896-916` (guard), `nous/heart/procedures.py:925-945` (`_get_by_name` filters `active = TRUE`)
+- **Evidence:** `is_procedure_name_superseded` has exactly one caller in `nous/` — `bootstrap.py:56`. In `learn_skill`, the dedup probe `heart.get_procedure_by_name(manifest.name)` (`tools.py:975`) only matches **active** rows. A consolidated duplicate has `active=False, superseded_by=<canonical>`, so `existing` is `None` and the code falls through to `heart.store_procedure(proc_input)` (`tools.py:986`), creating a brand-new active row under the consolidated name. The migration-058 unique index is `WHERE active`, so the insert succeeds. This is the same B1 resurrection loop F081 closed for the bootstrap and reactivation paths — left open on the one path the agent itself drives (skills are routinely re-imported from URLs/marketplace).
+- **Fix:** In `learn_skill`, when `existing is None`, check `await heart.is_procedure_name_superseded(manifest.name)`; if true, either refuse with a message pointing at the canonical procedure, or update the canonical procedure instead.
+
+### P2
+
+#### ID-1 — Initiation deadlock: abandoned/crashed initiation session leaves `is_initiated = NULL` forever; claim can never be re-won
+- **Severity:** P2 · **Reachability:** LATENT (prod agent already initiated; bites every fresh deployment whose first conversation doesn't reach `complete_initiation`)
+- **Where:** `nous/identity/manager.py:210-216` (claim sets NULL, predicate `is_initiated == False`), `nous/cognitive/layer.py:406-415` (fallback path), `nous/identity/manager.py:140-150` (`is_initiated()` maps NULL→False)
+- **Evidence:** `claim_initiation` flips `False → NULL` ("in progress"). In SQL, `is_initiated = FALSE` does not match NULL, so once the claim is committed, **no later turn can ever re-claim**: every subsequent `pre_turn` sees `is_initiated()==False` (NULL→`bool(None)`), attempts the claim, loses, logs "initiation already claimed by another session" (`layer.py:415`) and proceeds with an empty identity, indefinitely. There is no TTL, no reclaim of stale NULL, and `complete_initiation` is only callable from inside the initiation frame that can no longer be entered. Recovery requires a manual `POST /reinitiate`, or a process restart **plus** pre-existing preference/person/rule facts (the `auto_seed_from_facts` side door, `main.py:98-106`). A user who simply walks away from the first conversation (session timeout, container restart, crash) bricks initiation.
+- **Fix:** Make the claim reclaimable: `WHERE is_initiated IS NOT TRUE` plus a claimed-at timestamp with timeout (e.g., reclaim NULL older than 30 min), or revert NULL→False in `end_session` when initiation didn't complete.
+
+#### OB-1 — `nous_system.context_log` and `nous_system.behavior_snapshots` grow unbounded; `context_log_retention_days` is a dead setting
+- **Severity:** P2 · **Reachability:** LIVE (defaults on; prod on)
+- **Where:** `nous/config.py:846` (setting defined), `nous/main.py:540-569` (one INSERT per API call), `nous/heartbeat/checks.py:999-1014` (snapshot INSERT/hour); zero `DELETE` statements against either table anywhere in `nous/` or `sql/`
+- **Evidence:** `context_log_retention_days` is referenced exactly once in the codebase — its definition. `ContextLogger.log` runs on **every** Anthropic API call (`runner.py:828`), i.e., every tool-loop iteration of every turn, including background/heartbeat/subtask turns; each call inserts a row with a JSONB `token_breakdown` and `TEXT[]` tool names. `behavior_snapshots` adds ~24 rows/day. Neither sleep, session monitor, nor any migration prunes them. On a long-lived prod instance this is the largest unbounded write amplifier in the system after `events`.
+- **Fix:** Consume the existing setting: a periodic `DELETE FROM nous_system.context_log WHERE timestamp < now() - interval ':days days'` in the session-monitor sweep or sleep cycle; same for `behavior_snapshots`.
+
+#### OB-2 — Drift detection silently blind on 5 of its 11 monitored metrics: snapshot fields are never populated
+- **Severity:** P2 · **Reachability:** LIVE (BehaviorDriftCheck registered by default and in prod)
+- **Where:** `nous/observability/drift.py:26-38` (THRESHOLDS) vs `nous/heartbeat/checks.py:959-997` (`_capture_snapshot`)
+- **Evidence:** `_capture_snapshot` populates only `fact_count(_delta)`, `episode_count(_delta)`, `active_censor_count(_delta)`, `procedure_count`, and the event-bus fields. The THRESHOLDS entries `admission_rate`, `facts_pruned`, `findings_created`, `episodes_compacted`, and `contradictions_resolved` therefore monitor a constant-zero series: `stdev == 0` → `continue` at `drift.py:51-52`, every cycle, forever. The whole admission/sleep/heartbeat block of `BehaviorSnapshot` (`snapshots.py:26-53`: `facts_admitted`, `facts_rejected_*`, `checks_run`, `findings_resolved`, `triage_sessions_opened`, `sleep_ran`, `turns latency`, `tool_calls`, `decision_count`, `interval_changes`) is write-only dataclass surface — never assigned by any producer. The drift feature claims coverage it does not have; an admission-rate collapse or a fact-pruning runaway (both historically real incidents) would never raise an anomaly.
+- **Fix:** Either wire the producers (admission stats from Heart, sleep stats from sleep handler, heartbeat stats from the runner) or delete the dead THRESHOLDS entries and dataclass fields so the dashboard stops implying coverage.
+
+#### GD-1 — DriveCheck registration gate ignores the OAuth credential set the module itself prefers
+- **Severity:** P2 · **Reachability:** INERT in prod (no Google creds at all); bites any operator who configures the documented OAuth mode
+- **Where:** `nous/main.py:645` (`if settings.heartbeat_drive_enabled and settings.google_service_account_json`), vs `nous/integrations/gdrive.py:70-91,137-143` (OAuth preferred, read from raw `os.environ`)
+- **Evidence:** `GDrive.__init__` documents OAuth (`GDRIVE_CLIENT_ID/SECRET/REFRESH_TOKEN`) as the preferred mode ("preferred for uploads", auto-detected first). But the only consumer is registered solely on `settings.google_service_account_json` being non-empty (`config.py:800`). An operator who sets the three OAuth vars and flips `heartbeat_drive_enabled` (default already `True`, `config.py:811`) gets a silent no-op — no log line, no check. The OAuth vars are not even Settings fields, so there is nothing to gate on without a code change.
+- **Fix:** Gate on "any credential set present": `settings.google_service_account_json or os.environ.get("GDRIVE_REFRESH_TOKEN")`, or surface the GDRIVE_* trio in Settings and check both.
+
+#### SK-2 — Bootstrap registers skills with unmet `requires` as ACTIVE; `learn_skill` is the only path that gates on requirements
+- **Severity:** P2 · **Reachability:** LIVE (bootstrap runs every startup against `/tmp/nous-workspace/skills`)
+- **Where:** `nous/skills/bootstrap.py:60-61` (no requires check; `ProcedureInput.active` left `None` → `True` per `nous/heart/procedures.py:157`), vs `nous/api/tools.py:969-980` (learn_skill computes `skill_active` from env)
+- **Evidence:** `bootstrap_local_skills` converts and stores the manifest without ever inspecting `manifest.requires`. `_store` defaults `active=True`. A disk skill requiring e.g. `SERPER_API_KEY` (unset) is registered active, ranked into retrieval/catalog, and offered to the agent as usable — it will fail at execution time. The companion `reactivate_skills` only moves skills inactive→active (`bootstrap.py:95-99`); nothing ever moves an active-but-unsatisfied skill the other way, so the asymmetry is permanent. `learn_skill` got this right (`proc_input.active = skill_active`, `tools.py:980`); bootstrap predates it and was never aligned.
+- **Fix:** In bootstrap, mirror learn_skill: `missing = [v for v in manifest.requires if not os.environ.get(v)]; proc_input.active = not missing`.
+
+### P3
+
+#### SK-3 — UTF-8 BOM defeats every parse mode: `str.lstrip()` does not strip U+FEFF
+- **Severity:** P3 · **Reachability:** LIVE (any Windows-Notepad-saved or BOM-emitting SKILL.md; bootstrap reads `encoding="utf-8"`, not `utf-8-sig`, `bootstrap.py:43`; URL fetch via `resp.text` can preserve BOM)
+- **Where:** `nous/skills/parser.py:243-265` (all lenient fallbacks rely on `text.lstrip()`)
+- **Evidence:** Verified: `'﻿'.lstrip() == '﻿'` and `'﻿'.isspace() is False` (Python 3.12). A file beginning `﻿---\n` fails the strict match (BOM at pos 0), and all three lenient retries re-lstrip the same string ineffectively → `ValueError: SKILL.md must start with YAML frontmatter` with a misleading message (the file *does* start with `---` visually).
+- **Fix:** `text = markdown.lstrip("﻿")` (or `removeprefix("﻿")`) at the top of `parse()`.
+
+#### SK-4 — YAML comment line inside a block list silently truncates the list
+- **Severity:** P3 · **Reachability:** LIVE (any SKILL.md author using `# comment` inside `triggers:`/`frames:` lists)
+- **Where:** `nous/skills/parser.py:124-175` (`_parse_frontmatter` line loop)
+- **Evidence:** For `triggers:\n  - a\n  # note\n  - b`, the `  # note` line matches neither the list regex (`^\s+-\s+`) nor the dict regex (`^(\s+)(\w...)`), so the loop falls through to `_flush_block()` (`parser.py:152`) — `triggers=[a]` is committed and `current_key` cleared. The following `  - b` then matches the list regex but `current_key` is `None`, so the line is **silently dropped**. Same applies to blank-line-separated list items. No warning is appended.
+- **Fix:** Skip lines whose stripped form starts with `#` (and blank lines) before the flush fall-through.
+
+#### SK-5 — Bootstrap outer failure is logged at DEBUG: a fully broken skill subsystem is invisible at the default log level
+- **Severity:** P3 · **Reachability:** LIVE (startup path; default `NOUS_LOG_LEVEL=info`)
+- **Where:** `nous/main.py:471-472`
+- **Evidence:** `except Exception: logger.debug("Skill bootstrap skipped or failed (non-fatal)")` — no `exc_info`, DEBUG level. If `heart.get_procedure_by_name` raises on the first skill (e.g., post-migration schema drift — exactly the migration-058 family that `_reactivate` had to defend against at `procedures.py:802-805`), bootstrap AND `reactivate_skills` both silently no-op every startup. The per-skill handler inside the loop (`bootstrap.py:65-66`) warns properly; only catastrophic failure is muted.
+- **Fix:** `logger.warning(..., exc_info=True)`.
+
+#### SK-6 — Inactive (non-superseded) skill + `learn_skill` re-import creates a second row of the same name
+- **Severity:** P3 · **Reachability:** LIVE
+- **Where:** `nous/api/tools.py:975` (`get_procedure_by_name` → active-only), `nous/heart/procedures.py:938`
+- **Evidence:** A skill deactivated for unmet `requires` (`active=False`, `superseded_by` NULL, `archived_at` NULL) is invisible to the dedup probe. Re-learning the same skill (now with requires satisfied) inserts a **new** active row; the old inactive row remains. `reactivate_skills` will later try to reactivate the old row and only the B6 clash guard (`procedures.py:806-819`) prevents a unique-index abort — leaving permanent duplicate rows (one active, one inactive zombie). Embedding-based dedup is blind to this (cos 0.54-0.81 per the 2026-06-06 procedure audit).
+- **Fix:** Probe should also look up inactive non-superseded rows by name and update those in place (re-activating), rather than insert.
+
+#### ID-2 — Concurrent `update_section` race produces two `is_current=True` rows, which then bricks all future updates of that section
+- **Severity:** P3 · **Reachability:** LIVE (REST PUT `/identity/{section}` + initiation tool + auto-seed can interleave; no row lock)
+- **Where:** `nous/identity/manager.py:92-125` (read-then-write without `FOR UPDATE`), failure mode at `manager.py:102` (`scalar_one_or_none`)
+- **Evidence:** Two writers both read the same `current` row, both set `is_current=False` on it, both insert version N+1 with `is_current=True` → two current rows. From then on, every `update_section` for that section raises `MultipleResultsFound` from `scalar_one_or_none()` — the section becomes permanently un-updatable until manual SQL repair. `get_current` also returns a nondeterministic winner (`{r.section: r.content}` overwrite, `manager.py:68`).
+- **Fix:** `.with_for_update()` on the current-row select, or a partial unique index on `(agent_id, section) WHERE is_current`.
+
+#### ID-3 — `auto_seed_from_facts` defeats `POST /reinitiate` across a restart
+- **Severity:** P3 · **Reachability:** LATENT (requires reset + restart ordering)
+- **Where:** `nous/main.py:98-106` (runs unconditionally every startup), `nous/identity/manager.py:229-263`
+- **Evidence:** `/reinitiate` clears sections and `is_initiated=False` expecting the next conversation to run initiation. If the process restarts before that conversation (deploys do exactly this), `auto_seed_from_facts` sees empty identity + existing preference/person/rule facts (always true on a mature prod DB), seeds a `preferences` section, and calls `mark_initiated` — silently cancelling the operator's reset. The seeding path also cannot distinguish "fresh upgrade" from "deliberate reset".
+- **Fix:** Persist a `reinitiate_pending` marker (e.g., the existing `status` control section) that suppresses auto-seed, or only auto-seed when the agent row has never been initiated (`is_initiated IS DISTINCT FROM FALSE` won't work post-reset; needs an explicit marker).
+
+#### OB-3 — Actual token usage is never persisted: `context_log` columns `input_tokens_actual`/`output_tokens`/`cache_*`/`duration_ms`/`stop_reason` are always NULL
+- **Severity:** P3 · **Reachability:** LIVE
+- **Where:** `nous/main.py:544-566` (INSERT omits the columns), `nous/observability/context_logger.py:386-402` (`update_response` mutates only the in-memory entry), `sql/migrations/026_observability.sql:41-46` (columns exist)
+- **Evidence:** The DB row is written fire-and-forget at request time, before the response exists; `update_response` (called at `runner.py:1202,1601`) never issues an UPDATE. The schema promises actuals; any SQL analysis of cache efficiency or real token spend over history silently gets NULLs. Only the in-memory deque (last 200 calls, lost on restart) has the data.
+- **Fix:** Add a second db_writer hook in `update_response` (UPDATE by id), or drop the six columns.
+
+#### OB-4 — `parse_system_sections` markers are missing three live section headers, mis-attributing their tokens to the preceding section
+- **Severity:** P3 · **Reachability:** LIVE
+- **Where:** `nous/observability/context_logger.py:16-35` vs `nous/cognitive/context.py:358,384,401,418`
+- **Evidence:** ContextEngine emits `## Procedure Awareness` (context.py:384), `## Epistemic Routing` (context.py:401), and `## Cached Results` (context.py:418); none is in `SECTION_MARKERS`. Their lines are absorbed into whatever section preceded them — e.g., Procedure Awareness inflates `procedure_catalog`'s token estimate and the F079 catalog item counter (`_count_items("procedure_catalog", "- ")` counts any `- ` line in the absorbed text). Dashboard token-breakdown and delivery counters drift accordingly.
+- **Fix:** Add the three markers.
+
+#### OB-5 — Fire-and-forget DB write task is created without a strong reference (GC can cancel it mid-flight)
+- **Severity:** P3 · **Reachability:** LIVE
+- **Where:** `nous/observability/context_logger.py:376-382`
+- **Evidence:** `loop.create_task(self._db_writer(entry))` discards the returned Task. Per the documented asyncio footgun, the event loop holds only a weak reference; under GC pressure the task can be collected before completion, dropping log rows nondeterministically (compounds OB-3's already-partial persistence).
+- **Fix:** Keep a `set` of in-flight tasks with `task.add_done_callback(tasks.discard)`.
+
+#### GD-2 — `GDrive._call` is dead; the retry/rebuild recovery it implements protects only `list_files`
+- **Severity:** P3 · **Reachability:** INERT in prod (module unreachable), LATENT otherwise
+- **Where:** `nous/integrations/gdrive.py:192-204` (defined, zero callers), `gdrive.py:259-263` (list_files has its own inline copy), all other methods (`download_file:292`, `upload_file:355-363`, `update_file:393-402`, `delete_file:412`, `create_folder:428-433`, `get_file_info:441-448`, `health_check:504`) call `.execute()` raw
+- **Evidence:** The class docstring claims "Stale httplib2 connections are recovered via automatic service rebuild", but only `list_files` does. A stale-socket `BrokenPipeError` during `download_file`'s metadata `get` (`gdrive.py:292`) or any upload propagates uncaught. Note also `_TRANSIENT_ERRORS` (`gdrive.py:113`) ends with bare `OSError`, which makes the first three members redundant and would also retry non-transient `FileNotFoundError`/`PermissionError` raised inside the HTTP stack.
+- **Fix:** Route all `.execute()` calls through `_call`, and narrow `_TRANSIENT_ERRORS`.
+
+#### GD-3 — `upload_to_nousdrive` builds a Drive query with an unescaped subfolder name
+- **Severity:** P3 · **Reachability:** INERT in prod, LATENT otherwise
+- **Where:** `nous/integrations/gdrive.py:478` (`f"name = '{subfolder}' and ..."`), contrast `search_files` which escapes (`gdrive.py:276`)
+- **Evidence:** A subfolder name containing `'` (e.g., "Tim's docs") produces a malformed query → HttpError; a crafted value can alter the query semantics (match arbitrary folders inside NousDrive). Agent-controllable if the agent ever drives uploads.
+- **Fix:** Reuse the `search_files` escaping (`subfolder.replace("'", "\\'")`).
+
+#### GD-4 — `download_file` has no size limit and trusts the export/destination path blindly
+- **Severity:** P3 · **Reachability:** INERT in prod, LATENT otherwise
+- **Where:** `nous/integrations/gdrive.py:282-314`
+- **Evidence:** `MediaIoBaseDownload` loops until done with no byte cap — a multi-GB Drive file fills the container disk (8 GB prod VM). `destination.parent.mkdir(parents=True)` will create arbitrary directory trees for whatever path the caller passes. No mitigation anywhere in the call chain (DriveCheck never downloads, so currently latent).
+- **Fix:** Optional `max_bytes` parameter checked against `meta['size']` before downloading.
+
+#### SK-7 — `learn_skill` URL fetch: no size cap, no content-type check, arbitrary-host GET
+- **Severity:** P3 · **Reachability:** LIVE
+- **Where:** `nous/api/tools.py:949-955`
+- **Evidence:** `resp.text` is unbounded — a pathological URL yields a multi-MB "skill" persisted wholesale into `implementation_notes` and embedded (embed input built from the full body, `procedures.py:138-142`). The direct `httpx.AsyncClient.get` also bypasses the `web_fetch` tier's protections (internal-IP fetch = SSRF primitive), though the agent's `bash` access makes this a marginal escalation. Relative local paths can traverse out of the workspace via `..` (`tools.py:960`).
+- **Fix:** Cap at e.g. 256 KB, require `text/*` content type, and `Path.resolve()`-containment-check the local path.
+
+#### ID-4 — Identity content reaches the system prompt verbatim — fake `##` headers can spoof sibling sections
+- **Severity:** P3 (by design, but unhardened) · **Reachability:** LIVE
+- **Where:** `nous/identity/manager.py:273-283` (`assemble_prompt`), `nous/cognitive/context.py:214-221` (verbatim `## Identity` section)
+- **Evidence:** Procedure descriptions get `_one_line()` hardening specifically to stop `\n## ` header injection (`context.py:45-52`), but identity section content — written by the LLM during initiation from user-dictated text, by unauthenticated REST `PUT /identity/{section}`, and by `auto_seed` from learned facts (`manager.py:249-260`) — is interpolated with no newline/header sanitization. A `boundaries` section containing `\n## Active Censors\n(none)` both spoofs a section to the model and corrupts ContextLogger's per-section attribution (`context_logger.py:40-67`). The REST API has no authentication at all (no auth/middleware match in `rest.py`), so this is network-reachable.
+- **Fix:** Escape line-leading `#` in section content at assemble time (e.g., indent or zero-width-prefix), or at minimum length-cap and log.
+
+### INFO
+
+- **IN-1** `requires_human_review` bool/int branches are unreachable: `_parse_frontmatter` only ever produces `str | list | dict` values, never `bool`/`int` (`parser.py:349,363-372`); same for the `isinstance(val, int)` arm of `_parse_optional_positive_int` (`parser.py:206`). Harmless dead defensive code.
+- **IN-2** An empty `hooks:` block (key with no children) flushes as `[]` (`parser.py:114-116`) and then fails the dict check (`parser.py:328-331`) — the whole skill import errors on a semantically-empty declaration. Marginally harsher than necessary.
+- **IN-3** CRLF input: key/value and list items are `.strip()`ed clean, but block-scalar (`description: |`) bodies retain interior `\r` (`parser.py:101-109` joins raw lines) — carriage returns end up in the persisted description.
+- **IN-4** `main.py:466` comment "one-time, only if DB has no skills" is stale — bootstrap runs every startup and dedups per name.
+- **IN-5** `_count_items` legacy heuristic (`context_logger.py:175`) returns 1 for a non-empty section with zero bullets and over-counts embedded `\n-` in facts/decisions (documented as a known approximation at `context_logger.py:180-187`).
+- **IN-6** Prod runs `NOUS_CONTEXT_LOG_FULL_PAYLOAD=true`: complete system prompts + message histories (identity, censors, memory, user content) are retrievable via unauthenticated `GET /context/log/{id}/payload` (`rest.py:2354-2358`). In-memory only and ring-bounded, but it is the single most sensitive unauthenticated read in these subsystems.
+- **IN-7** `BehaviorDriftCheck` deltas reset on process restart (`_last_snapshot=None` → delta 0, `checks.py:986-991`), slightly diluting the baseline after deploys. Cosmetic given OB-2.
+- **IN-8** `GDrive` is fully synchronous; `DriveCheck` correctly wraps `list_files` in `asyncio.to_thread` (`checks.py:804`), but any future async caller using download/upload directly will block the loop. The hardcoded `NOUSDRIVE_FOLDER_ID` and "Ask Tim to re-authorize" string couple the module to one person's account.
+- **IN-9** `reset_identity` invalidates the TTL cache *before* the (possibly caller-deferred) commit (`manager.py:193`) — a concurrent `get_current` can re-cache pre-reset rows for up to 60 s. Same staleness window applies to cross-process cache invalidation generally (each process has its own cache).
+
+---
+
+## 3. Dead-code inventory
+
+| Item | Location | Note |
+|---|---|---|
+| `UPGRADE_INITIATION_PROMPT` | `nous/identity/protocol.py:59-75` | No caller in `nous/` (only tests). The upgrade path was implemented as `auto_seed_from_facts` instead; the prompt (and its `{existing_facts}` placeholder) is orphaned. |
+| `GDrive._call` | `nous/integrations/gdrive.py:192-204` | Never invoked; its retry semantics exist only as an inline copy in `list_files`. |
+| `import io`, `import time` | `nous/integrations/gdrive.py:28,34` | Unused imports. |
+| `"status"` identity section | `nous/identity/manager.py:29` | In `VALID_SECTIONS`, excluded from prompts, never written anywhere — a control field with no controller. |
+| `requires_human_review` bool/int parse arms | `nous/skills/parser.py:349,363-372` | Unreachable given `_parse_frontmatter`'s output types (also `_parse_optional_positive_int`'s int arm, `parser.py:206`). |
+| `BehaviorSnapshot` unproduced fields | `nous/observability/snapshots.py:26-53` | `facts_admitted/rejected_*`, `admission_rate`, `checks_run`, `findings_created/resolved`, `triage_sessions_opened`, `interval_changes`, `sleep_ran`, `episodes_compacted`, `facts_pruned`, `contradictions_resolved`, `avg_turn_latency_ms`, `tool_calls`, `decision_count` — defined, defaulted, serialized, never assigned by any producer (see OB-2). |
+| `context_log_retention_days` | `nous/config.py:846` | Setting with zero consumers (see OB-1). |
+| `cache_break*` fields persistence | `nous/observability/context_logger.py:127-130` | Set by runner (`runner.py:844-847`), exposed nowhere in `to_dict()` nor DB — in-memory write-only except for direct attribute access in REST section endpoints. Documented "in-memory only", borderline. |
+
+---
+
+## 4. Improvement opportunities
+
+1. **Unify the two skill ingestion paths.** Bootstrap and `learn_skill` have drifted (supersession guard, requires-gating, update-in-place). Extract a single `register_skill(manifest, *, source) -> outcome` in `nous/skills/` that both call; SK-1/SK-2/SK-6 all disappear structurally instead of patch-by-patch.
+2. **Replace the hand-rolled YAML subset with `yaml.safe_load`.** PyYAML is already in the transitive dependency set of the dev stack; the parser has accumulated five lenient modes plus block-scalar/dict/list state machines and still mishandles comments, BOM, and CRLF block scalars. Keep the lenient frontmatter *extraction* regexes, delegate value parsing.
+3. **Close the observability loop honestly.** Either wire producers for the dead drift metrics (admission stats are already computed by F023; sleep stats exist in the sleep handler) or prune them — a drift dashboard that shows flat zeros for `admission_rate` reads as "healthy", which is worse than absent. Same spirit as the repo's recurring severed-wire pattern (rubric loop, §14 telemetry).
+4. **Add a retention sweep task** covering `context_log`, `behavior_snapshots` (and arguably `events`) keyed off the existing `*_retention_days` settings — one generic "table TTL" helper in the session monitor would serve all three.
+5. **Initiation state machine**: replace the NULL-as-in-progress tri-state with an explicit `initiation_claimed_at TIMESTAMPTZ` — self-expiring claims, trivially observable, and removes the SQL-NULL-comparison trap that caused ID-1.
+6. **gdrive**: if the Drive integration is to stay, surface `GDRIVE_*` in `Settings`, route everything through `_call`, and parameterize the NousDrive folder id; if it isn't (INERT in prod for months), consider moving it to `scripts/` to shrink the audited runtime surface.

--- a/docs/reviews/storage-config-audit-2026-06-09.md
+++ b/docs/reviews/storage-config-audit-2026-06-09.md
@@ -1,0 +1,224 @@
+# Storage Layer + Configuration Audit — 2026-06-09
+
+**Scope:** `nous/storage/` (database.py, models.py, migrator.py, __init__.py), `nous/config.py`, `nous/runtime_config.py`, `nous/utils.py`, `sql/init.sql`, all 53 files in `sql/migrations/` (006–060), `docker-compose.yml` + `Dockerfile` (storage/env wiring only).
+
+**Method:** code-only. Every ORM table diffed against init.sql + cumulative migrations. Migrator splitter/ordering/atomicity traced. Every suspicious config field grepped for consumers. One empirical check (pydantic-settings empty-string behavior) run against the repo's installed pydantic-settings 2.13.1.
+
+**Headline:** the ORM ↔ SQL column inventory is in good shape — no ORM column is missing from the cumulative DB schema and no live DB column is silently invisible to the ORM (the GENERATED `search_tsv` columns are deliberately unmapped). The real problems live in (a) the docker-compose env wiring, which can crash a fresh install outright and silently reverts/blank several documented defaults, and (b) the migrator's atomicity contract, which eight existing migrations violate with embedded `BEGIN;`/`COMMIT;`.
+
+---
+
+## Findings Register
+
+Severity: P1 = breaks fresh install / data loss / wrong behavior on live path; P2 = significant risk or drift; P3 = minor; INFO = observation.
+Reachability: LIVE (hit on a normal path), LATENT (needs a specific-but-plausible trigger), INERT (flag-gated off), DEAD (no consumer).
+
+### P1
+
+**ST-1 — Fresh `docker compose up` without a host `.env` crashes Settings (empty-string JSON dict env).**
+- Severity: P1 · Reachability: **LIVE** (fresh-install path)
+- Where: `docker-compose.yml:70` + `nous/config.py:195`
+- `docker-compose.yml:70` sets `NOUS_CONTEXT_BUDGET_OVERRIDES=${NOUS_CONTEXT_BUDGET_OVERRIDES:-}` — when the var is unset on the host (fresh clone, no `.env`), the container gets the var set to **empty string**. `context_budget_overrides: dict[str, int]` (config.py:195) is a complex field with no `mode="before"` validator; pydantic-settings JSON-decodes the raw value.
+- Evidence (verified against installed pydantic-settings 2.13.1):
+  ```
+  NOUS_CONTEXT_BUDGET_OVERRIDES= python -c "... S() ..."
+  → SettingsError: error parsing value for field "context_budget_overrides" from source "EnvSettingsSource"
+  ```
+  `Settings()` is instantiated at startup in `nous/main.py`, so the container crash-loops before `Database()` is ever constructed.
+- Fix: either drop the line from compose (the var is optional), use `${NOUS_CONTEXT_BUDGET_OVERRIDES:-{}}`, or add a `@field_validator(..., mode="before")` on the three dict fields (`context_budget_overrides`, `relevance_min_results`/`relevance_max_results`, `frame_default_models`, `dag_global_max_concurrent_by_frame`) that maps `""` → `{}`. Setting `env_ignore_empty=True` in `model_config` is the structural fix for the whole class of empty-string env values.
+
+### P2
+
+**ST-2 — Eight migrations embed `BEGIN;`/`COMMIT;` inside the migrator's single outer transaction, breaking run atomicity and partial-failure recovery.**
+- Severity: P2 · Reachability: **LATENT** (bites on any mid-run failure/crash after migration 032)
+- Where: `nous/storage/migrator.py:100` (one `engine.begin()` wraps ALL pending files + their version-row INSERTs); offenders: `032_dag_orchestration.sql`, `047_f065_edge_provenance.sql`, `048_f066_1_dag_fix_stage.sql`, `049_f065_auto_linker_inferred.sql`, `052_f069_document_source_kind.sql`, `053_temporal_fact_extraction.sql`, `054_comention_extraction_method.sql`, `055_cooccurrence_edges.sql`.
+- The splitter (`migrator.py:30-85`) does not strip transaction-control statements, so `COMMIT` is executed in-band. The first embedded `COMMIT` (032 on a fresh DB) commits everything so far and drops the connection into autocommit; every subsequent statement commits individually. Consequences: (1) a failure mid-file after 032 leaves a *partially applied, committed* migration with no version row; (2) re-run then re-executes non-idempotent statements — concretely `033_dag_completion_check.sql:595-600` uses plain `ADD COLUMN` (no `IF NOT EXISTS`) ×6, so the retry fails with `duplicate column` and **the migrator is wedged: app cannot boot**; (3) a crash between a file's last statement and its version INSERT produces the same wedge.
+- Evidence the contract is known: `057_procedure_supersession.sql:1441-1443` — "no BEGIN/COMMIT (run_migrations wraps every file in one transaction)" — and the same note in 058/059. The eight earlier files predate the rule and were never cleaned.
+- Fix: strip `BEGIN`/`COMMIT` statements in `_split_sql_statements` (one-line filter), or remove them from the eight files (checksum column is never re-verified, see ST-17, so editing applied files is safe in this scheme). Separately consider transaction-per-migration instead of one-per-run.
+
+**ST-3 — docker-compose pins pre-F048 subtask timeouts, re-introducing the bug F048 fixed.**
+- Severity: P2 · Reachability: **LIVE** (any compose deployment that doesn't override)
+- Where: `docker-compose.yml:40-41` — `NOUS_SUBTASK_DEFAULT_TIMEOUT=${...:-120}`, `NOUS_SUBTASK_MAX_TIMEOUT=${...:-600}` vs `nous/config.py:477-478` (600 / 3600, "F048: bumped … so outer wait_for doesn't cancel inner streaming") and the CLAUDE.md env table (600 / 3600).
+- Because compose always *sets* the env var, the code default never applies in containers: the outer `asyncio.wait_for(120)` again cancels before the 600 s per-chunk background-streaming read completes — exactly the F048 failure mode.
+- Fix: update compose defaults to 600/3600 (and audit the rest of the list — see ST-5/ST-6).
+
+**ST-4 — compose blanks the built-in identity prompt: `NOUS_IDENTITY_PROMPT=${NOUS_IDENTITY_PROMPT:-}`.**
+- Severity: P2 · Reachability: **LIVE** (compose deployments without the var)
+- Where: `docker-compose.yml:35` vs `nous/config.py:308-314`.
+- Empty string is a valid `str`, so `identity_prompt` becomes `""` instead of the documented built-in default ("First section of every system prompt. How Nous knows who it is…"). The agent boots with no identity block. Same `:-` empty-string pattern, different failure shape than ST-1 (silent instead of crash).
+- Fix: remove the line or use a guard (`${NOUS_IDENTITY_PROMPT:?}`-style is wrong here; just drop it — Settings reads the env var directly when present).
+
+**ST-5 — compose `environment:` list is a whitelist; ~80% of documented `NOUS_*` flags cannot be set through it.**
+- Severity: P2 · Reachability: **LIVE** (operational trap)
+- Where: `docker-compose.yml:7-81` (nous service; no `env_file:` directive), `Dockerfile` (no `.env` copied — correct for secrets), `nous/config.py:19` (`env_file=".env"` resolves relative to CWD `/app`, where no `.env` exists).
+- Every flag added after ~F042 (`NOUS_EPISODE_CHUNKS_ENABLED`, `NOUS_TEMPORAL_EXTRACTION_ENABLED`, `NOUS_EPISTEMIC_GATE_ENABLED`, `NOUS_QUERY_EXPANSION_*`, `NOUS_PROC_CATALOG_ENABLED`, `NOUS_EMBEDDING_MODEL`, `NOUS_FACT_DEDUP_TIEBREAKER_ENABLED`, …) is absent from the list. CLAUDE.md and multiple feature rollouts instruct "operator flips NOUS_X post-deploy" — with this compose file the flip is **silently inert** inside the container.
+- Fix: add `env_file: .env` (or `${VAR}` passthrough block) to the nous service so host `.env` reaches the container, then prune the per-var list to genuine overrides.
+
+**ST-6 — compose default-value drift cluster vs config.py/CLAUDE.md.**
+- Severity: P2 (aggregate) · Reachability: **LIVE** in compose deployments
+- Where → code → compose:
+  - `NOUS_MODEL` / `NOUS_BACKGROUND_MODEL`: code `claude-sonnet-4-6` (config.py:349,329) vs compose `claude-sonnet-4-5-20250514` (compose:18,31) — a stale (and oddly-dated) model id.
+  - `NOUS_STALENESS_HALF_LIFE_DAYS`: code 30 (config.py:199), CLAUDE.md 30, compose **14** (compose:72).
+  - `NOUS_RELEVANCE_DROP_RATIO`: code **0.5** (config.py:183), CLAUDE.md **0.6**, compose 0.6 (compose:68) — three-way disagreement; the code default is the one nobody documents.
+  - `NOUS_CROSS_ENCODER_MODEL`: code `BAAI/bge-reranker-v2-m3` (config.py:768) vs compose + CLAUDE.md `cross-encoder/ms-marco-MiniLM-L-6-v2` (compose:77). Known-intentional for prod (BGE too slow on prod VM) but the intent lives nowhere in-tree.
+- Fix: reconcile each to one source of truth; document intentional prod-only pins in compose comments.
+
+**ST-7 — Migrator has no cross-process guard: concurrent boots race `run_migrations`.**
+- Severity: P2 · Reachability: **LATENT** (single-instance today; compose `restart: unless-stopped` + a second replica or a fast restart during a long migration run can race)
+- Where: `nous/storage/migrator.py:88-132`.
+- Two processes can both read `schema_migrations`, both see the same pending set, and both execute the files. Most statements are `IF NOT EXISTS`-guarded, but data migrations (049 reclassification, 058 consolidation, 060 edge DELETE) execute twice concurrently, and the loser of the version-row INSERT race aborts its entire outer transaction → boot failure with half the work committed via ST-2's autocommit hole.
+- Fix: take `pg_advisory_lock(<const>)` on the migration connection before reading `schema_migrations` (the repo already uses advisory-lock patterns in F047/F049).
+
+### P3
+
+**ST-8 — Splitter fragility: dollar-quoting unsupported, inline `--` comments unstripped.**
+- P3 · LATENT · `nous/storage/migrator.py:30-85`.
+- `023_procedure_fullbody_search.sql:345-347` contains `AS $$ SELECT array_to_string(arr, sep) $$;` — it parses correctly **only because** the `$$` body happens to contain no `;` or `'`. The docstring admits `$$` is unsupported. Also, only lines *starting* with `--` are stripped; a trailing comment containing an apostrophe (`ADD COLUMN x INT -- it's a count`) would flip the in-string tracker and mis-split. No current file trips either, but every new migration is one careless comment away.
+- Fix: add `$$`-tracking to the splitter (small), or lint migrations in CI for `$$`-with-semicolon and inline comments.
+
+**ST-9 — `Settings.workspace_dir = "/tmp/nous-workspace"` hardcodes POSIX.**
+- P3 · LATENT (Windows dev) · `nous/config.py:381`. Contrast `dag_workspace_root` (config.py:881-884) which correctly uses `tempfile.gettempdir()`. Same file, two conventions.
+
+**ST-10 — No bounds/cross-field validation on several numeric knobs.**
+- P3 · LATENT · `nous/config.py`:
+  - `vector_weight` (line 106) unbounded — the DB-load path validates `0.0 <= w <= 1.0` (`runtime_config.py:133`) but the env path accepts 1.5.
+  - `subtask_default_timeout` vs `subtask_max_timeout` (477-478): no `default <= max` validator (DAG timeouts have one at 1471-1478; subtasks don't).
+  - `heartbeat_quiet_start`/`quiet_end`/`digest_hour_utc` (805-806, 821): no 0–23 bounds.
+  - `embedding_dimensions` (41): no `ge`, and — more importantly — no guard that it equals the `vector(1536)` DDL dimension (see ST-11).
+
+**ST-11 — `embedding_dimensions` is configurable but every DDL column is `vector(1536)`; no startup cross-check.**
+- P3 · LATENT · `nous/config.py:41` vs `sql/init.sql:140,267,309,350,400` and `050_episode_chunks.sql:1165`.
+- Setting `NOUS_EMBEDDING_DIMENSIONS=3072` (the natural value for prod's text-embedding-3-large) makes every embed write/search fail at runtime with a pgvector dimension error — loud, but only after boot, and the error points at the query, not the config. A one-time startup probe (compare `atttypmod` on one embedding column vs settings) would fail fast with a clear message. Note CLAUDE.md still documents text-embedding-3-small while prod runs -large at 1536 reduced dims.
+
+**ST-12 — `nous_system.dynamic_checks.agent_id` defaults to `'nous'`, not `'nous-default'`.**
+- P3 · LATENT · `027_dynamic_checks.sql:457` (`DEFAULT 'nous'`) and ORM `models.py:912` (`default="nous"`).
+- Any insert path that omits `agent_id` creates rows invisible to the default agent (`nous-default`, config.py:39). Current writers pass it explicitly, but the default is a trap and disagrees with every other table's convention (no default, NOT NULL).
+
+**ST-13 — F061's promised `final_outcome` CHECK constraint never shipped.**
+- P3 · INERT · `041_subtask_hardening.sql:748-749`: "CHECK constraint on final_outcome is deferred to a follow-up migration (042) after pre-flag rows are backfilled" — migration 042 became F062 payload_schema instead. `final_outcome` (models.py:815) accepts any string forever.
+
+**ST-14 — `RuntimeConfig.load_from_db` swallows all exceptions at DEBUG.**
+- P3 · LATENT · `nous/runtime_config.py:153-154`. A real failure (permissions, bad jsonb, connection blip) is logged as "table not available yet (normal on first run)" at debug level — persisted overrides silently stop applying. Catch the specific missing-table error; log others at WARNING. Also `persist_to_db` (156-166) commits the caller's session — a surprising side effect for a helper.
+
+**ST-15 — DB-only constraints/indexes absent from the ORM ⇒ SQLite test mode enforces a weaker schema.**
+- P3 · LATENT · `tests/sqlite_compat.py:203-207` runs `Base.metadata.create_all`, so anything not declared on the ORM doesn't exist in tests:
+  - `uq_episode_chunks_episode_index` UNIQUE(episode_id, chunk_index) (050:1187-1188) — the F067 idempotent re-ingest invariant — not on `EpisodeChunk` (models.py:415-452).
+  - `idx_rubric_active_agent` one-active-rubric-per-agent partial unique (022:312-313) — not on `RubricVersion`.
+  - `uq_procedures_active_lower_name` (059:1532-1534) — not on `Procedure`.
+  - Value CHECKs that exist only in SQL: `decisions.confidence BETWEEN 0 AND 1` (init.sql:133), `episodes.surprise_level BETWEEN 0 AND 1` (init.sql:265), `chk_subtask_priority` (init.sql:465), `chk_schedule_has_timing` (init.sql:492-495), `chk_dag_budget` (032:541), `episode_chunks.source_kind` CHECK (052:1270).
+- Consequence: tests can pass writes that prod rejects (and vice versa for uniqueness). Declare the load-bearing ones (the three unique indexes) on the ORM via `Index(..., unique=True, postgresql_where=...)`.
+
+**ST-16 — `nous_system.config` runtime overrides are global, not agent-scoped.**
+- P3 · LATENT · `021_config_table.sql:285-289` (key PK, no agent_id) + `runtime_config.py`. `vector_weight` / `rrf_k` / `cross_encoder_enabled` overrides apply to every agent on the instance. Documented as deliberate in 021's header, but it contradicts the "all tables agent-scoped" project rule; fine single-agent, wrong multi-agent.
+
+**ST-17 — Migration checksums are stored but never verified.**
+- P3 · INFO-adjacent · `migrator.py:117,126-130`. `checksum` is written on apply and never read again — an edited already-applied migration silently diverges between environments. Either verify on boot (warn on mismatch) or drop the column.
+
+**ST-18 — No version-collision detection in the migrator.**
+- P3 · LATENT · `migrator.py:112-114`. Two files `035_a.sql` and `035_b.sql` would apply the first (lexicographic) and *silently skip* the second forever (version key already in `existing`). The 035/036 numbering gap (documented in `038_query_expansions.sql:664-666`) shows renumbering accidents already happened once. A one-line duplicate-prefix assertion would close it.
+
+### INFO
+
+**ST-19 — Doc-drift inventory (counts/comments, not behavior).**
+- `sql/init.sql:3` says "23 tables … heart (10)" and the heart banner (init.sql:246) says "(8 tables)" — heart actually has 11 in init.sql; cumulative DB now has ~34 tables.
+- `models.py:1` says "all 20 Nous tables" — file defines 31 models.
+- `nous/storage/__init__.py:26-47` exports only the original 19 names; 12 newer models (AgentIdentity, EpisodeChunk, ProcedureTaskAffinity, RubricVersion, OutcomeSignal, ConversationState, Subtask, Schedule, ToolCache, DynamicCheckModel, DAG*, WorkQueueItem, GraphHubSnapshot) must be imported from `nous.storage.models` directly. Harmless, just inconsistent.
+- `Dockerfile:1` is `python:3.12-slim`; CLAUDE.md claims "3.14 in container".
+- CLAUDE.md REST table says 42/52 endpoints in two places.
+
+**ST-20 — Vestigial initdb mount.** `docker-compose.yml:115` mounts `010_subtasks.sql` as a third initdb script, but init.sql already creates `heart.subtasks`/`heart.schedules` (init.sql:445-496) with the *newer* defaults; 010 is `IF NOT EXISTS` so the mount is a guaranteed no-op. Remove to avoid implying initdb-time migrations are a pattern.
+
+**ST-21 — `Database` pool/session posture.** `database.py:18-25`: `pool_size=10, max_overflow=5`, `pool_pre_ping=True`, no `pool_timeout`/`pool_recycle` overrides (SQLAlchemy defaults: 30 s wait then `TimeoutError`). With 2 subtask workers + heartbeat + scheduler + sleep + event handlers + API traffic on one pool, 15 connections is plausible to exhaust under burst; the failure mode (30 s stall then exception) is acceptable but worth a metric. `session()` (46-50) yields without commit and the sessionmaker context closes/rolls back properly — no leak path found. `echo=settings.log_level == "debug"` (line 23) is exact-match lowercase only.
+
+**ST-22 — `connect()` schema probe is the only preflight.** `database.py:27-40` verifies the three schemas exist but not init.sql completeness; an empty-but-schema'd DB would pass and then fail in the migrator/bootstrap. Acceptable: init.sql is only ever applied by initdb, which creates schemas and tables atomically.
+
+**ST-23 — `host: str = "0.0.0.0"`** (config.py:299) binds all interfaces by default; compose publishes the port anyway, but bare-metal runs expose the unauthenticated REST API LAN-wide.
+
+**ST-24 — Migration 058 hard-codes prod UUIDs + `agent_id='nous-default'`** as a permanent migration every fresh install executes (as guarded no-ops). Works, but one-time prod data surgery as a migration is a hygiene smell; the splitter-safety constraints it had to obey (no DO blocks) are a direct consequence of ST-8.
+
+---
+
+## ORM ↔ SQL Drift Table
+
+Legend: ✓ = match (cumulative: init.sql + migrations). Only deltas listed; all unlisted columns matched on name/type/null/default.
+
+| Table | ORM model | Columns | Constraints/indexes | Notes |
+|---|---|---|---|---|
+| nous_system.agents | Agent | ✓ | ✓ | |
+| nous_system.agent_identity | AgentIdentity | ✓ | partial unique `idx_identity_agent_section_current` DB-only (init.sql:74) | not exported in `__init__` |
+| nous_system.frames | Frame | ✓ | ✓ | |
+| nous_system.events | Event | ✓ | ORM `trace_id index=True` would emit `ix_…` name; DB has `idx_events_trace_id` (026:395) — names differ, SQLite-tests-only impact | |
+| nous_system.schema_migrations | — (raw SQL) | n/a | n/a | managed by migrator bootstrap |
+| nous_system.config | — (raw SQL) | n/a | trigger added in 021 | no agent_id (ST-16) |
+| nous_system.context_log | — (raw SQL) | n/a | n/a | consumers in observability/ |
+| nous_system.behavior_snapshots | — (raw SQL) | n/a | n/a | SERIAL pk (only non-UUID pk in DB) |
+| nous_system.dynamic_checks | DynamicCheckModel | ✓ (DB TEXT vs ORM String — fine) | UNIQUE(agent_id,name) DB-only (027:475) — **not in ORM** | agent_id default `'nous'` (ST-12) |
+| nous_system.execution_dags | ExecutionDAG | ✓ | `chk_dag_budget` DB-only | |
+| nous_system.dag_nodes | DAGNode | ✓ (incl. 033/043/048 adds) | status/node_type CHECKs ✓ post-048 | DB default timeout 120 vs Settings 600 — clamped at read sites (F046) |
+| nous_system.dag_edges | DAGEdge | ✓ | `chk_dag_edge_type` incl. `on_failure` (048:1056) **not in ORM** (no CHECK declared) | |
+| nous_system.work_queue_items | WorkQueueItem | ✓ | ✓ | |
+| nous_system.eval_runs | — (nous_eval raw SQL) | n/a | n/a | eval-only; created on main DB by 037 |
+| brain.decisions | Decision | ✓ (session_id/reviewer via 009; confidence_raw via 039) | DB `confidence BETWEEN 0 AND 1` not in ORM; DB constraint names auto-generated vs ORM `ck_*` | search_tsv unmapped (intentional) |
+| brain.decision_tags | DecisionTag | ✓ | ✓ | no agent_id (child) |
+| brain.decision_reasons | DecisionReason | ✓ | ✓ | no agent_id (child) |
+| brain.decision_bridge | DecisionBridge | ✓ | ✓ | no agent_id (child) |
+| brain.thoughts | Thought | ✓ | ✓ | |
+| brain.graph_edges | GraphEdge | ✓ (extraction_method via 047) | relation/type/method CHECK lists ✓ vs 055 final state; `idx_graph_edges_extraction_method` (047:984) not in ORM | FKs dropped by 016 — dangling-edge hazard handled by 060 + code fix |
+| brain.graph_hub_snapshots | GraphHubSnapshot | ✓ | 2 DB indexes not in ORM | |
+| brain.guardrails | Guardrail | ✓ | ✓ | |
+| brain.calibration_snapshots | CalibrationSnapshot | ✓ | ✓ | |
+| heart.episodes | Episode | ✓ (compaction_count 020, session_id 040, transcript 025/init) | `surprise_level BETWEEN 0 AND 1` DB-only; `idx_episodes_session_id` partial (040:733) not in ORM | search_tsv unmapped |
+| heart.episode_chunks | EpisodeChunk | ✓ (source_kind/source_ref 052) | **UNIQUE(episode_id, chunk_index)** (050:1187) and source_kind CHECK (052:1270) **not in ORM** (ST-15) | |
+| heart.episode_decisions | EpisodeDecision | ✓ | ✓ | no agent_id (join) |
+| heart.facts | Fact | ✓ (017/019/034/053 adds; `actionable_confidence` REAL↔Float fine) | `confidence BETWEEN 0 AND 1` DB-only; partial indexes (031, 034, 053, 060) not in ORM | search_tsv unmapped |
+| heart.procedures | Procedure | ✓ (runtime_metadata 044, superseded_by/archived_at 057) | `uq_procedures_active_lower_name` (059) **not in ORM** (ST-15) | search_tsv rebuilt by 023 = init.sql definition (fresh-DB no-op-equivalent) |
+| heart.episode_procedures | EpisodeProcedure | ✓ | ✓ | no agent_id (join) |
+| heart.procedure_task_affinity | ProcedureTaskAffinity | ✓ (DB TEXT vs ORM String(100) — fine) | ✓ | |
+| heart.rubric_versions | RubricVersion | ✓ | `idx_rubric_active_agent` partial unique **not in ORM** (ST-15) | |
+| heart.outcome_signals | OutcomeSignal | ✓ | ✓ | |
+| heart.censors | Censor | ✓ (024 + 056 adds; action default 'steer' ✓) | post-056 CHECK names ✓ | no search_tsv by design (embedding-only retrieval) |
+| heart.working_memory | WorkingMemory | ✓ | ✓ | `items`/`open_threads` typed `Mapped[dict]` but hold JSON arrays (`'[]'` default) — type annotation lie, cosmetic |
+| heart.conversation_state | ConversationState | ✓ | ✓ | |
+| heart.subtasks | Subtask | ✓ (011/012/041/042 adds) | `chk_subtask_priority` DB-only; promised final_outcome CHECK missing (ST-13) | parent_session_id DB VARCHAR (unbounded) vs ORM String(200) — fine |
+| heart.schedules | Schedule | ✓ (015/045 adds) | `chk_schedule_has_timing` DB-only | |
+| heart.tool_cache | ToolCache | ✓ | ✓ | |
+| heart.query_expansions | — (raw SQL) | n/a | n/a | deliberately global, no agent_id (documented in 038 header) |
+
+**Vector dimensions:** every embedding column in DDL and ORM is 1536 (decisions, episodes, facts, procedures, censors, episode_chunks). No 3072 anywhere; prod's text-embedding-3-large must run at `dimensions=1536` (it does, via `embedding_dimensions` default) — see ST-11 for the missing guard.
+**HNSW coverage:** all six embedded tables have `hnsw(embedding vector_cosine_ops)` (init.sql:531,564,574,582,591; 050:1183). Complete.
+**tsvector/GIN:** decisions, episodes, facts, procedures, episode_chunks all have GENERATED search_tsv + GIN. Censors intentionally have none.
+**Fresh-DB path:** linear replay of init.sql → 006…060 was traced statement-by-statement: no duplicate-object or missing-object failure on a clean run (023's DROP COLUMN/recreate of the already-final init.sql tsv works because DROP COLUMN cascades the GIN index; 028/058 are guarded no-ops; 033/029's bare ADD COLUMNs are fine linearly — they are only dangerous on the ST-2 retry path).
+
+---
+
+## Dead Config / Dead Table Inventory
+
+Config fields defined in `nous/config.py` with **zero consumers** in `nous/`, `nous_eval/`, `scripts/` (grep-verified; tests asserting the default don't count):
+
+| Field | Line | Status |
+|---|---|---|
+| `quality_block_threshold` | 53 | DEAD — quality gating reads the guardrail CEL (`decision.quality_score < 0.55`, seed.sql + migration 028), not this field |
+| `agent_description` | 307 | DEAD — seed.sql hardcodes the same string; nothing reads the setting |
+| `tim_chat_id` | 797 | DEAD |
+| `emerson_hook_url` / `emerson_hook_token` | 798-799 | DEAD |
+| `subtask_bootstrap_timeout` / `subtask_work_timeout` | 494-495 | DEAD (documented "observability-only labels until PR-2"; PR-2 never wired them) |
+| `schedule_continuation_default_prompt` | 904 | DEAD (documented reserved for F064.5-v2) |
+| `date_aware_boost_enabled` / `_factor` / `_window_pad_days` | 1229-1244 | DEAD (documented F075 Layer 3 deferred; no consumer) |
+
+Verified **alive** despite suspicion: `web_search_daily_limit` (web_tools.py:97), `cross_type_same_threshold` (graph_linker.py:286,293), `auto_link_threshold`/`auto_link_max` (brain.py:1597-1599), `heartbeat_drive_*` (main.py:645, checks.py:772), `critic_max_latency_ms`/`critic_passthrough_max_words` (critic.py), `procedure_staleness_days`/`procedure_weakness_threshold` (procedure_learner.py:479,487), `smart_compress_*` (smart_compress.py), `temporal_backfill_default_token_budget` (scripts/backfill_temporal_facts.py:344), `context_log_ring_size`/`max_total` (main.py:574-575), `graph_threshold_chunk_chunk_cross` (graph_densifier.py:1001 — the "reserved" CLAUDE.md note is stale; F070.1 consumes it).
+
+Dead tables: **none** — every table created by init.sql/migrations has either an ORM model with consumers or a raw-SQL consumer (`context_log`/`behavior_snapshots` → observability + main.py; `config` → runtime_config.py; `query_expansions` → heart/query_expansion.py; `eval_runs` → nous_eval/run_history; `work_queue_items` → heart/work_queue.py; `graph_hub_snapshots` → brain/hub_snapshots.py).
+
+Tables without `agent_id` (recurring-miss check): `nous_system.config` (ST-16, documented), `heart.query_expansions` (documented global), `nous_system.schema_migrations` (correct), plus pure child/join tables keyed by an agent-scoped parent (`decision_tags`, `decision_reasons`, `decision_bridge`, `episode_decisions`, `episode_procedures`, `dag_nodes`, `dag_edges`). No undocumented misses.
+
+---
+
+## Improvement Opportunities
+
+1. **Kill the empty-string env class structurally** — `env_ignore_empty=True` on `Settings.model_config` resolves ST-1 and ST-4's mechanism in one line (verify no field intentionally distinguishes `""` from unset; `email_allowlist`'s "empty = reject all" semantics survive because unset also yields `""` default).
+2. **Migrator hardening trio** (cheap, high leverage): filter `BEGIN`/`COMMIT` in the splitter (ST-2), advisory lock around the run (ST-7), duplicate-version-prefix assertion (ST-18). ~20 LOC total in migrator.py.
+3. **CI lint for migrations**: reject `$$` bodies containing `;`, inline `--` comments, bare `ADD COLUMN`/`CREATE TABLE`/`CREATE INDEX` without `IF NOT EXISTS`, and `BEGIN`/`COMMIT`. The conventions already exist as comments in 056-059; make them mechanical.
+4. **Startup dimension probe** (ST-11): one SELECT of `atttypmod` on `heart.facts.embedding` compared to `settings.embedding_dimensions` turns a confusing runtime failure into a clear boot error.
+5. **Declare load-bearing unique indexes on the ORM** (ST-15) so SQLite tests enforce the same invariants the prod code relies on (chunk re-ingest idempotency, one-active-rubric, one-active-procedure-name).
+6. **Single source of truth for env defaults**: the compose `environment:` block duplicating ~60 defaults is the root cause of ST-3/ST-4/ST-6. Replace with `env_file: .env` + a minimal override list; defaults live in config.py only.
+7. **config.py is 1528 lines and growing ~linearly with features** — consider splitting into per-domain Settings mixins composed into one `Settings`; it would also make dead-field sweeps (this audit found 9) tractable per-domain.

--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -1376,10 +1376,12 @@ class Brain:
         results = []
         for r in rows:
             ntype, rel, weight, method = edge_map[r.neighbor_id]
-            # F080: an inactive/superseded procedure was filtered out of the
-            # description resolution above — drop it rather than surfacing an
-            # archived skill as a "[procedure] <uuid>" placeholder.
-            if ntype == "procedure" and r.neighbor_id not in descriptions:
+            # F080 / Audit BR-1 (codex P1): an inactive/superseded procedure OR
+            # fact was filtered out of the description resolution above (both
+            # queries carry `active = true`). Drop it rather than surfacing an
+            # archived skill / superseded fact as a "[type] <uuid>" placeholder
+            # that would also consume a post-LIMIT ranking slot.
+            if ntype in ("procedure", "fact") and r.neighbor_id not in descriptions:
                 continue
             if r.neighbor_id in descriptions:
                 desc, created = descriptions[r.neighbor_id]

--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -1313,10 +1313,18 @@ class Brain:
                 descriptions[d.id] = (d.description, d.created_at)
 
         # Fact: heart.facts.content
+        # Audit BR-1 (2026-06-09): only ACTIVE facts. For facts, active=false
+        # is a soft-delete / supersession marker (F027), so superseded and
+        # contradiction-resolved facts must never resurface as graph neighbors
+        # via Path A or decision 1-hop expansion — mirrors the F080 procedure
+        # fix below. (Episodes/chunks are intentionally NOT filtered here:
+        # episode active=false is the normal *closed* lifecycle state, and
+        # episode_chunks has no soft-delete column.)
         if ids_by_type.get("fact"):
             f_result = await session.execute(
                 select(Fact.id, Fact.content, Fact.created_at)
                 .where(Fact.id.in_(ids_by_type["fact"]))
+                .where(Fact.active == True)  # noqa: E712
             )
             for f in f_result.all():
                 descriptions[f.id] = (f.content, f.created_at)

--- a/nous/cognitive/layer.py
+++ b/nous/cognitive/layer.py
@@ -661,6 +661,19 @@ class CognitiveLayer:
                     )
                 if subtask_context:
                     system_prompt = system_prompt + "\n\n" + subtask_context
+                    # Audit CL-1 (2026-06-09): also route into the dynamic tier.
+                    # The F036 cache-split path (default-on) ignores the flat
+                    # system_prompt, so without this the parent agent never saw
+                    # any subtask result even though the rows were marked
+                    # delivered above — permanent silent loss. Mirrors the F078
+                    # censor fix; same guard (only when build populated tiers).
+                    if sections_by_tier:
+                        _existing_dyn = sections_by_tier.get("dynamic", "")
+                        sections_by_tier["dynamic"] = (
+                            _existing_dyn + "\n\n" + subtask_context
+                            if _existing_dyn
+                            else subtask_context
+                        )
                     logger.info(
                         "Injected %d subtask results into session %s",
                         len(undelivered), session_id,
@@ -910,6 +923,17 @@ class CognitiveLayer:
                 )
                 if hub_shift_block:
                     system_prompt += "\n\n" + hub_shift_block
+                    # Audit CL-2 (2026-06-09): route into the dynamic tier too;
+                    # the F036 split path ignores the flat string, so the shift
+                    # notice was persisted as a consumed snapshot but never
+                    # actually shown to the model. Mirrors the F078 censor fix.
+                    if sections_by_tier:
+                        _existing_dyn = sections_by_tier.get("dynamic", "")
+                        sections_by_tier["dynamic"] = (
+                            _existing_dyn + "\n\n" + hub_shift_block
+                            if _existing_dyn
+                            else hub_shift_block
+                        )
             except Exception:
                 # Belt and braces: pre_turn never fails on a diagnostic.
                 logger.warning(

--- a/nous/config.py
+++ b/nous/config.py
@@ -5,12 +5,13 @@ env vars (DB_PASSWORD, DB_PORT, etc.) that docker-compose uses, so a single
 .env file drives both the container and the Python app.
 """
 
+import json
 import tempfile
 from pathlib import Path
-from typing import Literal
+from typing import Annotated, Literal
 
 from pydantic import Field, field_validator, model_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -192,7 +193,27 @@ class Settings(BaseSettings):
 
     # Context budget overrides — JSON dict applied on top of per-frame defaults
     # e.g. NOUS_CONTEXT_BUDGET_OVERRIDES='{"total": 12000, "decisions": 3000}'
-    context_budget_overrides: dict[str, int] = Field(default_factory=dict)
+    # Audit ST-1 (2026-06-09): NoDecode + the before-validator below tolerate an
+    # empty/whitespace env value. docker-compose passes
+    # `NOUS_CONTEXT_BUDGET_OVERRIDES=${...:-}` (empty string) on a fresh install
+    # with no host .env; pydantic-settings' default complex-field decoder calls
+    # json.loads("") and raises SettingsError, crash-looping the container at
+    # boot. NoDecode hands the raw string to our validator instead so "" -> {}.
+    context_budget_overrides: Annotated[dict[str, int], NoDecode] = Field(
+        default_factory=dict
+    )
+
+    @field_validator("context_budget_overrides", mode="before")
+    @classmethod
+    def _parse_context_budget_overrides(cls, v: object) -> object:
+        """Decode the JSON env string ourselves so an empty value is tolerated."""
+        if v is None:
+            return {}
+        if isinstance(v, str):
+            if not v.strip():
+                return {}
+            return json.loads(v)
+        return v
 
     # F017: Staleness penalty
     staleness_penalty_enabled: bool = True

--- a/nous/dag/orchestrator.py
+++ b/nous/dag/orchestrator.py
@@ -1375,10 +1375,21 @@ class DAGOrchestrator:
         if non_terminal:
             return
 
-        # All nodes are terminal — determine final status
-        if all(n.status == "completed" for n in dag.nodes):
+        # All nodes are terminal — determine final status.
+        # Audit DG-1 (2026-06-09): use _RESOLVED ({completed, skipped}) for the
+        # success branch, not "completed" only. A DAG that finished via the
+        # skip_and_continue success path (some nodes 'skipped', rest
+        # 'completed') previously fell through every branch to the "All nodes
+        # blocked" failure case and was finalized 'failed' despite succeeding.
+        if all(n.status in _RESOLVED for n in dag.nodes):
+            skipped = sum(1 for n in dag.nodes if n.status == "skipped")
+            summary = (
+                "All nodes completed successfully"
+                if not skipped
+                else f"All nodes resolved ({skipped} skipped via skip_and_continue)"
+            )
             await self._store.update_dag_status(
-                dag.id, "completed", result_summary="All nodes completed successfully"
+                dag.id, "completed", result_summary=summary
             )
         elif any(n.status == "failed" for n in dag.nodes):
             failed_names = [n.name for n in dag.nodes if n.status == "failed"]

--- a/nous/handlers/procedure_learner.py
+++ b/nous/handlers/procedure_learner.py
@@ -548,7 +548,16 @@ class ProcedureLearner:
     # ==================================================================
 
     async def _is_duplicate(self, procedure_data: dict[str, Any]) -> bool:
-        """Check if a similar procedure already exists (>0.85 similarity)."""
+        """Check if a similar procedure already exists (>0.85 cosine similarity).
+
+        Audit HD-1 (2026-06-09): must use the raw-cosine probe, NOT
+        ``search_procedures``. ``search()`` returns normalized RRF scores that
+        encode RANK — the nearest procedure scores ~0.95 for ANY non-empty
+        query — so ``score > 0.85`` was true for essentially every candidate
+        and silently suppressed all auto-procedure creation (the observed
+        prod "K-line = 0"). ``find_similar_procedures`` returns actual cosine
+        similarity, against which a 0.85 near-duplicate floor is meaningful.
+        """
         name = procedure_data.get("name", "")
         description = procedure_data.get("description", "")
         patterns = " ".join(procedure_data.get("core_patterns", []))
@@ -557,9 +566,9 @@ class ProcedureLearner:
         if not query_text:
             return False
 
-        existing = await self._heart.search_procedures(query_text, limit=1)
+        existing = await self._heart.find_similar_procedures(query_text, limit=1)
         if existing and existing[0].score is not None and existing[0].score > 0.85:
-            logger.debug("Skipping duplicate procedure: %s (score=%.2f)", name, existing[0].score)
+            logger.debug("Skipping duplicate procedure: %s (cosine=%.2f)", name, existing[0].score)
             return True
         return False
 

--- a/nous/handlers/sleep_handler.py
+++ b/nous/handlers/sleep_handler.py
@@ -756,7 +756,12 @@ class SleepHandler:
             return False
 
         try:
-            results = await self._heart.search_facts(referenced_content, limit=3)
+            # Audit HD-2 (2026-06-09): raw-cosine probe, NOT search_facts.
+            # search_facts returns rank-encoded RRF scores (top hit ~0.95 for
+            # ANY query), so the score<0.80 guard below never fired and the top
+            # RRF hit was always superseded — even when it was an unrelated
+            # fact. find_similar_facts returns thresholdable cosine similarity.
+            results = await self._heart.find_similar_facts(referenced_content, limit=3)
             if not results:
                 logger.debug("UPDATES: no matching fact found for '%s'", referenced_content[:50])
                 # Fall back to learning as new fact

--- a/nous/heart/episodes.py
+++ b/nous/heart/episodes.py
@@ -506,6 +506,14 @@ class EpisodeManager:
             except Exception:
                 logger.warning("Embedding generation failed for episode search")
 
+        # Audit HT-1 (2026-06-09): episode hybrid search was structurally dead.
+        # For episodes `active` is a LIFECYCLE flag — _end() sets active=False
+        # on close — not a soft-delete marker, so the default active_filter=true
+        # excluded every closed episode (the only ones worth recalling). And
+        # `outcome != 'abandoned'` is NULL (→ excluded) for ongoing/recovered
+        # episodes by SQL 3-valued logic. Together they excluded ALL episodes.
+        # Fix: active_filter=False (don't gate on lifecycle), and exclude only
+        # literal 'abandoned' via IS DISTINCT FROM so NULL-outcome rows pass.
         if variant_pairs and len(variant_pairs) > 1:
             results = await hybrid_search_multi(
                 session=session,
@@ -513,7 +521,8 @@ class EpisodeManager:
                 queries=variant_pairs,
                 agent_id=self.agent_id,
                 limit=limit,
-                extra_where="AND t.outcome != 'abandoned'",
+                active_filter=False,
+                extra_where="AND t.outcome IS DISTINCT FROM 'abandoned'",
             )
         else:
             results = await hybrid_search(
@@ -523,7 +532,8 @@ class EpisodeManager:
                 query_text=query,
                 agent_id=self.agent_id,
                 limit=limit,
-                extra_where="AND t.outcome != 'abandoned'",
+                active_filter=False,
+                extra_where="AND t.outcome IS DISTINCT FROM 'abandoned'",
             )
 
         if not results:

--- a/nous/heart/episodes.py
+++ b/nous/heart/episodes.py
@@ -512,8 +512,17 @@ class EpisodeManager:
         # excluded every closed episode (the only ones worth recalling). And
         # `outcome != 'abandoned'` is NULL (→ excluded) for ongoing/recovered
         # episodes by SQL 3-valued logic. Together they excluded ALL episodes.
-        # Fix: active_filter=False (don't gate on lifecycle), and exclude only
+        #
+        # Fix (refined per codex P1): active_filter=False, but DON'T blanket-
+        # include every inactive row — the trivial-session path soft-deletes
+        # noise via deactivate_episode (active=false, ended_at=NULL). Include
+        # ongoing (active=true) OR genuinely-closed (ended_at IS NOT NULL) rows,
+        # which excludes deactivated-but-unfinished noise; still drop only
         # literal 'abandoned' via IS DISTINCT FROM so NULL-outcome rows pass.
+        _episode_where = (
+            "AND (t.active = true OR t.ended_at IS NOT NULL) "
+            "AND t.outcome IS DISTINCT FROM 'abandoned'"
+        )
         if variant_pairs and len(variant_pairs) > 1:
             results = await hybrid_search_multi(
                 session=session,
@@ -522,7 +531,7 @@ class EpisodeManager:
                 agent_id=self.agent_id,
                 limit=limit,
                 active_filter=False,
-                extra_where="AND t.outcome IS DISTINCT FROM 'abandoned'",
+                extra_where=_episode_where,
             )
         else:
             results = await hybrid_search(
@@ -533,7 +542,7 @@ class EpisodeManager:
                 agent_id=self.agent_id,
                 limit=limit,
                 active_filter=False,
-                extra_where="AND t.outcome IS DISTINCT FROM 'abandoned'",
+                extra_where=_episode_where,
             )
 
         if not results:

--- a/nous/heartbeat/checks.py
+++ b/nous/heartbeat/checks.py
@@ -954,7 +954,7 @@ class BehaviorDriftCheck(BaseCheck):
             self._last_snapshot = snapshot
         except Exception:
             logger.exception("BehaviorDriftCheck failed")
-        return CheckResult(findings=findings)
+        return CheckResult(has_updates=bool(findings), findings=findings)
 
     async def _capture_snapshot(self):
         from nous.observability.snapshots import BehaviorSnapshot

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,3 +30,40 @@ class TestDAGTimeoutValidation:
         s = Settings(_env_file=None)
         assert s.dag_node_default_timeout == 600
         assert s.dag_node_max_timeout == 7200
+
+
+class TestContextBudgetOverridesParsing:
+    """Audit ST-1: empty/blank NOUS_CONTEXT_BUDGET_OVERRIDES must not crash boot.
+
+    docker-compose passes `NOUS_CONTEXT_BUDGET_OVERRIDES=${...:-}` (empty string)
+    on a fresh install with no host .env. Without NoDecode + the before-validator,
+    pydantic-settings' default complex-field decoder calls json.loads("") and
+    raises SettingsError, crash-looping the container.
+    """
+
+    def test_empty_string_yields_empty_dict(self, monkeypatch):
+        monkeypatch.setenv("NOUS_CONTEXT_BUDGET_OVERRIDES", "")
+        s = Settings(_env_file=None)
+        assert s.context_budget_overrides == {}
+
+    def test_whitespace_string_yields_empty_dict(self, monkeypatch):
+        monkeypatch.setenv("NOUS_CONTEXT_BUDGET_OVERRIDES", "   ")
+        s = Settings(_env_file=None)
+        assert s.context_budget_overrides == {}
+
+    def test_valid_json_is_parsed(self, monkeypatch):
+        monkeypatch.setenv(
+            "NOUS_CONTEXT_BUDGET_OVERRIDES", '{"total": 13000, "facts": 3000}'
+        )
+        s = Settings(_env_file=None)
+        assert s.context_budget_overrides == {"total": 13000, "facts": 3000}
+
+    def test_unset_uses_default_empty_dict(self, monkeypatch):
+        monkeypatch.delenv("NOUS_CONTEXT_BUDGET_OVERRIDES", raising=False)
+        s = Settings(_env_file=None)
+        assert s.context_budget_overrides == {}
+
+    def test_programmatic_dict_passthrough(self, monkeypatch):
+        monkeypatch.delenv("NOUS_CONTEXT_BUDGET_OVERRIDES", raising=False)
+        s = Settings(_env_file=None, context_budget_overrides={"total": 9000})
+        assert s.context_budget_overrides == {"total": 9000}

--- a/tests/test_dag_orchestrator.py
+++ b/tests/test_dag_orchestrator.py
@@ -1607,3 +1607,69 @@ class TestStaleReadyRecovery:
         # may or may not dispatch depending on dependency edges.
         wave0_completed = [n for n in fetched.nodes if n.wave == 0]
         assert all(n.status == "completed" for n in wave0_completed)
+
+
+class TestDAGCompletionStatus:
+    """Audit DG-1: a DAG that finishes via skip_and_continue (some nodes
+    'skipped', rest 'completed') must finalize 'completed', not 'failed'."""
+
+    def _orchestrator_with_mock_store(self):
+        store = AsyncMock()
+        return DAGOrchestrator(
+            store=store,
+            subtask_mgr=AsyncMock(),
+            dynamic_loader=AsyncMock(),
+            settings=Settings(),
+        ), store
+
+    def _node(self, status, name="n", node_type="subtask"):
+        return SimpleNamespace(
+            id=uuid.uuid4(), name=name, status=status,
+            node_type=node_type, parent_node=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_completed_plus_skipped_finalizes_completed(self):
+        orch, store = self._orchestrator_with_mock_store()
+        dag = SimpleNamespace(
+            id=uuid.uuid4(),
+            nodes=[self._node("completed", "a"), self._node("skipped", "b")],
+        )
+        await orch._check_dag_completion(dag)
+        store.update_dag_status.assert_awaited_once()
+        args, kwargs = store.update_dag_status.await_args
+        assert args[1] == "completed"
+        assert "skipped" in (kwargs.get("result_summary") or args[2])
+
+    @pytest.mark.asyncio
+    async def test_all_completed_finalizes_completed(self):
+        orch, store = self._orchestrator_with_mock_store()
+        dag = SimpleNamespace(
+            id=uuid.uuid4(),
+            nodes=[self._node("completed", "a"), self._node("completed", "b")],
+        )
+        await orch._check_dag_completion(dag)
+        args, _ = store.update_dag_status.await_args
+        assert args[1] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_failed_node_still_finalizes_failed(self):
+        orch, store = self._orchestrator_with_mock_store()
+        dag = SimpleNamespace(
+            id=uuid.uuid4(),
+            nodes=[self._node("completed", "a"), self._node("failed", "b")],
+        )
+        await orch._check_dag_completion(dag)
+        args, _ = store.update_dag_status.await_args
+        assert args[1] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_all_blocked_still_finalizes_failed(self):
+        orch, store = self._orchestrator_with_mock_store()
+        dag = SimpleNamespace(
+            id=uuid.uuid4(),
+            nodes=[self._node("blocked", "a"), self._node("blocked", "b")],
+        )
+        await orch._check_dag_completion(dag)
+        args, _ = store.update_dag_status.await_args
+        assert args[1] == "failed"

--- a/tests/test_drift_detection.py
+++ b/tests/test_drift_detection.py
@@ -6,6 +6,8 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
+from unittest.mock import AsyncMock, MagicMock
+
 from nous.observability.snapshots import BehaviorSnapshot
 from nous.observability.drift import Anomaly, DriftDetector
 
@@ -70,6 +72,50 @@ def _make_snapshot(delta: int = 0, **kwargs) -> BehaviorSnapshot:
     """Helper to create snapshots with offsets from 'now'."""
     ts = datetime.now(UTC) - timedelta(hours=delta)
     return BehaviorSnapshot(timestamp=ts, **kwargs)
+
+
+class TestBehaviorDriftCheckHasUpdates:
+    """Audit HB-1: BehaviorDriftCheck.run() must set has_updates=True when it
+    emits findings — the heartbeat runner gates on result.has_updates, so a
+    CheckResult(findings=...) without the flag silently drops every drift alert.
+    """
+
+    def _build_check(self):
+        from nous.heartbeat.checks import BehaviorDriftCheck
+
+        check = BehaviorDriftCheck.__new__(BehaviorDriftCheck)
+        # Bypass __init__ (which needs Heart/Brain); wire only what run() touches.
+        from nous.heartbeat.schemas import CheckResult  # noqa: F401
+        check._detector = MagicMock()
+        check._last_snapshot = None
+        check._last_anomalies = []
+        check._capture_snapshot = AsyncMock(
+            return_value=BehaviorSnapshot(timestamp=datetime.now(UTC))
+        )
+        check._load_baseline = AsyncMock(return_value=[object()])  # truthy baseline
+        check._store_snapshot = AsyncMock()
+        return check
+
+    @pytest.mark.asyncio
+    async def test_has_updates_true_when_anomaly_alert(self):
+        check = self._build_check()
+        check._detector.detect.return_value = [
+            Anomaly(
+                metric="fact_count_delta", current=99, mean=5.0, stddev=1.0,
+                z_score=94.0, direction="above", severity="alert",
+            )
+        ]
+        result = await check.run()
+        assert result.findings, "expected a drift finding"
+        assert result.has_updates is True
+
+    @pytest.mark.asyncio
+    async def test_has_updates_false_when_no_anomaly(self):
+        check = self._build_check()
+        check._detector.detect.return_value = []
+        result = await check.run()
+        assert result.findings == []
+        assert result.has_updates is False
 
 
 class TestDriftDetector:

--- a/tests/test_f031_consolidation.py
+++ b/tests/test_f031_consolidation.py
@@ -258,6 +258,8 @@ class TestOrientContext:
         heart = AsyncMock()
         heart.list_episodes = AsyncMock(return_value=[ep1, ep1])
         heart.search_facts = AsyncMock(return_value=[existing_fact])
+        # HD-2: UPDATES supersession now probes find_similar_facts (raw cosine).
+        heart.find_similar_facts = AsyncMock(return_value=[existing_fact])
         heart.supersede_fact = AsyncMock(return_value=MagicMock())
         heart.learn = AsyncMock(return_value=MagicMock())
 
@@ -296,6 +298,8 @@ class TestOrientContext:
         heart = AsyncMock()
         heart.list_episodes = AsyncMock(return_value=[ep1, ep1])
         heart.search_facts = AsyncMock(return_value=[existing_fact])
+        # HD-2: UPDATES supersession now probes find_similar_facts (raw cosine).
+        heart.find_similar_facts = AsyncMock(return_value=[existing_fact])
         heart.supersede_fact = AsyncMock(return_value=MagicMock())
         heart.learn = AsyncMock(return_value=MagicMock())
 
@@ -332,6 +336,8 @@ class TestOrientContext:
         heart = AsyncMock()
         heart.list_episodes = AsyncMock(return_value=[ep1, ep1])
         heart.search_facts = AsyncMock(return_value=[low_match])
+        # HD-2: UPDATES supersession now probes find_similar_facts (raw cosine).
+        heart.find_similar_facts = AsyncMock(return_value=[low_match])
         heart.supersede_fact = AsyncMock()
         heart.learn = AsyncMock(return_value=MagicMock())
 

--- a/tests/test_procedure_learner.py
+++ b/tests/test_procedure_learner.py
@@ -288,6 +288,10 @@ def _build_learner(settings: Settings | None = None):
     embeddings = AsyncMock()
     # No spec= constraint — LLMClient protocol uses .call() which isn't on httpx.AsyncClient
     llm_client = AsyncMock()
+    # Audit HD-1: _is_duplicate now probes find_similar_procedures (raw cosine),
+    # not search_procedures (RRF rank). Default to "no duplicate found" so the
+    # creation tests aren't blocked by an AsyncMock returning a truthy MagicMock.
+    heart.find_similar_procedures.return_value = []
     s = settings or _make_settings()
     learner = ProcedureLearner(brain, heart, embeddings, s, llm_client)
     return learner, brain, heart, embeddings, llm_client
@@ -501,13 +505,50 @@ async def test_dedup_skips_similar_existing():
 
     llm_client.call.return_value = _mock_llm_response(_llm_procedure_data())
 
-    # Existing procedure with high similarity score
-    heart.search_procedures.return_value = [_make_procedure_summary(score=0.90)]
+    # Existing procedure with high raw-cosine similarity (HD-1: dedup now
+    # probes find_similar_procedures, which returns cosine in .score).
+    heart.find_similar_procedures.return_value = [_make_procedure_summary(score=0.90)]
 
     stats = await learner.run_sleep_learning()
 
     assert stats["decisions_learned"] == 0
     heart.store_procedure.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dedup_uses_cosine_probe_not_rrf():
+    """Audit HD-1: _is_duplicate must use the raw-cosine probe, not the
+    RRF-ranked search_procedures whose top hit is ~0.95 for any query and so
+    suppressed every auto-procedure creation (prod K-line=0).
+
+    Regression guard: a high RRF rank score on search_procedures must NOT block
+    creation when the cosine probe reports no near-duplicate.
+    """
+    learner, brain, heart, embeddings, llm_client = _build_learner()
+
+    summaries = [_make_decision_summary() for _ in range(3)]
+    brain.list_decisions.side_effect = [(summaries, 3), ([], 0)]
+    details = [_make_decision_detail(s) for s in summaries]
+    brain.get.side_effect = details
+
+    base = _make_embedding(1.0)
+    embeddings.embed_batch.return_value = [
+        base,
+        _similar_embedding(base, 0.005),
+        _similar_embedding(base, 0.01),
+    ]
+    llm_client.call.return_value = _mock_llm_response(_llm_procedure_data())
+
+    # RRF rank score is high (it always is) but cosine probe finds no dup.
+    heart.search_procedures.return_value = [_make_procedure_summary(score=0.97)]
+    heart.find_similar_procedures.return_value = []
+
+    stats = await learner.run_sleep_learning()
+
+    # Creation must proceed; dedup must consult the cosine probe.
+    assert stats["decisions_learned"] == 1
+    heart.find_similar_procedures.assert_awaited()
+    heart.store_procedure.assert_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_sleep_handler.py
+++ b/tests/test_sleep_handler.py
@@ -728,6 +728,8 @@ class TestStructuredReflection:
         existing_fact.category = "technical"
         existing_fact.score = 0.95
         heart.search_facts = AsyncMock(return_value=[existing_fact])
+        # HD-2: UPDATES supersession now probes find_similar_facts (raw cosine).
+        heart.find_similar_facts = AsyncMock(return_value=[existing_fact])
         heart.supersede_fact = AsyncMock()
 
         reflection = {

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -262,17 +262,32 @@ class TestRecallDeep:
         assert "Brain Decisions" not in text
 
     @pytest.mark.asyncio
-    async def test_recall_deep_empty(self, tools):
-        """No results -> 'No results found.' in section output."""
-        # Use heart-only type "episode" — no episodes seeded by tool tests
-        result = await tools["recall_deep"](
-            query="zzz_nonexistent_query_no_match",
-            memory_types=["episode"],
-        )
+    async def test_recall_deep_empty(self, db, mock_embeddings):
+        """No results -> 'No results found.' in section output.
 
-        assert "content" in result
-        text = result["content"][0]["text"]
-        assert "No results found" in text
+        Built on an isolated agent_id so no other test's episodes leak in.
+        Before HT-1 (episode-search active-filter fix), this passed only
+        because episode search was structurally dead and returned nothing for
+        every query; under the shared default agent it would now surface
+        another test's seeded episode. Isolation makes the empty case real.
+        """
+        import uuid as _uuid
+
+        settings = Settings(agent_id=f"recall-empty-{_uuid.uuid4().hex[:8]}")
+        brain = Brain(database=db, settings=settings, embedding_provider=mock_embeddings)
+        heart = Heart(db, settings, embedding_provider=mock_embeddings)
+        try:
+            tools = create_nous_tools(brain, heart)
+            result = await tools["recall_deep"](
+                query="zzz_nonexistent_query_no_match",
+                memory_types=["episode"],
+            )
+            assert "content" in result
+            text = result["content"][0]["text"]
+            assert "No results found" in text
+        finally:
+            await brain.close()
+            await heart.close()
 
     @pytest.mark.integration
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Complete code-driven audit of every major Nous subsystem (11 parallel subsystem-scoped reviews + master synthesis), followed by a batch of 9 verified P1 fixes with regression tests.

Audit docs live in `docs/reviews/*-audit-2026-06-09.md`; the master synthesis is `docs/reviews/nous-complete-audit-2026-06-09.md`. Code-only, file:line evidence, reachability judged against the prod `.env` overlay. Every load-bearing P1 was personally re-verified against source (one agent claim — AT-2 — was refuted on verification and the doc corrected).

## Three dominant defect patterns

1. **RRF rank score compared to a similarity threshold** — the hybrid-search top hit scores ~0.95 for *any* query. PR #495 fixed this at fact-dedup sites; it survived elsewhere.
2. **F036 cache-split ignores the flat `system_prompt`** — F078 fixed censors by writing to both the flat string and the tiered sections; two producers still wrote only the ignored flat string.
3. **Severed self-improvement / telemetry wires** — built, flag-ON in prod, no consumer.

## Fixes in this PR (9)

| ID | Fix |
|----|-----|
| **HD-1** | `procedure_learner._is_duplicate` used the RRF rank score (~0.95) vs a 0.85 threshold → **all auto-procedure creation suppressed** (prod "K-line = 0"). Switch to raw-cosine `find_similar_procedures`. |
| **HD-2** | sleep-handler UPDATES-supersession had the same RRF-vs-threshold bug → could supersede an unrelated fact. Switch to `find_similar_facts`. |
| **CL-1** | Subtask results were appended only to the flat `system_prompt` the F036 split path ignores, while rows were marked *delivered* → parent agent permanently never saw subtask outcomes. Route into `sections_by_tier["dynamic"]`. |
| **CL-2** | F065 hub-shift notice had the same flat-string-ignored bug → route into the dynamic tier too. |
| **BR-1** | Graph fact-neighbor query lacked an `active` filter (only procedures got the F080 fix) → superseded facts resurfaced in recall. Add `active=true` to the fact query (episodes/chunks intentionally excluded — episode `active=false` is the normal *closed* state). |
| **HT-1** | Episode hybrid search filtered `active=true AND outcome!='abandoned'`, excluding both closed and ongoing episodes → episode semantic recall was structurally dead. Drop the active filter; use `IS DISTINCT FROM 'abandoned'`. |
| **HB-1** | `BehaviorDriftCheck` returned findings without `has_updates=True`; the runner gates on `has_updates` → all drift alerts silently dropped. |
| **DG-1** | A DAG finishing via `skip_and_continue` (completed+skipped) fell through to "All nodes blocked" and was finalized `failed`. Use `_RESOLVED` for the success branch. |
| **ST-1** | Empty `NOUS_CONTEXT_BUDGET_OVERRIDES` (the compose default) crash-looped a fresh install via `json.loads("")`. `NoDecode` + a before-validator tolerate it. |

## Tests

+12 regression tests (config ST-1 ×5, procedure HD-1, drift HB-1 ×2, dag DG-1 ×4), all green. Every edited file byte-compiles. Postgres-only paths (HT-1/BR-1/CL-1/CL-2/HD-2) verified at code level; adjacent F061/F065/F036 suites pass. No new test failures vs the clean tree (all observed failures pre-exist as SQLite-fixture limitations).

## Deferred to follow-ups (documented in the synthesis)

RM-1 (unauth REST/MCP + published Postgres w/ default password — deploy/compose change), HD-4 (auto-review corrupts calibration labels — semantics), CL-6 (budget-override REPLACE wipes prod env values — semantics), and Pattern-C wire reconnections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
