### PR TITLE
fix: procedure progressive disclosure — complete catalog index + stub-over-cap bodies

### DIFF
--- a/nous/cognitive/context.py
+++ b/nous/cognitive/context.py
@@ -326,8 +326,12 @@ class ContextEngine:
                 # Reserve room for the trailing "…N+ more" note so the size backstop never
                 # has to drop IT (the note must survive truncation).
                 _NOTE_RESERVE = 140
-                row_lines: list[str] = []
-                used = len(header) + 1
+
+                # Two-pass progressive degradation — names are never sacrificed before
+                # descriptions (progressive disclosure: complete index is always-on).
+                # Pass 1: build full "name (domain): desc" rows and name-only fallbacks.
+                full_rows: list[str] = []
+                name_rows: list[str] = []
                 for p in deduped:
                     # name: keep exact (it's the get_procedure key) but kill line breaks;
                     # domain/desc: full whitespace-collapse (not lookup keys).
@@ -336,15 +340,28 @@ class ContextEngine:
                     desc = _one_line(getattr(p, "description", None))
                     if len(desc) > desc_cap:
                         desc = desc[:desc_cap].rstrip() + "…"
-                    row = f"- {name} ({domain}): {desc}" if desc else f"- {name} ({domain})"
-                    if used + len(row) + 1 > max_chars - _NOTE_RESERVE and row_lines:
-                        break
-                    row_lines.append(row)
-                    used += len(row) + 1
-                # Size backstop: drop WHOLE trailing rows (never cut a name/row mid-string)
-                # until header + rows + a note fit. header + 1 row fits in the 500 floor.
-                while row_lines and len(header) + 1 + sum(len(r) + 1 for r in row_lines) > max_chars - _NOTE_RESERVE and len(row_lines) > 1:
+                    full_rows.append(f"- {name} ({domain}): {desc}" if desc else f"- {name} ({domain})")
+                    name_rows.append(f"- {name} ({domain})")
+
+                def _catalog_size(rows: list[str]) -> int:
+                    return len("\n".join([header, ""] + rows))
+
+                char_budget = max_chars - _NOTE_RESERVE
+                row_lines = list(full_rows)
+
+                # Pass 2: if over budget, strip descriptions from lowest-priority rows first
+                # (last in list = oldest/lowest priority). Names are never dropped here.
+                if _catalog_size(row_lines) > char_budget:
+                    for i in range(len(row_lines) - 1, -1, -1):
+                        if row_lines[i] != name_rows[i]:
+                            row_lines[i] = name_rows[i]
+                            if _catalog_size(row_lines) <= char_budget:
+                                break
+
+                # Pass 3: if still over budget, drop whole rows from the end (keep ≥1).
+                while len(row_lines) > 1 and _catalog_size(row_lines) > char_budget:
                     row_lines.pop()
+
                 shown = len(row_lines)
                 # Omitted lower bound: distinct names dropped by the caps PLUS rows not even
                 # fetched (active rows beyond the fetch window). "+" because dups make it a
@@ -1517,10 +1534,17 @@ class ContextEngine:
                     parts.append("Goals: " + "; ".join(str(x) for x in goals))
             block = "\n\n".join(parts)
             if len(block) > per_item_cap:
-                block = (
-                    block[:per_item_cap].rstrip()
-                    + f"\n…(truncated — call get_procedure('{name}') for the full skill)"
+                # Emit a stub: heading + description only, NO body/steps.
+                # A non-actionable stub forces the model to call get_procedure before acting.
+                # (A tail-sliced partial body is the anti-pattern — the model rationalizes it
+                # as sufficient and never fetches the rest.)
+                stub_parts: list[str] = [f"### {name} ({domain})"]
+                if desc:
+                    stub_parts.append(desc)
+                stub_parts.append(
+                    f"[Full skill body exceeds preview budget — call get_procedure('{name}') to load the steps before acting.]"
                 )
+                block = "\n\n".join(stub_parts)
             blocks.append(block)
         return blocks
 

--- a/nous/config.py
+++ b/nous/config.py
@@ -157,7 +157,7 @@ class Settings(BaseSettings):
     proc_catalog_enabled: bool = True  # render the static breadth catalog (catalog-first)
     proc_catalog_max: int = Field(default=100, ge=1, le=500)  # safety cap on catalog row count
     proc_catalog_desc_chars: int = Field(default=120, ge=20, le=500)  # per-row desc truncation
-    proc_catalog_max_chars: int = Field(default=4000, ge=500, le=40000)  # hard total-size cap (>= header + 1 row)
+    proc_catalog_max_chars: int = Field(default=8000, ge=500, le=40000)  # hard total-size cap (>= header + 1 row)
     proc_awareness_cue: bool = False  # cue-only fallback (instruction, no list) when catalog off
     # When False, the passive embedding-similarity (Track B) procedure slots are skipped —
     # those duplicate the recall_deep cosine path. Critic-recommended skills (Track A) are

--- a/tests/test_context_dual_track.py
+++ b/tests/test_context_dual_track.py
@@ -125,16 +125,37 @@ class TestGraphPrimarySelection:
         )
         assert [p.id for p in selected] == [crit.id]
 
-    @pytest.mark.asyncio
-    async def test_body_format_respects_per_item_cap(self):
+    def test_body_over_cap_emits_stub_not_slice(self):
+        """Over-cap body emits a stub with mandatory-fetch pointer — not a tail-slice.
+
+        Progressive disclosure: a partial body is the anti-pattern (model rationalises
+        it as sufficient and never calls get_procedure). The stub is non-actionable.
+        """
         engine = self._engine(neighbors=[])
         long_proc = _make_procedure_detail("x").model_copy(
-            update={"description": "Z" * 5000}
+            update={"implementation_notes": ["Step: " + "A" * 2000, "Step: " + "B" * 2000]}
         )
         blocks = engine._format_procedure_bodies([long_proc], 200)
         assert len(blocks) == 1
-        assert blocks[0].count("Z") <= 200  # body truncated to the per-item cap
-        assert "get_procedure('x')" in blocks[0]  # pointer to the untruncated full skill
+        stub = blocks[0]
+        # Mandatory-fetch pointer present
+        assert "get_procedure('x')" in stub
+        # No body/step text in stub — stub is non-actionable
+        assert "AAAA" not in stub
+        assert "BBBB" not in stub
+        # Stub is short (no tail-slice of the 4000-char body)
+        assert len(stub) < 400
+
+    def test_body_under_cap_renders_fully(self):
+        """Body that fits the cap renders exactly as before — regression guard."""
+        engine = self._engine(neighbors=[])
+        proc = _make_procedure_detail("deploy-step")
+        blocks = engine._format_procedure_bodies([proc], 2500)
+        assert len(blocks) == 1
+        block = blocks[0]
+        assert "Step 1: investigate the cause" in block
+        assert "Step 2: apply the fix" in block
+        assert "get_procedure" not in block  # no stub pointer when body fits
 
     def test_non_skill_procedure_keeps_core_patterns_as_steps(self):
         # Auto-learned (K-line, no 'skill' tag) procedures store the executable

--- a/tests/test_f079_pull_delivery.py
+++ b/tests/test_f079_pull_delivery.py
@@ -272,6 +272,64 @@ class TestBuildSurfaces:
         assert "more not shown" in content  # omitted note present
 
     @pytest.mark.asyncio
+    async def test_catalog_two_pass_names_survive_description_strip(self):
+        """Two-pass degradation: descriptions are stripped before names are dropped.
+
+        When the char budget is tight but names still fit, ALL names must appear
+        (some as name-only rows without descriptions). A name disappearing from the
+        catalog means the model cannot call get_procedure for it — the anti-pattern.
+        """
+        from nous.heart.schemas import ProcedureSummary
+        from uuid import uuid4
+        # 10 procedures with 200-char descriptions, tight 700-char budget.
+        # Full rows would overflow; name-only rows (≈15 chars each) should fit.
+        procs = [
+            ProcedureSummary(id=uuid4(), name=f"skill-{i}", domain="ops",
+                             description="D" * 200, activation_count=1,
+                             effectiveness=None, score=0.9)
+            for i in range(10)
+        ]
+        engine = self._engine(catalog_procs=procs, catalog_total=10,
+                              proc_catalog_enabled=True, proc_catalog_max_chars=700,
+                              proc_catalog_desc_chars=200)
+        r = await self._build(engine)
+        content = next(s.content for s in r.sections if s.label == "Procedure Catalog")
+        # All 10 names must appear — descriptions degrade first
+        for i in range(10):
+            assert f"skill-{i}" in content, f"skill-{i} missing from catalog"
+        # Some descriptions were stripped (not all 200-char blobs can fit in 700 chars)
+        assert "D" * 200 not in content
+
+    @pytest.mark.asyncio
+    async def test_catalog_drops_rows_only_when_names_do_not_fit(self):
+        """Rows are dropped (with 'more not shown') only when name-only rows still overflow.
+
+        With an extremely tight budget that cannot even fit all name-only rows, some
+        rows are dropped — but the drop count is correct and the note is present.
+        """
+        from nous.heart.schemas import ProcedureSummary
+        from uuid import uuid4
+        # 20 procedures, budget so tight only ~3-4 name-only rows fit.
+        procs = [
+            ProcedureSummary(id=uuid4(), name=f"proc-longname-{i:02d}", domain="d",
+                             description="desc", activation_count=1,
+                             effectiveness=None, score=0.9)
+            for i in range(20)
+        ]
+        engine = self._engine(catalog_procs=procs, catalog_total=20,
+                              proc_catalog_enabled=True, proc_catalog_max_chars=500)
+        r = await self._build(engine)
+        content = next(s.content for s in r.sections if s.label == "Procedure Catalog")
+        rows = [ln for ln in content.splitlines() if ln.startswith("- ")]
+        # At least 1 row kept, fewer than 20 (budget too tight for all)
+        assert 1 <= len(rows) < 20
+        # The "more not shown" note must be present when rows are dropped
+        assert "more not shown" in content
+        # All shown rows are name-only (descriptions were stripped first)
+        for row in rows:
+            assert "desc" not in row
+
+    @pytest.mark.asyncio
     async def test_option_c_catalog_plus_critic_emits_slim_pointer(self):
         """Option C: with the catalog on, Critic's picks are a slim DYNAMIC pointer (names
         only) into the catalog — NOT a full Known Procedures re-listing (no content dup)."""


### PR DESCRIPTION
## Summary

Implements two progressive-disclosure fixes to procedure context rendering, aligning Nous with how Anthropic Agent Skills, the MCP meta-tool pattern, and langgraph-bigtool all handle progressive disclosure.

**Anti-pattern removed:** A truncated procedure body (`…(truncated — call get_procedure(name))`) is advisory, not a forcing function. Empirically the model proceeds on the visible partial steps and never calls `get_procedure`. Similarly, dropping procedure _names_ from the catalog means the model can't call `get_procedure` for them at all — they become invisible.

### Change 1 — Catalog two-pass degradation (`nous/cognitive/context.py`, `nous/config.py`)

**Before:** The size backstop dropped whole rows when the catalog overflowed `proc_catalog_max_chars`, causing procedure names to silently disappear from the catalog and become unfetchable.

**After:** Two-pass build:
1. Pass 1: build full `name (domain) — description` rows for all procedures
2. Pass 2 (if over budget): strip descriptions from lowest-priority rows first — names survive; rows degrade to name-only
3. Pass 3 (last resort): drop whole rows only when even name-only rows overflow

Net guarantee: every procedure name is present whenever it physically fits as a name-only row. Descriptions degrade gracefully first.

Also bumps `proc_catalog_max_chars` default from 4000 → 8000 (`nous/config.py`) so description-strip degradation rarely triggers in practice.

### Change 2 — Stub-over-cap for Recommended Procedures (`nous/cognitive/context.py`)

**Before:** When a procedure body exceeded `proc_recommended_body_max_chars`, it was tail-sliced to the cap and an advisory note appended.

**After:** When a body exceeds the cap, a **non-actionable stub** is emitted instead — heading + one-line description + mandatory-fetch pointer. Zero body/step text. The stub makes `get_procedure` structurally required before acting (the fetch becomes an unavoidable step, not an optional hint).

```
### deploy-to-prod (ops)

Deploy production services safely.

[Full skill body exceeds preview budget — call get_procedure('deploy-to-prod') to load the steps before acting.]
```

Bodies that fit within the cap render exactly as before (regression-guarded).

## Test plan

- [x] `test_body_over_cap_emits_stub_not_slice` — stub present, pointer present, no body/step text, stub is short
- [x] `test_body_under_cap_renders_fully` — under-cap body renders fully unchanged (regression guard)
- [x] `test_catalog_two_pass_names_survive_description_strip` — 10 procedures with large descriptions in tight budget: all 10 names present, descriptions stripped
- [x] `test_catalog_drops_rows_only_when_names_do_not_fit` — 20 procedures in extremely tight budget: rows dropped only after descriptions stripped, note present, shown rows are name-only

All 49 tests in `test_context_dual_track.py` + `test_f079_pull_delivery.py` pass.

## References

Architecture decisions 7f7a3921 and dc65b892.

🤖 Generated with [Claude Code](https://claude.com/claude-code)