### PR TITLE
fix(F078.1.4): decode HTML entities before secret scan in html_body path

### DIFF
--- a/nous/api/email_tools.py
+++ b/nous/api/email_tools.py
@@ -265,12 +265,17 @@ def create_send_email_tool(settings: Settings):
                     "(operator action)."
                 )
 
-        # 3. Secret scan (secondary guard). html_body is scanned twice: raw
-        # source (catches secrets inside tag attributes, which tag-stripping
-        # would remove) AND entity-decoded text (#484 — catches secrets a
-        # mail client would render from entity-encoded source).
-        html_text = _html_to_text(html_body) if html_body else ""
-        if _scan_secrets(f"{subject}\n{body}\n{html_body or ''}\n{html_text}"):
+        # 3. Secret scan (secondary guard). html_body is scanned in three
+        # views (#484): raw source (secrets in tag attributes), entity-decoded
+        # source (codex P1 — encoded secrets *inside* attributes, which
+        # tag-stripping would remove before decoding), and tag-stripped +
+        # decoded text (secrets a mail client renders from encoded content).
+        html_views = (
+            f"\n{html.unescape(html_body)}\n{_html_to_text(html_body)}"
+            if html_body
+            else ""
+        )
+        if _scan_secrets(f"{subject}\n{body}\n{html_body or ''}{html_views}"):
             return _error(
                 "email appears to contain a secret (API key, password, or token); "
                 "refusing to send."

--- a/nous/api/email_tools.py
+++ b/nous/api/email_tools.py
@@ -16,6 +16,7 @@ return only a generic ``email send failed: <ExceptionType>`` to the model.
 from __future__ import annotations
 
 import asyncio
+import html
 import logging
 import os
 import re
@@ -103,6 +104,18 @@ def _read_allowlist_file(path: str, cache: dict[str, Any]) -> set[str]:
 def _scan_secrets(text: str) -> bool:
     """Return True if the text matches any known secret pattern."""
     return any(p.search(text) for p in _SECRET_PATTERNS)
+
+
+def _html_to_text(s: str) -> str:
+    """Strip HTML tags and decode entities for secret scanning (#484).
+
+    Mail clients render entity-encoded content (``sk-&#97;bcd...`` displays
+    as ``sk-abcd...``), so the scan must also see the decoded text. Tags are
+    replaced with a space; entities are decoded after tag-stripping so a
+    decoded ``&lt;`` cannot fabricate a tag. The raw HTML is still scanned
+    separately — this is an additional view, not a replacement.
+    """
+    return html.unescape(re.sub(r"<[^>]+>", " ", s))
 
 
 def _normalize_paths(value: Any) -> list[str]:
@@ -252,8 +265,12 @@ def create_send_email_tool(settings: Settings):
                     "(operator action)."
                 )
 
-        # 3. Secret scan (secondary guard).
-        if _scan_secrets(f"{subject}\n{body}\n{html_body or ''}"):
+        # 3. Secret scan (secondary guard). html_body is scanned twice: raw
+        # source (catches secrets inside tag attributes, which tag-stripping
+        # would remove) AND entity-decoded text (#484 — catches secrets a
+        # mail client would render from entity-encoded source).
+        html_text = _html_to_text(html_body) if html_body else ""
+        if _scan_secrets(f"{subject}\n{body}\n{html_body or ''}\n{html_text}"):
             return _error(
                 "email appears to contain a secret (API key, password, or token); "
                 "refusing to send."

--- a/nous/api/email_tools.py
+++ b/nous/api/email_tools.py
@@ -106,6 +106,29 @@ def _scan_secrets(text: str) -> bool:
     return any(p.search(text) for p in _SECRET_PATTERNS)
 
 
+def _strip_tags(s: str) -> str:
+    """Single-pass, linear-time tag removal (codex P2 on #484).
+
+    The naive ``<[^>]+>`` regex rescans to end-of-string from every
+    unclosed ``<``, going quadratic on malformed HTML — and this runs
+    synchronously inside the async handler on an unbounded body. Tags
+    become a space. Text after an unclosed trailing ``<`` is dropped from
+    THIS view only; the raw and unescape-only views still scan it.
+    """
+    out: list[str] = []
+    in_tag = False
+    for ch in s:
+        if in_tag:
+            if ch == ">":
+                in_tag = False
+        elif ch == "<":
+            in_tag = True
+            out.append(" ")
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
 def _html_to_text(s: str) -> str:
     """Strip HTML tags and decode entities for secret scanning (#484).
 
@@ -115,7 +138,7 @@ def _html_to_text(s: str) -> str:
     decoded ``&lt;`` cannot fabricate a tag. The raw HTML is still scanned
     separately — this is an additional view, not a replacement.
     """
-    return html.unescape(re.sub(r"<[^>]+>", " ", s))
+    return html.unescape(_strip_tags(s))
 
 
 def _normalize_paths(value: Any) -> list[str]:

--- a/tests/test_email_tools.py
+++ b/tests/test_email_tools.py
@@ -377,6 +377,23 @@ def test_html_body_entity_encoded_secret_rejected(no_real_send):
     assert len(no_real_send) == 0
 
 
+def test_html_body_entity_encoded_attribute_secret_rejected(no_real_send):
+    """#484 codex P1: an entity-encoded secret INSIDE a tag attribute must be
+    caught — raw view sees it encoded, tag-stripping removes it before
+    decoding, so a decode-without-strip view is required."""
+    tool = create_send_email_tool(_make_settings())
+    resp = asyncio.run(
+        tool(
+            to="tim@example.com",
+            subject="newsletter",
+            body="plain text is clean",
+            html_body='<a href="https://x.example?key=sk-&#97;bcdEFGH1234567890zz">report</a>',
+        )
+    )
+    assert "secret" in _text(resp).lower()
+    assert len(no_real_send) == 0
+
+
 def test_html_body_attribute_secret_still_rejected(no_real_send):
     """#484 regression guard: a secret inside a tag attribute (stripped from
     the rendered text) must still be caught via the raw-HTML scan."""

--- a/tests/test_email_tools.py
+++ b/tests/test_email_tools.py
@@ -356,3 +356,38 @@ def test_html_body_secret_scan_rejected(no_real_send):
     )
     assert "secret" in _text(resp).lower()
     assert len(no_real_send) == 0
+
+
+def test_html_body_entity_encoded_secret_rejected(no_real_send):
+    """#484: an HTML-entity-encoded secret in html_body is rejected.
+
+    Mail clients render `sk-&#97;bcd...` as `sk-abcd...`, so the scan must
+    run on the decoded text, not just the raw HTML source.
+    """
+    tool = create_send_email_tool(_make_settings())
+    resp = asyncio.run(
+        tool(
+            to="tim@example.com",
+            subject="newsletter",
+            body="plain text is clean",
+            html_body="<p>key: sk-&#97;bcdEFGH1234567890zz</p>",
+        )
+    )
+    assert "secret" in _text(resp).lower()
+    assert len(no_real_send) == 0
+
+
+def test_html_body_attribute_secret_still_rejected(no_real_send):
+    """#484 regression guard: a secret inside a tag attribute (stripped from
+    the rendered text) must still be caught via the raw-HTML scan."""
+    tool = create_send_email_tool(_make_settings())
+    resp = asyncio.run(
+        tool(
+            to="tim@example.com",
+            subject="newsletter",
+            body="plain text is clean",
+            html_body='<a href="https://x.example?key=sk-abcdEFGH1234567890zz">report</a>',
+        )
+    )
+    assert "secret" in _text(resp).lower()
+    assert len(no_real_send) == 0

--- a/tests/test_email_tools.py
+++ b/tests/test_email_tools.py
@@ -7,6 +7,7 @@ Nothing is ever sent for real: we monkeypatch the blocking SMTP send
 from __future__ import annotations
 
 import asyncio
+import time
 
 import pytest
 
@@ -392,6 +393,26 @@ def test_html_body_entity_encoded_attribute_secret_rejected(no_real_send):
     )
     assert "secret" in _text(resp).lower()
     assert len(no_real_send) == 0
+
+
+def test_html_body_malformed_html_fast_and_scanned(no_real_send):
+    """#484 codex P2: a flood of '<' without '>' must not go quadratic, and
+    a secret after an unclosed '<' is still caught via the raw view."""
+    tool = create_send_email_tool(_make_settings())
+    flood = "<" * 80_000
+    start = time.monotonic()
+    resp = asyncio.run(
+        tool(
+            to="tim@example.com",
+            subject="newsletter",
+            body="plain text is clean",
+            html_body=f"{flood}\nunclosed sk-abcdEFGH1234567890zz",
+        )
+    )
+    elapsed = time.monotonic() - start
+    assert "secret" in _text(resp).lower()
+    assert len(no_real_send) == 0
+    assert elapsed < 2.0  # linear scan; the old regex took seconds at 80 KB
 
 
 def test_html_body_attribute_secret_still_rejected(no_real_send):


### PR DESCRIPTION
Closes #484 (Codex finding from #483 review).

## Problem
`_scan_secrets` ran against raw HTML source only. An entity-encoded secret (`sk-&#97;bcdEFGH...`) passes the regexes but renders as a real key in any mail client.

## Fix
- New `_html_to_text()` helper: strip tags (`<[^>]+>` → space), **then** `html.unescape` — decode-after-strip so a decoded `&lt;` can't fabricate a tag that hides content.
- The scan now sees **both views**: raw HTML source **and** decoded text. The issue's snippet replaced raw with decoded, which would have regressed secrets inside tag attributes (e.g. `href="...?key=sk-..."`) that tag-stripping removes — scanning both is a strict superset.

## Tests
- `test_html_body_entity_encoded_secret_rejected` — **failed before the fix** (email sent), passes after ✅ (issue acceptance)
- `test_html_body_attribute_secret_still_rejected` — regression guard locking the raw-scan view
- 25/25 `tests/test_email_tools.py` pass

## Known residual (out of scope)
Tag-split secrets (`sk-ab<b>cd</b>...`) still evade — tags become spaces per the issue spec. Joining with `''` instead would catch it but risks false positives from adjacent text runs; can revisit if it ever shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)