### PR TITLE
fix(#369): heartbeat SelfInitiatedCheck — question-form filter + staleness age cap

### DIFF
--- a/nous/heartbeat/checks.py
+++ b/nous/heartbeat/checks.py
@@ -198,7 +198,13 @@ class SelfInitiatedCheck(BaseCheck):
             "max_pending_items": TunableParam("max_pending_items", 5, 2, 15, 1),
             # #369: upper bound on the age-based promise heuristic (hours).
             # Episodes older than this are too old to be actionable.
-            "max_stale_age_hours": TunableParam("max_stale_age_hours", 336, 72, 720, 24),
+            # pinned=True (codex P2): the generic tuner's relax=+step would
+            # WIDEN this window on noisy feedback — inverted for an upper
+            # bound. Operator-adjustable via the params API; excluded from
+            # auto-tuning until TunableParam grows direction metadata.
+            "max_stale_age_hours": TunableParam(
+                "max_stale_age_hours", 336, 72, 720, 24, pinned=True
+            ),
         }
 
     async def _ensure_prototypes(self) -> list[list[float]]:

--- a/nous/heartbeat/checks.py
+++ b/nous/heartbeat/checks.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import imaplib
 import logging
+import re
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
@@ -145,6 +146,13 @@ PENDING_PROTOTYPES = [
     "Action required but not yet taken",
 ]
 
+# #369: episode summaries that open as a question or conversational filler are
+# not commitments — _promise_scan skips them before flagging.
+_QUESTION_PREFIX = re.compile(
+    r"^\s*(what|how|where|when|why|who|is|are|do|does|did|can|could|should|would|hey|ok|okay)\b",
+    re.IGNORECASE,
+)
+
 
 class SelfInitiatedCheck(BaseCheck):
     """Check for pending actions and due schedules (permanent).
@@ -173,6 +181,9 @@ class SelfInitiatedCheck(BaseCheck):
             "similarity_threshold": TunableParam("similarity_threshold", 0.75, 0.6, 0.9, 0.02),
             "lookback_days": TunableParam("lookback_days", 14, 3, 30, 1),
             "max_pending_items": TunableParam("max_pending_items", 5, 2, 15, 1),
+            # #369: upper bound on the age-based promise heuristic (hours).
+            # Episodes older than this are too old to be actionable.
+            "max_stale_age_hours": TunableParam("max_stale_age_hours", 336, 72, 720, 24),
         }
 
     async def _ensure_prototypes(self) -> list[list[float]]:
@@ -265,6 +276,7 @@ class SelfInitiatedCheck(BaseCheck):
         """Search recent episode summaries for unresolved commitments."""
         findings: list[Finding] = []
         max_items = int(self.get_param_value("max_pending_items"))
+        max_stale_hours = float(self.get_param_value("max_stale_age_hours"))
 
         promise_queries = [
             "I'll look into",
@@ -286,16 +298,23 @@ class SelfInitiatedCheck(BaseCheck):
                         continue
                     seen_episode_ids.add(eid)
 
-                    # Check if episode is ongoing or old enough to be stale
+                    # Check if episode is ongoing or old enough to be stale.
+                    # #369: the age-based heuristic is bounded above — beyond
+                    # max_stale_age_hours it's too old to be actionable.
+                    # outcome=ongoing is an explicit state and is NOT capped.
                     is_ongoing = getattr(ep, "outcome", None) == "ongoing"
                     started = getattr(ep, "started_at", None)
                     is_stale = False
                     if started:
                         age_hours = (datetime.now(UTC) - started).total_seconds() / 3600
-                        is_stale = age_hours > 48
+                        is_stale = 48 < age_hours <= max_stale_hours
 
                     if is_ongoing or is_stale:
                         summary_text = getattr(ep, "summary", None) or getattr(ep, "title", "")
+                        # #369: questions / conversational openers are not
+                        # commitments — skip before flagging.
+                        if _QUESTION_PREFIX.match(summary_text):
+                            continue
                         findings.append(Finding(
                             source="episodes",
                             summary=f"Unresolved commitment: {summary_text[:100]}",

--- a/nous/heartbeat/checks.py
+++ b/nous/heartbeat/checks.py
@@ -146,12 +146,27 @@ PENDING_PROTOTYPES = [
     "Action required but not yet taken",
 ]
 
-# #369: episode summaries that open as a question or conversational filler are
-# not commitments — _promise_scan skips them before flagging.
-_QUESTION_PREFIX = re.compile(
-    r"^\s*(what|how|where|when|why|who|is|are|do|does|did|can|could|should|would|hey|ok|okay)\b",
-    re.IGNORECASE,
+# #369: episode summaries that are questions / conversational filler are not
+# commitments — _promise_scan skips them before flagging. A bare first-word
+# check over-suppresses ("Okay, I'll follow up with Tim", "Should update the
+# docs" are commitments — codex P2 on PR #503), so: strip leading filler,
+# then treat as a question only on an interrogative wh-start or a trailing
+# question mark. Modal/aux starts alone do NOT suppress.
+_FILLER_PREFIX = re.compile(r"^\s*(?:(?:hey|ok|okay)[\s,!.:-]+)+", re.IGNORECASE)
+_INTERROGATIVE_PREFIX = re.compile(
+    r"^\s*(what|how|where|when|why|who|whom|whose|which)\b", re.IGNORECASE
 )
+
+
+def _is_question_form(text: str) -> bool:
+    """True if an episode summary reads as a question / conversational filler
+    rather than a commitment (#369)."""
+    stripped = _FILLER_PREFIX.sub("", text).strip()
+    if not stripped:
+        return True  # pure filler ("ok", "hey") — nothing to commit to
+    if stripped.endswith("?"):
+        return True
+    return bool(_INTERROGATIVE_PREFIX.match(stripped))
 
 
 class SelfInitiatedCheck(BaseCheck):
@@ -313,7 +328,7 @@ class SelfInitiatedCheck(BaseCheck):
                         summary_text = getattr(ep, "summary", None) or getattr(ep, "title", "")
                         # #369: questions / conversational openers are not
                         # commitments — skip before flagging.
-                        if _QUESTION_PREFIX.match(summary_text):
+                        if _is_question_form(summary_text):
                             continue
                         findings.append(Finding(
                             source="episodes",

--- a/tests/test_heartbeat_intelligent.py
+++ b/tests/test_heartbeat_intelligent.py
@@ -307,6 +307,39 @@ class TestSelfInitiatedPromiseTracking:
         assert len(promise_findings) == 0
 
     @pytest.mark.asyncio
+    async def test_commitment_with_filler_or_modal_start_still_flagged(self):
+        """#369 codex P2 regression: filler/modal openers on COMMITMENTS must
+        not be suppressed — only real questions are."""
+        heart = MagicMock()
+        brain = MagicMock()
+        settings = _mock_settings()
+
+        episodes = []
+        for i, summary in enumerate([
+            "Okay, I'll follow up with Tim",
+            "Should update the deployment docs",
+            "Can finish the migration tomorrow",
+        ]):
+            ep = MagicMock()
+            ep.id = f"ep-c{i}"
+            ep.outcome = "ongoing"
+            ep.started_at = datetime.now(UTC) - timedelta(hours=72)
+            ep.summary = summary
+            episodes.append(ep)
+
+        heart.facts.search = AsyncMock(return_value=[])
+        heart.search_episodes = AsyncMock(return_value=episodes)
+        heart.schedules.get_due = AsyncMock(return_value=[])
+
+        check = SelfInitiatedCheck(heart, brain, settings, embeddings=None)
+        result = await check.run()
+
+        promise_findings = [
+            f for f in result.findings if f.raw_data.get("detection") == "promise_scan"
+        ]
+        assert len(promise_findings) == 3
+
+    @pytest.mark.asyncio
     async def test_stale_episode_beyond_age_cap_not_flagged(self):
         """#369: the age-based heuristic has an upper bound — an episode older
         than max_stale_age_hours (default 14 days) is too old to be actionable."""

--- a/tests/test_heartbeat_intelligent.py
+++ b/tests/test_heartbeat_intelligent.py
@@ -280,6 +280,110 @@ class TestSelfInitiatedPromiseTracking:
         ]
         assert len(promise_findings) == 0
 
+    @pytest.mark.asyncio
+    async def test_question_form_summary_not_flagged(self):
+        """#369: a question/conversational opener is not a commitment, even on
+        an otherwise-flaggable (ongoing) episode."""
+        heart = MagicMock()
+        brain = MagicMock()
+        settings = _mock_settings()
+
+        mock_episode = MagicMock()
+        mock_episode.id = "ep-q"
+        mock_episode.outcome = "ongoing"
+        mock_episode.started_at = datetime.now(UTC) - timedelta(hours=72)
+        mock_episode.summary = "ok what outstanding items we do have?"
+
+        heart.facts.search = AsyncMock(return_value=[])
+        heart.search_episodes = AsyncMock(return_value=[mock_episode])
+        heart.schedules.get_due = AsyncMock(return_value=[])
+
+        check = SelfInitiatedCheck(heart, brain, settings, embeddings=None)
+        result = await check.run()
+
+        promise_findings = [
+            f for f in result.findings if f.raw_data.get("detection") == "promise_scan"
+        ]
+        assert len(promise_findings) == 0
+
+    @pytest.mark.asyncio
+    async def test_stale_episode_beyond_age_cap_not_flagged(self):
+        """#369: the age-based heuristic has an upper bound — an episode older
+        than max_stale_age_hours (default 14 days) is too old to be actionable."""
+        heart = MagicMock()
+        brain = MagicMock()
+        settings = _mock_settings()
+
+        mock_episode = MagicMock()
+        mock_episode.id = "ep-old"
+        mock_episode.outcome = "partial"  # not ongoing — age path only
+        mock_episode.started_at = datetime.now(UTC) - timedelta(days=20)
+        mock_episode.summary = "I'll draft the migration plan"
+
+        heart.facts.search = AsyncMock(return_value=[])
+        heart.search_episodes = AsyncMock(return_value=[mock_episode])
+        heart.schedules.get_due = AsyncMock(return_value=[])
+
+        check = SelfInitiatedCheck(heart, brain, settings, embeddings=None)
+        result = await check.run()
+
+        promise_findings = [
+            f for f in result.findings if f.raw_data.get("detection") == "promise_scan"
+        ]
+        assert len(promise_findings) == 0
+
+    @pytest.mark.asyncio
+    async def test_stale_episode_within_age_cap_flagged(self):
+        """#369 regression guard: a statement-form episode in the 48h..14d
+        window is still flagged by the age-based path."""
+        heart = MagicMock()
+        brain = MagicMock()
+        settings = _mock_settings()
+
+        mock_episode = MagicMock()
+        mock_episode.id = "ep-mid"
+        mock_episode.outcome = "partial"  # not ongoing — age path only
+        mock_episode.started_at = datetime.now(UTC) - timedelta(hours=72)
+        mock_episode.summary = "I'll draft the migration plan"
+
+        heart.facts.search = AsyncMock(return_value=[])
+        heart.search_episodes = AsyncMock(return_value=[mock_episode])
+        heart.schedules.get_due = AsyncMock(return_value=[])
+
+        check = SelfInitiatedCheck(heart, brain, settings, embeddings=None)
+        result = await check.run()
+
+        promise_findings = [
+            f for f in result.findings if f.raw_data.get("detection") == "promise_scan"
+        ]
+        assert len(promise_findings) >= 1
+
+    @pytest.mark.asyncio
+    async def test_old_ongoing_episode_still_flagged(self):
+        """#369: outcome=ongoing is an explicit state, not a heuristic — the
+        age cap does NOT suppress it."""
+        heart = MagicMock()
+        brain = MagicMock()
+        settings = _mock_settings()
+
+        mock_episode = MagicMock()
+        mock_episode.id = "ep-old-ongoing"
+        mock_episode.outcome = "ongoing"
+        mock_episode.started_at = datetime.now(UTC) - timedelta(days=30)
+        mock_episode.summary = "Researching the embedding migration"
+
+        heart.facts.search = AsyncMock(return_value=[])
+        heart.search_episodes = AsyncMock(return_value=[mock_episode])
+        heart.schedules.get_due = AsyncMock(return_value=[])
+
+        check = SelfInitiatedCheck(heart, brain, settings, embeddings=None)
+        result = await check.run()
+
+        promise_findings = [
+            f for f in result.findings if f.raw_data.get("detection") == "promise_scan"
+        ]
+        assert len(promise_findings) >= 1
+
 
 # ===========================================================================
 # TestObservationPatternSuppression — coverage for the 10 patterns added in


### PR DESCRIPTION
Closes #369 (the two filters remaining after the F047 `actionable` mitigation shipped).

## Changes
- **Question-form guard** (`_QUESTION_PREFIX`, issue's verbatim prefix list): episode summaries opening as a question/conversational filler are skipped before flagging — they're not commitments.
- **Staleness upper bound**: the age-based heuristic is now `48 < age_hours <= max_stale_age_hours` instead of `> 48`-forever. Shipped as a `TunableParam` (`max_stale_age_hours`, default 336 h = 14 d, range 72–720, step 24) so the F034.3 self-tuning system owns it rather than a config global.
- **Deliberate scope choice:** `outcome=ongoing` is an explicit recorded state, not a heuristic — the age cap does **not** suppress it (test locks this in). The issue's snippet gated only the `is_stale` path; this matches it.

## Tests (4 new, TDD — the two filter tests failed pre-fix)
- `test_question_form_summary_not_flagged`
- `test_stale_episode_beyond_age_cap_not_flagged`
- `test_stale_episode_within_age_cap_flagged` (regression guard)
- `test_old_ongoing_episode_still_flagged` (regression guard)

124/124 heartbeat tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)