### PR TITLE
fix(#354): edge-audit reads the same content exprs as the densifier (single source of truth)

### DIFF
--- a/nous_eval/run_edge_audit.py
+++ b/nous_eval/run_edge_audit.py
@@ -46,6 +46,7 @@ from uuid import UUID
 
 from sqlalchemy import text
 
+from nous.brain._entity_config import _ENTITY_CONFIG
 from nous.config import Settings
 from nous.storage.database import Database
 from nous_eval.config import EvalSettings
@@ -54,15 +55,17 @@ from nous_eval.retrieval_runner import _settings_for_eval_db
 
 logger = logging.getLogger(__name__)
 
-# Per-type content fetch is structural — facts.content, decisions.context,
-# episodes.summary, procedures.steps_text. Mirrors fetch_candidate_content
-# in nous/brain/backfill_rerank.py but inline here to keep the audit tool
-# free of brain-internal imports.
+# #354: single source of truth — derive the per-type content mapping from the
+# densifier's _ENTITY_CONFIG so the judge sees EXACTLY what the densifier
+# embeds/links on. The previous hand-rolled mapping had drifted on every
+# non-fact type (decision read `context`, NULL for ~34% of prod decisions,
+# while the densifier reads `description`; episode missed the F058 COALESCE;
+# procedure used a different expr; chunk was absent entirely, so chunk edges
+# were silently skipped). Exprs use the `t.` alias — the hydration query
+# below aliases the table accordingly.
 _CONTENT_BY_TYPE: dict[str, tuple[str, str]] = {
-    "fact": ("heart.facts", "content"),
-    "decision": ("brain.decisions", "context"),
-    "episode": ("heart.episodes", "summary"),
-    "procedure": ("heart.procedures", "name || ': ' || description"),
+    etype: (table, content_expr)
+    for etype, (table, _type_name, content_expr, _extra) in _ENTITY_CONFIG.items()
 }
 
 
@@ -129,9 +132,9 @@ async def _sample_edges_per_type(
             id_list = list(ids)
             params2 = {f"id_{i}": cid for i, cid in enumerate(id_list)}
             rows = await session.execute(text(f"""
-                SELECT id, {content_expr} AS content
-                FROM {table}
-                WHERE id IN ({placeholders})
+                SELECT t.id, {content_expr} AS content
+                FROM {table} t
+                WHERE t.id IN ({placeholders})
             """), params2)
             for row in rows:
                 content_map[(entity_type, str(row.id))] = row.content or ""

--- a/tests/test_edge_audit_regression.py
+++ b/tests/test_edge_audit_regression.py
@@ -15,7 +15,9 @@ from pathlib import Path
 
 import pytest
 
+from nous.brain._entity_config import _ENTITY_CONFIG
 from nous_eval.run_edge_audit import (
+    _CONTENT_BY_TYPE,
     _autodetect_prior_baseline,
     _check_regressions,
     _load_prior_precisions,
@@ -26,6 +28,30 @@ from nous_eval.run_edge_audit import (
 def tmpreports():
     with tempfile.TemporaryDirectory() as d:
         yield Path(d)
+
+
+class TestContentMappingSharedWithDensifier:
+    """#354: the audit must read EXACTLY what the densifier reads — the two
+    mappings drifted once (audit read decisions.context, densifier reads
+    description) and F054 was tuned on the resulting noise."""
+
+    def test_mapping_derived_from_entity_config(self):
+        assert set(_CONTENT_BY_TYPE) == set(_ENTITY_CONFIG)
+        for etype, (table, _tn, content_expr, _extra) in _ENTITY_CONFIG.items():
+            assert _CONTENT_BY_TYPE[etype] == (table, content_expr), (
+                f"audit content mapping for '{etype}' drifted from _ENTITY_CONFIG"
+            )
+
+    def test_decision_reads_description_not_context(self):
+        table, expr = _CONTENT_BY_TYPE["decision"]
+        assert table == "brain.decisions"
+        assert "description" in expr
+        assert "context" not in expr
+
+    def test_chunk_type_present(self):
+        # The old hand-rolled mapping lacked chunk — chunk edges were
+        # silently dropped from every audit.
+        assert "chunk" in _CONTENT_BY_TYPE
 
 
 def _make_baseline(path: Path, precisions: dict[str, float], n: int = 30) -> None:


### PR DESCRIPTION
Closes #354.

## Problem
`run_edge_audit.py` hand-rolled its entity→content mapping and it drifted from the densifier's `_ENTITY_CONFIG` on **every non-fact type** — worse than the issue reported:

| type | audit read | densifier reads |
|---|---|---|
| decision | `context` (NULL for ~34% of decisions) | `description` |
| episode | `summary` | F058 `COALESCE(structured_summary->>'summary', summary)` |
| procedure | `name \|\| ': ' \|\| description` | `description` |
| chunk | **absent** — chunk edges silently skipped | `content` |

The Apr-26 audit fed the LLM judge empty `context` for decisions that had real `description` content, and F054's threshold relaxation was tuned on that noise.

## Fix
`_CONTENT_BY_TYPE` is now **derived** from `_ENTITY_CONFIG` (same import `density_eval.py` already uses); the hydration query aliases the table as `t` to match the shared exprs. No densifier changes — the audit aligns to the densifier, never vice versa (densifier exprs feed backfill embeddings; changing those is out of scope).

## Tests
3 new drift-lock tests in `test_edge_audit_regression.py`. 16/16 pass.

## Follow-on (issue acceptance items 3–4, not in this PR)
Re-run the edge audit with the corrected mapping and re-confirm/revise F054's `NOUS_CE_BACKFILL_THRESHOLD_*` relaxation — eval-DB run, tracked after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)