### PR TITLE
fix(#379): NO PADDING RULE — summary length scales with transcript

### DIFF
--- a/nous/handlers/episode_summarizer.py
+++ b/nous/handlers/episode_summarizer.py
@@ -36,10 +36,12 @@ Transcript:
 
 CRITICAL FAITHFULNESS RULE (F056 #379): Only include claims directly supported by the transcript above. Do NOT invent user motivation, prior session context, or success criteria that are not literally in the transcript. If the transcript is primarily an assistant action (e.g. "I sent X", "I booked Y", "I added a reminder"), summarize what was DONE — do not speculate about why the user wanted it.
 
+NO PADDING RULE (#379): summary length must scale with the transcript. A short transcript (one or two exchanges) gets a 1-3 sentence summary — nothing more. NEVER pad with meta-commentary: do not describe what the transcript does NOT contain ("no additional context was provided", "no details such as X were specified"), do not characterize the interaction itself ("brief and transactional", "a single request followed by a confirmation"), and do not restate the same fact in different words. Every sentence must restate content literally present in the transcript.
+
 Return ONLY valid JSON (no markdown, no explanation):
 {{
   "title": "<5-10 word descriptive title focusing on WHAT WAS ACCOMPLISHED>",
-  "summary": "<100-150 word prose summary. Faithful to the transcript only. For assistant-action transcripts, describe the action(s) the assistant took.>",
+  "summary": "<prose summary, up to 150 words for substantial transcripts, 1-3 sentences for short ones. Faithful to the transcript only. For assistant-action transcripts, describe the action(s) the assistant took.>",
   "key_points": [
     "<lesson or reusable knowledge that IS supported by the transcript — NOT speculation>",
     "<pattern or insight that would help in similar future situations, only if it appears in the transcript>"


### PR DESCRIPTION
Closes #379.

## Root cause (final residual)
The F056 faithfulness rule (already shipped) fixed invented motivation, but the prompt's **100–150-word floor** still forced the summarizer to pad 2-line transcripts with meta-commentary ('no additional context was provided', 'brief and transactional') — exactly what the Haiku judge scores as unsupported claims. 6/13 single-session-assistant rows sat at faithfulness=0.

## Fix (prompt-only, 2 lines)
- Summary length scales with the transcript: 1–3 sentences for short ones, up to 150 words for substantial ones.
- NO PADDING RULE: never describe absent content, never characterize the interaction itself, never restate a fact in different words.

## Eval evidence (80-row F056 fixture, Haiku judge, fresh migrated `nous_eval_summary` DB)
| type | Apr-28 baseline | pre-fix today | post-fix |
|---|---|---|---|
| **single-session-assistant** | 0.051 | 0.321 | **0.607** ✅ (target >0.5) |
| temporal-reasoning | 0.145 | 0.375 | 0.685 |
| knowledge-update | 0.263 | 0.649 | 0.780 |
| single-session-user | 0.377 | 0.782 | 0.962 |
| multi-session | 0.412 | 0.718 | 0.859 |
| single-session-preference | 0.781 | 0.936 | 0.795 |
| **overall** | 0.303 | 0.611 | **0.778** |

All six types beat the issue's baseline — acceptance met ('single-session-assistant > 0.5 without regressing the other 5 question types'). Reports: `reports/handlers/summary-20260610-145528.md` (pre) / `summary-20260610-151822.md` (post).

🤖 Generated with [Claude Code](https://claude.com/claude-code)