### PR TITLE
fix(heartbeat): tuner direction metadata for volume-type params

### DIFF
--- a/nous/heartbeat/checks.py
+++ b/nous/heartbeat/checks.py
@@ -50,10 +50,21 @@ class HealthCheck(BaseCheck):
         self._brain = brain
         self.interval = settings.heartbeat_health_interval
         self._params = {
-            "stale_decision_days": TunableParam("stale_decision_days", 7, 3, 30, 1),
+            # increases_findings: raising stale_decision_days WIDENS the
+            # created_at >= cutoff window in Brain.get_unreviewed → more
+            # findings. stale_fact_days is the opposite (older_than filter).
+            "stale_decision_days": TunableParam(
+                "stale_decision_days", 7, 3, 30, 1, increases_findings=True
+            ),
             "stale_fact_days": TunableParam("stale_fact_days", 30, 7, 90, 5),
-            "low_effectiveness_threshold": TunableParam("low_effectiveness_threshold", 0.5, 0.3, 0.8, 0.05),
-            "max_findings_per_run": TunableParam("max_findings_per_run", 10, 3, 25, 1),
+            # Raising the threshold flags MORE procedures (effectiveness < t).
+            "low_effectiveness_threshold": TunableParam(
+                "low_effectiveness_threshold", 0.5, 0.3, 0.8, 0.05,
+                increases_findings=True,
+            ),
+            "max_findings_per_run": TunableParam(
+                "max_findings_per_run", 10, 3, 25, 1, increases_findings=True
+            ),
         }
 
     async def run(self) -> CheckResult:
@@ -194,16 +205,23 @@ class SelfInitiatedCheck(BaseCheck):
         self._prototype_cache: list[list[float]] | None = None
         self._params = {
             "similarity_threshold": TunableParam("similarity_threshold", 0.75, 0.6, 0.9, 0.02),
-            "lookback_days": TunableParam("lookback_days", 14, 3, 30, 1),
-            "max_pending_items": TunableParam("max_pending_items", 5, 2, 15, 1),
+            # Volume params: raising them produces MORE findings (wider
+            # windows / higher caps), so the tuner must move them with
+            # inverted sign — increases_findings=True.
+            "lookback_days": TunableParam(
+                "lookback_days", 14, 3, 30, 1, increases_findings=True
+            ),
+            "max_pending_items": TunableParam(
+                "max_pending_items", 5, 2, 15, 1, increases_findings=True
+            ),
             # #369: upper bound on the age-based promise heuristic (hours).
             # Episodes older than this are too old to be actionable.
-            # pinned=True (codex P2): the generic tuner's relax=+step would
-            # WIDEN this window on noisy feedback — inverted for an upper
-            # bound. Operator-adjustable via the params API; excluded from
-            # auto-tuning until TunableParam grows direction metadata.
+            # Was pinned=True until TunableParam grew direction metadata
+            # (the codex-P2 inversion concern); now tunable with the
+            # correct sign.
             "max_stale_age_hours": TunableParam(
-                "max_stale_age_hours", 336, 72, 720, 24, pinned=True
+                "max_stale_age_hours", 336, 72, 720, 24,
+                increases_findings=True,
             ),
         }
 
@@ -818,7 +836,11 @@ class DriveCheck(BaseCheck):
 
         self._params = {
             "significance_threshold": TunableParam("significance_threshold", 1.0, 0.0, 2.0, 0.5),
-            "cross_reference_lookback_hours": TunableParam("cross_reference_lookback_hours", 48, 6, 168, 6),
+            # Wider lookback → more cross-reference matches → more findings.
+            "cross_reference_lookback_hours": TunableParam(
+                "cross_reference_lookback_hours", 48, 6, 168, 6,
+                increases_findings=True,
+            ),
         }
 
     def _ensure_gdrive(self) -> None:

--- a/nous/heartbeat/registry.py
+++ b/nous/heartbeat/registry.py
@@ -122,6 +122,9 @@ class BaseCheck(ABC):
             name=p.name, value=clamped,
             min_val=p.min_val, max_val=p.max_val,
             step=p.step, pinned=p.pinned,
+            # Must thread through — set_param reconstructs the dataclass,
+            # and dropping the flag would silently reset tuner direction.
+            increases_findings=p.increases_findings,
         )
         return True
 

--- a/nous/heartbeat/schemas.py
+++ b/nous/heartbeat/schemas.py
@@ -108,6 +108,12 @@ class TunableParam:
     max_val: float
     step: float
     pinned: bool = False  # manual override, skip auto-tuning
+    # Direction metadata (2026-06-10): the tuner's "relax" means "produce
+    # FEWER findings". For sensitivity thresholds (similarity_threshold)
+    # that is +step; for volume params (lookback windows, item caps) a
+    # HIGHER value produces MORE findings, so relax must be -step. Without
+    # this flag the tuner moved volume params in the wrong direction.
+    increases_findings: bool = False
 
 
 @dataclass

--- a/nous/heartbeat/tuner.py
+++ b/nous/heartbeat/tuner.py
@@ -140,10 +140,16 @@ class HeartbeatTuner:
         max_step = param_range * 0.1
         step = min(step, max_step)
 
+        # Direction semantics: relax = fewer findings, tighten = more.
+        # For sensitivity thresholds that is +step / -step; for volume
+        # params (increases_findings=True: lookback windows, item caps)
+        # the sign inverts — raising them produces MORE findings.
+        if param.increases_findings:
+            step = -step
         if direction == "relax":
-            new_val = old_val + step  # relax = increase threshold
+            new_val = old_val + step
         elif direction == "tighten":
-            new_val = old_val - step  # tighten = decrease threshold
+            new_val = old_val - step
         else:
             return (old_val, old_val)
 

--- a/tests/test_heartbeat_tuner.py
+++ b/tests/test_heartbeat_tuner.py
@@ -76,6 +76,30 @@ class MultiParamCheck(BaseCheck):
         return CheckResult()
 
 
+class VolumeDummyCheck(BaseCheck):
+    """Check whose single param is volume-type (increases_findings=True) —
+    e.g. a lookback window: raising it produces MORE findings."""
+
+    name = "volume_dummy"
+    interval = 60
+
+    def __init__(self, param_value: float = 5.0) -> None:
+        super().__init__()
+        self._params = {
+            "lookback": TunableParam(
+                name="lookback",
+                value=param_value,
+                min_val=1.0,
+                max_val=10.0,
+                step=1.0,
+                increases_findings=True,
+            ),
+        }
+
+    async def run(self) -> CheckResult:
+        return CheckResult()
+
+
 def _make_store_with_outcomes(
     check_name: str,
     outcomes: list[OutcomeSignal],
@@ -157,6 +181,51 @@ class TestTuningEngine:
         adj = report.adjustments[0]
         assert adj.direction == "tighten"
         assert adj.new_value < adj.old_value  # tighten = decrease
+
+    @pytest.mark.asyncio
+    async def test_relax_decreases_volume_param(self):
+        """Direction metadata (2026-06-10): for increases_findings=True
+        params (lookback windows, item caps), 'relax' (fewer findings)
+        must DECREASE the value — the generic +step was inverted."""
+        outcomes = [OutcomeSignal.NEGATIVE] * 7 + [OutcomeSignal.POSITIVE] * 3
+        store = _make_store_with_outcomes("volume_dummy", outcomes)
+        registry = CheckRegistry()
+        registry.register(VolumeDummyCheck(param_value=5.0))
+
+        tuner = HeartbeatTuner()
+        report = await tuner.tune(store, registry)
+
+        assert len(report.adjustments) >= 1
+        adj = report.adjustments[0]
+        assert adj.direction == "relax"
+        assert adj.new_value < adj.old_value  # relax = narrower window
+
+    @pytest.mark.asyncio
+    async def test_tighten_increases_volume_param(self):
+        """Mirror: 'tighten' (catch more) must INCREASE a volume param."""
+        outcomes = [OutcomeSignal.POSITIVE] * 9 + [OutcomeSignal.NEGATIVE] * 1
+        store = _make_store_with_outcomes("volume_dummy", outcomes)
+        registry = CheckRegistry()
+        registry.register(VolumeDummyCheck(param_value=5.0))
+
+        tuner = HeartbeatTuner()
+        report = await tuner.tune(store, registry)
+
+        assert len(report.adjustments) >= 1
+        adj = report.adjustments[0]
+        assert adj.direction == "tighten"
+        assert adj.new_value > adj.old_value  # tighten = wider window
+
+    def test_set_param_preserves_direction_flag(self):
+        """set_param reconstructs TunableParam — the direction flag must
+        survive or the tuner silently reverts to the inverted behavior
+        after the first adjustment."""
+        check = VolumeDummyCheck(param_value=5.0)
+        assert check.set_param("lookback", 6.0) is True
+        p = check.get_param("lookback")
+        assert p is not None
+        assert p.value == 6.0
+        assert p.increases_findings is True
 
     @pytest.mark.asyncio
     async def test_no_change_on_balanced(self):


### PR DESCRIPTION
Surfaced during #369 (codex flagged the inversion would hit the new `max_stale_age_hours` param; investigation showed the same inversion has affected `lookback_days` and `max_pending_items` since F034.3 shipped).

## Problem
`HeartbeatTuner._apply_adjustment` applies `relax = +step` / `tighten = −step` to every param. 'Relax' means *produce fewer findings* — correct for sensitivity thresholds, **inverted** for volume params: raising a lookback window or an item cap produces MORE findings. On >60% negative feedback the tuner widened exactly the params it meant to narrow.

## Fix
- `TunableParam.increases_findings: bool = False` — direction metadata
- tuner flips the step sign when set
- `BaseCheck.set_param` threads the flag through its dataclass reconstruction (would otherwise silently reset after the first adjustment)
- params marked per **verified usage** (each checked against the consuming query/cap, citations in comments); ambiguous ones deliberately left default
- `max_stale_age_hours` un-pinned — the #369 pin existed only because this metadata didn't exist (note: `pinned` also blocked operator `set_param`, so un-pinning restores runtime adjustability too)

## Exposure
Low in prod today (`NOUS_HEARTBEAT_TUNING_ENABLED` defaults false), but anyone flipping tuning on would get a self-defeating loop on the SelfInitiated and Health checks.

## Tests
3 new (volume relax decreases / tighten increases / set_param preserves flag). 138/138 heartbeat tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)