### PR TITLE
test: fix 14 pre-existing failures (py3.14 event loop + .env contamination)

### DIFF
--- a/tests/test_compaction_phase2.py
+++ b/tests/test_compaction_phase2.py
@@ -208,7 +208,7 @@ class TestCompact:
         messages = _make_messages(conv)
         mock_api = _mock_call_api()
 
-        asyncio.get_event_loop().run_until_complete(
+        asyncio.run(
             compactor.compact(conv, messages, call_api=mock_api, cut_point=10)
         )
 
@@ -229,7 +229,7 @@ class TestCompact:
         conv = _make_conversation(2)
         messages = _make_messages(conv)
         try:
-            asyncio.get_event_loop().run_until_complete(
+            asyncio.run(
                 compactor.compact(conv, messages, call_api=AsyncMock(), cut_point=0)
             )
             assert False, "Should have raised"
@@ -242,7 +242,7 @@ class TestCompact:
         messages = _make_messages(conv)
         messages.append({"role": "user", "content": "extra"})  # Misalign
         try:
-            asyncio.get_event_loop().run_until_complete(
+            asyncio.run(
                 compactor.compact(conv, messages, call_api=AsyncMock(), cut_point=2)
             )
             assert False, "Should have raised"
@@ -256,7 +256,7 @@ class TestCompact:
         messages = _make_messages(conv)
         mock_api = AsyncMock(side_effect=RuntimeError("API down"))
 
-        asyncio.get_event_loop().run_until_complete(
+        asyncio.run(
             compactor.compact(conv, messages, call_api=mock_api, cut_point=10)
         )
 
@@ -273,7 +273,7 @@ class TestCompact:
         # structured path return None and fall through.
         mock_api = _mock_call_api(summary_text="too short", with_tool_use=False)
 
-        asyncio.get_event_loop().run_until_complete(
+        asyncio.run(
             compactor.compact(conv, messages, call_api=mock_api, cut_point=10)
         )
 
@@ -291,7 +291,7 @@ class TestCompact:
         messages = _make_messages(conv)
         mock_api = _mock_call_api()
 
-        asyncio.get_event_loop().run_until_complete(
+        asyncio.run(
             compactor.compact(conv, messages, call_api=mock_api, cut_point=12)
         )
 
@@ -316,7 +316,7 @@ class TestCompact:
         mock_api = _mock_call_api()
 
         # Cut at index 4 (only assistant message remains)
-        asyncio.get_event_loop().run_until_complete(
+        asyncio.run(
             compactor.compact(conv, messages, call_api=mock_api, cut_point=4)
         )
 
@@ -331,7 +331,7 @@ class TestCompact:
         messages = _make_messages(conv)
         mock_api = _mock_call_api()
 
-        asyncio.get_event_loop().run_until_complete(
+        asyncio.run(
             compactor.compact(conv, messages, call_api=mock_api, cut_point=10)
         )
         assert conv.compaction_count == 1
@@ -356,7 +356,7 @@ class TestCompact:
         messages = _make_messages(conv)
         mock_api = _mock_call_api()
 
-        asyncio.get_event_loop().run_until_complete(
+        asyncio.run(
             compactor.compact(conv, messages, call_api=mock_api, cut_point=10)
         )
 

--- a/tests/test_f066_1_llm_dispatch.py
+++ b/tests/test_f066_1_llm_dispatch.py
@@ -353,12 +353,15 @@ class TestOrchestratorLLMDispatch:
         llm_client = MagicMock()
         llm_client.call = AsyncMock(return_value=_llm_response("skip_and_continue"))
 
-        # Default settings: flag is False.
+        # Default settings: flag is False. _env_file=None — the repo .env
+        # sets NOUS_DAG_FIX_LLM_DISPATCH_ENABLED=true, which would turn
+        # this flag-OFF test into a flag-ON run (the mock's
+        # skip_and_continue then marks the parent 'skipped').
         orch = DAGOrchestrator(
             store=store,
             subtask_mgr=subtask_mgr,
             dynamic_loader=dynamic_loader,
-            settings=Settings(),
+            settings=Settings(_env_file=None),
             llm_client=llm_client,
         )
 

--- a/tests/test_f066_1_llm_dispatch.py
+++ b/tests/test_f066_1_llm_dispatch.py
@@ -353,15 +353,16 @@ class TestOrchestratorLLMDispatch:
         llm_client = MagicMock()
         llm_client.call = AsyncMock(return_value=_llm_response("skip_and_continue"))
 
-        # Default settings: flag is False. _env_file=None — the repo .env
-        # sets NOUS_DAG_FIX_LLM_DISPATCH_ENABLED=true, which would turn
-        # this flag-OFF test into a flag-ON run (the mock's
+        # Flag explicitly OFF: the repo .env sets
+        # NOUS_DAG_FIX_LLM_DISPATCH_ENABLED=true (and a process-level
+        # export would survive _env_file=None — codex P2), which would
+        # turn this flag-OFF test into a flag-ON run (the mock's
         # skip_and_continue then marks the parent 'skipped').
         orch = DAGOrchestrator(
             store=store,
             subtask_mgr=subtask_mgr,
             dynamic_loader=dynamic_loader,
-            settings=Settings(_env_file=None),
+            settings=Settings(_env_file=None, dag_fix_llm_dispatch_enabled=False),
             llm_client=llm_client,
         )
 

--- a/tests/test_model_aware_compaction.py
+++ b/tests/test_model_aware_compaction.py
@@ -3,6 +3,23 @@
 from nous.cognitive.schemas import MODEL_CONTEXT_WINDOWS
 from nous.config import Settings
 
+# Env vars that override the dynamic computation under test. _env_file=None
+# shields against the repo .env, but NOT against process-level exports
+# (codex P2 on PR #508) — and compaction_threshold/keep_recent_tokens are
+# explicit-set-tracked via model_fields_set, so they cannot be neutralized
+# by passing defaults; they must be absent from the environment entirely.
+_OVERRIDE_VARS = (
+    "NOUS_CONTEXT_WINDOW",
+    "NOUS_COMPACTION_THRESHOLD",
+    "NOUS_KEEP_RECENT_TOKENS",
+)
+
+
+def _clean_settings(monkeypatch, **kwargs) -> Settings:
+    for var in _OVERRIDE_VARS:
+        monkeypatch.delenv(var, raising=False)
+    return Settings(_env_file=None, **kwargs)
+
 
 class TestModelContextWindows:
     def test_1m_models(self):
@@ -14,38 +31,42 @@ class TestModelContextWindows:
 
 
 class TestEffectiveThresholds:
-    def test_dynamic_threshold_1m_model(self):
-        s = Settings(_env_file=None, model="claude-sonnet-4-6-20250514")
+    def test_dynamic_threshold_1m_model(self, monkeypatch):
+        s = _clean_settings(monkeypatch, model="claude-sonnet-4-6-20250514")
         assert s.effective_compaction_threshold == 600_000
         assert s.effective_keep_recent == 200_000
 
-    def test_dynamic_threshold_200k_model(self):
-        s = Settings(_env_file=None, model="claude-sonnet-4-5-20250514")
+    def test_dynamic_threshold_200k_model(self, monkeypatch):
+        s = _clean_settings(monkeypatch, model="claude-sonnet-4-5-20250514")
         assert s.effective_compaction_threshold == 120_000
         assert s.effective_keep_recent == 40_000
 
-    def test_explicit_override_takes_priority(self):
-        s = Settings(
-            _env_file=None,
+    def test_explicit_override_takes_priority(self, monkeypatch):
+        s = _clean_settings(
+            monkeypatch,
             model="claude-sonnet-4-6-20250514",
             NOUS_COMPACTION_THRESHOLD="50000",
         )
         assert s.effective_compaction_threshold == 50_000
 
-    def test_unknown_model_defaults_200k(self):
-        s = Settings(_env_file=None, model="some-unknown-model")
+    def test_unknown_model_defaults_200k(self, monkeypatch):
+        s = _clean_settings(monkeypatch, model="some-unknown-model")
         assert s.effective_compaction_threshold == 120_000
 
-    def test_longest_key_first_matching(self):
+    def test_longest_key_first_matching(self, monkeypatch):
         """Ensure 'claude-sonnet-4-5' matches before 'claude-sonnet-4-6' for model claude-sonnet-4-5-20250514."""
-        s = Settings(_env_file=None, model="claude-sonnet-4-5-20250514")
+        s = _clean_settings(monkeypatch, model="claude-sonnet-4-5-20250514")
         assert s.effective_compaction_threshold == 120_000  # 200K * 0.6, not 1M * 0.6
 
 
 class TestShouldCompactUsesEffective:
-    def test_should_compact_uses_effective_threshold(self):
+    def test_should_compact_uses_effective_threshold(self, monkeypatch):
         from nous.api.compaction import ConversationCompactor
-        s = Settings(_env_file=None, model="claude-sonnet-4-6-20250514", NOUS_COMPACTION_ENABLED="true")
+        s = _clean_settings(
+            monkeypatch,
+            model="claude-sonnet-4-6-20250514",
+            NOUS_COMPACTION_ENABLED="true",
+        )
         c = ConversationCompactor(s)
         # With 1M model, threshold is 600K
         assert not c.should_compact(10_000, 100_000)  # 110K < 600K

--- a/tests/test_model_aware_compaction.py
+++ b/tests/test_model_aware_compaction.py
@@ -15,36 +15,37 @@ class TestModelContextWindows:
 
 class TestEffectiveThresholds:
     def test_dynamic_threshold_1m_model(self):
-        s = Settings(model="claude-sonnet-4-6-20250514")
+        s = Settings(_env_file=None, model="claude-sonnet-4-6-20250514")
         assert s.effective_compaction_threshold == 600_000
         assert s.effective_keep_recent == 200_000
 
     def test_dynamic_threshold_200k_model(self):
-        s = Settings(model="claude-sonnet-4-5-20250514")
+        s = Settings(_env_file=None, model="claude-sonnet-4-5-20250514")
         assert s.effective_compaction_threshold == 120_000
         assert s.effective_keep_recent == 40_000
 
     def test_explicit_override_takes_priority(self):
         s = Settings(
+            _env_file=None,
             model="claude-sonnet-4-6-20250514",
             NOUS_COMPACTION_THRESHOLD="50000",
         )
         assert s.effective_compaction_threshold == 50_000
 
     def test_unknown_model_defaults_200k(self):
-        s = Settings(model="some-unknown-model")
+        s = Settings(_env_file=None, model="some-unknown-model")
         assert s.effective_compaction_threshold == 120_000
 
     def test_longest_key_first_matching(self):
         """Ensure 'claude-sonnet-4-5' matches before 'claude-sonnet-4-6' for model claude-sonnet-4-5-20250514."""
-        s = Settings(model="claude-sonnet-4-5-20250514")
+        s = Settings(_env_file=None, model="claude-sonnet-4-5-20250514")
         assert s.effective_compaction_threshold == 120_000  # 200K * 0.6, not 1M * 0.6
 
 
 class TestShouldCompactUsesEffective:
     def test_should_compact_uses_effective_threshold(self):
         from nous.api.compaction import ConversationCompactor
-        s = Settings(model="claude-sonnet-4-6-20250514", NOUS_COMPACTION_ENABLED="true")
+        s = Settings(_env_file=None, model="claude-sonnet-4-6-20250514", NOUS_COMPACTION_ENABLED="true")
         c = ConversationCompactor(s)
         # With 1M model, threshold is 600K
         assert not c.should_compact(10_000, 100_000)  # 110K < 600K


### PR DESCRIPTION
No production code changes. Three root causes:

| File | Count | Cause | Fix |
|---|---|---|---|
| `test_compaction_phase2.py` | 9 | `asyncio.get_event_loop().run_until_complete` raises on Python 3.14 (implicit loop creation removed) | `asyncio.run()` |
| `test_model_aware_compaction.py` | 4 | bare `Settings(model=…)` loads the repo `.env` — `NOUS_CONTEXT_WINDOW=700000` overrides the dynamic threshold under test (0.6×700000 = the observed 420000) | `_env_file=None` on every construction |
| `test_f066_1_llm_dispatch.py` | 1 | flag-OFF test read `NOUS_DAG_FIX_LLM_DISPATCH_ENABLED=true` from `.env`, becoming a flag-ON run (mock chose `skip_and_continue` → `skipped`) | `Settings(_env_file=None)` |

All 14 verified failing on clean main (byte-identical with the branch stashed); 104/104 across the four files after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)