### PR TITLE
test: fix CI-red event-bus test (template-size coupling + MagicMock chunk gate)

### DIFF
--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -61,6 +61,10 @@ def _mock_settings(**overrides) -> MagicMock:
     s.sleep_enabled = True
     s.transcript_max_chars = 16000
     s.fact_dedup_threshold = 0.92
+    # Bare-MagicMock footgun: episode_chunks_enabled would return a truthy
+    # Mock, sending the summarizer into the F067 chunking path with Mock
+    # numeric settings (TypeError in chunk_text).
+    s.episode_chunks_enabled = False
     for k, v in overrides.items():
         setattr(s, k, v)
     return s
@@ -435,12 +439,17 @@ class TestEpisodeSummarizer:
 
         # Long transcript gets chunked — at least one LLM call should have been made
         assert len(captured_payloads) >= 1
-        # Each chunk's transcript portion in the prompt should be within budget
+        # Each chunk's TRANSCRIPT portion must be within the 8000-char budget.
+        # Asserted via the transcript's 'x' filler (12000 x's total) rather
+        # than total prompt length — the old `len(prompt) < len(transcript)`
+        # bound coupled the assertion to the template size and broke
+        # whenever the summary prompt grew (PR #506 NO PADDING RULE).
         for payload in captured_payloads:
             user_msg = payload["messages"][0]["content"]
             if isinstance(user_msg, list):
                 user_msg = user_msg[0]["text"]
-            assert len(user_msg) < len(long_transcript)
+            # small slack for incidental x's in the prompt template
+            assert user_msg.count("x") <= 8000 + 200
 
     @pytest.mark.asyncio
     async def test_summary_includes_new_fields(self):

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -439,17 +439,24 @@ class TestEpisodeSummarizer:
 
         # Long transcript gets chunked — at least one LLM call should have been made
         assert len(captured_payloads) >= 1
-        # Each chunk's TRANSCRIPT portion must be within the 8000-char budget.
-        # Asserted via the transcript's 'x' filler (12000 x's total) rather
-        # than total prompt length — the old `len(prompt) < len(transcript)`
-        # bound coupled the assertion to the template size and broke
-        # whenever the summary prompt grew (PR #506 NO PADDING RULE).
+        # Each chunk's TRANSCRIPT slice must be within the 8000-char budget.
+        # Measured by extracting the slice between the prompt's template
+        # anchors ("Transcript:" .. the faithfulness rule) and asserting its
+        # FULL length (labels + separators included — codex P2 on PR #509),
+        # rather than total prompt length: the old
+        # `len(prompt) < len(transcript)` bound coupled the assertion to the
+        # template size and broke whenever the summary prompt grew (#506).
         for payload in captured_payloads:
             user_msg = payload["messages"][0]["content"]
             if isinstance(user_msg, list):
                 user_msg = user_msg[0]["text"]
-            # small slack for incidental x's in the prompt template
-            assert user_msg.count("x") <= 8000 + 200
+            assert "Transcript:" in user_msg
+            transcript_slice = user_msg.split("Transcript:", 1)[1].split(
+                "CRITICAL FAITHFULNESS RULE", 1
+            )[0]
+            # small slack for surrounding template whitespace / an empty
+            # decision-context block between the anchors
+            assert len(transcript_slice) <= 8000 + 100
 
     @pytest.mark.asyncio
     async def test_summary_includes_new_fields(self):

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -454,9 +454,10 @@ class TestEpisodeSummarizer:
             transcript_slice = user_msg.split("Transcript:", 1)[1].split(
                 "CRITICAL FAITHFULNESS RULE", 1
             )[0]
-            # small slack for surrounding template whitespace / an empty
-            # decision-context block between the anchors
-            assert len(transcript_slice) <= 8000 + 100
+            # strip() removes the fixed surrounding template newlines, so
+            # the budget can be asserted EXACTLY (codex round 3) — any
+            # over-budget chunk fails.
+            assert len(transcript_slice.strip()) <= 8000
 
     @pytest.mark.asyncio
     async def test_summary_includes_new_fields(self):


### PR DESCRIPTION
CI on main has been red since PR #506. Root cause: `test_truncates_long_transcripts` asserted `len(prompt) < len(transcript)` — a bound coupled to the summary **template** size. The #379 NO PADDING RULE grew the template ~430 chars, pushing the prompt 216 chars past the bound (`12684 < 12468`).

**Fix:** assert what the test means — each chunk's *transcript portion* is within the 8000-char budget, measured by counting the transcript's `x` filler (+200 slack for incidental template x's). Robust to any future prompt growth.

**Bonus latent bug exposed by the failure:** `_mock_settings` is a bare MagicMock, so `episode_chunks_enabled` returned a truthy Mock → the F067 chunking path ran with Mock numeric settings (`TypeError: '<' not supported between 'int' and 'MagicMock'`). Now pinned False (the recurring bare-MagicMock-Settings footgun).

**Process note:** I merged #505–#508 on local-scope tests + codex review without checking CI — this PR also restores that gate; full local suite run is in progress and gates the merge.

70/70 `test_event_bus.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)