### PR TITLE
fix: recall_recent reads structured summaries (parity with recall_deep) + unsummarized marker

### DIFF
--- a/nous/api/tools.py
+++ b/nous/api/tools.py
@@ -914,11 +914,21 @@ def create_nous_tools(brain: Brain, heart: Heart, settings: Settings | None = No
 
             lines = [f"Recent episodes (last {hours}h):"]
             for e in episodes:
-                title = e.title or (e.summary[:60] if e.summary else "Untitled")
+                # Prefer the summarizer's output over the legacy columns —
+                # mirrors recall_deep's COALESCE(structured_summary->>'summary',
+                # summary). For un-summarized episodes the legacy `summary` is
+                # the raw creation-time echo (often the first user message);
+                # the title-line marker keeps it from masquerading as a
+                # produced summary (short echoes BECOME the title, so a
+                # body-line suffix would not always be visible).
+                structured = e.structured_summary or {}
+                body = structured.get("summary") or e.summary
+                title = structured.get("title") or e.title or (body[:60] if body else "Untitled")
+                marker = "" if structured.get("summary") else " (unsummarized)"
                 time_str = e.started_at.strftime("%b %d %H:%M")
-                lines.append(f"- [{time_str}] {title}")
-                if e.summary and e.summary != e.title:
-                    lines.append(f"  {e.summary[:150]}")
+                lines.append(f"- [{time_str}] {title}{marker}")
+                if body and body != title:
+                    lines.append(f"  {body[:150]}")
 
             return {"content": [{"type": "text", "text": "\n".join(lines)}]}
 

--- a/nous/heart/episodes.py
+++ b/nous/heart/episodes.py
@@ -393,6 +393,11 @@ class EpisodeManager:
                 outcome=e.outcome,
                 started_at=e.started_at,
                 tags=e.tags or [],
+                # Without this, consumers (recall_recent) can only show the
+                # legacy creation-time echo even for summarized episodes —
+                # the recall_deep parent-episode path already COALESCEs to
+                # structured_summary->>'summary' (tools.py, codex fix).
+                structured_summary=e.structured_summary,
             )
             for e in episodes
         ]

--- a/tests/test_recall_recent_structured.py
+++ b/tests/test_recall_recent_structured.py
@@ -1,0 +1,65 @@
+"""recall_recent must prefer the summarizer's structured summary (parity
+with recall_deep's COALESCE(structured_summary->>'summary', summary) — the
+codex fix that never reached this tool) and must mark un-summarized
+episodes' raw creation echo as such."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+from nous.api.tools import create_nous_tools
+from nous.heart.schemas import EpisodeSummary
+
+
+def _episode(summary: str, title: str | None, structured: dict | None) -> EpisodeSummary:
+    return EpisodeSummary(
+        id=uuid4(),
+        title=title,
+        summary=summary,
+        outcome="success",
+        started_at=datetime(2026, 6, 10, 12, 0, tzinfo=UTC),
+        tags=[],
+        structured_summary=structured,
+    )
+
+
+def _make_tool(episodes: list[EpisodeSummary]):
+    heart = MagicMock()
+    heart.list_episodes = AsyncMock(return_value=episodes)
+    brain = MagicMock()
+    tools = create_nous_tools(brain, heart)
+    return tools["recall_recent"]
+
+
+def _text(resp: dict) -> str:
+    return resp["content"][0]["text"]
+
+
+def test_summarized_episode_prefers_structured_summary():
+    ep = _episode(
+        summary="hey can you check the deploy?",  # raw creation echo
+        title=None,
+        structured={"title": "Deploy verification", "summary": "Verified the prod deploy and confirmed all services healthy."},
+    )
+    text = _text(asyncio.run(_make_tool([ep])(hours=48)))
+    assert "Deploy verification" in text
+    assert "Verified the prod deploy" in text
+    assert "hey can you check the deploy?" not in text
+    assert "(unsummarized)" not in text
+
+
+def test_unsummarized_episode_marks_raw_echo():
+    ep = _episode(
+        summary="hey can you check the deploy?",
+        title=None,
+        structured=None,
+    )
+    text = _text(asyncio.run(_make_tool([ep])(hours=48)))
+    # Legacy behavior preserved (echo still shown) but flagged so it can't
+    # masquerade as a produced summary — on the TITLE line, since a short
+    # echo becomes the title itself.
+    assert "hey can you check the deploy?" in text
+    assert "(unsummarized)" in text


### PR DESCRIPTION
User-reported gap: `recall_deep`'s parent-episode path was codex-patched to `COALESCE(structured_summary->>'summary', summary)` (tools.py:205-209), but `recall_recent` (tools.py:915+) never got the same fix — it reads legacy `e.title`/`e.summary` directly. For summarized episodes the columns converge, so it's invisible; for un-summarized episodes the raw creation echo surfaces with zero placeholder signal (which is exactly what masqueraded as a #379 NO-PADDING failure).

**Validation found it one layer deeper:** `episodes._list_recent` never populated `structured_summary` on `EpisodeSummary` at all — the schema field existed but stayed `None`, so the tool couldn't prefer it even in principle.

## Fix
- `_list_recent` populates `structured_summary`
- `recall_recent` prefers structured `title`/`summary`; un-summarized episodes get ` (unsummarized)` on the **title line** (short echoes become the title, so a body-line suffix wouldn't always be visible)

## Tests
`test_recall_recent_structured.py`: structured preferred over echo / echo shown but marked. 11/11 across the episode-rendering files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)