### PR TITLE
fix: audit Batch 0 — mechanical hardening (AS-3/6/7/10, CR-7, R-11)

### DIFF
--- a/nous/api/mcp.py
+++ b/nous/api/mcp.py
@@ -234,7 +234,9 @@ def create_mcp_server(
     async def _handle_recall(args: dict) -> list[TextContent]:
         query = args["query"]
         memory_type = args.get("memory_type", "all")
-        limit = args.get("limit", 5)
+        # AS-10: cap caller-supplied limit so a hostile/buggy client can't
+        # request an unbounded expensive recall.
+        limit = min(int(args.get("limit", 5)), 100)
 
         results: list[dict] = []
 

--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -787,7 +787,10 @@ async def _apply_graph_adjacency_boost(
                 "  AND target_id = ANY(CAST(:ids AS uuid[]))"
             ), {"a": brain.agent_id, "ids": candidate_ids})).all()
     except Exception:
-        return results  # fail-open — adjacency boost is a refinement
+        # R-11: fail-open (boost is a refinement) but log — previously silent,
+        # so a broken graph table degraded ranking with no operator signal.
+        logger.warning("Adjacency boost failed; returning unboosted results", exc_info=True)
+        return results
 
     degree: dict[str, float] = {}
     for src, tgt, w in rows:

--- a/nous/api/telegram_tools.py
+++ b/nous/api/telegram_tools.py
@@ -6,6 +6,7 @@ via sendPhoto (images) and sendDocument (everything else).
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from typing import Any
@@ -15,6 +16,12 @@ import httpx
 from nous.config import Settings
 
 logger = logging.getLogger(__name__)
+
+
+def _read_bytes(path: str) -> bytes:
+    """Read a file's bytes (run off-loop via asyncio.to_thread — AS-6)."""
+    with open(path, "rb") as f:
+        return f.read()
 
 # Telegram Bot API base URL
 _TG_API = "https://api.telegram.org/bot{token}/{method}"
@@ -89,6 +96,14 @@ def create_send_file_tool(settings: Settings, http_client: httpx.AsyncClient):
         target_chat = chat_id or settings.telegram_chat_id
         if not target_chat:
             return _error("No chat_id provided and NOUS_TELEGRAM_CHAT_ID not configured.")
+        # AS-3: outbound recipient allowlist. When a default chat is configured,
+        # an explicit chat_id must match it — prevents file exfiltration to an
+        # arbitrary chat if the tool call is manipulated.
+        if (
+            settings.telegram_chat_id
+            and str(target_chat) != str(settings.telegram_chat_id)
+        ):
+            return _error("chat_id not permitted; files may only be sent to the configured chat.")
 
         # Validate file exists
         if not os.path.isfile(file_path):
@@ -110,13 +125,14 @@ def create_send_file_tool(settings: Settings, http_client: httpx.AsyncClient):
         url = _TG_API.format(token=token, method=method)
 
         try:
-            with open(file_path, "rb") as f:
-                files = {file_key: (os.path.basename(file_path), f)}
-                data: dict[str, str] = {"chat_id": target_chat}
-                if caption:
-                    data["caption"] = caption
+            # AS-6: read off the event loop so a large/slow file doesn't block it.
+            content = await asyncio.to_thread(_read_bytes, file_path)
+            files = {file_key: (os.path.basename(file_path), content)}
+            data: dict[str, str] = {"chat_id": target_chat}
+            if caption:
+                data["caption"] = caption
 
-                response = await http_client.post(url, files=files, data=data)
+            response = await http_client.post(url, files=files, data=data)
 
             result = response.json()
             if not result.get("ok"):

--- a/nous/api/tool_cache.py
+++ b/nous/api/tool_cache.py
@@ -25,8 +25,12 @@ NON_REFETCHABLE_TOOLS = frozenset({"web_search", "web_fetch"})
 
 
 def compute_hash_key(content: str) -> str:
-    """SHA256 of content, truncated to 16 hex chars."""
-    return hashlib.sha256(content.encode()).hexdigest()[:16]
+    """SHA256 of content, truncated to 32 hex chars (128-bit).
+
+    CR-7: widened from 16 (64-bit) to make same-session collisions — which
+    would return the wrong cached content via cache_retrieve — negligible.
+    """
+    return hashlib.sha256(content.encode()).hexdigest()[:32]
 
 
 async def cache_compressed_result(

--- a/nous/config.py
+++ b/nous/config.py
@@ -215,6 +215,20 @@ class Settings(BaseSettings):
             return json.loads(v)
         return v
 
+    @field_validator("context_budget_overrides", mode="after")
+    @classmethod
+    def _reject_negative_budget_overrides(
+        cls, v: dict[str, int]
+    ) -> dict[str, int]:
+        """AS-7: reject negative budget values — they silently underflow the
+        context budget rather than failing loudly."""
+        for key, val in v.items():
+            if val < 0:
+                raise ValueError(
+                    f"context_budget_overrides[{key!r}]={val} must be >= 0"
+                )
+        return v
+
     # F017: Staleness penalty
     staleness_penalty_enabled: bool = True
     staleness_half_life_days: int = 30

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -67,3 +67,9 @@ class TestContextBudgetOverridesParsing:
         monkeypatch.delenv("NOUS_CONTEXT_BUDGET_OVERRIDES", raising=False)
         s = Settings(_env_file=None, context_budget_overrides={"total": 9000})
         assert s.context_budget_overrides == {"total": 9000}
+
+    def test_negative_value_rejected(self, monkeypatch):
+        # AS-7: negative budgets silently underflow context — reject at load.
+        monkeypatch.setenv("NOUS_CONTEXT_BUDGET_OVERRIDES", '{"total": -1}')
+        with pytest.raises(ValidationError):
+            Settings(_env_file=None)

--- a/tests/test_telegram_tools.py
+++ b/tests/test_telegram_tools.py
@@ -143,15 +143,46 @@ async def test_send_with_caption(tmp_png, mock_settings, mock_http):
 
 
 @pytest.mark.asyncio
-async def test_send_custom_chat_id(tmp_png, mock_settings, mock_http):
+async def test_send_explicit_matching_chat_id(tmp_png, mock_settings, mock_http):
+    # AS-3: an explicit chat_id equal to the configured chat is allowed.
+    from nous.api.telegram_tools import create_send_file_tool
+    mock_http.post = AsyncMock(return_value=_ok_response())
+
+    send_file = create_send_file_tool(mock_settings, mock_http)
+    result = await send_file(file_path=tmp_png, chat_id="12345")
+
+    call_args = mock_http.post.call_args
+    assert call_args.kwargs["data"]["chat_id"] == "12345"
+    assert "sent successfully" in result["content"][0]["text"].lower()
+
+
+@pytest.mark.asyncio
+async def test_send_mismatched_chat_id_rejected(tmp_png, mock_settings, mock_http):
+    # AS-3: a chat_id that differs from the configured chat is rejected
+    # (exfiltration guard); no HTTP call is made.
     from nous.api.telegram_tools import create_send_file_tool
     mock_http.post = AsyncMock(return_value=_ok_response())
 
     send_file = create_send_file_tool(mock_settings, mock_http)
     result = await send_file(file_path=tmp_png, chat_id="99999")
 
-    call_args = mock_http.post.call_args
-    assert call_args.kwargs["data"]["chat_id"] == "99999"
+    assert "not permitted" in result["content"][0]["text"].lower()
+    mock_http.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_uploads_file_bytes(tmp_png, mock_settings, mock_http):
+    # AS-6: the file is read (off-loop) and its bytes are uploaded.
+    from nous.api.telegram_tools import create_send_file_tool
+    mock_http.post = AsyncMock(return_value=_ok_response())
+
+    send_file = create_send_file_tool(mock_settings, mock_http)
+    await send_file(file_path=tmp_png)
+
+    files = mock_http.post.call_args.kwargs["files"]
+    _name, content = files["photo"]
+    assert isinstance(content, bytes)
+    assert content == open(tmp_png, "rb").read()
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_cache.py
+++ b/tests/test_tool_cache.py
@@ -18,9 +18,10 @@ class TestHashKey:
         h2 = compute_hash_key(content)
         assert h1 == h2
 
-    def test_16_chars(self):
+    def test_32_chars(self):
+        # CR-7: widened 16 -> 32 hex chars (128-bit) to make collisions negligible.
         h = compute_hash_key("test content")
-        assert len(h) == 16
+        assert len(h) == 32
 
     def test_different_content_different_hash(self):
         h1 = compute_hash_key("content A")


### PR DESCRIPTION
First of the audit-remediation PRs. Batch 0 = the trivial, no-regression mechanical fixes from the reviewed plan (`docs/plans/2026-06-11-audit-fixes-plan.md`). Each item traces to a verified-real issue in `docs/reviews/verified-issues-2026-06-11.md` (15 verified-real issues distilled from ~87 audit findings via adversarial adjudication + personal code verification).

## Fixes
| ID | Issue | Fix | File |
|----|-------|-----|------|
| AS-10 | MCP `nous_recall` limit uncapped → expensive query / pool pressure | `min(limit, 100)` | `api/mcp.py` |
| AS-7 | `context_budget_overrides` accepted negatives → silent context underflow | after-validator rejects `< 0` | `config.py` |
| CR-7 | tool-cache key 64-bit → same-session collision returned wrong content | widen to 128-bit | `api/tool_cache.py` |
| R-11 | adjacency-boost `except` was silent | log on failure (still fail-open) | `api/retrieval_pipeline.py` |
| AS-3 | `send_file` accepted any outbound `chat_id` (exfiltration) | allowlist to configured chat | `api/telegram_tools.py` |
| AS-6 | `send_file` blocked the event loop on `open()` | read via `asyncio.to_thread` | `api/telegram_tools.py` |

## Tests
- New/updated unit tests for AS-7, CR-7, AS-3 (matching-chat allowed + mismatched-chat rejected), AS-6 (bytes uploaded). `test_send_custom_chat_id` was the AS-3 vuln case (sent to a non-configured chat) → rewritten to assert rejection.
- AS-10 is a self-evident `min()` cap covered by existing recall tests; a dedicated test needs real-PG + 100 seeded facts (disproportionate).
- R-3 (PipelineStats CE/MMR threading) deferred to the ranking PR where `heart.recall` is already touched.

## Verification
- Batch 0 test files: all green (`test_tool_cache.py`, `test_config.py`, `test_telegram_tools.py`).
- One unrelated pre-existing failure remains on this branch and on `main`: `test_default_equals_max_is_ok` (`.env` contamination — the test reads the repo `.env` so an ambient `NOUS_DAG_NODE_MAX_STALL_TIMEOUT` collides with its `max_timeout=900`). Not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)