### PR TITLE
fix: audit Batch 1 — write-path hardening (W-8 dedup race, W-7 bypass audit)

### DIFF
--- a/nous/heart/admission.py
+++ b/nous/heart/admission.py
@@ -48,6 +48,11 @@ DEFAULT_WEIGHTS = {
 
 DEFAULT_THRESHOLD = 0.55
 
+# W-7: bypass sources split into authoritative (fully trusted) vs derived
+# (machine-generated supersede/contradict/consolidation — bypass scoring but
+# must still carry an embedding). Any bypass source NOT listed here is derived.
+_AUTHORITATIVE_SOURCES = frozenset({"user_stated", "identity", "censor"})
+
 # Exponential decay: λ = 0.01/hour → half-life ≈ 69 hours (~3 days)
 RECENCY_DECAY_LAMBDA = 0.01
 
@@ -383,13 +388,27 @@ Respond with ONLY a number between 0.0 and 1.0."""
     ) -> AdmissionResult:
         """Score a candidate fact for admission."""
         # Check bypass first
-        if fact_input.source in self.config.bypass_sources:
+        source = fact_input.source
+        if source in self.config.bypass_sources:
+            # W-7: bypass behavior is unchanged (the <30-char content floor
+            # already runs upstream in Heart._learn, and a deliberate fix
+            # added consolidation bypass after admission wrongly rejected
+            # valid merges — see bypass_sources note). The only change is an
+            # audit trail distinguishing fully-trusted AUTHORITATIVE sources
+            # from machine-DERIVED ones, so the derived-bypass false-positive
+            # rate is measurable before any stricter gate is considered.
+            is_authoritative = source in _AUTHORITATIVE_SOURCES
+            if not is_authoritative:
+                logger.info(
+                    "Admission bypass (derived) source=%s content=%.80s",
+                    source, fact_input.content,
+                )
             return AdmissionResult(
                 admitted=True,
                 composite_score=1.0,
                 threshold=self.config.threshold,
                 scores={},
-                explanation=f"Bypassed: source '{fact_input.source}' is in bypass list",
+                explanation=f"Bypassed: source '{source}' is in bypass list",
                 bypassed=True,
             )
 

--- a/nous/heart/facts.py
+++ b/nous/heart/facts.py
@@ -434,6 +434,22 @@ class FactManager:
                 explanation="Content too short (< 30 chars)",
             )
 
+        # W-8: serialize concurrent learns of identical content for this agent so
+        # two racing callers (e.g. the fact_extractor tiebreaker runs its
+        # LLM check outside any transaction) can't both pass dedup and
+        # double-insert. The transaction-scoped advisory lock releases on
+        # commit/rollback and is keyed per (agent, content), so distinct content
+        # never serializes. The existing event_date-aware dedup below then runs
+        # under the lock and decides correctly (F075 distinct-date facts still
+        # coexist — the lock only orders the racers, it doesn't dedup).
+        # Postgres-only (pg_advisory_xact_lock); the SQLite test backend is
+        # serial, so there is no cross-connection race to protect there.
+        if session.bind is not None and session.bind.dialect.name == "postgresql":
+            await session.execute(
+                text("SELECT pg_advisory_xact_lock(hashtextextended(:k, 0))"),
+                {"k": f"fact_learn:{self.agent_id}:{input.content}"},
+            )
+
         # Generate embedding
         embedding = None
         if self.embeddings:

--- a/tests/test_admission_integration.py
+++ b/tests/test_admission_integration.py
@@ -4,9 +4,33 @@ Tests the full flow through FactManager._learn() with real Postgres.
 Uses shadow mode and active mode to verify admission gate behavior.
 """
 
+import asyncio
+from datetime import date
+
 import pytest
+from sqlalchemy import delete, func, select
 
 from nous.heart.schemas import FactDetail, FactInput, FactRejected
+from nous.storage.models import Fact
+
+
+async def _active_count(heart, content: str) -> int:
+    async with heart.db.session() as s:
+        return await s.scalar(
+            select(func.count())
+            .select_from(Fact)
+            .where(
+                Fact.agent_id == heart.facts.agent_id,
+                Fact.content == content,
+                Fact.active.is_(True),
+            )
+        )
+
+
+async def _cleanup(heart, content: str) -> None:
+    async with heart.db.session() as s:
+        await s.execute(delete(Fact).where(Fact.content == content))
+        await s.commit()
 
 
 def _fact(**overrides) -> FactInput:
@@ -116,3 +140,39 @@ async def test_supersede_bypasses_gate(heart_with_strict_admission, session):
         session=session,
     )
     assert isinstance(new_result, FactDetail)
+
+
+# ---------------------------------------------------------------------------
+# W-8: concurrent-learn advisory lock (Postgres-only — the lock is a no-op on
+# the SQLite test backend, which is serial). These use own sessions (commit)
+# so the advisory lock actually contends across two pooled connections.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_w8_concurrent_identical_learn_single_active_row(heart):
+    """Two concurrent identical learns must yield exactly one active fact."""
+    content = "Tim migrated the billing database to the new replica cluster overnight"
+    try:
+        await asyncio.gather(
+            heart.learn(_fact(content=content, source="fact_extractor")),
+            heart.learn(_fact(content=content, source="fact_extractor")),
+        )
+        assert await _active_count(heart, content) == 1
+    finally:
+        await _cleanup(heart, content)
+
+
+@pytest.mark.asyncio
+async def test_w8_concurrent_distinct_event_dates_two_rows(heart):
+    """F075 is preserved under the lock: same content on distinct event_dates
+    are distinct events and both persist."""
+    content = "The staging API token was rotated during the security review window"
+    try:
+        await asyncio.gather(
+            heart.learn(_fact(content=content, source="fact_extractor", event_date=date(2026, 3, 10))),
+            heart.learn(_fact(content=content, source="fact_extractor", event_date=date(2026, 3, 12))),
+        )
+        assert await _active_count(heart, content) == 2
+    finally:
+        await _cleanup(heart, content)


### PR DESCRIPTION
Second audit-remediation PR. Write-path fixes from the reviewed plan. Builds on #511 (Batch 0).

## W-8 — concurrent dedup race (P2, **was LIVE in prod**)
The fact_extractor tiebreaker runs its LLM check *outside* any transaction, so two concurrent learns of identical content could both pass dedup and double-insert (no UNIQUE on content). Fix: a per-`(agent, content)` **transaction-scoped advisory lock** at the top of `Heart._learn`, serializing the racers so the second sees the first's commit and dedups.

- **Advisory lock, not a UNIQUE constraint** — the plan review rejected the constraint because it would false-reject the legitimate F075 case (same content, different `event_date` = distinct events), mis-return ids on conflict, and fail migration on existing dup-active rows. The lock preserves all existing event_date-aware dedup semantics.
- Postgres-only via a dialect guard (`pg_advisory_xact_lock`); no-op on the serial SQLite test backend.
- **2 new concurrency integration tests** (real Postgres, own sessions): identical concurrent learns → exactly 1 active row; same content on distinct `event_date`s → 2 active rows (F075 preserved under the lock).

## W-7 — admission bypass audit (P2)
Adds an audit log distinguishing **authoritative** (`user_stated`/`identity`/`censor`) from machine-**derived** (`supersede`/`contradict`/consolidation) admission bypasses, so the derived-bypass false-positive rate is measurable.

**Bypass behavior is intentionally unchanged.** On closer reading: the `<30-char` content floor already runs upstream in `_learn`, and the consolidation bypass was deliberately added after admission *wrongly rejected valid merges* (see `bypass_sources` note, admission.py). The plan's structural reject-gate would have re-introduced that regression and broke 3 deliberate bypass tests, so it was dropped in favor of the observability the reviewer actually asked for.

## W-1 — deferred
The admission LLM call holding the open write transaction is a **perf-only P2** requiring a restructure of the hot `_learn` read/write interleaving + the concurrency benchmark the plan calls for. Too risky to bundle; it gets its own focused PR.

## Verification
- `test_admission.py` (56) + `test_admission_integration.py` (8, incl. the 2 new W-8 tests) green on Postgres.
- W-7 unit bypass tests (`test_supersede_bypasses`, `test_contradict_bypasses`, `test_cluster_consolidation_bypasses`) still green — behavior preserved.
- Pre-existing/unrelated: 3 `test_admission_dashboard.py` failures fail identically on `main` (verified via stash) — a separate data-isolation issue.
- Requires `NOUS_TEST_DB=postgres` for the integration lane (pgvector + advisory lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)