### PR TITLE
fix: audit Batch 2 — resource & safety hygiene (CR-4 session leak, CR-10 compaction)

### DIFF
--- a/nous/api/compaction.py
+++ b/nous/api/compaction.py
@@ -203,8 +203,18 @@ def detect_hallucinated_entities(input_text: str, summary: str) -> list[str]:
         if ent in input_lc:
             continue
         words = ent.split()
-        if len(words) > 1 and any(
-            len(w) >= 4 and w in input_lc for w in words
+        # Rule 2 rescues a multi-word entity when one of its words appears in
+        # the input — meant for names unpacked from an email (`marcus webb`
+        # from `marcus.webb@acme.com`). CR-10: it must NOT rescue a VALUE
+        # substitution. `port 6379` (summary) vs `port 6380` (input) was
+        # passing because the word `port` matched while the number changed.
+        # So skip rule 2 when any word carries a digit (port/IP/version
+        # values) — require the value itself to match (rule 1).
+        has_value_word = any(any(c.isdigit() for c in w) for w in words)
+        if (
+            len(words) > 1
+            and not has_value_word
+            and any(len(w) >= 4 and w in input_lc for w in words)
         ):
             continue
         suspects.append(ent)

--- a/nous/cognitive/layer.py
+++ b/nous/cognitive/layer.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 import re
+import time
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
@@ -261,12 +262,53 @@ class CognitiveLayer:
         self._active_episodes: dict[str, str] = {}  # session_id -> episode_id
 
         # 005.5: Session metadata for significance filtering
-        # P1-8: Known memory leak on abandoned sessions (same as _active_episodes)
+        # P1-8 / CR-4: in-process per-session dicts are popped by end_session,
+        # but a session that crashes or is abandoned never calls it. The
+        # last-activity stamp + periodic sweep below evict orphaned state.
         self._session_metadata: dict[str, SessionMetadata] = {}  # session_id -> metadata
+        self._session_last_activity: dict[str, float] = {}  # session_id -> monotonic ts
+        self._last_session_sweep: float = 0.0
 
     def set_epistemic_classifier(self, classifier: "EpistemicClassifier | None") -> None:
         """Wire the §2 Haiku epistemic classifier (called from main.py when flag on)."""
         self._epistemic_classifier = classifier
+
+    def _purge_session_state(self, session_id: str) -> None:
+        """Remove all in-process per-session state for one session (CR-4).
+
+        Shared by end_session and the stale-session sweep so the two cannot
+        drift on which dicts hold per-session state.
+        """
+        self._active_episodes.pop(session_id, None)
+        self._session_metadata.pop(session_id, None)
+        self._session_tool_history.pop(session_id, None)
+        self._session_response_lengths.pop(session_id, None)
+        self._session_user_messages.pop(session_id, None)
+        self._pending_nudges.pop(session_id, None)
+        self._session_last_activity.pop(session_id, None)
+        self._monitor._session_censor_counts.pop(session_id, None)
+
+    def _sweep_stale_sessions(self) -> None:
+        """CR-4: evict in-process state for sessions idle past 2x the session
+        timeout — the safety net for sessions that never call end_session
+        (crash/orphan). Rate-limited to one sweep per session-timeout window.
+        The current turn's session is refreshed in pre_turn *before* this runs,
+        so an active session is never swept mid-conversation.
+        """
+        timeout = float(getattr(self._settings, "session_timeout", 1800) or 1800)
+        now = time.monotonic()
+        if now - self._last_session_sweep < max(timeout, 60.0):
+            return
+        self._last_session_sweep = now
+        ttl = timeout * 2
+        stale = [
+            sid for sid, last in self._session_last_activity.items()
+            if now - last > ttl
+        ]
+        for sid in stale:
+            self._purge_session_state(sid)
+        if stale:
+            logger.info("CR-4: swept %d stale in-process session(s)", len(stale))
 
     async def list_frames(self, agent_id: str, session: AsyncSession | None = None) -> list:
         """Public delegation to FrameEngine.list_frames()."""
@@ -379,6 +421,11 @@ class CognitiveLayer:
             user_id: Optional user identifier for episode tracking.
             user_display_name: Optional user display name for episode tracking.
         """
+        # CR-4: refresh this session's activity stamp BEFORE sweeping, so an
+        # active session is never evicted, then sweep orphaned sessions.
+        self._session_last_activity[session_id] = time.monotonic()
+        self._sweep_stale_sessions()
+
         # 1b. Track user input for significance (005.5 Phase A)
         meta = self._session_metadata.setdefault(session_id, SessionMetadata())
         meta.total_user_chars += len(user_input)
@@ -1815,14 +1862,10 @@ class CognitiveLayer:
         except Exception:
             logger.warning("Failed to clear working memory for session %s", session_id)
 
-        # 3b. Clean up monitor session censor counts
-        self._monitor._session_censor_counts.pop(session_id, None)
-
-        # F024: Clean up critic session state
-        self._session_tool_history.pop(session_id, None)
-        self._pending_nudges.pop(session_id, None)
-        self._session_response_lengths.pop(session_id, None)
-        self._session_user_messages.pop(session_id, None)
+        # 3b. CR-4: drop all in-process per-session state (monitor censor
+        # counts, critic tool history/nudges/response lengths/user messages,
+        # active episode, metadata, activity stamp) via the shared helper.
+        self._purge_session_state(session_id)
 
         # 4. Emit session_ended event — 006: bus.emit with backward compat
         # transcript_text already computed above for end_episode (F025 P3-C)

--- a/tests/test_cognitive_layer.py
+++ b/tests/test_cognitive_layer.py
@@ -866,3 +866,49 @@ async def test_task_synthesis_existing_task_preserved(cognitive, heart, session)
     assert wm_after is not None
     # Task should remain the same (not overwritten)
     assert wm_after.current_task == original_task
+
+
+# ---------------------------------------------------------------------------
+# CR-4: stale in-process session-state sweep (orphaned-session leak guard)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cr4_sweep_evicts_stale_sessions(cognitive):
+    import time as _time
+
+    from nous.cognitive.schemas import SessionMetadata
+
+    timeout = float(getattr(cognitive._settings, "session_timeout", 1800) or 1800)
+    now = _time.monotonic()
+    cognitive._session_metadata["old"] = SessionMetadata()
+    cognitive._session_user_messages["old"] = ["x"]
+    cognitive._session_metadata["live"] = SessionMetadata()
+    cognitive._session_last_activity["old"] = now - (timeout * 2 + 10)
+    cognitive._session_last_activity["live"] = now
+    cognitive._last_session_sweep = 0.0  # force a sweep
+
+    cognitive._sweep_stale_sessions()
+
+    assert "old" not in cognitive._session_metadata
+    assert "old" not in cognitive._session_user_messages
+    assert "old" not in cognitive._session_last_activity
+    assert "live" in cognitive._session_metadata
+    assert "live" in cognitive._session_last_activity
+
+
+@pytest.mark.asyncio
+async def test_cr4_sweep_is_rate_limited(cognitive):
+    import time as _time
+
+    from nous.cognitive.schemas import SessionMetadata
+
+    timeout = float(getattr(cognitive._settings, "session_timeout", 1800) or 1800)
+    now = _time.monotonic()
+    cognitive._session_metadata["old"] = SessionMetadata()
+    cognitive._session_last_activity["old"] = now - (timeout * 2 + 10)
+    cognitive._last_session_sweep = now  # swept just now -> next call is a no-op
+
+    cognitive._sweep_stale_sessions()
+
+    assert "old" in cognitive._session_metadata  # rate-limited, not yet swept

--- a/tests/test_cognitive_layer.py
+++ b/tests/test_cognitive_layer.py
@@ -886,7 +886,12 @@ async def test_cr4_sweep_evicts_stale_sessions(cognitive):
     cognitive._session_metadata["live"] = SessionMetadata()
     cognitive._session_last_activity["old"] = now - (timeout * 2 + 10)
     cognitive._session_last_activity["live"] = now
-    cognitive._last_session_sweep = 0.0  # force a sweep
+    # Force a sweep regardless of the absolute monotonic clock: the rate-limit
+    # guard compares (now - last_sweep) against max(timeout, 60), so 0.0 only
+    # forces a sweep when monotonic() already exceeds the timeout (true on a
+    # long-running host, false in a fresh CI container — that gap is what failed
+    # CI). Subtract the interval explicitly instead.
+    cognitive._last_session_sweep = now - max(timeout, 60.0) - 1.0
 
     cognitive._sweep_stale_sessions()
 

--- a/tests/test_compaction_hallucination_guard.py
+++ b/tests/test_compaction_hallucination_guard.py
@@ -421,3 +421,12 @@ async def test_guard_disabled_no_check(caplog) -> None:
         "hallucination guard" in r.message.lower() for r in caplog.records
     )
     assert conv.summary is not None
+
+
+def test_cr10_port_value_substitution_flagged() -> None:
+    # CR-10: a value substitution must NOT be excused by the multi-word
+    # partial-match rule just because a non-numeric word ("port") matches.
+    input_text = "Redis listens on port 6380 in staging"
+    summary = "Redis port 6379 configured for cache"
+    suspects = detect_hallucinated_entities(input_text, summary)
+    assert "port 6379" in suspects


### PR DESCRIPTION
Third audit-remediation PR. Resource/safety fixes from the reviewed plan.

## CR-4 — in-process session-state leak (P2)
`end_session` pops 7 per-session dicts, but a crashed or abandoned session never calls it → unbounded growth (`_session_metadata` holds the full transcript). Fix:
- `_session_last_activity` stamp refreshed at the **start** of `pre_turn` (before the sweep, so an active session is never evicted mid-conversation — review guard).
- `_purge_session_state(session_id)` shared helper, now used by **both** `end_session` and the sweep so they can't drift on which dicts hold state.
- `_sweep_stale_sessions()` rate-limited to once per session-timeout window, evicts sessions idle past 2× the timeout.

Tests: `test_cr4_sweep_evicts_stale_sessions` (stale evicted, live retained), `test_cr4_sweep_is_rate_limited`.

## CR-10 — compaction value-substitution guard (P2)
The hallucination guard's multi-word partial-match rule excused value substitutions: `port 6379` (summary) vs `port 6380` (input) passed because the word `port` matched while the *number* changed. Fix: skip that rule when any word carries a digit (port/IP/version values), requiring the value to match. Names like `marcus webb` (unpacked from an email) are unaffected.

Test: `test_cr10_port_value_substitution_flagged`. All 5 existing guard tests still green (names have no digit-words; single-token versions/ports unaffected).

## Verification
- `test_compaction_hallucination_guard.py` (incl. new) + 2 new CR-4 tests: green.
- Full `test_cognitive_layer.py` on Postgres: my changes add 2 passing tests (39→41) with **zero new failures** — the 15 failures present are pre-existing on `main` (verified via stash; SAVEPOINT/env issues unrelated to this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)