### PR TITLE
fix: audit Batch 4a — remove dead quality_block_threshold config (BR-1)

### DIFF
--- a/nous/brain/quality.py
+++ b/nous/brain/quality.py
@@ -19,7 +19,9 @@ def compute_quality_score(
     - Reason diversity (>=2 types): +0.10
 
     Total possible: 1.0
-    Block threshold: < 0.55 (enforced by guardrail, not here)
+
+    NOTE: this score is advisory (surfaced for human review on the decision
+    detail / dashboard). Nothing gates on it — there is no block threshold.
     """
     score = 0.0
 

--- a/nous/config.py
+++ b/nous/config.py
@@ -51,7 +51,9 @@ class Settings(BaseSettings):
     openai_api_key: str = Field("", validation_alias="OPENAI_API_KEY")
     auto_link_threshold: float = 0.85
     auto_link_max: int = 3
-    quality_block_threshold: float = 0.5
+    # BR-1: removed `quality_block_threshold` — it had zero readers (decision
+    # quality_score is advisory for human review; nothing gates on it). A stale
+    # NOUS_QUALITY_BLOCK_THRESHOLD in an operator .env is harmless (extra=ignore).
 
     # F058: Confidence calibration scaling. Agent-recorded confidence is
     # systemically ~20% overconfident on Nous prod data (Brier 0.252,


### PR DESCRIPTION
Fourth audit-remediation PR. A small, standalone P3 cleanup.

## BR-1 — misleading dead config
`quality_block_threshold` (config.py) had **zero code readers** — decision `quality_score` is advisory (surfaced for human review / dashboard); nothing gates on it. The `quality.py` docstring claimed `Block threshold: < 0.55 (enforced by guardrail, not here)`, pointing at the **unwired** CEL guardrail engine. Removed the field and corrected the docstring.

Forward-compatible: a stale `NOUS_QUALITY_BLOCK_THRESHOLD` in an operator `.env` is ignored (`extra="ignore"`).

## Deferred (needs a decision)
The rest of Batch 4 — **deleting the dead CEL `GuardrailEngine`** (BR-4/6: `Brain.check()` has no runtime caller, it's test-only) — removes a nominal capability, so per the plan it's **operator-gated**: kill it, or wire it into the deliberation path? Not included here.

## Verification
- `config` + `brain.quality` import clean; `quality_block_threshold` attribute gone.
- `test_config.py`: 7 passed (the 1 failure is the pre-existing `.env`-contamination `test_default_equals_max_is_ok`, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)