### PR TITLE
fix: audit Batch 4b — wire the CEL guardrail engine (advisory) (BR-4/6)

### DIFF
--- a/nous/cognitive/deliberation.py
+++ b/nous/cognitive/deliberation.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import re
 from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from sqlalchemy import select as sa_select
@@ -18,6 +19,9 @@ from nous.brain.brain import Brain
 from nous.brain.schemas import ReasonInput, RecordInput
 from nous.cognitive.schemas import FrameSelection
 from nous.storage.models import Decision as DecisionModel
+
+if TYPE_CHECKING:
+    from nous.config import Settings
 
 logger = logging.getLogger(__name__)
 
@@ -71,8 +75,9 @@ class DeliberationEngine:
     a clean start -> think -> finalize flow.
     """
 
-    def __init__(self, brain: Brain) -> None:
+    def __init__(self, brain: Brain, settings: Settings | None = None) -> None:
         self._brain = brain
+        self._settings = settings
 
     async def start(
         self,
@@ -177,6 +182,39 @@ class DeliberationEngine:
             tags=tags,
             session=session,
         )
+
+        # BR-4/6: wire the CEL guardrail engine, which previously had no runtime
+        # caller. ADVISORY only — Brain.check() evaluates active guardrails,
+        # emits guardrail_blocked/warned events and increments activation
+        # counts; we log matches but never abort the turn. (The seed guardrails
+        # are block-severity and unvalidated — one blocks ALL critical decisions
+        # — so enforcement is deferred until those CEL expressions are fixed.)
+        if getattr(self._settings, "guardrail_check_enabled", False):
+            try:
+                gr = await self._brain.check(
+                    description=description,
+                    stakes=stakes,
+                    confidence=confidence,
+                    category=detail.category,
+                    tags=tags,
+                    reasons=[{"type": r.type, "text": r.text} for r in (detail.reasons or [])],
+                    pattern=pattern,
+                    quality_score=detail.quality_score,
+                    session=session,
+                )
+                if not gr.allowed:
+                    logger.warning(
+                        "Guardrails flagged decision %s — blocked_by=%s warnings=%s (advisory)",
+                        decision_id, gr.blocked_by, gr.warnings,
+                    )
+                elif gr.warnings:
+                    logger.info(
+                        "Guardrail warnings on decision %s: %s", decision_id, gr.warnings,
+                    )
+            except Exception:
+                logger.warning(
+                    "Guardrail check failed for decision %s", decision_id, exc_info=True
+                )
         return decision_id
 
     async def delete(

--- a/nous/cognitive/layer.py
+++ b/nous/cognitive/layer.py
@@ -240,7 +240,7 @@ class CognitiveLayer:
         self._context = ContextEngine(
             brain, heart, settings, identity_prompt, deduplicator=_deduplicator
         )
-        self._deliberation = DeliberationEngine(brain)
+        self._deliberation = DeliberationEngine(brain, settings)
         self._monitor = MonitorEngine(brain, heart, settings)
 
         # F024: Critic Agent

--- a/nous/config.py
+++ b/nous/config.py
@@ -54,6 +54,11 @@ class Settings(BaseSettings):
     # BR-1: removed `quality_block_threshold` — it had zero readers (decision
     # quality_score is advisory for human review; nothing gates on it). A stale
     # NOUS_QUALITY_BLOCK_THRESHOLD in an operator .env is harmless (extra=ignore).
+    # BR-4/6: evaluate the CEL guardrail engine at decision finalize. ADVISORY
+    # only (logs + emits guardrail_blocked/warned events + increments activation
+    # counts) — the seed guardrails are block-severity and not yet validated
+    # (one blocks ALL critical decisions), so enforcement stays a follow-up.
+    guardrail_check_enabled: bool = True
 
     # F058: Confidence calibration scaling. Agent-recorded confidence is
     # systemically ~20% overconfident on Nous prod data (Brier 0.252,

--- a/tests/test_guardrail_wire.py
+++ b/tests/test_guardrail_wire.py
@@ -1,0 +1,65 @@
+"""BR-4/6: the CEL guardrail engine is wired into deliberation.finalize as an
+advisory check — it evaluates and surfaces guardrails but never rejects the
+decision. These tests use a mocked Brain so no DB is required."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nous.brain.schemas import GuardrailResult
+from nous.cognitive.deliberation import DeliberationEngine
+
+_DESC = "Adopt cursor-based pagination for the public decisions API endpoint"
+
+
+def _brain_with(guardrail_result: GuardrailResult) -> MagicMock:
+    brain = MagicMock()
+    detail = MagicMock(stakes="high", category="architecture", quality_score=0.6, reasons=[])
+    brain.get = AsyncMock(return_value=detail)
+    brain.update = AsyncMock()
+    brain.check = AsyncMock(return_value=guardrail_result)
+    return brain
+
+
+@pytest.mark.asyncio
+async def test_guardrail_block_is_advisory_not_rejecting():
+    """A blocking guardrail is evaluated and logged but the decision is still
+    finalized (advisory wire — not enforcement)."""
+    did = str(uuid.uuid4())
+    brain = _brain_with(GuardrailResult(allowed=False, blocked_by=["no-high-stakes-low-confidence"], warnings=[]))
+    delib = DeliberationEngine(brain, MagicMock(guardrail_check_enabled=True))
+
+    result = await delib.finalize(did, _DESC, confidence=0.3)
+
+    assert result == did  # finalized despite the block
+    brain.check.assert_awaited_once()
+    brain.update.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_guardrail_check_skipped_when_disabled():
+    did = str(uuid.uuid4())
+    brain = _brain_with(GuardrailResult(allowed=True, blocked_by=[], warnings=[]))
+    delib = DeliberationEngine(brain, MagicMock(guardrail_check_enabled=False))
+
+    result = await delib.finalize(did, _DESC, confidence=0.3)
+
+    assert result == did
+    brain.check.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_guardrail_engine_error_does_not_break_finalize():
+    """If the engine raises (e.g. a malformed CEL expression), finalize still
+    succeeds — the check is best-effort."""
+    did = str(uuid.uuid4())
+    brain = _brain_with(GuardrailResult(allowed=True, blocked_by=[], warnings=[]))
+    brain.check = AsyncMock(side_effect=RuntimeError("CEL boom"))
+    delib = DeliberationEngine(brain, MagicMock(guardrail_check_enabled=True))
+
+    result = await delib.finalize(did, _DESC, confidence=0.3)
+
+    assert result == did


### PR DESCRIPTION
Wires the dead CEL guardrail engine (you chose **wire** over kill). **Stacked on #514** (Batch 4a / BR-1) — base is that branch, so this diff shows only the wire.

## What
`GuardrailEngine` had no runtime caller (`Brain.check()` was test-only). Now `DeliberationEngine.finalize()` evaluates every finalized decision against active guardrails — `guardrail_blocked`/`guardrail_warned` events fire, activation counts increment, and matches are logged.

## Advisory, not enforcing — deliberately
The seed guardrails are **block-severity and unvalidated**. One (`no-critical-without-review`) is just `decision.stakes == 'critical'` — it would block **every** critical decision unconditionally. Hard-enforcing these would break the agent's ability to record critical/high-stakes/reasonless decisions. So the wire is advisory (log + events + counts + surface); the check is wrapped so an engine error never breaks `finalize`. Enforcement is a follow-up that first needs the seed CEL expressions fixed. Gated by `guardrail_check_enabled` (default True).

## Tests (`test_guardrail_wire.py`, mocked Brain — no DB)
- a blocking guardrail is evaluated but the decision is still finalized (advisory, not rejecting)
- the check is skipped when `guardrail_check_enabled=False`
- an engine exception does not break `finalize`

## Verification
- 3 new wire tests + 2 `test_brain.py` guardrail tests green.
- 2 `test_cognitive_layer.py` deliberation tests fail on this branch **and on `main`** (verified via stash) — a stale local test-DB schema (`procedures.superseded_by` missing) aborts the transaction during *context build*, before the guardrail check runs. Unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)