### PR TITLE
fix: audit W-1 — move admission LLM utility call off the open write txn

### DIFF
--- a/nous/heart/admission.py
+++ b/nous/heart/admission.py
@@ -378,6 +378,16 @@ Respond with ONLY a number between 0.0 and 1.0."""
     # Public API
     # ------------------------------------------------------------------
 
+    async def precompute_utility(self, fact_input: FactInput) -> float | None:
+        """W-1: compute the (LLM) utility score OUTSIDE any DB session so
+        score() doesn't hold a pooled connection through the Haiku call while
+        the dedup/insert transaction (+ the W-8 advisory lock) is open. Returns
+        None for bypass sources (score() short-circuits them — no wasted call).
+        """
+        if fact_input.source in self.config.bypass_sources:
+            return None
+        return await self._score_utility(fact_input)
+
     async def score(
         self,
         fact_input: FactInput,
@@ -385,8 +395,15 @@ Respond with ONLY a number between 0.0 and 1.0."""
         max_existing_similarity: float | None,
         source_text: str | None,
         session,  # AsyncSession | None — not used yet, reserved for future
+        *,
+        utility_override: float | None = None,
     ) -> AdmissionResult:
-        """Score a candidate fact for admission."""
+        """Score a candidate fact for admission.
+
+        ``utility_override`` (W-1): when provided, use it instead of making the
+        utility LLM call here — the caller computed it before opening the write
+        transaction.
+        """
         # Check bypass first
         source = fact_input.source
         if source in self.config.bypass_sources:
@@ -414,7 +431,11 @@ Respond with ONLY a number between 0.0 and 1.0."""
 
         scores = {}
 
-        scores["utility"] = await self._score_utility(fact_input)
+        scores["utility"] = (
+            utility_override
+            if utility_override is not None
+            else await self._score_utility(fact_input)
+        )
         scores["confidence"] = self._score_confidence(fact_input, source_text)
         scores["novelty"] = self._score_novelty(max_existing_similarity)
         scores["recency"] = self._score_recency(fact_input)

--- a/nous/heart/facts.py
+++ b/nous/heart/facts.py
@@ -399,9 +399,20 @@ class FactManager:
         # same <30-char floor _learn applies, and skipped for bypass sources
         # inside precompute_utility — so the only wasted call is for a fact that
         # later turns out to be a Leg-2 dupe (rare; Leg-1 filters most upstream).
+        #
+        # Only precompute when learn() owns the session (`session is None`).
+        # With an injected session the caller's transaction is already open
+        # (e.g. CognitiveLayer.end_session updates the episode on its session
+        # before calling heart.learn(..., session=session)), so running the
+        # Haiku call here would still pin the caller's connection — no better
+        # than the inline score() call. For injected sessions we pass
+        # utility_override=None and score() computes utility inline, exactly as
+        # before W-1. Moving the call ahead of an injected caller's transaction
+        # is that caller's responsibility.
         utility_override: float | None = None
         if (
-            self._admission_controller is not None
+            session is None
+            and self._admission_controller is not None
             and len(input.content.strip()) >= 30
         ):
             utility_override = await self._admission_controller.precompute_utility(input)

--- a/nous/heart/facts.py
+++ b/nous/heart/facts.py
@@ -393,6 +393,19 @@ class FactManager:
             encoded_frame: Frame active when this fact was learned (003.2).
             encoded_censors: Censors active when this fact was learned (003.2).
         """
+        # W-1: precompute the admission LLM utility BEFORE opening the write
+        # session, so the Haiku call doesn't hold a pooled connection through
+        # the dedup/insert transaction (+ the W-8 advisory lock). Gated on the
+        # same <30-char floor _learn applies, and skipped for bypass sources
+        # inside precompute_utility — so the only wasted call is for a fact that
+        # later turns out to be a Leg-2 dupe (rare; Leg-1 filters most upstream).
+        utility_override: float | None = None
+        if (
+            self._admission_controller is not None
+            and len(input.content.strip()) >= 30
+        ):
+            utility_override = await self._admission_controller.precompute_utility(input)
+
         if session is None:
             async with self.db.session() as session:
                 result = await self._learn(
@@ -402,6 +415,7 @@ class FactManager:
                     session,
                     encoded_frame=encoded_frame,
                     encoded_censors=encoded_censors,
+                    utility_override=utility_override,
                 )
                 await session.commit()
                 return result
@@ -412,6 +426,7 @@ class FactManager:
             session,
             encoded_frame=encoded_frame,
             encoded_censors=encoded_censors,
+            utility_override=utility_override,
         )
 
     async def _learn(
@@ -423,6 +438,7 @@ class FactManager:
         *,
         encoded_frame: str | None = None,
         encoded_censors: list[str] | None = None,
+        utility_override: float | None = None,
     ) -> FactDetail | FactRejected:
         # F038-1.2: Reject facts with content < 30 characters
         if len(input.content.strip()) < 30:
@@ -513,7 +529,8 @@ class FactManager:
             source_text = await self._get_source_text(input, session)
 
             admission_result = await self._admission_controller.score(
-                input, embedding, max_sim, source_text, session
+                input, embedding, max_sim, source_text, session,
+                utility_override=utility_override,
             )
             if not admission_result.admitted:
                 logger.info(

--- a/tests/test_admission.py
+++ b/tests/test_admission.py
@@ -373,6 +373,76 @@ class TestUtilityLLM:
 
 
 # ---------------------------------------------------------------------------
+# W-1: Utility precompute (move the LLM call off the open write transaction)
+# ---------------------------------------------------------------------------
+
+
+class TestUtilityPrecompute:
+    @pytest.mark.asyncio
+    async def test_precompute_returns_score_for_non_bypass(self):
+        mock_client = AsyncMock()
+        mock_client.complete = AsyncMock(return_value="0.85")
+        ctrl = AdmissionController(
+            config=AdmissionConfig(utility_llm_enabled=True),
+            llm_client=mock_client,
+        )
+        score = await ctrl.precompute_utility(_fact(source="fact_extractor"))
+        assert score == pytest.approx(0.85, abs=0.01)
+        mock_client.complete.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_precompute_skips_bypass_source(self):
+        mock_client = AsyncMock()
+        mock_client.complete = AsyncMock(return_value="0.85")
+        ctrl = AdmissionController(
+            config=AdmissionConfig(utility_llm_enabled=True),
+            llm_client=mock_client,
+        )
+        score = await ctrl.precompute_utility(_fact(source="user_stated"))
+        assert score is None
+        mock_client.complete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_score_uses_override_without_llm_call(self):
+        """When utility_override is passed, score() must NOT make the LLM
+        utility call — the caller already computed it off the write txn."""
+        mock_client = AsyncMock()
+        mock_client.complete = AsyncMock(return_value="0.10")
+        ctrl = AdmissionController(
+            config=AdmissionConfig(utility_llm_enabled=True, shadow_mode=False),
+            llm_client=mock_client,
+        )
+        result = await ctrl.score(
+            fact_input=_fact(source="fact_extractor"),
+            embedding=None,
+            max_existing_similarity=0.3,
+            source_text="Tim mentioned he prefers dark mode for coding",
+            session=None,
+            utility_override=0.95,
+        )
+        assert result.scores["utility"] == 0.95
+        mock_client.complete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_score_computes_utility_when_no_override(self):
+        mock_client = AsyncMock()
+        mock_client.complete = AsyncMock(return_value="0.42")
+        ctrl = AdmissionController(
+            config=AdmissionConfig(utility_llm_enabled=True, shadow_mode=False),
+            llm_client=mock_client,
+        )
+        result = await ctrl.score(
+            fact_input=_fact(source="fact_extractor"),
+            embedding=None,
+            max_existing_similarity=0.3,
+            source_text="Tim mentioned he prefers dark mode for coding",
+            session=None,
+        )
+        assert result.scores["utility"] == pytest.approx(0.42, abs=0.01)
+        mock_client.complete.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
 # Composite Scoring
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

`FactManager.learn()` opened the write session, then inside `_learn()` called `AdmissionController.score()`, which made the Haiku **utility LLM call while the dedup/insert transaction (and the W-8 advisory lock) held a pooled DB connection**. A slow or timing-out Haiku call pinned that connection for its full duration, under lock — a write-path connection-pool hazard flagged in the 2026-06-11 audit (W-1).

## Fix

Precompute the utility score in `learn()` **before** opening the session and thread it through:

```
learn()  ──precompute_utility()──►  Haiku call (no txn, no lock)
   │
   └─ _learn(session, utility_override=…)  ──►  score(utility_override=…)
```

- `AdmissionController.precompute_utility()` runs `_score_utility` outside any session; returns `None` for bypass sources (so `score()` short-circuits them with no wasted call).
- `score()` gains a keyword-only `utility_override`; uses it when present, otherwise falls back to the original in-band LLM call.
- Gated on the same `>=30`-char floor `_learn` already enforces.

Behavior is identical — same `_score_utility` path, heuristic fallback preserved. Only the call site moves off the transaction. The single wasted call is for a fact that later turns out to be a Leg-2 dupe (rare; Leg-1 filters most upstream); documented in code.

## Tests

4 new tests in `TestUtilityPrecompute`:
- precompute returns a score for non-bypass sources / `None` for bypass
- `score()` honors the override **without** making an LLM call
- `score()` still computes utility when no override is supplied

Full `tests/test_admission.py` (60 tests) green. (`tests/test_facts.py` failures are pre-existing — pgvector `<=>` requires a real Postgres backend, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)