### PR TITLE
fix: supersession lineage + graph consumer-consistency (memory-bug plan PR-2)

### DIFF
--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import selectinload
 
 from nous.brain.bridge import BridgeExtractor
 from nous.brain.calibration import CalibrationEngine
+from nous.brain.graph_constants import RETRIEVAL_EXCLUDED_RELATIONS
 from nous.brain.embeddings import EmbeddingProvider
 from nous.brain.guardrails import GuardrailEngine
 from nous.brain.quality import QualityScorer
@@ -1218,6 +1219,15 @@ class Brain:
         if relation:
             source_q = source_q.where(GraphEdge.relation == relation)
             target_q = target_q.where(GraphEdge.relation == relation)
+        else:
+            # 2b: never surface lineage (supersedes) or negative (contradicts)
+            # edges as retrieval connectivity. (co_occurred / co_mention ARE
+            # legitimate associative connectivity for retrieval, so they are NOT
+            # excluded here — graph_constants.RETRIEVAL_EXCLUDED_RELATIONS.) Only
+            # applied to the unfiltered fan-out; an explicit `relation=` request
+            # is honoured verbatim.
+            source_q = source_q.where(GraphEdge.relation.notin_(RETRIEVAL_EXCLUDED_RELATIONS))
+            target_q = target_q.where(GraphEdge.relation.notin_(RETRIEVAL_EXCLUDED_RELATIONS))
 
         # F070 fix: push the neighbor-type filter into SQL so LIMIT N
         # returns N rows of the requested type, not N rows that may all

--- a/nous/brain/graph_constants.py
+++ b/nous/brain/graph_constants.py
@@ -1,0 +1,55 @@
+"""Canonical graph-edge exclusion sets for graph consumers.
+
+The 2026-06-13 audit (Theme 6) found the relation-exclusion logic had drifted
+across the graph consumers — each excluded a different subset, so every new edge
+relation leaked through whichever consumer forgot it (supersedes was fixed in
+PR #518; contradicts / co_occurred / happened_before still leaked). These
+constants centralise the rule so a future relation is a single-site edit.
+
+Two sets, because the correct exclusion depends on consumer PURPOSE:
+
+- **Auto-behavior consumers** — the auto-spreading density gate, spreading
+  traversal, orphan detection, cluster discovery — must not be *driven* by edges
+  that are not associative connectivity: lineage (``supersedes``), negative
+  (``contradicts``), temporal (``happened_before``), or builder-generated
+  co-occurrence (``co_occurred`` / ``co_mention``, whose builder flags can flip
+  silently and change behaviour). Counting these can flip auto-spreading on or
+  strand facts from densification.
+
+- **Retrieval neighbour expansion** (``brain._neighbors``) must not surface
+  *lineage* or *negative* edges as connectivity. ``co_occurred`` / ``co_mention``
+  ARE legitimate associative connectivity for retrieval, so they are NOT excluded
+  there — changing that is a live ranking decision (deferred, eval-gated).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+# --- auto-behavior consumers (density gate, spreading, orphan, cluster) ---
+AUTOBEHAVIOR_EXCLUDED_RELATIONS: frozenset[str] = frozenset(
+    {"supersedes", "contradicts", "happened_before", "co_occurred"}
+)
+# co_mention edges carry relation='related_to', so they're excluded by
+# extraction_method, not relation name.
+AUTOBEHAVIOR_EXCLUDED_METHODS: frozenset[str] = frozenset({"co_mention"})
+
+# --- retrieval neighbour expansion (lineage + negative only) ---
+RETRIEVAL_EXCLUDED_RELATIONS: frozenset[str] = frozenset({"supersedes", "contradicts"})
+
+
+def _sql_list(values: Iterable[str]) -> str:
+    return ", ".join(f"'{v}'" for v in sorted(values))
+
+
+def autobehavior_exclusion_sql(col_prefix: str = "") -> str:
+    """SQL boolean fragment excluding non-associative edges from auto-behavior
+    consumers. ``col_prefix`` e.g. ``"e."`` for an aliased ``graph_edges`` table.
+    Values are fixed literals (no user input), so interpolation is safe."""
+    p = col_prefix
+    rels = _sql_list(AUTOBEHAVIOR_EXCLUDED_RELATIONS)
+    methods = _sql_list(AUTOBEHAVIOR_EXCLUDED_METHODS)
+    return (
+        f"{p}relation NOT IN ({rels}) "
+        f"AND ({p}extraction_method IS NULL OR {p}extraction_method NOT IN ({methods}))"
+    )

--- a/nous/brain/graph_densifier.py
+++ b/nous/brain/graph_densifier.py
@@ -16,6 +16,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from nous.brain._entity_config import _ENTITY_CONFIG
+from nous.brain.graph_constants import autobehavior_exclusion_sql
 from nous.brain.backfill_rerank import (
     ce_rerank_backfill_candidates,
     fetch_candidate_content,
@@ -147,6 +148,7 @@ class GraphDensifier:
 
         table, type_name, content_col, extra_where = config
         embedding_clause = "AND t.embedding IS NOT NULL" if require_embedding else ""
+        orphan_excl = autobehavior_exclusion_sql("e.")  # 2b
 
         sql = text(f"""
             SELECT t.id, {content_col} AS content
@@ -157,20 +159,12 @@ class GraphDensifier:
               AND NOT EXISTS (
                   SELECT 1 FROM brain.graph_edges e
                   WHERE e.agent_id = :agent_id
-                    -- F076: a co_mention edge must NOT make a fact look non-orphan.
-                    -- It only links fact<->fact on a shared entity; it does NOT give
-                    -- the cross-type (fact->decision/episode) connectivity the F040
-                    -- backfill provides. Counting it here would permanently skip such
-                    -- facts from later backfill cycles (find_orphans consumes the
-                    -- orphan signal). IS DISTINCT FROM keeps NULL/legacy rows counting.
-                    AND e.extraction_method IS DISTINCT FROM 'co_mention'
-                    -- 2026-06-13 audit: a supersedes edge is lineage, not usable
-                    -- connectivity — _neighbors and spreading both refuse to
-                    -- traverse it. If it counted here, a replacement fact whose
-                    -- only edge is supersedes would look non-orphan and the F040
-                    -- backfill would never densify it, leaving it graph-isolated.
-                    -- Exclude it from the orphan signal, same as co_mention.
-                    AND e.relation <> 'supersedes'
+                    -- 2b: a non-associative edge (co_mention/co_occurred builder,
+                    -- supersedes lineage, contradicts negative, happened_before
+                    -- temporal) must NOT make a fact look non-orphan, or the F040
+                    -- backfill permanently skips it and leaves it graph-isolated.
+                    -- Single source of truth: graph_constants.
+                    AND {orphan_excl}
                     AND (
                         (e.source_id = t.id AND e.source_type = :type_name)
                         OR (e.target_id = t.id AND e.target_type = :type_name)
@@ -1485,7 +1479,9 @@ class GraphDensifier:
             result = await session.execute(text(
                 "SELECT source_id, target_id, source_type, target_type "
                 "FROM brain.graph_edges WHERE agent_id = :agent_id "
-                "AND relation <> 'supersedes'"
+                # 2b: exclude non-associative edges so cluster discovery doesn't
+                # union a replacement with its lineage/co-occurrence partner.
+                f"AND {autobehavior_exclusion_sql()}"
             ), {"agent_id": self._agent_id})
             edges = result.all()
 

--- a/nous/brain/spreading_activation.py
+++ b/nous/brain/spreading_activation.py
@@ -12,6 +12,10 @@ from uuid import UUID
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from nous.brain.graph_constants import (
+    AUTOBEHAVIOR_EXCLUDED_RELATIONS,
+    autobehavior_exclusion_sql,
+)
 from nous.config import Settings
 
 logger = logging.getLogger(__name__)
@@ -34,21 +38,20 @@ async def compute_graph_density(session: AsyncSession, agent_id: str) -> float:
     ``auto`` mode into spreading activation unintentionally. (1e — folded into
     PR-1 so the new in-band contradiction edges can't inflate density.)
     """
-    sql = text("""
+    # 2b: single source of truth for the auto-behavior exclusion (graph_constants).
+    excl = autobehavior_exclusion_sql()
+    sql = text(f"""
         WITH node_counts AS (
             SELECT COUNT(*) AS edge_count,
                    (SELECT COUNT(DISTINCT node_id) FROM (
                        SELECT source_id AS node_id FROM brain.graph_edges
-                       WHERE agent_id = :agent_id AND extraction_method IS DISTINCT FROM 'co_mention'
-                       AND relation NOT IN ('supersedes', 'contradicts', 'happened_before', 'co_occurred')
+                       WHERE agent_id = :agent_id AND {excl}
                        UNION
                        SELECT target_id AS node_id FROM brain.graph_edges
-                       WHERE agent_id = :agent_id AND extraction_method IS DISTINCT FROM 'co_mention'
-                       AND relation NOT IN ('supersedes', 'contradicts', 'happened_before', 'co_occurred')
+                       WHERE agent_id = :agent_id AND {excl}
                    ) nodes) AS unique_nodes
             FROM brain.graph_edges
-            WHERE agent_id = :agent_id AND extraction_method IS DISTINCT FROM 'co_mention'
-                       AND relation NOT IN ('supersedes', 'contradicts', 'happened_before', 'co_occurred')
+            WHERE agent_id = :agent_id AND {excl}
         )
         SELECT CASE WHEN unique_nodes = 0 THEN 0.0
                     ELSE edge_count::float / unique_nodes
@@ -103,6 +106,8 @@ async def spreading_activation_search(
         params[f"score_{i}"] = float(score)
 
     values_clause = ", ".join(values_parts)
+    # 2b: same auto-behavior exclusion as the density gate (graph_constants).
+    excl_e = autobehavior_exclusion_sql("e.")
 
     sql = text(f"""
         WITH RECURSIVE activation AS (
@@ -120,18 +125,11 @@ async def spreading_activation_search(
             JOIN brain.graph_edges e
                 ON (e.source_id = a.id OR e.target_id = a.id)
             WHERE a.depth < :max_depth
-                -- Exclude contradicts (negative) and supersedes (lineage to an
-                -- inactive/obsolete fact). The 2026-06-13 supersedes-edge
-                -- backfill makes active->inactive fact bridges traversable;
-                -- spreading must not resurface the superseded fact.
-                AND e.relation NOT IN ('contradicts', 'supersedes')
-                -- F076: co_mention edges are NOT a spreading-activation consumer.
-                -- Spreading is decision-seeded and auto-enabled by non-co_mention
-                -- density; without this filter, once spreading is on for an agent the
-                -- default-on co_mention builder would change decision retrieval before
-                -- any documented co_mention consumer flag (Path A / adjacency / seed-
-                -- score) is rolled out. IS DISTINCT FROM keeps NULL/legacy rows.
-                AND e.extraction_method IS DISTINCT FROM 'co_mention'
+                -- 2b: exclude non-associative edges (lineage supersedes,
+                -- negative contradicts, temporal happened_before, builder
+                -- co_occurred/co_mention) so spreading never traverses them.
+                -- Single source of truth: graph_constants.autobehavior_exclusion_sql.
+                AND {excl_e}
                 AND e.agent_id = :agent_id
         )
         SELECT id, node_type, SUM(activation) AS total_activation

--- a/nous/handlers/sleep_handler.py
+++ b/nous/handlers/sleep_handler.py
@@ -823,10 +823,18 @@ class SleepHandler:
             orm = await session.get(Fact, loser_id)
             if orm is None:
                 return
-            # Don't clobber an existing chain (a concurrent supersede may have
-            # linked this fact between candidate selection and now).
-            if orm.superseded_by is None:
-                orm.superseded_by = winner_id
+            # codex P1 (PR #520): if a concurrent path already superseded this
+            # fact, skip EVERYTHING — writing a winner->loser edge now would
+            # record a second, conflicting winner while the column still names
+            # the original. Mirror the MERGE path: leave the existing chain
+            # intact (the active flip is paired — already-superseded is inactive).
+            if orm.superseded_by is not None:
+                logger.debug(
+                    "F031 supersede: skip %s — already superseded by %s",
+                    loser_id, orm.superseded_by,
+                )
+                return
+            orm.superseded_by = winner_id
             orm.active = False
             await self._heart.link_facts(winner_id, loser_id, "supersedes", 1.0, session)
             await session.commit()

--- a/nous/handlers/sleep_handler.py
+++ b/nous/handlers/sleep_handler.py
@@ -813,6 +813,24 @@ class SleepHandler:
             logger.warning("UPDATES prefix handling failed", exc_info=True)
             return False
 
+    async def _apply_supersede(self, winner_id, loser_id) -> None:
+        """2a (2026-06-13 audit): deactivate the loser AND preserve the supersede
+        chain — set ``loser.superseded_by = winner`` and write the supersedes
+        edge — all in one session+commit, mirroring the F031 MERGE atomicity and
+        clobber guard. The SUPERSEDE_A/B branches previously called
+        ``deactivate_fact`` alone, severing lineage (no column, no edge)."""
+        async with self._heart.db.session() as session:
+            orm = await session.get(Fact, loser_id)
+            if orm is None:
+                return
+            # Don't clobber an existing chain (a concurrent supersede may have
+            # linked this fact between candidate selection and now).
+            if orm.superseded_by is None:
+                orm.superseded_by = winner_id
+            orm.active = False
+            await self._heart.link_facts(winner_id, loser_id, "supersedes", 1.0, session)
+            await session.commit()
+
     async def _phase_resolve_contradictions(self, sleep_stats: dict) -> bool:
         """Phase 4.5: Find and resolve contradictory facts (F031)."""
         if not self._llm:
@@ -912,18 +930,20 @@ class SleepHandler:
 
                 try:
                     if action == "SUPERSEDE_A":
-                        # Deactivate the loser — winner (fact2) already exists and is active
-                        await self._heart.deactivate_fact(fact1_id)
+                        # loser=fact1, winner=fact2 (already active). 2a: preserve
+                        # the chain (superseded_by + edge), not a bare deactivate.
+                        await self._apply_supersede(winner_id=fact2_id, loser_id=fact1_id)
                         sleep_stats["contradictions_resolved"] += 1
                         logger.info(
-                            "F031 resolve: %s — deactivated %s, kept %s (%.2f confidence)",
+                            "F031 resolve: %s — superseded %s by %s (%.2f confidence)",
                             action, fact1_id, fact2_id, confidence,
                         )
                     elif action == "SUPERSEDE_B":
-                        await self._heart.deactivate_fact(fact2_id)
+                        # loser=fact2, winner=fact1 (inverted from SUPERSEDE_A).
+                        await self._apply_supersede(winner_id=fact1_id, loser_id=fact2_id)
                         sleep_stats["contradictions_resolved"] += 1
                         logger.info(
-                            "F031 resolve: %s — deactivated %s, kept %s (%.2f confidence)",
+                            "F031 resolve: %s — superseded %s by %s (%.2f confidence)",
                             action, fact2_id, fact1_id, confidence,
                         )
                     elif action == "MERGE":

--- a/tests/test_brain.py
+++ b/tests/test_brain.py
@@ -668,6 +668,36 @@ async def test_neighbors_excludes_inactive_fact(brain, session):
     assert inactive_id not in ids  # superseded/inactive fact filtered out
 
 
+async def test_neighbors_excludes_lineage_and_negative_relations(brain, session):
+    """2b: the unfiltered neighbor fan-out must never surface supersedes (lineage)
+    or contradicts (negative) edges as connectivity; co_occurred IS legitimate
+    associative connectivity for retrieval and is kept. An explicit relation=
+    request is still honoured verbatim (not exercised here)."""
+    from uuid import uuid4
+
+    from nous.storage.models import Fact, GraphEdge
+
+    seed, related, cooc, contra = uuid4(), uuid4(), uuid4(), uuid4()
+    for fid, name in [(seed, "seed"), (related, "related nb"), (cooc, "cooc nb"), (contra, "contra nb")]:
+        session.add(Fact(id=fid, agent_id=brain.agent_id, content=f"{name} fact", active=True))
+    def _edge(t, rel, method):
+        session.add(GraphEdge(
+            source_id=seed, target_id=t, source_type="fact", target_type="fact",
+            agent_id=brain.agent_id, relation=rel, weight=1.0, auto_linked=True,
+            extraction_method=method,
+        ))
+    _edge(related, "related_to", "heuristic")
+    _edge(cooc, "co_occurred", "co_occurrence")
+    _edge(contra, "contradicts", "inferred")
+    await session.flush()
+
+    ids = [n.id for n in await brain.neighbors(
+        seed, node_type="fact", limit=10, session=session, neighbor_type="fact")]
+    assert related in ids
+    assert cooc in ids               # co_occurred kept (associative for retrieval)
+    assert contra not in ids         # contradicts excluded
+
+
 # ---------------------------------------------------------------------------
 # 18a-Path-A. test_neighbors_resolves_content_for_all_node_types
 # ---------------------------------------------------------------------------

--- a/tests/test_f031_consolidation.py
+++ b/tests/test_f031_consolidation.py
@@ -368,69 +368,71 @@ class TestContradictionResolution:
     """Phase 4.5: resolve accumulated contradictions during sleep."""
 
     @pytest.mark.asyncio
-    async def test_supersede_a_deactivates_loser(self):
-        """SUPERSEDE_A should deactivate fact1, leaving fact2 untouched."""
-        fact1_id = uuid4()
-        fact2_id = uuid4()
-
+    @staticmethod
+    def _heart_with_session(loser_id, winner_id, candidate):
+        """2a (PR #520): SUPERSEDE now preserves the chain in-session, so mock a
+        real session CM + link_facts. orm.superseded_by=None so the race guard
+        proceeds."""
         heart = AsyncMock()
-        heart.find_contradiction_candidates = AsyncMock(return_value=[{
-            "fact1_id": fact1_id,
-            "fact2_id": fact2_id,
-            "content1": "Tim's timezone is EST",
-            "content2": "Tim's timezone is PST",
-            "date1": "2026-03-01",
-            "date2": "2026-03-15",
-            "similarity": 0.88,
-        }])
+        heart.find_contradiction_candidates = AsyncMock(return_value=[candidate])
         heart.deactivate_fact = AsyncMock()
         heart.search_facts = AsyncMock(return_value=[])
+        heart.link_facts = AsyncMock()
+        orm = MagicMock()
+        orm.superseded_by = None
+        mock_session = MagicMock()
+        mock_session.get = AsyncMock(return_value=orm)
+        mock_session.commit = AsyncMock()
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=mock_session)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        heart.db = MagicMock()
+        heart.db.session = MagicMock(return_value=cm)
+        return heart, orm
 
-        llm_response = json.dumps({
-            "action": "SUPERSEDE_A",
-            "confidence": 0.9,
-            "reason": "Fact B is newer",
+    async def test_supersede_a_preserves_chain(self):
+        """SUPERSEDE_A: loser=fact1 superseded_by winner=fact2, + supersedes edge."""
+        fact1_id, fact2_id = uuid4(), uuid4()
+        heart, orm = self._heart_with_session(fact1_id, fact2_id, {
+            "fact1_id": fact1_id, "fact2_id": fact2_id,
+            "content1": "Tim's timezone is EST", "content2": "Tim's timezone is PST",
+            "date1": "2026-03-01", "date2": "2026-03-15", "similarity": 0.88,
         })
-        handler, _, _, bus, _ = _make_sleep_handler(
-            heart=heart, llm_client=_mock_llm_client(llm_response)
+        handler, *_ = _make_sleep_handler(
+            heart=heart,
+            llm_client=_mock_llm_client(json.dumps(
+                {"action": "SUPERSEDE_A", "confidence": 0.9, "reason": "B newer"})),
         )
         sleep_stats = {"facts_created": 0, "procedures_created": 0, "censors_retired": 0}
         result = await handler._phase_resolve_contradictions(sleep_stats)
         assert result is True
-        heart.deactivate_fact.assert_called_once_with(fact1_id)
-        assert sleep_stats["contradictions_found"] == 1
+        assert orm.superseded_by == fact2_id and orm.active is False
+        heart.link_facts.assert_awaited_once()
+        args = heart.link_facts.await_args.args
+        assert args[0] == fact2_id and args[1] == fact1_id and args[2] == "supersedes"
+        heart.deactivate_fact.assert_not_called()
         assert sleep_stats["contradictions_resolved"] == 1
 
     @pytest.mark.asyncio
-    async def test_supersede_b_deactivates_loser(self):
-        """SUPERSEDE_B should deactivate fact2."""
-        fact1_id = uuid4()
-        fact2_id = uuid4()
-
-        heart = AsyncMock()
-        heart.find_contradiction_candidates = AsyncMock(return_value=[{
-            "fact1_id": fact1_id,
-            "fact2_id": fact2_id,
-            "content1": "Correct info",
-            "content2": "Outdated info",
-            "date1": "2026-03-01",
-            "date2": "2026-03-15",
-            "similarity": 0.85,
-        }])
-        heart.deactivate_fact = AsyncMock()
-        heart.search_facts = AsyncMock(return_value=[])
-
-        llm_response = json.dumps({
-            "action": "SUPERSEDE_B",
-            "confidence": 0.85,
-            "reason": "Fact A is correct",
+    async def test_supersede_b_preserves_chain(self):
+        """SUPERSEDE_B inverts: loser=fact2, winner=fact1."""
+        fact1_id, fact2_id = uuid4(), uuid4()
+        heart, orm = self._heart_with_session(fact2_id, fact1_id, {
+            "fact1_id": fact1_id, "fact2_id": fact2_id,
+            "content1": "Correct info", "content2": "Outdated info",
+            "date1": "2026-03-01", "date2": "2026-03-15", "similarity": 0.85,
         })
-        handler, _, _, bus, _ = _make_sleep_handler(
-            heart=heart, llm_client=_mock_llm_client(llm_response)
+        handler, *_ = _make_sleep_handler(
+            heart=heart,
+            llm_client=_mock_llm_client(json.dumps(
+                {"action": "SUPERSEDE_B", "confidence": 0.85, "reason": "A correct"})),
         )
         sleep_stats = {"facts_created": 0, "procedures_created": 0, "censors_retired": 0}
         await handler._phase_resolve_contradictions(sleep_stats)
-        heart.deactivate_fact.assert_called_once_with(fact2_id)
+        assert orm.superseded_by == fact1_id
+        args = heart.link_facts.await_args.args
+        assert args[0] == fact1_id and args[1] == fact2_id and args[2] == "supersedes"
+        heart.deactivate_fact.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_merge_supersedes_both_originals(self):
@@ -723,19 +725,13 @@ class TestContradictionResolution:
     @pytest.mark.asyncio
     async def test_action_normalization(self):
         """Action string should be normalized (uppercase, stripped)."""
-        fact1_id = uuid4()
-        heart = AsyncMock()
-        heart.find_contradiction_candidates = AsyncMock(return_value=[{
-            "fact1_id": fact1_id,
-            "fact2_id": uuid4(),
-            "content1": "A",
-            "content2": "B",
-            "date1": "2026-03-01",
-            "date2": "2026-03-15",
-            "similarity": 0.85,
-        }])
-        heart.deactivate_fact = AsyncMock()
-        heart.search_facts = AsyncMock(return_value=[])
+        fact1_id, fact2_id = uuid4(), uuid4()
+        # SUPERSEDE_A → loser=fact1, winner=fact2.
+        heart, orm = self._heart_with_session(fact1_id, fact2_id, {
+            "fact1_id": fact1_id, "fact2_id": fact2_id,
+            "content1": "A", "content2": "B",
+            "date1": "2026-03-01", "date2": "2026-03-15", "similarity": 0.85,
+        })
 
         # Lowercase action with whitespace
         llm_response = json.dumps({
@@ -748,7 +744,9 @@ class TestContradictionResolution:
         )
         sleep_stats = {"facts_created": 0, "procedures_created": 0, "censors_retired": 0}
         await handler._phase_resolve_contradictions(sleep_stats)
-        heart.deactivate_fact.assert_called_once_with(fact1_id)
+        # Normalized to SUPERSEDE_A → chain preserved (not a bare deactivate).
+        assert orm.superseded_by == fact2_id
+        heart.link_facts.assert_awaited_once()
 
 
 # ===========================================================================

--- a/tests/test_graph_constants.py
+++ b/tests/test_graph_constants.py
@@ -1,0 +1,55 @@
+"""2b (2026-06-13 audit): canonical graph-edge exclusion sets + the meta-check
+that every graph consumer routes through them (so the relation-exclusion logic
+can't drift across consumers again)."""
+
+from __future__ import annotations
+
+import inspect
+
+from nous.brain.graph_constants import (
+    AUTOBEHAVIOR_EXCLUDED_METHODS,
+    AUTOBEHAVIOR_EXCLUDED_RELATIONS,
+    RETRIEVAL_EXCLUDED_RELATIONS,
+    autobehavior_exclusion_sql,
+)
+
+
+def test_autobehavior_set_covers_the_audit_relations():
+    assert {"supersedes", "contradicts", "happened_before", "co_occurred"} <= AUTOBEHAVIOR_EXCLUDED_RELATIONS
+    assert "co_mention" in AUTOBEHAVIOR_EXCLUDED_METHODS
+
+
+def test_retrieval_set_is_lineage_and_negative_only():
+    # co_occurred / co_mention are legitimate associative connectivity for
+    # retrieval and MUST NOT be excluded there.
+    assert RETRIEVAL_EXCLUDED_RELATIONS == {"supersedes", "contradicts"}
+    assert "co_occurred" not in RETRIEVAL_EXCLUDED_RELATIONS
+
+
+def test_exclusion_sql_renders_all_relations_and_method():
+    sql = autobehavior_exclusion_sql("e.")
+    for rel in AUTOBEHAVIOR_EXCLUDED_RELATIONS:
+        assert f"'{rel}'" in sql
+    assert "e.relation NOT IN" in sql
+    assert "e.extraction_method" in sql
+    assert "IS NULL" in sql  # keeps NULL/legacy rows counted
+
+
+def test_all_autobehavior_consumers_use_the_constant():
+    """Every auto-behavior consumer must route through graph_constants so a new
+    relation is a single-site edit."""
+    from nous.brain import graph_densifier, spreading_activation
+
+    dens_src = inspect.getsource(spreading_activation)
+    densifier_src = inspect.getsource(graph_densifier)
+    assert "autobehavior_exclusion_sql" in dens_src  # density + traversal
+    assert "autobehavior_exclusion_sql" in densifier_src  # find_orphans + discover_clusters
+    # No stray hardcoded single-relation exclusions left behind.
+    assert "relation <> 'supersedes'" not in dens_src
+    assert "relation <> 'supersedes'" not in densifier_src
+
+
+def test_neighbors_uses_retrieval_constant():
+    from nous.brain import brain
+    src = inspect.getsource(brain)
+    assert "RETRIEVAL_EXCLUDED_RELATIONS" in src

--- a/tests/test_graph_densifier.py
+++ b/tests/test_graph_densifier.py
@@ -338,6 +338,37 @@ async def test_find_orphans_ignores_supersedes_edges(db, settings, mock_embeddin
 
 @pytest.mark.postgres_only
 @pytest.mark.asyncio
+async def test_find_orphans_ignores_co_occurred_and_contradicts(db, settings, mock_embeddings, _fix_stale_relation_constraint):
+    """2b: co_occurred / contradicts / happened_before are not associative
+    connectivity for densification — a fact whose only edge is one of them must
+    still be an orphan (else F040 never densifies it)."""
+    agent_id = f"test-orphan-2b-{uuid4().hex[:8]}"
+    linker = GraphLinker(db, mock_embeddings, settings, agent_id)
+    densifier = GraphDensifier(db, linker, mock_embeddings, settings, agent_id)
+
+    async with db.session() as session:
+        emb = await mock_embeddings.embed("co")
+        f_cooc = await _insert_fact(session, agent_id, "co-occurred only fact here", emb)
+        f_other = await _insert_fact(session, agent_id, "co-occurred partner fact here", emb)
+        await session.execute(text(
+            "INSERT INTO brain.graph_edges (agent_id, source_id, target_id, source_type, "
+            "target_type, relation, weight, auto_linked, extraction_method) "
+            "VALUES (:a, :s, :t, 'fact', 'fact', 'co_occurred', 1.0, true, 'co_occurrence')"
+        ), {"a": agent_id, "s": f_cooc, "t": f_other})
+        # control
+        cos_a = await _insert_fact(session, agent_id, "cosine masked fact A3", emb)
+        cos_b = await _insert_fact(session, agent_id, "cosine masked fact B3", emb)
+        await _insert_edge(session, agent_id, cos_a, cos_b, "fact", "fact")
+        await session.commit()
+
+    async with db.session() as session:
+        orphan_ids = [oid for oid, _ in await densifier.find_orphans("fact", 100, session)]
+    assert f_cooc in orphan_ids   # co_occurred does NOT mask
+    assert cos_a not in orphan_ids  # control still masks
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
 async def test_comention_skips_pair_with_contradicts_edge(db, settings, mock_embeddings, _fix_stale_relation_constraint):
     """F076 (codex P2-D): build_comention_edges must NOT add a related_to edge over a
     pair that already has a contradicts edge — adjacency-boost/spreading filter only

--- a/tests/test_sleep_handler.py
+++ b/tests/test_sleep_handler.py
@@ -810,6 +810,18 @@ class TestStructuredContradictionResolution:
             }
         ])
         heart.deactivate_fact = AsyncMock()
+        # 2a: SUPERSEDE now preserves the chain via _apply_supersede, which opens
+        # a session and writes the supersedes edge. Mock the session CM + link.
+        _orm = MagicMock()
+        _orm.superseded_by = None
+        _sess = AsyncMock()
+        _sess.__aenter__ = AsyncMock(return_value=_sess)
+        _sess.__aexit__ = AsyncMock(return_value=False)
+        _sess.get = AsyncMock(return_value=_orm)
+        _sess.commit = AsyncMock()
+        heart.db = MagicMock()
+        heart.db.session = MagicMock(return_value=_sess)
+        heart.link_facts = AsyncMock()
 
         resolution = {"action": "SUPERSEDE_A", "confidence": 0.9, "reason": "Newer info"}
         response = MagicMock()
@@ -823,7 +835,11 @@ class TestStructuredContradictionResolution:
 
         assert result is True
         assert sleep_stats["contradictions_resolved"] == 1
-        heart.deactivate_fact.assert_called_once_with("f1")
+        # 2a: SUPERSEDE_A preserves the chain instead of a bare deactivate —
+        # loser=f1 superseded_by winner=f2, active=False, + supersedes edge.
+        assert _orm.superseded_by == "f2"
+        assert _orm.active is False
+        heart.link_facts.assert_awaited_once_with("f2", "f1", "supersedes", 1.0, _sess)
 
         # Verify tool_choice in payload
         payload = llm_client.call.call_args[0][0]


### PR DESCRIPTION
**PR-2 of the memory-bug fix plan** — re-targeted to `main` after #519 merged (the original #520 was auto-closed when its stacked base branch was deleted; identical content, rebased onto main).

### 2a — F031 SUPERSEDE_A/B preserve the supersede chain
Both branches called `deactivate_fact` alone (no `superseded_by`, no edge), severing lineage. New `_apply_supersede` sets `loser.superseded_by = winner` + writes the `supersedes` edge in one session+commit, per-branch winner/loser (SUPERSEDE_B inverts), with an early-return when the loser is already superseded (codex). REMOVE stays deactivate-only.

### 2b — One canonical relation-exclusion across graph consumers
New `nous/brain/graph_constants.py` with two purpose-specific sets:
- **AUTOBEHAVIOR** (supersedes/contradicts/happened_before/co_occurred + co_mention) → density gate, spreading traversal, `find_orphans`, `discover_clusters`.
- **RETRIEVAL** (supersedes/contradicts only) → `brain._neighbors` (co_occurred kept as legit associative connectivity; the adjacency-boost/co_occurred-in-neighbors ranking change is deferred to the eval-gated PR-3).

Tests: graph_constants unit + meta (every consumer routes through the constant); find_orphans ignores co_occurred; `_neighbors` excludes lineage/negative but keeps co_occurred; SUPERSEDE_A/B direction + chain. Green on Postgres (the 3 `TestGetThreshold` failures are pre-existing `.env`-contamination).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
