### PR TITLE
exp(rank): sort pre-turn memory by boosted relevance, not frame-tier (PR-3a)

### DIFF
--- a/nous/cognitive/context.py
+++ b/nous/cognitive/context.py
@@ -1067,7 +1067,10 @@ class ContextEngine:
             wrapped = _wrap_with_score(item, (getattr(item, "score", 0) or 0) * boost)
             boosted.append((wrapped, boost))
 
-        boosted.sort(key=lambda x: x[1], reverse=True)
+        # 3a: sort by the boosted score, not the usage multiplier (same fix as
+        # apply_frame_boost — this is the LAST sort before the gap-cut, so a
+        # multiplier-order here re-corrupts the relevance order the gap-cut reads).
+        boosted.sort(key=lambda x: x[0].score, reverse=True)
         return [item for item, _ in boosted]
 
     def _apply_relevance_filter(self, results: list, memory_type: str) -> list:

--- a/nous/heart/search.py
+++ b/nous/heart/search.py
@@ -491,8 +491,13 @@ def apply_frame_boost(
         wrapped = _wrap_with_score(item, min((getattr(item, "score", 0) or 0) * boost, 1.0))
         boosted.append((wrapped, boost))
 
-    # Sort by boost descending (stable sort preserves relevance order within same boost)
-    boosted.sort(key=lambda x: x[1], reverse=True)
+    # 3a (2026-06-13 audit, eval-gated): sort by the BOOSTED SCORE, not the boost
+    # multiplier. The old `key=x[1]` produced a frame-tier order — every same-frame
+    # item ranked above every non-frame item regardless of relevance, so a 0.3-
+    # relevance frame match buried a 0.95-relevance non-match. Frame match is a
+    # boost on relevance, not an override of it; sort by the boosted score so a
+    # close-relevance frame match still wins but a large relevance gap dominates.
+    boosted.sort(key=lambda x: x[0].score, reverse=True)
     return [item for item, _ in boosted]
 
 

--- a/tests/test_frame_tagged_encoding.py
+++ b/tests/test_frame_tagged_encoding.py
@@ -20,10 +20,17 @@ from nous.heart.search import apply_frame_boost
 # ---------------------------------------------------------------------------
 
 
-def _make_item(encoded_frame=None, encoded_censors=None, name="item"):
-    """Create a mock memory item with frame encoding metadata."""
+def _make_item(encoded_frame=None, encoded_censors=None, name="item", score=0.5):
+    """Create a mock memory item with frame encoding metadata.
+
+    3a (2026-06-13): frame/censor boost MULTIPLIES the relevance score, so items
+    need a base score for the boost to order them. With equal base scores the
+    higher-boost item still ranks first (boost ordering preserved); the fix only
+    changes behaviour when relevance differs (see
+    test_high_relevance_nonframe_beats_low_relevance_frame)."""
     return SimpleNamespace(
         name=name,
+        score=score,
         encoded_frame=encoded_frame,
         encoded_censors=encoded_censors,
     )
@@ -44,6 +51,25 @@ class TestApplyFrameBoost:
         item = _make_item(encoded_frame="debug", name="debug_item")
         results = apply_frame_boost([item], current_frame="decision")
         assert results[0].name == "debug_item"  # Still returned, just not boosted
+
+    def test_high_relevance_nonframe_beats_low_relevance_frame(self):
+        """3a (eval-gated): the core fix. A highly-relevant NON-frame fact must
+        outrank a barely-relevant SAME-frame fact — the old multiplier-sort
+        buried it behind every frame match regardless of relevance."""
+        hi_nonframe = _make_item(encoded_frame="conversation", name="hi", score=0.95)
+        lo_frame = _make_item(encoded_frame="decision", name="lo", score=0.30)
+        results = apply_frame_boost([lo_frame, hi_nonframe], current_frame="decision")
+        # 0.95 * 1.0 = 0.95  vs  0.30 * 1.3 = 0.39  → relevance dominates.
+        assert results[0].name == "hi"
+        assert results[1].name == "lo"
+
+    def test_close_relevance_frame_match_still_wins(self):
+        """Frame boost still breaks a near-tie — a same-frame fact at 0.80 beats a
+        non-frame fact at 0.85 (0.80*1.3=1.04 clamp 1.0 > 0.85)."""
+        frame = _make_item(encoded_frame="decision", name="frame", score=0.80)
+        nonframe = _make_item(encoded_frame="conversation", name="nonframe", score=0.85)
+        results = apply_frame_boost([nonframe, frame], current_frame="decision")
+        assert results[0].name == "frame"
 
     def test_null_frame_neutral(self):
         """NULL encoded_frame = no boost, no penalty."""

--- a/tests/test_scored_wrapper.py
+++ b/tests/test_scored_wrapper.py
@@ -39,12 +39,14 @@ class TestScoredWrapper:
 class TestFrameBoostWriteback:
     def test_boost_writes_score(self):
         items = [
-            FakeItem(score=0.5, encoded_frame="task"),
-            FakeItem(score=0.7, encoded_frame="debug"),
+            FakeItem(score=0.5, encoded_frame="task", name="task_item"),
+            FakeItem(score=0.7, encoded_frame="debug", name="debug_item"),
         ]
         result = apply_frame_boost(items, current_frame="task")
-        # First item (task frame) gets 1.3x boost: 0.5 * 1.3 = 0.65
-        boosted_item = [r for r in result if r.name == "item"][0]  # the task one
+        # The task-frame item gets the 1.3x boost: 0.5 * 1.3 = 0.65 written to its
+        # .score. (3a: order is now by boosted score — 0.65 < 0.7, so the
+        # unboosted debug item ranks first; find the boosted one by name.)
+        boosted_item = [r for r in result if r.name == "task_item"][0]
         assert abs(boosted_item.score - 0.65) < 0.01
 
     def test_no_frame_no_change(self):


### PR DESCRIPTION
**PR-3a — eval-gated ranking experiment** (memory-bug plan). Not a correctness fix; the prior frame-tier behaviour was intentional/tested, so this is a measured behaviour change.

### The bug
The pre-turn context boost stages — `apply_frame_boost` (`search.py`) and `_apply_usage_boost` (`context.py`) — sorted by the boost **multiplier** (`key=x[1]`), not the boosted **score** they'd just computed. Result: a frame-tier order where every same-frame fact ranked above every non-frame fact *regardless of relevance* — a 0.3-relevance frame match buried a 0.95-relevance non-match in every fact/procedure/episode section of the prompt, every turn. `_apply_usage_boost` is the last sort before the gap-cut, so its multiplier-order also fed the relevance filter a mis-ordered list.

### The change
Sort by `x[0].score` (the boosted score). Frame/censor match is now a **boost on relevance**, not an **override** of it.

### Measurement (the gate)
A deterministic **context-assembly probe** (this path is *not* exercised by `nous_eval`/`run_recall_pipeline`):
- `test_high_relevance_nonframe_beats_low_relevance_frame` — 0.95 non-frame now outranks 0.30 frame ✓
- `test_close_relevance_frame_match_still_wins` — 0.80 frame still beats 0.85 non-frame (boost breaks near-ties) ✓
- existing frame/censor-boost tests pass once given base scores (equal relevance → higher boost still wins)

**Scope:** pre-turn `ContextEngine` only → **zero recall_deep regression surface**. The 3b staleness-clamp concern is subsumed (clamped ties keep relevance order; gap-cut/context-quality suite green).

**Honest caveat:** a full QA A/B (LongMemEval-style) is the ideal confirmation of "better for the LLM"; it wasn't run given the small expected signal and the strong a-priori case (computing a boosted score then ignoring it for sorting, and burying relevant facts, is hard to defend). Merge decision is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
