### PR TITLE
fix(summarizer): non-dict parse result is a clean skip, not a crash

### DIFF
--- a/docs/reviews/2026-06-14-extraction-coverage-audit.md
+++ b/docs/reviews/2026-06-14-extraction-coverage-audit.md
@@ -112,3 +112,32 @@ flipping `NOUS_EXTRACTION_COVERAGE_BROADENED=true`.
   `coverage_audit.py`, P2). The **authoritative delivered-coverage measure is
   the QA flip-gate** — it runs the full storage→admission→retrieval→QA pipeline
   end-to-end, which is what actually gates the prod flip.
+
+### QA flip-gate result (matched Opus BEAM-100K n=5 A/B) — PASS
+
+`scripts/diag/beam_flipgate.sh`: same corpus, same session, Opus, OFF then ON.
+
+| ability | OFF | ON | Δ |
+|---|---|---|---|
+| temporal_reasoning | 0.575 | 0.625 | **+0.050** |
+| abstention | 0.950 | 1.000 | +0.050 |
+| knowledge_update | 0.575 | 0.600 | +0.025 |
+| contradiction_resolution | 0.794 | 0.806 | +0.013 |
+| information_extraction | 0.729 | 0.738 | +0.008 |
+| multi_session_reasoning | 0.751 | 0.732 | −0.019 |
+| event_ordering | 0.039 | 0.036 | −0.003 |
+| **AGGREGATE** | **0.654** | **0.667** | **+0.013** |
+
+**No QA regression — a small net gain (+0.013), concentrated in the
+coverage-relevant abilities** (temporal_reasoning, knowledge_update,
+information_extraction, abstention). `event_ordering` stays flat (canonical-event
+topical-choice gated, not coverage-gated). Both measures now agree — recall up
+(0.73→0.91) AND QA up — so the gate **passes**: recommend
+`NOUS_EXTRACTION_COVERAGE_BROADENED=true` in prod.
+
+The first flip-gate attempt was confounded and stopped early: it surfaced (a)
+eval-scratch `graph_edges` constraint drift (synced), and (b) a **flag-correlated
+parse crash** — broadened (longer) output more often makes
+`_summarize_single`'s `parse_llm_json` return a bare list, crashing the episode's
+fact storage. Fixed as a real prod robustness bug (non-dict parse → clean skip,
+not a crash) so the matched A/B isn't biased against the ON arm.

--- a/nous/handlers/episode_summarizer.py
+++ b/nous/handlers/episode_summarizer.py
@@ -563,10 +563,22 @@ class EpisodeSummarizer:
             return None
 
         try:
-            return parse_llm_json(text)
+            result = parse_llm_json(text)
         except json.JSONDecodeError as e:
             logger.warning("Summary generation failed: %s", e)
             return None
+        # parse_llm_json can return a bare list when the model emits a JSON
+        # array instead of the summary object (truncation / format drift —
+        # more likely with the longer coverage-broadened output). The caller
+        # and _merge_summaries call .get() on the result, so a non-dict must be
+        # a clean skip (None), not a crash that loses the whole episode.
+        if not isinstance(result, dict):
+            logger.warning(
+                "Summary parse returned %s, not an object; skipping summary",
+                type(result).__name__,
+            )
+            return None
+        return result
 
     def _chunk_transcript(self, transcript: str, max_chars: int = 16000) -> list[str]:
         """F025 P3-B: Split long transcript into chunks at turn boundaries.

--- a/scripts/diag/beam_flipgate.sh
+++ b/scripts/diag/beam_flipgate.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# QA flip-gate: matched BEAM-100K n=5 A/B for extraction_coverage_broadened.
+# Both arms: same corpus, same session, Opus. OFF then ON. Reports official
+# BEAM scores per arm to reports/beam/flipgate_{off,on}.json.
+cd /e/Projects/nous
+export NOUS_BEAM_BEAM_PYTHON='E:\Projects\nous\tools\beam\.venv\Scripts\python.exe'
+export NOUS_TEMPORAL_EXTRACTION_ENABLED=true   # held constant (matches prod)
+export PYTHONUTF8=1
+export PYTHONPATH=.
+
+# Revive the harness from bytecode (source is gitignored/lost; .pyc remain).
+( cd nous_eval/beam && for f in __pycache__/*.cpython-314.pyc; do
+    cp "$f" "$(basename "$f" .cpython-314.pyc).pyc"; done )
+
+clear_scratch() {
+  uv run python - <<'PY'
+import asyncio, asyncpg
+async def m():
+    c = await asyncpg.connect(host='localhost', port=5433, user='nous',
+                              password='nous_eval', database='nous_eval_scratch')
+    for t in ['brain.graph_edges','heart.episode_chunks','heart.facts',
+              'heart.episodes','heart.procedures','heart.working_memory','brain.decisions']:
+        try: await c.execute(f"DELETE FROM {t} WHERE agent_id LIKE 'beam%'")
+        except Exception as e: print('clear err', t, str(e)[:40])
+    await c.close()
+asyncio.run(m())
+PY
+}
+
+run_arm() {
+  local flag=$1 name=$2
+  echo "================ ARM $name (extraction_coverage_broadened=$flag) ================"
+  clear_scratch
+  NOUS_EXTRACTION_COVERAGE_BROADENED=$flag \
+    uv run python -m nous_eval.beam --conv-limit 5 --cost-cap-usd 35 run
+  echo "---- report $name ----"
+  uv run python -m nous_eval.beam --conv-limit 5 report
+  cp reports/beam/100K_summary.json "reports/beam/flipgate_${name}.json"
+  cp -r reports/beam/answers/100K "reports/beam/_flipgate_${name}_answers"
+  echo "================ ARM $name DONE ================"
+}
+
+run_arm false off
+run_arm true on
+echo "================ FLIP-GATE COMPLETE ================"

--- a/scripts/diag/beam_flipgate.sh
+++ b/scripts/diag/beam_flipgate.sh
@@ -2,6 +2,10 @@
 # QA flip-gate: matched BEAM-100K n=5 A/B for extraction_coverage_broadened.
 # Both arms: same corpus, same session, Opus. OFF then ON. Reports official
 # BEAM scores per arm to reports/beam/flipgate_{off,on}.json.
+#
+# Fail-closed: any failure (scratch clear, BEAM run/cost-cap, report) ABORTS the
+# gate rather than continuing — a half-cleared DB or a stale summary would
+# silently invalidate the matched A/B (codex PR #525).
 cd /e/Projects/nous
 export NOUS_BEAM_BEAM_PYTHON='E:\Projects\nous\tools\beam\.venv\Scripts\python.exe'
 export NOUS_TEMPORAL_EXTRACTION_ENABLED=true   # held constant (matches prod)
@@ -12,17 +16,20 @@ export PYTHONPATH=.
 ( cd nous_eval/beam && for f in __pycache__/*.cpython-314.pyc; do
     cp "$f" "$(basename "$f" .cpython-314.pyc).pyc"; done )
 
+# Clears all beam-agent rows. Errors propagate (no per-table swallow) so a
+# partial clear aborts the gate instead of contaminating the next arm.
 clear_scratch() {
   uv run python - <<'PY'
 import asyncio, asyncpg
 async def m():
     c = await asyncpg.connect(host='localhost', port=5433, user='nous',
                               password='nous_eval', database='nous_eval_scratch')
-    for t in ['brain.graph_edges','heart.episode_chunks','heart.facts',
-              'heart.episodes','heart.procedures','heart.working_memory','brain.decisions']:
-        try: await c.execute(f"DELETE FROM {t} WHERE agent_id LIKE 'beam%'")
-        except Exception as e: print('clear err', t, str(e)[:40])
-    await c.close()
+    try:
+        for t in ['brain.graph_edges','heart.episode_chunks','heart.facts',
+                  'heart.episodes','heart.procedures','heart.working_memory','brain.decisions']:
+            await c.execute(f"DELETE FROM {t} WHERE agent_id LIKE 'beam%'")
+    finally:
+        await c.close()
 asyncio.run(m())
 PY
 }
@@ -30,13 +37,18 @@ PY
 run_arm() {
   local flag=$1 name=$2
   echo "================ ARM $name (extraction_coverage_broadened=$flag) ================"
-  clear_scratch
+  clear_scratch        || { echo "ABORT: scratch clear failed (arm $name)"; exit 1; }
+  # Remove any prior summary so a failed report can't archive a stale one.
+  rm -f reports/beam/100K_summary.json
   NOUS_EXTRACTION_COVERAGE_BROADENED=$flag \
-    uv run python -m nous_eval.beam --conv-limit 5 --cost-cap-usd 35 run
+    uv run python -m nous_eval.beam --conv-limit 5 --cost-cap-usd 35 run \
+    || { echo "ABORT: BEAM run failed/cost-capped (arm $name)"; exit 1; }
   echo "---- report $name ----"
-  uv run python -m nous_eval.beam --conv-limit 5 report
+  uv run python -m nous_eval.beam --conv-limit 5 report \
+    || { echo "ABORT: report failed (arm $name)"; exit 1; }
+  [ -f reports/beam/100K_summary.json ] \
+    || { echo "ABORT: report produced no summary (arm $name)"; exit 1; }
   cp reports/beam/100K_summary.json "reports/beam/flipgate_${name}.json"
-  cp -r reports/beam/answers/100K "reports/beam/_flipgate_${name}_answers"
   echo "================ ARM $name DONE ================"
 }
 


### PR DESCRIPTION
## Bug (surfaced by the coverage QA flip-gate)

`EpisodeSummarizer._summarize_single` returns `parse_llm_json(text)` directly. `parse_llm_json` can return a **bare list** when the model emits a JSON array instead of the summary object (truncation / format drift). The caller (`summarize_episode` / `_merge_summaries`) and `FactExtractor` call `.get()` on the result, so a non-dict crashed the episode's fact storage:

```
AttributeError: 'list' object has no attribute 'get'
```

This is **flag-correlated**: `extraction_coverage_broadened` produces longer output (`max_tokens` 3000), which is more likely to truncate/malform → more bare-list returns → more crashed episodes in the ON arm. That would bias a coverage A/B against ON, which is why I caught it while running the flip-gate.

## Fix

Guard the parse result: a non-dict logs a warning and returns `None` — a clean skip, consistent with the existing `JSONDecodeError` path. The episode produces no summary instead of crashing the ingest.

## Flip-gate result (this is what found the bug)

Matched Opus BEAM-100K n=5 A/B (`scripts/diag/beam_flipgate.sh`, OFF vs ON, same session/corpus): aggregate **0.654 → 0.667 (+0.013)**, no regression, gains in temporal_reasoning (+0.05), knowledge_update (+0.025), information_extraction. → recommend `NOUS_EXTRACTION_COVERAGE_BROADENED=true` in prod (the #524 feature, now QA-validated).

## Tests
Existing summarizer tests green (the LLM mocks return valid JSON → `isinstance` dict path unchanged); the guard only adds a skip for the malformed-array case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)