### PR TITLE
fix(F031): raise resolver max_tokens 300->800 (91% of merges silently failed)

### DIFF
--- a/docs/reviews/2026-06-14-contradiction-loop-audit.md
+++ b/docs/reviews/2026-06-14-contradiction-loop-audit.md
@@ -40,8 +40,10 @@ cycle.
 
 ## Fix
 
-- `sleep_handler.py:874` resolver `max_tokens` **300 → 800** (the confirmed fix).
-- `sleep_handler.py:1275` cluster `merge_facts` `max_tokens` **600 → 800**
+- `sleep_handler.py:874` resolver `max_tokens` **300 → 1000** (800 was proven
+  sufficient at 6/6 with ~2× headroom over the ~400-token observed usage; 1000
+  is free tail headroom since `max_tokens` is a ceiling).
+- `sleep_handler.py:1275` cluster `merge_facts` `max_tokens` **600 → 1000**
   (precautionary — same truncation class, multi-fact merges can be longer).
 
 Tests green (`test_f031_consolidation`, `test_sleep_handler`).

--- a/docs/reviews/2026-06-14-contradiction-loop-audit.md
+++ b/docs/reviews/2026-06-14-contradiction-loop-audit.md
@@ -1,0 +1,59 @@
+# Contradiction-loop audit — prod (`nous-default`), 2026-06-14
+
+Started as "close the deferred Fix C: surface fact contradictions in recall."
+The data redirected it: genuine contradictions are rare, and the real bug is a
+**91% silent MERGE-consolidation failure** caused by a too-small token cap.
+
+## What the loop actually does on prod
+
+| signal | count |
+|---|---|
+| `f031_contradiction_resolution` events | 819 |
+| `contradicts` graph edges | **0** |
+| facts with `contradiction_of` | 1 |
+
+Resolution **raw** action: MERGE 774, KEEP_BOTH 40, SUPERSEDE 5.
+Resolution **applied** action: KEEP_BOTH 748, MERGE 66, SUPERSEDE 5.
+**`MERGE → KEEP_BOTH` downgrades for missing content: 708.**
+
+So 95% of "contradictions" are actually **complementary facts the classifier
+wants to merge** (genuine conflicts are 5/819), and **708 of 774 intended merges
+(91%) were silently downgraded to KEEP_BOTH** because the MERGE arrived with
+empty `merged_content`.
+
+## Root cause — `max_tokens=300` truncation (confirmed 6/6)
+
+`_phase_resolve_contradictions` called the resolver at `max_tokens=300`
+(`sleep_handler.py:874`). The `resolve_contradiction` schema emits
+`action, confidence, reason, merged_content` **in that order**, and the model
+writes a verbose `reason` (~500 chars ≈ 130 tokens, despite "brief") that
+exhausts the 300-token budget before `merged_content` (last) is emitted →
+empty → the safety floor downgrades MERGE → KEEP_BOTH.
+
+`scripts/diag/probe_merge_truncation.py` re-ran 6 real downgraded pairs at 300 vs
+800: **6/6 returned MERGE with empty `merged_content` at 300 and MERGE with
+510–819-char `merged_content` at 800.** Not the model declining — pure truncation.
+
+**Impact:** 708 complementary-fact pairs that should have consolidated into one
+fact were instead left as two near-duplicate facts — memory bloat, every sleep
+cycle.
+
+## Fix
+
+- `sleep_handler.py:874` resolver `max_tokens` **300 → 800** (the confirmed fix).
+- `sleep_handler.py:1275` cluster `merge_facts` `max_tokens` **600 → 800**
+  (precautionary — same truncation class, multi-fact merges can be longer).
+
+Tests green (`test_f031_consolidation`, `test_sleep_handler`).
+
+## Secondary finding (low value — noted, not fixed)
+
+The recall-surfacing of fact contradictions IS broken — `run_recall_pipeline`
+Stage 5 (`retrieval_pipeline.py:680-686`) populates its contradiction-query id
+set **only from `decision_results` + `graph_expanded`**, never facts, so
+fact↔fact `contradicts` edges can never surface. But it's low value here:
+genuine contradictions are rare (5), `contradicts` edges aren't even written on
+KEEP_BOTH (#518 shipped Fix A/supersedes only; Fix B deferred), and after the
+MERGE fix the genuine-KEEP_BOTH population shrinks further. Closing the surfacing
+loop (Fix B contradicts edges + Stage 5 fact inclusion) stays deferred — the
+corpus doesn't have enough genuine fact contradictions to justify it.

--- a/nous/handlers/sleep_handler.py
+++ b/nous/handlers/sleep_handler.py
@@ -871,7 +871,15 @@ class SleepHandler:
                     tool_name="resolve_contradiction",
                     tool_description="Resolve a contradiction between two facts in memory.",
                     output_schema=_CONTRADICTION_RESOLUTION_SCHEMA,
-                    max_tokens=300,
+                    # 300 truncated the tool call: the model writes a ~500-char
+                    # `reason` (schema-ordered before `merged_content`) which
+                    # exhausted the budget, so MERGE verdicts arrived with empty
+                    # merged_content and the safety floor downgraded them to
+                    # KEEP_BOTH. Prod: 708/774 (91%) of intended merges silently
+                    # failed this way, leaving complementary facts unconsolidated.
+                    # Probe (scripts/diag/probe_merge_truncation.py) recovered
+                    # merged_content on 6/6 of those pairs at 800.
+                    max_tokens=800,
                 )
 
                 if not resolution:
@@ -1264,7 +1272,12 @@ class SleepHandler:
                         "irreconcilable contradictions."
                     ),
                     output_schema=_CLUSTER_MERGE_SCHEMA,
-                    max_tokens=600,
+                    # Align with the pairwise resolver (600 -> 800): same
+                    # truncation class — a multi-fact cluster merge can need a
+                    # longer merged_content than 600 leaves room for after the
+                    # should_merge analysis. Precautionary (cluster path not
+                    # separately measured, but same failure mode).
+                    max_tokens=800,
                 )
 
                 # Per-action event for retrospective audit (sleep eval

--- a/nous/handlers/sleep_handler.py
+++ b/nous/handlers/sleep_handler.py
@@ -878,8 +878,11 @@ class SleepHandler:
                     # KEEP_BOTH. Prod: 708/774 (91%) of intended merges silently
                     # failed this way, leaving complementary facts unconsolidated.
                     # Probe (scripts/diag/probe_merge_truncation.py) recovered
-                    # merged_content on 6/6 of those pairs at 800.
-                    max_tokens=800,
+                    # merged_content on 6/6 of those pairs at 800 (observed usage
+                    # ~400 tok: reason ~170 + merged_content ~205). Set to 1000
+                    # for tail headroom — max_tokens is a ceiling, so the extra
+                    # costs nothing unless a generation actually needs it.
+                    max_tokens=1000,
                 )
 
                 if not resolution:
@@ -1272,12 +1275,12 @@ class SleepHandler:
                         "irreconcilable contradictions."
                     ),
                     output_schema=_CLUSTER_MERGE_SCHEMA,
-                    # Align with the pairwise resolver (600 -> 800): same
-                    # truncation class — a multi-fact cluster merge can need a
-                    # longer merged_content than 600 leaves room for after the
-                    # should_merge analysis. Precautionary (cluster path not
-                    # separately measured, but same failure mode).
-                    max_tokens=800,
+                    # Align with the pairwise resolver (600 -> 1000): same
+                    # truncation class, and a multi-fact cluster merge can need a
+                    # longer merged_content than the pairwise case. Precautionary
+                    # (cluster path not separately measured); the ceiling costs
+                    # nothing unless hit.
+                    max_tokens=1000,
                 )
 
                 # Per-action event for retrospective audit (sleep eval

--- a/scripts/diag/probe_merge_truncation.py
+++ b/scripts/diag/probe_merge_truncation.py
@@ -1,0 +1,93 @@
+"""Confirm the F031 MERGE 91%-missing-content failure is max_tokens=300 truncation.
+
+Pulls real prod pairs that were downgraded MERGE->KEEP_BOTH for missing content,
+re-runs the resolution LLM call at 300 (repro) vs 800 tokens, and reports whether
+merged_content appears only at the higher budget.
+
+    PROD_PW=... NOUS_BACKGROUND_MODEL=claude-sonnet-4-6 \\
+    PYTHONPATH=. uv run python scripts/diag/probe_merge_truncation.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+
+import asyncpg
+
+from nous.api.anthropic_client import create_client
+from nous.config import Settings
+from nous.handlers import call_background_llm_structured
+from nous.handlers.sleep_handler import (
+    _CONTRADICTION_RESOLUTION_PROMPT,
+    _CONTRADICTION_RESOLUTION_SCHEMA,
+)
+
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+PROD = dict(host="192.168.1.141", port=5432, user="nous",
+            password=os.environ["PROD_PW"], database="nous")
+AGENT = "nous-default"
+
+
+async def _run(client, model, prompt, max_tokens):
+    r = await call_background_llm_structured(
+        client=client, model=model,
+        system_prompt="You are a memory management system resolving contradictory facts.",
+        user_message=prompt, tool_name="resolve_contradiction",
+        tool_description="Resolve a contradiction between two facts in memory.",
+        output_schema=_CONTRADICTION_RESOLUTION_SCHEMA, max_tokens=max_tokens,
+    )
+    if not r:
+        return ("(no result)", 0, 0)
+    return (str(r.get("action", "?")),
+            len(str(r.get("reason", "") or "")),
+            len(str(r.get("merged_content", "") or "").strip()))
+
+
+async def main() -> None:
+    s = Settings()
+    client = create_client(s)
+    await client.start()
+    conn = await asyncpg.connect(**PROD)
+    try:
+        evs = await conn.fetch(
+            "SELECT data FROM nous_system.events WHERE agent_id=$1 "
+            "AND event_type='f031_contradiction_resolution' "
+            "ORDER BY random() LIMIT 40", AGENT)
+        pairs = []
+        for e in evs:
+            d = e["data"]; d = json.loads(d) if isinstance(d, str) else d
+            if d.get("raw_action") == "MERGE" and d.get("downgraded_due_to_missing_content"):
+                pairs.append((d["fact1_id"], d["fact2_id"]))
+            if len(pairs) >= 6:
+                break
+
+        print(f"model={s.background_model}  testing {len(pairs)} missing-content MERGE pairs\n")
+        print(f"{'pair':<5}{'@300 action':<14}{'reason':>7}{'merged':>8}   {'@800 action':<14}{'reason':>7}{'merged':>8}")
+        fixed = 0
+        for i, (f1, f2) in enumerate(pairs, 1):
+            rows = await conn.fetch(
+                "SELECT id, content, learned_at FROM heart.facts WHERE id = ANY($1::uuid[])",
+                [f1, f2])
+            by = {str(r["id"]): r for r in rows}
+            a, b = by.get(f1), by.get(f2)
+            if not a or not b:
+                print(f"{i:<5}(a fact is gone — skip)"); continue
+            prompt = _CONTRADICTION_RESOLUTION_PROMPT.format(
+                date_a=str(a["learned_at"])[:10], date_b=str(b["learned_at"])[:10],
+                content_a=a["content"][:500], content_b=b["content"][:500])
+            act3, rl3, mc3 = await _run(client, s.background_model, prompt, 300)
+            act8, rl8, mc8 = await _run(client, s.background_model, prompt, 800)
+            if mc3 == 0 and mc8 > 0 and act8 == "MERGE":
+                fixed += 1
+            print(f"{i:<5}{act3:<14}{rl3:>7}{mc3:>8}   {act8:<14}{rl8:>7}{mc8:>8}")
+        print(f"\npairs where 800-tokens recovered merged_content (300 empty -> 800 filled): {fixed}/{len(pairs)}")
+    finally:
+        await conn.close()
+        await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Finding (contradiction-loop audit)

Started as "surface fact contradictions in recall" — the prod data redirected it.

`f031_contradiction_resolution`: **819 events, 0 `contradicts` edges, 1 `contradiction_of`.** Genuine contradictions are rare (5 SUPERSEDE); **95% are complementary facts the classifier wants to MERGE.** But:

| | RAW | APPLIED |
|---|---|---|
| MERGE | 774 | 66 |
| KEEP_BOTH | 40 | 748 |
| SUPERSEDE | 5 | 5 |

**708 of 774 intended merges (91%) were downgraded `MERGE → KEEP_BOTH` for missing `merged_content`.**

## Root cause: `max_tokens=300` truncation (confirmed 6/6)

The `resolve_contradiction` call used `max_tokens=300`. The schema emits `action, confidence, reason, merged_content` **in that order**, and the model writes a ~500-char `reason` (~130 tokens, despite the prompt saying "brief") that exhausts the budget before `merged_content` (last) is emitted → empty → the safety floor downgrades MERGE → KEEP_BOTH.

`scripts/diag/probe_merge_truncation.py` re-ran 6 real downgraded pairs at 300 vs 800: **6/6 empty `merged_content` at 300, 510–819 chars at 800.** Not the model declining — pure truncation.

**Impact:** 708 complementary-fact pairs left as two near-duplicate facts instead of consolidated into one — memory bloat, every sleep cycle.

## Fix
- resolver `max_tokens` **300 → 800** (confirmed)
- cluster `merge_facts` **600 → 800** (precautionary, same truncation class)

Tests green (`test_f031_consolidation`, `test_sleep_handler`).

## Secondary finding (low value, deferred)
Recall Stage 5 contradiction surfacing is decision-scoped (`retrieval_pipeline.py:680-686` never adds facts) so fact↔fact `contradicts` edges can't surface — but genuine fact contradictions are too rare here (5) to justify closing it (and edges aren't written on KEEP_BOTH; #518 Fix B deferred). Documented in `docs/reviews/2026-06-14-contradiction-loop-audit.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)