### PR TITLE
fix(F031): re-check cooldown so settled KEEP_BOTH pairs aren't re-resolved every cycle

### DIFF
--- a/nous/config.py
+++ b/nous/config.py
@@ -667,6 +667,19 @@ class Settings(BaseSettings):
     contradiction_detection: bool = True
     contradiction_similarity_threshold: float = 0.85
     contradiction_model: str = "claude-haiku-4-5-20251001"
+    contradiction_recheck_cooldown_days: int = Field(
+        default=30,
+        ge=0,
+        description=(
+            "F031 re-check cooldown (2026-06-14 audit). find_contradiction_candidates "
+            "had no 'already-resolved' filter, so genuine-KEEP_BOTH pairs (both stay "
+            "active) were re-fetched + re-resolved every sleep cycle forever — wasted "
+            "LLM calls, and at scale they fill the ORDER BY similarity LIMIT slots and "
+            "starve new candidates. When > 0, a pair with an f031_contradiction_resolution "
+            "event within this many days is skipped (re-evaluated after the window, so a "
+            "changed pair still gets reconsidered). 0 disables the cooldown."
+        ),
+    )
 
     # F022 Phase 4: Spreading activation
     spreading_activation_enabled: str = "auto"  # "auto", "true", "false"

--- a/nous/heart/facts.py
+++ b/nous/heart/facts.py
@@ -2061,6 +2061,13 @@ class FactManager:
         # so genuine-KEEP_BOTH pairs aren't re-resolved every sleep cycle (wasted
         # LLM calls + LIMIT-slot starvation). Reuses the persisted resolution
         # events — no new table. After the window the pair is reconsidered.
+        # BEST-EFFORT BY DESIGN: this is an optimization, not a correctness gate.
+        # The f031 event is written fire-and-forget (sleep_handler), so a lost
+        # event (crash before the task runs, or insert failure) simply means the
+        # pair is re-processed once more next cycle — re-resolved KEEP_BOTH
+        # (idempotent) and the event re-written. It can never produce a wrong
+        # result, only momentarily revert to the pre-cooldown re-processing it
+        # reduces; not worth synchronizing the background event write to harden.
         cooldown_days = (
             getattr(self._settings, "contradiction_recheck_cooldown_days", 30)
             if self._settings is not None else 30

--- a/nous/heart/facts.py
+++ b/nous/heart/facts.py
@@ -2056,7 +2056,35 @@ class FactManager:
         limit: int,
         session: AsyncSession,
     ) -> list[dict]:
-        sql = text("""
+        params: dict = {"agent_id": self.agent_id, "limit": limit}
+        # F031 re-check cooldown: skip pairs resolved within the cooldown window
+        # so genuine-KEEP_BOTH pairs aren't re-resolved every sleep cycle (wasted
+        # LLM calls + LIMIT-slot starvation). Reuses the persisted resolution
+        # events — no new table. After the window the pair is reconsidered.
+        cooldown_days = (
+            getattr(self._settings, "contradiction_recheck_cooldown_days", 30)
+            if self._settings is not None else 30
+        )
+        cooldown_clause = ""
+        if cooldown_days and cooldown_days > 0:
+            params["cooldown_days"] = int(cooldown_days)
+            cooldown_clause = """
+              AND NOT EXISTS (
+                  SELECT 1 FROM nous_system.events e
+                  WHERE e.agent_id = :agent_id
+                    AND e.event_type = 'f031_contradiction_resolution'
+                    AND e.created_at > now() - (:cooldown_days * interval '1 day')
+                    -- Only cool down GENUINE keep-both verdicts. Truncation-
+                    -- downgraded merges (raw_action='MERGE') must still retry —
+                    -- they are mergeable and now succeed under the 1000-token cap,
+                    -- so they should NOT be suppressed by the cooldown.
+                    AND e.data->>'raw_action' = 'KEEP_BOTH'
+                    AND (
+                        (e.data->>'fact1_id' = f1.id::text AND e.data->>'fact2_id' = f2.id::text)
+                        OR (e.data->>'fact1_id' = f2.id::text AND e.data->>'fact2_id' = f1.id::text)
+                    )
+              )"""
+        sql = text(f"""
             SELECT f1.id AS fact1_id, f2.id AS fact2_id,
                    f1.content AS content1, f2.content AS content2,
                    f1.created_at AS date1, f2.created_at AS date2,
@@ -2075,10 +2103,11 @@ class FactManager:
               AND f1.active = true
               AND f1.embedding IS NOT NULL
               AND f1.subject IS NOT NULL
+              {cooldown_clause}
             ORDER BY similarity DESC
             LIMIT :limit
         """)
-        result = await session.execute(sql, {"agent_id": self.agent_id, "limit": limit})
+        result = await session.execute(sql, params)
         return [
             {
                 "fact1_id": row.fact1_id,

--- a/tests/test_f031_consolidation.py
+++ b/tests/test_f031_consolidation.py
@@ -138,6 +138,45 @@ class TestFindContradictionCandidates:
         result = await heart.find_contradiction_candidates(limit=10)
         assert result == []
 
+    @pytest.mark.asyncio
+    async def test_recheck_cooldown_clause_gated(self):
+        """F031 re-check cooldown (2026-06-14): the candidate SQL skips pairs
+        with a recent GENUINE keep-both resolution when cooldown_days>0, and
+        omits the clause at 0. raw_action='KEEP_BOTH' so truncation-downgraded
+        merges still retry."""
+        from types import SimpleNamespace
+
+        from nous.heart.facts import FactManager
+
+        captured: dict = {}
+
+        class _EmptyResult:
+            def all(self):
+                return []
+
+            def __iter__(self):
+                return iter([])
+
+        async def _exec(sql, params):
+            captured["sql"] = str(sql)
+            captured["params"] = dict(params)
+            return _EmptyResult()
+
+        session = SimpleNamespace(execute=_exec)
+        mgr = FactManager.__new__(FactManager)
+        mgr.agent_id = "a"
+
+        mgr._settings = SimpleNamespace(contradiction_recheck_cooldown_days=30)
+        await mgr._find_contradiction_candidates(10, session)
+        assert "NOT EXISTS" in captured["sql"]
+        assert "raw_action" in captured["sql"] and "KEEP_BOTH" in captured["sql"]
+        assert captured["params"].get("cooldown_days") == 30
+
+        mgr._settings = SimpleNamespace(contradiction_recheck_cooldown_days=0)
+        await mgr._find_contradiction_candidates(10, session)
+        assert "NOT EXISTS" not in captured["sql"]
+        assert "cooldown_days" not in captured["params"]
+
 
 # ===========================================================================
 # Task 2: Orient context in sleep reflection


### PR DESCRIPTION
## Follow-up to the contradiction-loop audit (#526)

`find_contradiction_candidates` has no "already-resolved" filter — it re-fetches every active same-subject pair in the 0.75–0.95 band every sleep cycle, regardless of prior verdicts. Genuine-KEEP_BOTH pairs (both correctly stay active) are therefore **re-resolved every cycle forever**: wasted LLM calls, and at scale they fill the `ORDER BY similarity DESC LIMIT 10` slots and **starve new candidates**. The audit data showed it: 819 resolution events spanned only **81 distinct pairs** (~10 re-resolutions each).

## Fix

A re-check cooldown (`NOUS_CONTRADICTION_RECHECK_COOLDOWN_DAYS`, default 30, 0 disables): skip a pair that has an `f031_contradiction_resolution` event with **`raw_action='KEEP_BOTH'`** within the window. After the window it's reconsidered (so a changed pair still gets re-evaluated — a cooldown, not a permanent block). Reuses the persisted events — **no new table/migration**.

The `raw_action='KEEP_BOTH'` discriminator is the key detail: it cools down **genuine** keep-both verdicts but **not** the truncation-*downgraded* merges (`raw_action='MERGE'`), which must still retry and now succeed under #526's 1000-token cap. So the cooldown does **not** block the existing backlog from draining.

## Prod validation (read-only)

The 10 current active candidates → **9** with the cooldown: it suppressed the **1 genuine KEEP_BOTH** pair while keeping the **9 downgraded-merges** eligible (which #526 will now merge). Exactly the intended discrimination.

## Tests
Wiring regression test: clause + `raw_action='KEEP_BOTH'` present when `cooldown_days>0`, absent at 0. `test_f031_consolidation` + `test_sleep_handler` green (71 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)