### PR TITLE
fix(cache): stable tool superset across frames to stop prompt-cache busting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -477,7 +477,8 @@ DB connection vars are **unprefixed** (shared with docker-compose). All others u
 | `NOUS_CACHE_BREAK_DETECTION_ENABLED` | `true` | Enable cache break detection logging (F036) |
 | `NOUS_CACHE_SPLIT_SYSTEM_PROMPT` | `true` | Enable 3-tier system prompt splitting (F036) |
 | `NOUS_CACHE_SINGLE_BREAKPOINT` | `true` | Use single cache breakpoint strategy (F036) |
-| `NOUS_TOOL_SCHEMA_CACHE_ENABLED` | `true` | Cache tool schemas per frame (F036) |
+| `NOUS_TOOL_SCHEMA_CACHE_ENABLED` | `true` | Cache tool schemas per frame (F036) — process-side Python memoization only; does NOT affect the Anthropic prompt cache |
+| `NOUS_STABLE_TOOL_SET_ENABLED` | `true` | Send a STABLE tool superset across all non-`initiation` frames instead of frame-scoped tool arrays. Tools sit at the front of the Anthropic cacheable prefix, so frame-scoped tools busted the whole prefix on every frame change (~10% of prod cache-creation tokens, measured 2026-06-14). Collapses conversational frames to the `task` (`*`) superset; `initiation` keeps its distinct minimal set; `store_identity`/`complete_initiation` are excluded from the superset. `FRAME_TOOLS` still drives the textual frame instructions. Set `false` to restore per-frame tool gating. |
 | `NOUS_DAG_ENABLED` | `true` | Enable DAG orchestration (F038) |
 | `NOUS_CORRECTION_EXTRACTION_ENABLED` | `true` | Enable correction learning pipeline (F039) |
 | `NOUS_GRAPH_BACKFILL_ENABLED` | `true` | Enable graph densification backfill during sleep (F040) |

--- a/docs/reviews/2026-06-14-llm-caching-audit.md
+++ b/docs/reviews/2026-06-14-llm-caching-audit.md
@@ -1,0 +1,102 @@
+# LLM calls & prompt-caching audit — prod (`nous-default`), 2026-06-14
+
+Read-only audit of how Nous assembles LLM calls and whether context is grouped
+to preserve the Anthropic prompt cache. Two halves: **(A) measure prod cache
+performance** from `nous_system.context_log`, **(B) trace the prompt-assembly +
+`cache_control` placement** for stable-before-volatile discipline.
+
+## Verdict
+
+**The cache discipline is fundamentally sound and prod is healthy (88.2% hit
+rate).** One real, quantified inefficiency: **frame-scoped tool schemas bust the
+entire cached prefix on every frame change** (~10% of all cache-creation tokens,
+avoidable). Everything else — tier grouping, block ordering, within-turn reuse —
+is correct.
+
+## A. Prod measurement (`context_log`, 2026-05-14 → 06-14, 857 calls w/ token data)
+
+| metric | value |
+|---|---|
+| overall hit rate (`cache_read / total_input`) | **88.2%** |
+| cache-creation share | 11.8% |
+| non-cached input share | ~0.0% (1,292 tok total — just user-message text) |
+| by type: `subtask` | n=489, 89.6% hit |
+| by type: `chat` | n=368, 86.1% hit |
+
+Within-turn tool loops cache **excellently** (87–98% per call after the turn's
+first call). The cache prefix is *not* being broken mid-turn by volatile content —
+the grouping works.
+
+## B. Assembly & `cache_control` placement (correct)
+
+System blocks, in order (`runner.py:707-786`):
+0. Claude Code preamble — always cached
+1. **static** identity — always cached
+1b. **semi_stable** — cached via single-breakpoint strategy (only when its hash
+    matches the previous turn)
+2. **dynamic** — never cached
+…then `messages[]`, with `cache_control` on the last user message.
+
+Tier classification (`context.py:32-42`, `SECTION_TIERS`):
+- **static**: Identity, Context Safety, Procedure Awareness, Procedure Catalog
+- **semi_stable**: User Profile, Active Censors, Current Frame
+- **dynamic** (default): Date/Time, Working Memory, Relevant Facts, Related
+  Decisions, Procedures, Recent Conversations, Past Episodes, Epistemic Routing,
+  Cached Results — plus runner extras (frame instructions, ledger, corrections,
+  diagnostic nudges, telegram format).
+
+All volatile, per-turn content is correctly in `dynamic` (uncached). Stable
+content is in `static`. Ordering within a tier is deterministic
+(`sorted(sections, key=priority)`, `context.py:1005`). Block order is
+stable→semi→volatile→messages. **No volatile leak into the cached prefix.**
+
+## C. The one real finding: frame-scoped tools bust the whole prefix
+
+**Root cause.** `FRAME_TOOLS` (`runner.py:92-100`) gives each frame a different
+tool array: conversation=27, question=19, decision=14, creative=8, debug=24,
+task=all. Tools sit at the **front of the cacheable prefix** (before the system
+blocks). When the frame changes between turns, the tools array changes →
+everything downstream (tools + all system blocks) busts → the turn's first call
+is a **full re-creation** (`cache_read=0`, full `cache_creation`).
+
+In interactive chat the frame changes almost every turn
+(question→task→conversation→decision), so most turns pay a full prefix rewrite on
+their first call.
+
+**Evidence.** Of 32 full-prefix re-creations that had a prior in-session call:
+- 13 were >5 min apart → legitimate 5-min cache TTL expiry (not a bug)
+- **19 were ≤5 min (cache still warm) → real busts; 17 of 19 coincide with a
+  frame change**
+
+**Quantified cost.** ~**423,865 cache-creation tokens (10.1% of all
+cache-creation)** over the one-month window are frame-change busts —
+re-created at 1.25× base that could have been 0.1× cache reads.
+
+**Note:** F036's "tool schema cache" (`tools.py:120-144`) is only **process-side
+Python memoization** (avoids rebuilding the schema list). It does **nothing** for
+the Anthropic-side prefix cache; the cross-frame API bust is unaddressed.
+
+**Two same-frame warm busts** (`0e1e11a6` t12, t14) are intra-turn (same turn
+number) re-creations — likely mid-loop message rewrite (SmartCompress/pruning),
+1.4% of cc; not pursued.
+
+## Fix options (frame-scoped tools)
+
+1. **Stable tool superset every turn** — stop frame-filtering the API `tools`
+   array; keep `FRAME_TOOLS` only for the *textual* frame instructions.
+   Eliminates the bust. Cost: slightly larger tool schema per call, but those
+   tokens become 0.1× cached reads → net large win. Behavioral change: the model
+   can call any tool in any frame (today `task` frame already does this, and
+   frame *instructions* already steer tool use), so read-only frames lose their
+   hard tool gate.
+2. **`cache_control` breakpoint inside the tools array** — order tools as
+   [stable common subset][frame tail], breakpoint after the common subset. More
+   surgical but only partially works: system blocks are downstream of the
+   variable tail, so they still re-cache.
+3. **Leave as-is** — accept the 10% creation overhead; within-turn caching
+   already keeps the aggregate at 88%.
+
+**Recommendation: Option 1.** Biggest win, simplest, and the only real cost is
+removing per-frame tool gating — a soft guardrail that frame *instructions*
+already duplicate. It's a behavioral change (read-only frames gain action tools),
+so it's the user's call.

--- a/nous/api/tools.py
+++ b/nous/api/tools.py
@@ -37,6 +37,13 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
+# Protocol-only tools registered for the one-time `initiation` frame. They must
+# never leak into the conversational-frame tool superset (the "*" / task set).
+_INITIATION_ONLY_TOOLS: frozenset[str] = frozenset(
+    {"store_identity", "complete_initiation"}
+)
+
+
 class ToolDispatcher:
     """Registers tool handlers and dispatches tool calls from the API.
 
@@ -46,11 +53,20 @@ class ToolDispatcher:
     The dispatcher extracts plain text for the Anthropic API tool_result format.
     """
 
-    def __init__(self, *, tool_schema_cache_enabled: bool = True) -> None:
+    def __init__(
+        self,
+        *,
+        tool_schema_cache_enabled: bool = True,
+        stable_tool_set_enabled: bool = True,
+    ) -> None:
         self._handlers: dict[str, Callable[..., Any]] = {}
         self._schemas: dict[str, dict[str, Any]] = {}  # P0-7 fix
         self._tool_schema_cache: dict[str, list[dict[str, Any]]] = {}  # F036
         self._tool_schema_cache_enabled = tool_schema_cache_enabled  # F036
+        # Cache stabilization: collapse conversational frames to one tool
+        # superset so the Anthropic prompt-cache prefix isn't busted on frame
+        # change (tools sit at the front of the cacheable prefix).
+        self._stable_tool_set_enabled = stable_tool_set_enabled
 
     def register(self, name: str, handler: Callable[..., Any], schema: dict[str, Any]) -> None:
         """Register a tool handler with its JSON schema."""
@@ -115,18 +131,39 @@ class ToolDispatcher:
 
         F036: Results cached per frame_id. Returns deep copy to prevent
         mutation from corrupting the cache.
+
+        Cache stabilization: when stable_tool_set_enabled, all non-initiation
+        frames resolve to the same "task" ("*") superset so the Anthropic
+        prompt-cache prefix (tools sit at its front) is not busted when the
+        frame changes turn-to-turn. Per-frame *behavioral* steering still
+        happens via _get_frame_instructions; FRAME_TOOLS no longer gates the
+        wire-level tool array for these frames. 'initiation' keeps its distinct
+        minimal set (isolated one-time protocol, never interleaved with chat).
         """
+        # Collapse conversational frames to one cache-stable superset. The
+        # effective frame is used as BOTH the cache key and the FRAME_TOOLS
+        # lookup, so every non-initiation frame returns a byte-identical list.
+        effective_frame = (
+            "task"
+            if self._stable_tool_set_enabled and frame_id != "initiation"
+            else frame_id
+        )
+
         # F036: Check cache first (skip if caching disabled)
-        if self._tool_schema_cache_enabled and frame_id in self._tool_schema_cache:
-            return copy.deepcopy(self._tool_schema_cache[frame_id])
+        if self._tool_schema_cache_enabled and effective_frame in self._tool_schema_cache:
+            return copy.deepcopy(self._tool_schema_cache[effective_frame])
 
         from nous.api.runner import FRAME_TOOLS
 
-        allowed = FRAME_TOOLS.get(frame_id, [])
+        allowed = FRAME_TOOLS.get(effective_frame, [])
 
-        # Wildcard means all tools
+        # Wildcard means all tools — minus initiation-only protocol tools,
+        # which must never leak into a conversational-frame tool array.
         if "*" in allowed:
-            result = self.tool_definitions()
+            result = [
+                d for d in self.tool_definitions()
+                if d["name"] not in _INITIATION_ONLY_TOOLS
+            ]
         else:
             result = [
                 {
@@ -140,7 +177,7 @@ class ToolDispatcher:
 
         # F036: Cache and return deep copy
         if self._tool_schema_cache_enabled:
-            self._tool_schema_cache[frame_id] = result
+            self._tool_schema_cache[effective_frame] = result
             return copy.deepcopy(result)
         return result
 

--- a/nous/config.py
+++ b/nous/config.py
@@ -484,6 +484,9 @@ class Settings(BaseSettings):
     tool_schema_cache_enabled: bool = Field(
         default=True, validation_alias="NOUS_TOOL_SCHEMA_CACHE_ENABLED"
     )
+    stable_tool_set_enabled: bool = Field(
+        default=True, validation_alias="NOUS_STABLE_TOOL_SET_ENABLED"
+    )
 
     # Compaction: Layer 1 (Tool Pruning)
     tool_pruning_enabled: bool = Field(

--- a/nous/main.py
+++ b/nous/main.py
@@ -473,7 +473,10 @@ async def create_components(settings: Settings) -> dict:
         logger.debug("Skill bootstrap skipped or failed (non-fatal)")
 
     # Create tool dispatcher and register all tools
-    dispatcher = ToolDispatcher(tool_schema_cache_enabled=settings.tool_schema_cache_enabled)
+    dispatcher = ToolDispatcher(
+        tool_schema_cache_enabled=settings.tool_schema_cache_enabled,
+        stable_tool_set_enabled=settings.stable_tool_set_enabled,
+    )
     register_nous_tools(dispatcher, brain, heart, settings=settings)
     register_builtin_tools(dispatcher, settings)
 

--- a/scripts/diag/probe_cache_cost.py
+++ b/scripts/diag/probe_cache_cost.py
@@ -1,0 +1,46 @@
+import asyncio, asyncpg, sys
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+DSN = "postgresql://nous:nous_dev_password@192.168.1.141:5432/nous"
+Q = """
+WITH ordered AS (
+  SELECT session_id, timestamp, call_type, frame_id, turn_number,
+         input_tokens_actual AS inp, cache_read AS cr, cache_creation AS cc,
+         lag(timestamp) OVER (PARTITION BY session_id ORDER BY timestamp) AS prev_ts,
+         lag(frame_id)  OVER (PARTITION BY session_id ORDER BY timestamp) AS prev_frame,
+         lag(turn_number) OVER (PARTITION BY session_id ORDER BY timestamp) AS prev_turn
+  FROM nous_system.context_log WHERE cache_read IS NOT NULL
+)
+SELECT * FROM ordered
+"""
+async def main():
+    c = await asyncpg.connect(DSN)
+    try:
+        rows = await c.fetch(Q)
+        # within-window (<=5min) calls that have a prev call
+        warm = [r for r in rows if r["prev_ts"] is not None and (r["timestamp"]-r["prev_ts"]).total_seconds()<=300]
+        full = [r for r in warm if (r["cr"] or 0)==0 and (r["cc"] or 0)>0]
+        fc_full = [r for r in full if r["prev_frame"]!=r["frame_id"]]
+        sf_full = [r for r in full if r["prev_frame"]==r["frame_id"]]
+        total_cc = sum((r["cc"] or 0) for r in rows)
+        warm_cc = sum((r["cc"] or 0) for r in warm)
+        fc_full_cc = sum((r["cc"] or 0) for r in fc_full)
+        sf_full_cc = sum((r["cc"] or 0) for r in sf_full)
+        print(f"TOTAL cache_creation (all logged): {total_cc:,}")
+        print(f"warm (<=5min, prev exists) calls: {len(warm)}  cc={warm_cc:,}")
+        print(f"  full-prefix busts within warm window: {len(full)}  cc={sum((r['cc'] or 0) for r in full):,}")
+        print(f"    - FRAME-CHANGED busts: {len(fc_full)}  cc={fc_full_cc:,}  <-- AVOIDABLE via stable tools")
+        print(f"    - same-frame busts:    {len(sf_full)}  cc={sf_full_cc:,}")
+        print(f"  => avoidable share of TOTAL cc (frame-change busts): {fc_full_cc/total_cc*100:.1f}%")
+        # If those were cache reads instead of creates: creation ~1.25x base, read ~0.1x base.
+        # Savings factor ~ (1.25-0.1)/1.25 = 92% of those tokens' cost avoided, plus they'd read at 0.1x.
+        print(f"  => ~{fc_full_cc:,} tokens/month re-created at 1.25x that could be 0.1x reads")
+        # same-frame busts: are these explained by learn events (static/semi drift)?
+        print("\n=== same-frame warm full busts (cause = static/semi drift, not tools) ===")
+        for r in sf_full:
+            gap=(r["timestamp"]-r["prev_ts"]).total_seconds()
+            print(f"  {r['session_id'][:8]} t{r['prev_turn']}->t{r['turn_number']} {r['frame_id']:<10} gap={gap:.0f}s cc={r['cc']}")
+        # Frame-change rate across turn boundaries (first call of each turn)
+        # Approximate: count distinct (session,turn) and how often frame differs from prev turn's frame
+    finally:
+        await c.close()
+asyncio.run(main())

--- a/scripts/diag/probe_cache_perf.py
+++ b/scripts/diag/probe_cache_perf.py
@@ -1,0 +1,57 @@
+import asyncio, asyncpg, sys
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+DSN = "postgresql://nous:nous_dev_password@192.168.1.141:5432/nous"
+
+Q_SUMMARY = """
+SELECT
+  count(*) AS rows,
+  count(*) FILTER (WHERE cache_read IS NOT NULL) AS with_token_data,
+  count(*) FILTER (WHERE cache_read > 0) AS with_cache_hit,
+  coalesce(sum(cache_read),0) AS tot_cache_read,
+  coalesce(sum(cache_creation),0) AS tot_cache_created,
+  coalesce(sum(input_tokens_actual),0) AS tot_input_noncached,
+  min(timestamp)::date AS first_day,
+  max(timestamp)::date AS last_day
+FROM nous_system.context_log;
+"""
+Q_BY_TYPE = """
+SELECT call_type,
+  count(*) AS n,
+  count(*) FILTER (WHERE cache_read > 0) AS hits,
+  coalesce(sum(cache_read),0) AS cr,
+  coalesce(sum(cache_creation),0) AS cc,
+  coalesce(sum(input_tokens_actual),0) AS inp
+FROM nous_system.context_log
+WHERE cache_read IS NOT NULL
+GROUP BY call_type ORDER BY n DESC;
+"""
+Q_RECENT = """
+SELECT call_type, frame_id, session_id, turn_number,
+  input_tokens_actual AS inp, cache_read AS cr, cache_creation AS cc
+FROM nous_system.context_log
+WHERE cache_read IS NOT NULL
+ORDER BY timestamp DESC LIMIT 30;
+"""
+async def main():
+    c = await asyncpg.connect(DSN)
+    try:
+        r = await c.fetchrow(Q_SUMMARY)
+        print("=== context_log SUMMARY ===")
+        for k,v in r.items(): print(f"  {k}: {v}")
+        cr=r["tot_cache_read"]; cc=r["tot_cache_created"]; inp=r["tot_input_noncached"]
+        ti = cr+cc+inp
+        if ti:
+            print(f"  -> total_input(cr+cc+inp) = {ti}")
+            print(f"  -> overall hit_rate (cache_read/total_input) = {cr/ti*100:.1f}%")
+            print(f"  -> cache_creation share = {cc/ti*100:.1f}%   noncached share = {inp/ti*100:.1f}%")
+        print("\n=== BY call_type (rows with token data) ===")
+        for row in await c.fetch(Q_BY_TYPE):
+            t=row["cr"]+row["cc"]+row["inp"]; hr=row["cr"]/t*100 if t else 0
+            print(f"  {row['call_type']:<22} n={row['n']:<5} hits={row['hits']:<5} hit={hr:5.1f}%  cr={row['cr']:<9} cc={row['cc']:<8} inp={row['inp']}")
+        print("\n=== RECENT 30 (newest first) ===")
+        for row in await c.fetch(Q_RECENT):
+            t=(row["cr"] or 0)+(row["cc"] or 0)+(row["inp"] or 0); hr=(row["cr"] or 0)/t*100 if t else 0
+            print(f"  {row['call_type']:<18} {(row['frame_id'] or '-'):<11} {row['session_id'][:8]} t{row['turn_number']:<3} inp={row['inp']:<6} cr={row['cr']:<7} cc={row['cc']:<6} hit={hr:5.1f}%")
+    finally:
+        await c.close()
+asyncio.run(main())

--- a/scripts/diag/probe_cache_ttl.py
+++ b/scripts/diag/probe_cache_ttl.py
@@ -1,0 +1,49 @@
+import asyncio, asyncpg, sys
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+DSN = "postgresql://nous:nous_dev_password@192.168.1.141:5432/nous"
+
+# For every call, compute gap since previous call in same session, and classify
+Q = """
+WITH ordered AS (
+  SELECT session_id, timestamp, call_type, frame_id, turn_number,
+         input_tokens_actual AS inp, cache_read AS cr, cache_creation AS cc,
+         lag(timestamp) OVER (PARTITION BY session_id ORDER BY timestamp) AS prev_ts,
+         lag(frame_id)  OVER (PARTITION BY session_id ORDER BY timestamp) AS prev_frame
+  FROM nous_system.context_log
+  WHERE cache_read IS NOT NULL
+)
+SELECT * FROM ordered
+"""
+async def main():
+    c = await asyncpg.connect(DSN)
+    try:
+        rows = await c.fetch(Q)
+        # Focus on "full creation" calls: cr==0 and cc>0
+        full_create = [r for r in rows if (r["cr"] or 0)==0 and (r["cc"] or 0)>0]
+        with_prev = [r for r in full_create if r["prev_ts"] is not None]
+        print(f"total token rows: {len(rows)}")
+        print(f"full-creation calls (cr=0, cc>0): {len(full_create)}")
+        print(f"  ...of which have a previous call in session: {len(with_prev)}")
+        gt5=lt5=0; frame_changed=0
+        gaps=[]
+        for r in with_prev:
+            gap=(r["timestamp"]-r["prev_ts"]).total_seconds()
+            gaps.append(gap)
+            if gap>300: gt5+=1
+            else: lt5+=1
+            if r["prev_frame"]!=r["frame_id"]: frame_changed+=1
+        print(f"\nFull-creation calls WITH prev call in same session:")
+        print(f"  gap > 5min (TTL expiry, expected): {gt5}")
+        print(f"  gap <=5min (cache still warm -> REAL bust): {lt5}")
+        if lt5:
+            print(f"  ...of those <=5min busts, frame changed vs prev call: {frame_changed}")
+        # Show the <=5min busts in detail (the suspicious ones)
+        susp=[r for r in with_prev if (r["timestamp"]-r["prev_ts"]).total_seconds()<=300]
+        print(f"\n=== Suspicious <=5min full-creation busts (first 20) ===")
+        for r in susp[:20]:
+            gap=(r["timestamp"]-r["prev_ts"]).total_seconds()
+            fc = "FRAME-CHG" if r["prev_frame"]!=r["frame_id"] else "same-frame"
+            print(f"  {r['session_id'][:8]} t{r['turn_number']:<3} {r['call_type']:<8} {(r['frame_id'] or '-'):<11} gap={gap:6.0f}s cc={r['cc']:<7} prevframe={r['prev_frame']} {fc}")
+    finally:
+        await c.close()
+asyncio.run(main())

--- a/tests/test_f036_tool_cache.py
+++ b/tests/test_f036_tool_cache.py
@@ -14,8 +14,13 @@ from nous.api.tools import ToolDispatcher
 # ---------------------------------------------------------------------------
 
 def _make_dispatcher() -> ToolDispatcher:
-    """Create a ToolDispatcher with two registered dummy tools."""
-    dispatcher = ToolDispatcher()
+    """Create a ToolDispatcher with two registered dummy tools.
+
+    stable_tool_set_enabled=False isolates the F036 cache mechanism + per-frame
+    FRAME_TOOLS mapping under test from the cache-stabilization collapse (which
+    is covered separately in test_stable_tool_set.py).
+    """
+    dispatcher = ToolDispatcher(stable_tool_set_enabled=False)
 
     async def dummy(**kwargs):
         return {"content": [{"type": "text", "text": "ok"}]}

--- a/tests/test_stable_tool_set.py
+++ b/tests/test_stable_tool_set.py
@@ -1,0 +1,107 @@
+"""Tests for cache-stabilizing tool superset (NOUS_STABLE_TOOL_SET_ENABLED).
+
+When enabled (default), all non-initiation frames resolve to one byte-identical
+tool superset so the Anthropic prompt-cache prefix (tools sit at its front) is
+not busted when the cognitive frame changes between turns. The `initiation`
+frame keeps its distinct minimal set, and initiation-only protocol tools never
+leak into the conversational superset.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nous.api.tools import ToolDispatcher, _INITIATION_ONLY_TOOLS
+
+
+async def _dummy(**kwargs):
+    return {"content": [{"type": "text", "text": "ok"}]}
+
+
+def _register(dispatcher: ToolDispatcher, names: list[str]) -> None:
+    for name in names:
+        dispatcher.register(
+            name, _dummy, {"description": f"{name} tool", "type": "object", "properties": {}}
+        )
+
+
+# A realistic-ish mix: normal tools + the two initiation-only protocol tools.
+_NORMAL = ["record_decision", "recall_deep", "learn_fact", "bash", "write_file", "web_search"]
+_INIT = ["store_identity", "complete_initiation"]
+
+# FRAME_TOOLS stub mirroring the real shape: conversational frames are subsets,
+# task is wildcard, initiation is the two protocol tools.
+_FRAME_TOOLS = {
+    "conversation": ["record_decision", "learn_fact", "recall_deep", "bash", "write_file", "web_search"],
+    "question": ["recall_deep", "web_search"],
+    "decision": ["record_decision", "recall_deep"],
+    "creative": ["learn_fact", "recall_deep"],
+    "task": ["*"],
+    "debug": ["record_decision", "recall_deep", "bash"],
+    "initiation": ["store_identity", "complete_initiation"],
+}
+
+_CONVERSATIONAL = ["conversation", "question", "decision", "creative", "task", "debug"]
+
+
+@pytest.fixture
+def dispatcher(monkeypatch):
+    d = ToolDispatcher(stable_tool_set_enabled=True)
+    _register(d, _NORMAL + _INIT)
+    monkeypatch.setattr("nous.api.runner.FRAME_TOOLS", _FRAME_TOOLS)
+    return d
+
+
+def test_all_conversational_frames_return_identical_list(dispatcher):
+    """Every non-initiation frame returns a byte-identical tool array, so the
+    cached prefix is stable across frame changes."""
+    lists = {f: dispatcher.available_tools(f) for f in _CONVERSATIONAL}
+    baseline = lists["task"]
+    for frame, tools in lists.items():
+        assert tools == baseline, f"{frame} diverged from the stable superset"
+
+
+def test_superset_excludes_initiation_only_tools(dispatcher):
+    """store_identity / complete_initiation must NOT leak into the superset."""
+    names = {t["name"] for t in dispatcher.available_tools("conversation")}
+    assert names == set(_NORMAL)
+    assert not (_INITIATION_ONLY_TOOLS & names)
+
+
+def test_initiation_frame_keeps_distinct_minimal_set(dispatcher):
+    """initiation is never collapsed — it returns exactly its protocol tools."""
+    names = {t["name"] for t in dispatcher.available_tools("initiation")}
+    assert names == set(_INIT)
+
+
+def test_superset_is_cached_under_single_key(dispatcher):
+    """All conversational frames share one cache entry (keyed 'task'), so the
+    cache is not bypassed per-frame."""
+    for f in _CONVERSATIONAL:
+        dispatcher.available_tools(f)
+    # Only the effective 'task' key (plus nothing per-frame) should be present.
+    assert set(dispatcher._tool_schema_cache.keys()) == {"task"}
+
+
+def test_deep_copy_isolation_holds_for_superset(dispatcher):
+    """Mutating a returned superset must not corrupt the shared cache entry."""
+    first = dispatcher.available_tools("question")
+    first.append({"name": "injected"})
+    first[0]["description"] = "CORRUPTED"
+    second = dispatcher.available_tools("decision")
+    assert all(t.get("name") != "injected" for t in second)
+    assert all(t["description"] != "CORRUPTED" for t in second)
+
+
+def test_flag_off_restores_per_frame_gating(monkeypatch):
+    """With the flag disabled, frames filter to their FRAME_TOOLS subset."""
+    d = ToolDispatcher(stable_tool_set_enabled=False)
+    _register(d, _NORMAL + _INIT)
+    monkeypatch.setattr("nous.api.runner.FRAME_TOOLS", _FRAME_TOOLS)
+
+    q = {t["name"] for t in d.available_tools("question")}
+    assert q == {"recall_deep", "web_search"}
+    dec = {t["name"] for t in d.available_tools("decision")}
+    assert dec == {"record_decision", "recall_deep"}
+    # Distinct per-frame cache entries under legacy behavior.
+    assert {"question", "decision"} <= set(d._tool_schema_cache.keys())

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -491,7 +491,7 @@ class TestToolDispatcher:
         Register several tools, verify that frame filtering works.
         The 'question' frame only allows 'recall_deep'.
         """
-        dispatcher = ToolDispatcher()
+        dispatcher = ToolDispatcher(stable_tool_set_enabled=False)
 
         # Register multiple tools (using mock handlers)
         handler = AsyncMock(return_value={"content": [{"type": "text", "text": "ok"}]})
@@ -506,7 +506,7 @@ class TestToolDispatcher:
 
     def test_dispatcher_available_tools_wildcard_frame(self):
         """Frame with wildcard '*' returns all registered tools."""
-        dispatcher = ToolDispatcher()
+        dispatcher = ToolDispatcher(stable_tool_set_enabled=False)
 
         handler = AsyncMock(return_value={"content": [{"type": "text", "text": "ok"}]})
         for name in ["record_decision", "recall_deep", "bash", "read_file", "write_file"]:
@@ -519,7 +519,7 @@ class TestToolDispatcher:
 
     def test_dispatcher_available_tools_unknown_frame(self):
         """Unknown frame ID returns empty tool list."""
-        dispatcher = ToolDispatcher()
+        dispatcher = ToolDispatcher(stable_tool_set_enabled=False)
 
         handler = AsyncMock(return_value={"content": [{"type": "text", "text": "ok"}]})
         dispatcher.register("recall_deep", handler, {"type": "object", "description": "test"})


### PR DESCRIPTION
## Summary

Prod prompt-cache audit (read-only, `nous_system.context_log`, 2026-05-14→06-14). Caching is **healthy overall (88.2% hit rate, 11.8% creation, ~0% uncached input)** and the tier grouping is correct — no volatile content leaks into the cached prefix. One real, quantified inefficiency: **frame-scoped tool schemas bust the entire cached prefix on every frame change.**

`FRAME_TOOLS` gives each cognitive frame a different tool array (conversation=27, question=19, decision=14, creative=8, task=all, debug=24). Tools sit at the **front of the Anthropic cacheable prefix**, so when the frame changes between turns — constant in interactive chat — the tools array changes and busts everything downstream (tools + all system blocks). The turn's first call becomes a full re-creation.

**Measured cost:** of 32 warm full-prefix re-creations with a prior in-session call, 13 were >5 min apart (legit 5-min TTL) but **19 were ≤5 min real busts, 17 of them on a frame change** — **~424K cache-creation tokens (10.1% of all cache-creation) per month**, re-created at 1.25× that could have been 0.1× cache reads.

## Fix

When `NOUS_STABLE_TOOL_SET_ENABLED` (default `true`), `ToolDispatcher.available_tools` collapses all non-`initiation` frames to the `task` (`*`) tool superset, using the **effective frame as both the schema-cache key and the FRAME_TOOLS lookup** so every conversational frame returns a byte-identical, deterministically-ordered list. The tools array no longer varies turn-to-turn → the cached prefix holds across frame changes.

- `FRAME_TOOLS` still drives the **textual** frame instructions (`_get_frame_instructions`); only the wire-level tool array is stabilized.
- `initiation` keeps its distinct minimal set (isolated one-time protocol, never interleaved with chat).
- Per-turn refuse (F078) and subtask tool filters run **after** `available_tools` and are unchanged.
- Behavioral note: read-only frames (question/creative) gain action tools — frame instructions already steer tool use, and the `task` frame already sent all tools. Flag-gated (default on) for instant rollback.

## Architecture review

`feature-dev:code-reviewer` returned **APPROVE-WITH-NITS**; both issues incorporated:
1. **Redirect the cache KEY** to `effective_frame` for both lookup and store — otherwise the per-frame cache is bypassed on every call.
2. **Exclude `_INITIATION_ONLY_TOOLS` = {store_identity, complete_initiation}** from the `*` superset — also fixes a pre-existing `task`-frame leak of protocol tools into normal turns.

Also clarified in docs: F036's "tool schema cache" is only **process-side Python memoization** — it does nothing for the Anthropic-side prefix.

## Tests

- New `tests/test_stable_tool_set.py`: identical lists across all conversational frames, `initiation` distinct, protocol-tool exclusion, single-key cache, deep-copy isolation, flag-off legacy gating (7 tests).
- Existing per-frame tests (`test_f036_tool_cache.py`, `test_tools.py`) pinned to `stable_tool_set_enabled=False` to isolate the legacy gating path they assert.
- `test_runner_background`, `test_f061_runner_subtask_hooks`, `test_tool_loop`, `test_streaming` all green (63 passed). The 4 `test_tools.py` `TestLearnFact`/`TestRecallDeep` failures are pre-existing pgvector-on-sqlite issues (need the Postgres lane), confirmed identical on the base branch.

## Operator

Default-on. To revert: `NOUS_STABLE_TOOL_SET_ENABLED=false` + restart (no redeploy).

Audit: `docs/reviews/2026-06-14-llm-caching-audit.md`. Decision: `ea4f4adb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
