### PR TITLE
docs(F038.1): correct completion_check to three-state exit-code contract

### DIFF
--- a/docs/features/F038.1-dag-completion-check.md
+++ b/docs/features/F038.1-dag-completion-check.md
@@ -1,6 +1,6 @@
 # F038.1 — DAG Node Completion Check
 
-> **Status:** Draft v1
+> **Status:** Draft v2 (three-state completion_check contract corrected, 2026-06-14)
 > **Priority:** P1
 > **Author:** Nous + Tim
 > **Date:** 2026-04-10
@@ -45,33 +45,38 @@ Add an **optional `completion_check` field** to any DAG node. This is a **shell 
 ```
 completion_check: "<any shell command>"
 
-Exit code 0  → node is complete, advance to next wave
-Exit code !0 → still running, check again next tick
+Exit code 0  → node is complete (success), advance to next wave
+Exit code 1  → node has terminally FAILED, mark node failed
+Exit code 2  → still running, check again next tick
 ```
 
-The orchestrator doesn't interpret the command's output — it only checks the exit code. This makes it universally composable with any tool, process, or system.
+> **Three-state contract.** Earlier drafts used a two-state model (`0` = done, any non-zero = "still running"). That was replaced (see #296) so fix-nodes (F066.1) can distinguish a genuine failure from a job that is merely still in flight. **Do not use `grep -q` as the whole check** — `grep -q` exits `1` on no-match, which the orchestrator now reads as a terminal FAILURE, so a still-running job gets mis-marked failed on its very first poll. Always branch the exit code explicitly (see examples).
+
+The orchestrator interprets only the exit code, not the command's output. This keeps it universally composable with any tool, process, or system while letting a check signal "failed" distinctly from "not yet."
 
 ### Examples
 
 ```yaml
-# Claude Code job
-completion_check: "python3 /path/to/runner.sh status job-abc123 | grep -q completed"
+# Claude Code job — branch the three states explicitly
+completion_check: "S=$(python3 /path/to/runner.sh status job-abc123); echo \"$S\" | grep -q 'Status: completed' && exit 0; echo \"$S\" | grep -q 'Status: failed' && exit 1; exit 2"
 
-# File existence
-completion_check: "test -f /tmp/results/output.json"
+# File existence — present = done, otherwise keep polling (no terminal-fail case)
+completion_check: "test -f /tmp/results/output.json && exit 0 || exit 2"
 
-# CI pipeline
-completion_check: "curl -sf https://api.github.com/repos/org/repo/actions/runs/123 | jq -e '.status == \"completed\"'"
+# CI pipeline — distinguish success / failure / in-progress
+completion_check: "R=$(curl -sf https://api.github.com/repos/org/repo/actions/runs/123); echo \"$R\" | jq -e '.conclusion==\"success\"' >/dev/null && exit 0; echo \"$R\" | jq -e '.status==\"completed\"' >/dev/null && exit 1; exit 2"
 
-# Process finished
-completion_check: "! pgrep -f 'my-long-process'"
+# Process finished — gone = done, still alive = keep polling
+completion_check: "pgrep -f 'my-long-process' >/dev/null && exit 2 || exit 0"
 
-# Custom script
+# Custom script — the script itself returns 0/1/2 per the contract
 completion_check: "python3 /path/to/check_status.py --job-id xyz"
 
-# Multiple conditions (all must pass)
-completion_check: "test -f /tmp/done.flag && curl -sf http://localhost:8080/health"
+# Multiple conditions (all must pass) — map to exit 0, else still-running
+completion_check: "test -f /tmp/done.flag && curl -sf http://localhost:8080/health && exit 0 || exit 2"
 ```
+
+> ⚠️ **Common pitfall:** a bare `... | grep -q completed` returns exit `1` while the job is still running, which the orchestrator treats as a terminal failure. Convert "no match" into `exit 2`, and reserve `exit 1` for an explicitly-detected failure state.
 
 ---
 
@@ -110,7 +115,8 @@ New flow:
   node.status == "awaiting_check":
     → run completion_check shell command
     → exit 0?  → node.status = "completed"
-    → exit !0? → stay in "awaiting_check", try again next tick
+    → exit 1?  → node.status = "failed"  (terminal failure signalled by the check)
+    → exit 2 (or other non-0/1)? → stay in "awaiting_check", try again next tick
     → timed out (node.timeout_seconds exceeded)? → node.status = "failed"
 ```
 
@@ -147,7 +153,7 @@ The subtask that launches a CC job writes the job ID to this path. The `completi
 Example flow for a CC node:
 
 1. Subtask prompt: "Launch CC job, write job ID to `/tmp/nous-workspace/dag-status/{dag_id}/{node_name}/job_id`"
-2. `completion_check`: `"JOB=$(cat /tmp/nous-workspace/dag-status/{dag_id}/{node_name}/job_id) && python3 runner.sh status $JOB | grep -q completed"`
+2. `completion_check`: `"JOB=$(cat /tmp/nous-workspace/dag-status/{dag_id}/{node_name}/job_id); S=$(python3 runner.sh status $JOB); echo \"$S\" | grep -q 'Status: completed' && exit 0; echo \"$S\" | grep -q 'Status: failed' && exit 1; exit 2"`
 
 ### Result Capture
 


### PR DESCRIPTION
## What

Reconciles the F038.1 spec with the **actual** orchestrator behaviour for `completion_check`.

## Why

The contract changed from two-state to **three-state** in #296 (`exit 0`=success, `1`=terminal failure, `2`=still running) so F066.1 fix-nodes can tell a real failure apart from an in-flight job. The spec was never updated — the Contract block, all six examples, the status-file example, and the orchestrator pseudocode still documented the old two-state model.

Worse, the examples used a bare `... | grep -q completed`. `grep -q` exits **1** on no-match (i.e. while the job is still running), which the orchestrator now reads as a **terminal FAILURE** — so a still-running job is mis-marked failed on its very first poll.

**Observed in the wild:** DAG `a8fa1b44` sat `running` for 4 days because its `launch-job` node falsely failed on poll #1, even though the underlying Claude Code job (`job-20260610-075741`) completed successfully and its PR (#500) merged.

## Changes (docs-only, zero runtime)

- Contract block → three-state with explicit exit-1/exit-2 semantics
- All examples rewritten to branch the exit code (and convert grep no-match into `exit 2`)
- Status-file convention example fixed
- Orchestrator behaviour pseudocode updated
- Added an explicit ⚠️ pitfall callout for the `grep -q` trap
- Status header → Draft v2

No code or behaviour change.