### PR TITLE
fix(critic): coerce string confidence in confidence-drift critic (prod 500)

### DIFF
--- a/nous/cognitive/critic.py
+++ b/nous/cognitive/critic.py
@@ -369,6 +369,19 @@ Respond ONLY with valid JSON. No markdown, no explanation outside the JSON."""
             )
         return self._not_fired(name)
 
+    @staticmethod
+    def _coerce_confidence(value: Any) -> float:
+        """Coerce a tool-supplied confidence to float for numeric comparison.
+
+        record_decision confidence arrives from LLM tool args and may be None,
+        a float, or a numeric string ("0.8"). Parse numerics; map None and
+        non-numeric values to a neutral 0.5 (preserves a real 0.0).
+        """
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return 0.5
+
     def _check_confidence_drift(self, tool_history: list[dict[str, Any]]) -> DiagnosticResult:
         """Multiple low-confidence decisions in sequence."""
         name = "confidence_drift"
@@ -380,10 +393,13 @@ Respond ONLY with valid JSON. No markdown, no explanation outside the JSON."""
             # default when the key is ABSENT. record_decision may store an
             # explicit confidence=None, which returns None here and crashes the
             # `None < 0.4` comparison below (TypeError) on the non-streaming
-            # post_turn path. Coerce None -> 0.5 while preserving a real 0.0.
+            # post_turn path. 2026-06-14: the LLM also passes confidence as a
+            # STRING ("0.8") via tool args, which raised "'<' not supported
+            # between instances of 'str' and 'float'" in prod. Coerce robustly:
+            # parse numeric strings, map None/non-numeric to a neutral 0.5,
+            # preserve a real 0.0.
             confidences = [
-                c if (c := d.get("confidence")) is not None else 0.5
-                for d in decisions[-3:]
+                self._coerce_confidence(d.get("confidence")) for d in decisions[-3:]
             ]
             if all(c < 0.4 for c in confidences):
                 return self._fire(

--- a/tests/test_critic.py
+++ b/tests/test_critic.py
@@ -324,6 +324,34 @@ class TestDiagnosticCritics:
             d.fired and d.critic_name == "confidence_drift" for d in results
         )
 
+    def test_confidence_drift_handles_string_confidence(self):
+        """2026-06-14 prod bug: the LLM passes confidence as a STRING via tool
+        args; `"0.2" < 0.4` raised "'<' not supported between instances of
+        'str' and 'float'". Numeric strings must parse and still trip the gate."""
+        agent = CriticAgent(_settings())
+        tool_history = [
+            {"tool": "record_decision", "confidence": "0.3"},
+            {"tool": "record_decision", "confidence": "0.25"},
+            {"tool": "record_decision", "confidence": "0.2"},
+        ]
+        results = agent.run_diagnostics(tool_history, turn_number=1)
+        assert any(d.fired and d.critic_name == "confidence_drift" for d in results)
+
+    def test_confidence_drift_handles_non_numeric_string(self):
+        """A non-numeric confidence string must not crash; it coerces to the
+        neutral 0.5 (not low), so the gate does not fire."""
+        agent = CriticAgent(_settings())
+        tool_history = [
+            {"tool": "record_decision", "confidence": "high"},
+            {"tool": "record_decision", "confidence": "0.2"},
+            {"tool": "record_decision", "confidence": 0.3},
+        ]
+        # Must not raise; "high" -> 0.5 breaks the all(<0.4) gate.
+        results = agent.run_diagnostics(tool_history, turn_number=1)
+        assert not any(
+            d.fired and d.critic_name == "confidence_drift" for d in results
+        )
+
     def test_frame_mismatch_detector(self):
         agent = CriticAgent(_settings())
         tool_history = [


### PR DESCRIPTION
## Summary

Prod `/chat` turns returned **500** with `Chat error: '<' not supported between instances of 'str' and 'float'`, raised in `CriticAgent._check_confidence_drift` during `post_turn`.

The LLM passes `record_decision` `confidence` as a **string** (`"0.8"`) through tool args. The earlier CL-5 fix only coerced `None`, so a string operand hit `"0.2" < 0.4` → `TypeError`, which propagated to the chat handler as a 500. It manifested on memory-heavy multi-turn sessions where the agent had recorded ≥3 decisions.

## Fix

`_coerce_confidence(value)` parses numeric strings, maps `None`/non-numeric to a neutral `0.5`, and preserves a real `0.0`. Applied at the confidence-drift gate.

## Tests

- `test_confidence_drift_handles_string_confidence`: numeric strings (`"0.3"/"0.25"/"0.2"`) still trip the gate.
- `test_confidence_drift_handles_non_numeric_string`: `"high"` coerces to `0.5` (gate doesn't fire), and nothing raises.
- Existing None/float/mixed tests still pass (5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
