### PR TITLE
fix(heart): tolerate legacy list-valued structured_summary (sleep-cycle crash)

### DIFF
--- a/nous/heart/episodes.py
+++ b/nous/heart/episodes.py
@@ -397,7 +397,10 @@ class EpisodeManager:
                 # legacy creation-time echo even for summarized episodes —
                 # the recall_deep parent-episode path already COALESCEs to
                 # structured_summary->>'summary' (tools.py, codex fix).
-                structured_summary=e.structured_summary,
+                # Guard against legacy pre-#525 rows where a bare-list summary
+                # was persisted — a non-dict crashes EpisodeSummary validation
+                # and takes down the whole batch (sleep-cycle procedure learner).
+                structured_summary=e.structured_summary if isinstance(e.structured_summary, dict) else None,
             )
             for e in episodes
         ]
@@ -682,7 +685,9 @@ class EpisodeManager:
             tags=episode.tags or [],
             decision_ids=decision_ids,
             active=episode.active,
-            structured_summary=episode.structured_summary,
+            # Legacy bad-row guard (see list_recent): a non-dict structured_summary
+            # would fail EpisodeDetail validation.
+            structured_summary=episode.structured_summary if isinstance(episode.structured_summary, dict) else None,
             user_id=episode.user_id,
             user_display_name=episode.user_display_name,
             created_at=episode.created_at,

--- a/tests/test_episodes.py
+++ b/tests/test_episodes.py
@@ -253,6 +253,36 @@ async def test_update_summary_backfills_columns(heart, session):
     assert updated.structured_summary == structured
 
 
+async def test_list_recent_tolerates_legacy_list_structured_summary(heart, session):
+    """Regression: a legacy pre-#525 row whose structured_summary is a bare LIST
+    must not crash list_recent / get_episode — that ValidationError took down the
+    whole batch and killed sleep-cycle procedure learning (episodes.py:400/688).
+    """
+    from datetime import UTC, datetime
+
+    from nous.storage.models import Episode
+
+    inp = _episode_input(summary="legacy bad row")
+    detail = await heart.start_episode(inp, session=session)
+    # Simulate the bad row: a bare list persisted where a dict is expected
+    # (update_episode_summary is typed dict but stores raw; the LLM-parse guard
+    # that prevents this is PR #525, so only old rows look like this).
+    await heart.update_episode_summary(detail.id, ["A truncated body"], session=session)
+    # Mark ended (list_recent only returns ended episodes) without going through
+    # end_episode's embedding path.
+    ep = (await session.execute(select(Episode).where(Episode.id == detail.id))).scalar_one()
+    ep.ended_at = datetime.now(UTC)
+    ep.outcome = "success"
+    await session.flush()
+
+    listed = await heart.list_episodes(limit=50, session=session)  # must not raise
+    bad = next(e for e in listed if e.id == detail.id)
+    assert bad.structured_summary is None  # coerced, not crashed
+
+    fetched = await heart.get_episode(detail.id, session=session)  # _to_detail must not raise
+    assert fetched.structured_summary is None
+
+
 # ---------------------------------------------------------------------------
 # 9. test_update_summary_partial_data (008.3)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
A pre-#525 episode row whose `structured_summary` was persisted as a bare JSON **list** crashes `EpisodeSummary`/`EpisodeDetail` pydantic validation. Because `list_recent` builds the whole batch eagerly, **one** bad row takes down `list_episodes` entirely — killing sleep-cycle procedure learning:

```
ValidationError: 1 validation error for EpisodeSummary
structured_summary  Input should be a valid dictionary [input_value=["A truncated body..."], input_type=list]
  ... heart/episodes.py:389 EpisodeSummary(
  ... handlers/procedure_learner.py:373 _learn_from_episodes -> list_episodes(limit=50)
```

## Root cause
- **Write path is already fixed** by PR #525 (`_summarize_single` skips non-dict LLM parses). The crashing row is **legacy** — written before #525.
- **Read-side gap:** `episodes.py:470` already guards with `isinstance(e.structured_summary, dict) else None`, but `:400` (`list_recent`) and `:688` (`_to_detail`) passed the raw DB value → crash.

## Fix
Mirror the existing `:470` guard at both unguarded read sites. A legacy bad row is now treated as "no structured summary" (`None`) instead of crashing the whole batch — the episode itself is still listed.

## Test
`test_list_recent_tolerates_legacy_list_structured_summary` — inserts a list-valued `structured_summary` row and asserts `list_episodes`/`get_episode` return it with `structured_summary=None` instead of raising. Full `test_episodes.py` green (12/12).

## Operator note (optional)
The read guard makes legacy rows harmless. If desired, prod's bad rows can be nulled directly: `UPDATE heart.episodes SET structured_summary = NULL WHERE jsonb_typeof(structured_summary) <> 'object';`

🤖 Generated with [Claude Code](https://claude.com/claude-code)