### PR TITLE
fix(dashboard): post-merge fixes — nav routing + Observability drill-down

### DIFF
--- a/dashboard-app/src/lib/api.test.ts
+++ b/dashboard-app/src/lib/api.test.ts
@@ -19,6 +19,15 @@ describe('apiGet', () => {
     expect(f).toHaveBeenCalledTimes(2);
   });
 
+  it('does NOT retry a 4xx and exposes the status', async () => {
+    const f = vi.fn(async () => new Response('', { status: 404 }));
+    vi.stubGlobal('fetch', f);
+    await expect(apiGet('/context/log/x/payload', { retries: 3, backoffMs: 1 })).rejects.toMatchObject({
+      status: 404,
+    });
+    expect(f).toHaveBeenCalledTimes(1); // definitive — no retries
+  });
+
   it('honors an AbortSignal', async () => {
     const ac = new AbortController(); ac.abort();
     vi.stubGlobal('fetch', vi.fn(async (_u, o) => {

--- a/dashboard-app/src/lib/api.ts
+++ b/dashboard-app/src/lib/api.ts
@@ -2,16 +2,28 @@ const API_BASE = ''; // same-origin; /dashboard/* and /status are root-relative
 
 export interface ApiOpts { retries?: number; backoffMs?: number; signal?: AbortSignal; }
 
+/** Error carrying the HTTP status so callers can branch (e.g. 404 = not captured). */
+export interface ApiError extends Error { status?: number; }
+
 export async function apiGet<T>(path: string, opts: ApiOpts = {}): Promise<T> {
   const { retries = 3, backoffMs = 1000, signal } = opts;
   let lastErr: unknown;
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
       const res = await fetch(API_BASE + path, { signal });
-      if (!res.ok) throw new Error(`HTTP ${res.status} for ${path}`);
+      if (!res.ok) {
+        const err: ApiError = new Error(`HTTP ${res.status} for ${path}`);
+        err.status = res.status;
+        throw err;
+      }
       return (await res.json()) as T;
     } catch (err) {
       if (signal?.aborted) throw err;
+      // 4xx responses are definitive (not-found, bad-request) — retrying won't
+      // help, and burns the full backoff before surfacing the error. Only
+      // retry 5xx and network/transport failures (no status).
+      const status = (err as ApiError).status;
+      if (status !== undefined && status >= 400 && status < 500) throw err;
       lastErr = err;
       if (attempt < retries) await sleep(backoffMs * 2 ** attempt);
     }

--- a/dashboard-app/src/lib/ui/Nav.svelte
+++ b/dashboard-app/src/lib/ui/Nav.svelte
@@ -96,7 +96,7 @@
 <nav aria-label={navLabel}>
   {#each NAV_ITEMS as item (item.id)}
     <a
-      href="#{item.id}"
+      href="#/{item.id}"
       class="nav-link"
       class:active={currentRoute === item.id}
       aria-label={item.label}

--- a/dashboard-app/src/lib/ui/Nav.test.ts
+++ b/dashboard-app/src/lib/ui/Nav.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+import Nav from './Nav.svelte';
+import { ROUTES, currentRoute, initRouter } from '../router';
+
+// Regression guard: the Nav link hrefs MUST be in the exact hash format the
+// router accepts (`#/<route>`). They previously used `#<route>` (no slash),
+// which the router's tightened parse() ignored — silently breaking all nav
+// (stuck on Overview). Keep Nav and the router in lock-step.
+describe('Nav', () => {
+  beforeEach(() => {
+    location.hash = '';
+  });
+
+  it('renders one #/<route> link per known route, all router-parseable', () => {
+    const { container } = render(Nav, { props: { currentRoute: 'overview' } });
+    const hrefs = Array.from(container.querySelectorAll('a.nav-link')).map((a) =>
+      a.getAttribute('href'),
+    );
+    expect(hrefs.length).toBe(ROUTES.length);
+    for (const href of hrefs) {
+      expect(href).toMatch(/^#\//); // must be a router-recognised fragment, not a bare anchor
+      const route = href!.slice(2);
+      expect(ROUTES).toContain(route as (typeof ROUTES)[number]);
+    }
+  });
+
+  it('clicking a nav href format actually drives the router', () => {
+    initRouter();
+    // Simulate what a nav click does: set the hash to the Nav's href format.
+    location.hash = '#/cache';
+    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    expect(get(currentRoute)).toBe('cache');
+  });
+});

--- a/dashboard-app/src/views/Observability.svelte
+++ b/dashboard-app/src/views/Observability.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { SvelteSet } from 'svelte/reactivity';
-  import { apiGet } from '../lib/api';
+  import { apiGet, type ApiError } from '../lib/api';
   import { makePollStore } from '../lib/stores/registry';
   import { usePoll } from '../lib/poll';
   import type { ObservabilityData, ObsContextLogEntry } from '../lib/types/api';
@@ -63,9 +63,12 @@
         ctxSections[id] = await apiGet<CtxSections>(
           '/context/log/' + encodeURIComponent(id) + '/sections',
         );
-      } catch {
+      } catch (e) {
         delete ctxSections[id];
-        ctxError[id] = 'Failed to load context text';
+        ctxError[id] =
+          (e as ApiError).status === 404
+            ? 'Context text not available (entry expired or capture disabled).'
+            : 'Failed to load context text';
       }
     }
   }
@@ -79,9 +82,12 @@
         ctxPayload[id] = await apiGet<unknown>(
           '/context/log/' + encodeURIComponent(id) + '/payload',
         );
-      } catch {
+      } catch (e) {
         delete ctxPayload[id];
-        ctxError[id] = 'Failed to load raw payload';
+        ctxError[id] =
+          (e as ApiError).status === 404
+            ? 'Raw payload was not captured (full-payload capture disabled or evicted).'
+            : 'Failed to load raw payload';
       }
     }
   }

--- a/dashboard-app/src/views/Observability.svelte
+++ b/dashboard-app/src/views/Observability.svelte
@@ -40,6 +40,56 @@
     }
   }
 
+  // ── Recent-call drill-down: structured section text + raw payload ──────────
+  // Lazy-loaded from /context/log/{id}/sections and /context/log/{id}/payload
+  // ONLY on button click (never during render). State keyed by entry id:
+  //   ctx*[id] === undefined → not fetched, === null → loading, else → loaded.
+  type CtxView = 'sections' | 'payload';
+  interface CtxSections {
+    sections: Record<string, number>;
+    sections_text: Record<string, string>;
+  }
+  let ctxView = $state<Record<string, CtxView>>({});
+  let ctxSections = $state<Record<string, CtxSections | null>>({});
+  let ctxPayload = $state<Record<string, unknown>>({});
+  let ctxError = $state<Record<string, string>>({});
+
+  async function viewSections(id: string) {
+    ctxError[id] = '';
+    ctxView[id] = 'sections';
+    if (ctxSections[id] === undefined) {
+      ctxSections[id] = null; // loading
+      try {
+        ctxSections[id] = await apiGet<CtxSections>(
+          '/context/log/' + encodeURIComponent(id) + '/sections',
+        );
+      } catch {
+        delete ctxSections[id];
+        ctxError[id] = 'Failed to load context text';
+      }
+    }
+  }
+
+  async function viewPayload(id: string) {
+    ctxError[id] = '';
+    ctxView[id] = 'payload';
+    if (ctxPayload[id] === undefined) {
+      ctxPayload[id] = null; // loading
+      try {
+        ctxPayload[id] = await apiGet<unknown>(
+          '/context/log/' + encodeURIComponent(id) + '/payload',
+        );
+      } catch {
+        delete ctxPayload[id];
+        ctxError[id] = 'Failed to load raw payload';
+      }
+    }
+  }
+
+  function hideCtx(id: string) {
+    delete ctxView[id];
+  }
+
   // ── Helpers ───────────────────────────────────────────────────────────────
 
   function fmtAgo(iso: string | null | undefined): string {
@@ -440,6 +490,55 @@
               {#if row.tool_names.length > 0}
                 <p class="ctx-tags">Tools: {row.tool_names.join(', ')}</p>
               {/if}
+
+              <!-- Structured section text + raw payload (lazy-loaded on click) -->
+              <div class="ctx-actions">
+                <button
+                  type="button"
+                  class="ctx-btn"
+                  class:active={ctxView[row.id] === 'sections'}
+                  onclick={() => viewSections(row.id)}
+                >View Context Text</button>
+                <button
+                  type="button"
+                  class="ctx-btn"
+                  class:active={ctxView[row.id] === 'payload'}
+                  onclick={() => viewPayload(row.id)}
+                >View Raw Payload</button>
+                {#if ctxView[row.id]}
+                  <button type="button" class="ctx-btn ghost" onclick={() => hideCtx(row.id)}>Hide</button>
+                {/if}
+              </div>
+              {#if ctxError[row.id]}
+                <p class="ctx-err">{ctxError[row.id]}</p>
+              {/if}
+
+              {#if ctxView[row.id] === 'sections'}
+                {#if ctxSections[row.id] === null}
+                  <p class="ctx-loading muted">Loading…</p>
+                {:else if ctxSections[row.id]}
+                  {@const sec = ctxSections[row.id]!}
+                  {#if Object.keys(sec.sections_text ?? {}).length > 0}
+                    {#each Object.keys(sec.sections_text) as name}
+                      <details class="ctx-section">
+                        <summary>
+                          <span class="ctx-section-name">{name}</span>
+                          <span class="muted">{fmtNum((sec.sections ?? {})[name] ?? 0)} tokens</span>
+                        </summary>
+                        <pre class="ctx-pre">{sec.sections_text[name]}</pre>
+                      </details>
+                    {/each}
+                  {:else}
+                    <p class="ctx-loading muted">No section text available</p>
+                  {/if}
+                {/if}
+              {:else if ctxView[row.id] === 'payload'}
+                {#if ctxPayload[row.id] === null}
+                  <p class="ctx-loading muted">Loading…</p>
+                {:else if ctxPayload[row.id] !== undefined}
+                  <pre class="ctx-pre ctx-payload">{JSON.stringify(ctxPayload[row.id], null, 2)}</pre>
+                {/if}
+              {/if}
             </div>
           {/snippet}
         </DataTable>
@@ -759,6 +858,55 @@
     margin: 0.25rem 0 0;
     line-height: 1.5;
   }
+
+  /* ── Recent-call drill-down (context text + raw payload) ── */
+  .ctx-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+  }
+  .ctx-btn {
+    font-size: 0.6875rem;
+    padding: 0.25rem 0.75rem;
+    background: var(--surface-2, var(--border));
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    cursor: pointer;
+    min-height: 28px;
+  }
+  .ctx-btn:hover { border-color: var(--accent); }
+  .ctx-btn.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+  .ctx-btn.ghost { background: transparent; color: var(--muted); }
+  .ctx-err { color: var(--red); font-size: 0.6875rem; margin: 0.5rem 0 0; }
+  .ctx-loading { font-size: 0.75rem; margin: 0.5rem 0 0; }
+  .ctx-section { margin-top: 0.5rem; }
+  .ctx-section > summary {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    cursor: pointer;
+    font-size: 0.75rem;
+    padding: 0.25rem 0;
+  }
+  .ctx-section-name { font-weight: 600; color: #38bdf8; }
+  .ctx-pre {
+    max-height: 400px;
+    overflow: auto;
+    font-size: 0.6875rem;
+    line-height: 1.5;
+    padding: 0.5rem 0.75rem;
+    margin: 0.375rem 0 0;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--text);
+    font-family: var(--font-mono, monospace);
+  }
+  .ctx-payload { max-height: 500px; }
 
   /* ── Shared ── */
   .muted { color: var(--muted); }


### PR DESCRIPTION
Two post-merge fixes to the Svelte v2 dashboard (#539), both browser-verified against a live instance.

## 1. Nav links broken — stuck on Overview
**Bug:** left-nav clicks did nothing; the dashboard never left Overview.
**Cause:** a regression from the codex round-4 skip-link fix — `router.ts` `parse()` now ignores any hash not starting with `#/` (so `#main-content` from the skip link can't reset the route), but `Nav.svelte` links used `href="#{item.id}"` → `#cache` (**no slash**), so every nav click became a non-route fragment and was dropped. The formats were always inconsistent; the old tolerant regex hid it and the router unit test used `#/cache`.
**Fix:** `Nav.svelte` → `href="#/{item.id}"` (canonical format; skip-link fix preserved). New `Nav.test.ts` locks the Nav↔router hash-format contract.

## 2. Observability — restore recent-call drill-down
**Bug:** the "Recent API Calls" table lost the ability to see structured content and raw JSON.
**Cause:** the v2 view dropped the legacy per-row **"View Context Text"** (`/context/log/{id}/sections` — per-section text + token counts) and **"View Raw Payload"** (`/context/log/{id}/payload` — raw request JSON) viewers; only token *counts* remained.
**Fix:** re-added both to the row detail, lazy-loaded **only on button click** (no `$state` mutation in render, per the earlier codex rule), keyed by entry id. Structured view = collapsible `<details>` per section; raw view = `<pre>` JSON.

## Verify
`npm run check` 0 errors; 20 tests pass (2 new). Browser-confirmed: nav routes correctly (Cache/Heartbeat); Observability shows 10 collapsible sections with text + tokens and the full 32 KB request payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
