### PR TITLE
feat: resolve_decision / resolve_decisions / list_decisions agent tools + widen outcome enum (#538)

### DIFF
--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -208,6 +208,7 @@ class Brain:
                 pattern=d.pattern,
                 tags=tags_by_id.get(d.id, []),
                 reviewed_at=d.reviewed_at,
+                superseded_by=d.superseded_by,
                 created_at=d.created_at,
             )
             for d in decisions
@@ -265,6 +266,7 @@ class Brain:
                 outcome=d.outcome or "pending",
                 pattern=d.pattern,
                 tags=[],
+                superseded_by=d.superseded_by,
                 created_at=d.created_at,
             )
             for d in decisions
@@ -819,6 +821,7 @@ class Brain:
                     pattern=d.pattern,
                     tags=tags_by_id.get(d.id, []),
                     score=scores_by_id.get(d.id),
+                    superseded_by=d.superseded_by,
                     created_at=d.created_at,
                 )
             )
@@ -1894,5 +1897,6 @@ class Brain:
             pattern=decision.pattern,
             tags=[],
             reviewed_at=decision.reviewed_at,
+            superseded_by=decision.superseded_by,
             created_at=decision.created_at,
         )

--- a/nous/brain/schemas.py
+++ b/nous/brain/schemas.py
@@ -98,6 +98,7 @@ class DecisionSummary(BaseModel):
     tags: list[str] = []
     score: float | None = None  # Relevance score from search
     reviewed_at: datetime | None = None
+    superseded_by: UUID | None = None
     created_at: datetime
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -138,12 +138,20 @@ class TestResolveDecision:
     """Test the resolve_decision / resolve_decisions / list_decisions tools."""
 
     async def _make_decision(self, tools, brain) -> str:
-        await tools["record_decision"](
-            description="Decision to resolve in tool test",
-            confidence=0.7, category="tooling", stakes="low",
-        )
-        decisions, _ = await brain.list_decisions(limit=1)
-        return str(decisions[0].id)
+        """Record a decision and return its UUID string.
+
+        Uses brain.record() to get the ID directly, avoiding the
+        fragile list_decisions(limit=1) pattern which is ambiguous when
+        multiple decisions share the same created_at timestamp (SQLite).
+        """
+        from nous.brain.schemas import RecordInput
+        detail = await brain.record(RecordInput(
+            description=f"Decision to resolve in tool test {uuid.uuid4()}",
+            confidence=0.7,
+            category="tooling",
+            stakes="low",
+        ))
+        return str(detail.id)
 
     @pytest.mark.asyncio
     async def test_resolve_decision_success(self, tools, brain):
@@ -182,6 +190,33 @@ class TestResolveDecision:
         text = result["content"][0]["text"]
         assert "Resolved 1/2" in text
         assert "Failures" in text
+
+    @pytest.mark.asyncio
+    async def test_list_decisions_returns_pending(self, tools, brain):
+        """list_decisions with outcome='pending' returns newly recorded decision."""
+        did = await self._make_decision(tools, brain)
+        result = await tools["list_decisions"](outcome="pending", limit=50)
+        text = result["content"][0]["text"]
+        assert did in text
+
+    @pytest.mark.asyncio
+    async def test_superseded_by_roundtrip_via_tool(self, tools, brain):
+        """resolve_decision with outcome=superseded preserves superseded_by on the summary."""
+        old_id = await self._make_decision(tools, brain)
+        new_id = await self._make_decision(tools, brain)
+        await tools["resolve_decision"](
+            decision_id=old_id,
+            outcome="superseded",
+            superseded_by=new_id,
+        )
+        detail = await brain.get(uuid.UUID(old_id))
+        assert detail.outcome == "superseded"
+        assert str(detail.superseded_by) == new_id
+        # superseded_by propagates to DecisionSummary via list_decisions
+        decisions, _ = await brain.list_decisions(outcome="superseded", limit=10)
+        match = next((d for d in decisions if str(d.id) == old_id), None)
+        assert match is not None
+        assert str(match.superseded_by) == new_id
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #538. References decision `06d62894-9569-4914-8223-9e9a67d49f6e`.

The three agent tools (`resolve_decision`, `resolve_decisions`, `list_decisions`) and migration `062_decision_resolution_states.sql` were already shipped in main as part of prior work. This PR closes the remaining two gaps identified during final review:

- **`DecisionSummary.superseded_by` was absent.** `DecisionDetail` and the ORM already had the field, but `DecisionSummary` (returned by `list_decisions`, `query()`, and sweep helpers) was missing it. All four `DecisionSummary()` construction sites in `brain.py` now propagate `superseded_by`.
- **`_make_decision` test helper was fragile.** `TestResolveDecision._make_decision` used `list_decisions(limit=1)` to retrieve the just-created decision. When multiple decisions share the same `created_at` timestamp (common in fast SQLite runs), the ORDER BY is non-deterministic and the helper returned the wrong decision, causing `test_resolve_decision_blocked_in_background` to flap. Fixed to use `brain.record()` directly which returns the ID.

## Changes

| File | Change |
|------|--------|
| `nous/brain/schemas.py` | Add `superseded_by: UUID \| None = None` to `DecisionSummary` |
| `nous/brain/brain.py` | Propagate `superseded_by=d.superseded_by` at 4 `DecisionSummary()` sites (`_list_decisions`, `get_recent_decisions`, `query`, `_decision_to_summary`) |
| `tests/test_tools.py` | Fix `_make_decision` helper; add `test_list_decisions_returns_pending` and `test_superseded_by_roundtrip_via_tool` |

## Definition of Done

- [x] Migration `062_decision_resolution_states.sql` (already in main — idempotent)
- [x] ORM `Decision` model updated (`superseded_by` column + widened `ck_decisions_outcome`)
- [x] `OutcomeType` and `ReviewInput` widened (`noise`, `superseded`) in `schemas.py`
- [x] `Brain.review()` / `Brain._review()` accept `superseded_by`
- [x] `Brain.review_many()` batch-resolves decisions
- [x] `resolve_decision` tool registered
- [x] `resolve_decisions` (batch) tool registered
- [x] `list_decisions` tool registered
- [x] All three tools in `task`/`decision`/`conversation`/`question` frames (`FRAME_TOOLS` in `runner.py`)
- [x] `DecisionSummary.superseded_by` propagated at all construction sites **← this PR**
- [x] Tests pass (`TestResolveDecision`: 5/5, `test_review_noise_and_superseded`, `test_review_many_batch_survives_bad_item`, `test_calibration_excludes_noise_and_superseded`)
- [x] Test helper reliability fix **← this PR**

## Test plan

- [ ] `pytest tests/test_tools.py::TestResolveDecision -v` — all 5 tests green
- [ ] `pytest tests/test_brain.py::test_review_noise_and_superseded tests/test_brain.py::test_review_many_batch_survives_bad_item tests/test_brain.py::test_calibration_excludes_noise_and_superseded -v` — all green
- [ ] `pytest tests/test_decision_reviewer.py -v` — all green (minus env-dependent `github_token_default`)

## Out of scope

`TestLearnFact::test_learn_fact_success` fails in isolation due to a pre-existing SQLite/pgvector incompatibility in the fact dedup search path — unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)