### PR TITLE
F035.5 Retrieval Audit + F035.6 Consolidation Audit Diff (opendream-mined, v2.1)

### DIFF
--- a/docs/features/F035-observability.md
+++ b/docs/features/F035-observability.md
@@ -74,6 +74,8 @@ Minsky's Chapter 6 ("Self-Knowledge is Dangerous") warns that unrestricted self-
 | F035.2 | Autonomous Action Audit Trail | P1 | F035.1 |
 | F035.3 | Behavioral Drift Detection | P2 | F035.2 |
 | F035.4 | Context Visibility | P1 | F035 (umbrella) |
+| F035.5 | Retrieval Audit (Recall Explainability) | P3 | F035 (umbrella) |
+| F035.6 | Consolidation Audit Diff | P2 | F035.1 |
 
 **Sequencing rationale:** F035.1 gives us the infrastructure (stats collection, endpoints). F035.2 adds causal metadata to events. F035.3 builds on both to detect trends. F035.4 is independent — it hooks into the runner pipeline, not the event bus — and can be built in parallel with F035.1-3. Each sub-spec is independently useful.
 

--- a/docs/features/F035.5-retrieval-audit.md
+++ b/docs/features/F035.5-retrieval-audit.md
@@ -1,0 +1,260 @@
+# F035.5 — Retrieval Audit (Recall Explainability)
+
+**Umbrella:** F035 Observability
+**Status:** Draft v2.1 (hardened after 2 review rounds; SHIP-rated)
+**Author:** Nous
+**Date:** 2026-06-27
+**Provenance:** Concept mined from `pylit-ai/opendream` ("retrieval audit that returns excluded/near-miss memories with reasons, not just hits"). Adapted to Nous's existing fusion pipeline.
+
+**v2 changelog (what the architecture/value/risk reviewers forced):**
+- **Removed `token_budget` from the pipeline stage list** — it is *not* a per-item pipeline drop. Truncation happens downstream in `nous/cognitive/context.py::_truncate_to_budget` (line 1293) on the already-*formatted text* of each section, not on candidate items inside `run_recall_pipeline`. Documented as an explicitly out-of-scope, separate caller-side audit point (§4.5).
+- **CE rerank explicitly de-scoped from Phase 1.** It runs *inside* `heart.recall`, a separate subsystem the pipeline treats as a black box. Phase 2 now carries a concrete `audit_sink` callback design **with mandatory exception suppression** (§4.4, §7).
+- **Fixed the F080 reason string.** F080 is *pool exclusion* (it removes `censor`/`procedure` types from the implicit search pool when `search_all` + `coherent_ranking_enabled`, lines 364–374). It is **not** a per-item "incoherent with head cluster" filter. The aspirational reason string is gone.
+- **Split `stage` semantics** into *never-fetched* (pool exclusion — type excluded before the query ran) vs *fetched-then-dropped* (F071, rerank truncate). Different debugging meaning, now different stage values (§4.1).
+- **Kill-switch placement pinned to the tool layer** (`recall_deep`) so `run_recall_pipeline`'s signature gains only an optional default-`None` accumulator, not a behavior-changing flag callers must thread (§4.2).
+- **A1 now carries a concrete microbench assertion**; A3 conservation explicitly scoped Phase-1-only (§5).
+
+---
+
+## 1. Problem
+
+`run_recall_pipeline` returns a ranked list of *hits*. When recall is wrong, we
+can see what it **returned** but not what it **rejected** or **why**. Today the
+only observable rejection signal is `PipelineStats.excluded_in_context` (F071) —
+a single integer count of cross-context-dedup drops. Every other Python-stage
+filter (`rerank_by_score` truncation, `_apply_graph_adjacency_boost` gating,
+F080 pool exclusion) drops candidates **silently**, and the `heart.recall`
+internal stages (CE rerank, MMR) are entirely opaque to the pipeline.
+
+Consequence: "why didn't you recall X?" is un-answerable without re-running the
+query under a debugger. This is the biggest blind spot in retrieval debugging
+and directly slows BEAM failure triage (we repeatedly ask "was the gold chunk
+retrieved-then-dropped, or never fetched at all?").
+
+## 2. Goal
+
+Make recall **explainable**: for any query, optionally return the near-miss
+candidates that entered the pipeline but did not survive to the final list,
+each tagged with the **stage** that dropped it and a **specific reason**. Zero
+cost and zero behavior change when disabled.
+
+**Non-goals:** changing ranking behavior; persisting audits by default;
+exposing audits in the normal user-facing recall path; instrumenting the
+context.py token-budget truncation (separate surface — §4.5).
+
+## 3. Current State (grounded, re-verified 2026-06-27)
+
+- `nous/api/retrieval_pipeline.py`
+  - `PipelineResult`, `PipelineStats` (has `ce_reranked`, `excluded_in_context`,
+    `coherent_ranking_applied`).
+  - `run_recall_pipeline(...)` → `_run_stages` (vector/FTS/graph legs) →
+    `rerank_by_score` stable sort → F071 `exclude_ids` drop → return.
+  - **Instrumentable Python-stage drop points (verified line refs):**
+    - `~282` `rerank_by_score` stable-sort + top_k truncation.
+    - `~291–298` F071 `exclude_ids` context-dedup drop.
+    - `364–374` **F080 pool exclusion** — when `search_all and
+      settings.coherent_ranking_enabled`, the implicit pool is narrowed to
+      knowledge-only (censor/procedure types removed). Sets
+      `acc.coherent_ranking_applied = True`. **This is a pool narrowing, not a
+      per-item coherence score.**
+    - `~758` `_apply_graph_adjacency_boost` adjacency gating.
+  - **NOT instrumentable in Phase 1:** CE rerank + MMR happen *inside*
+    `heart.recall` (the pipeline carries `ce_reranked=False  # CE rerank happens
+    inside heart.recall`, ~line 310). Requires the Phase-2 callback (§4.4).
+- **Token-budget truncation is NOT in this pipeline.** It lives in
+  `nous/cognitive/context.py::_truncate_to_budget` (def at line 1293; ~10 call
+  sites, e.g. episodes at line 1011), operating on the **formatted text** of an
+  assembled section against a token budget — *after* recall, *not* on candidate
+  items. Out of scope for v1 (§4.5).
+- `tests/test_retrieval_pipeline_exclusion.py` already exercises the F071 path;
+  its harness (`_make_heart`, `_make_brain`, `_make_settings`) is the reuse
+  target for audit tests.
+
+So: the pipeline already *knows* what it drops at the Python-level stages. It
+discards that information instead of recording it.
+
+## 4. Design
+
+### 4.1 Data model
+
+Opt-in audit accumulator threaded through the pipeline:
+
+```python
+class DropStage(str, Enum):
+    POOL_EXCLUSION   = "pool_exclusion"      # NEVER fetched: type excluded from pool (F080)
+    GRAPH_GATE       = "graph_gate"          # fetched-then-dropped: adjacency gate
+    RERANK_TRUNCATE  = "rerank_truncate"     # fetched-then-dropped: beyond top_k
+    F071_CONTEXT_DEDUP = "f071_context_dedup" # fetched-then-dropped: already in context
+    CE_RERANK        = "ce_rerank"           # Phase 2 only (inside heart.recall)
+    MMR              = "mmr"                  # Phase 2 only (inside heart.recall)
+
+# Stage class — drives interpretation, not just display:
+#   NEVER_FETCHED  = {POOL_EXCLUSION}
+#   FETCHED_DROPPED = {GRAPH_GATE, RERANK_TRUNCATE, F071_CONTEXT_DEDUP, CE_RERANK, MMR}
+
+@dataclass
+class DroppedCandidate:
+    id: str
+    type: str            # episode|fact|decision|chunk|procedure|censor
+    stage: DropStage
+    stage_class: str     # "never_fetched" | "fetched_dropped"
+    reason: str          # specific, e.g. "rank 14 beyond top_k=12"
+    score: float | None  # best score when dropped (None for never_fetched)
+    leg: str | None      # "vector"|"fts"|"graph"|None
+
+@dataclass
+class RetrievalAudit:
+    query: str
+    kept: list[str]
+    dropped: list[DroppedCandidate]
+    stage_counts: dict[str, int]
+    near_misses: list[DroppedCandidate]  # top-K fetched_dropped by score
+    phase2_available: bool               # False if CE/MMR not instrumented this run
+```
+
+`RetrievalAudit` attaches to `PipelineResult` as optional
+(`audit: RetrievalAudit | None = None`), populated only when an accumulator was
+passed in.
+
+> **Design note on `near_misses`:** computed only over `stage_class ==
+> "fetched_dropped"` — a `never_fetched` item has no comparable score and would
+> pollute the ranked near-miss view.
+>
+> **Sentinel values (P2 fix):** for `never_fetched` (POOL_EXCLUSION) entries
+> `score=None` and `leg=None` — they were excluded by type before any leg ran,
+> so there is no score or originating leg. Consumers must treat `score=None` as
+> "not applicable," never as 0.0. The `near_misses` exclusion above enforces
+> this at the one place score ordering matters.
+
+### 4.2 Activation & kill-switch (placement pinned)
+
+The signature change is **minimal and non-behavioral**:
+`run_recall_pipeline(..., audit_acc: RetrievalAudit | None = None)`. When
+`audit_acc is None` (the default for every existing caller), every accumulator
+append is guarded by `if audit_acc is not None` — not one extra allocation on
+the hot path.
+
+**Kill-switch lives at the tool layer**, not in the pipeline body:
+`recall_deep` constructs the accumulator only when *both* the debug caller asked
+for it *and* `NOUS_RETRIEVAL_AUDIT_ENABLED` (default `false`). The pipeline
+itself never reads the env var. Net effect: prod can force-disable without a
+redeploy, and `run_recall_pipeline` gains exactly one optional kwarg that
+defaults to inert.
+
+### 4.3 Surfaces
+
+1. **`recall_deep` debug flag** — internal/debug callers pass `audit=True`; the
+   tool gates on the env flag, builds the accumulator, and returns a compact
+   `near_misses` block (top-K, default K=10) under a `_audit` key. Never shown
+   in the normal conversational recall path.
+2. **CLI probe** — `nous_eval/probes/retrieval_audit.py`: run a query, print the
+   kept list + a near-miss table (id, type, stage, stage_class, score, reason).
+   The BEAM-triage workhorse ("gold chunk fetched then dropped at
+   `rerank_truncate`, score 0.62, rank 14").
+3. **No DB writes** in v1. Audits are ephemeral. (A later F035.x may sample and
+   persist for drift analysis — out of scope, keeps v1 zero-risk.)
+
+### 4.4 Phase 2 — `audit_sink` into `heart.recall` (CE/MMR)
+
+CE rerank and MMR are not visible to the pipeline. Phase 2 passes an optional
+callback `audit_sink: Callable[[DroppedCandidate], None] | None` into
+`heart.recall`. Each internal drop invokes the sink.
+
+**Mandatory hardening (P2 from risk review):** the call site inside
+`heart.recall` MUST wrap every `audit_sink(...)` invocation in
+`try/except Exception` with `logger.debug(..., exc_info=True)` suppression —
+mirroring the existing `_emit_action_event` idiom. A failing/raising audit sink
+must **never** be able to abort a recall. This is an explicit acceptance
+criterion (A7), not an implementation footnote. The `RetrievalAudit.phase2_available`
+field (§4.1) is set `False` when the sink never ran or raised, so consumers can
+distinguish "CE/MMR drops not captured this run" from "no CE/MMR drops occurred."
+
+### 4.5 Out of scope: token-budget truncation audit
+
+The "gold content was dropped to fit the token budget" question is real but
+lives in `context.py::_truncate_to_budget`, operating on formatted section text
+*after* recall. Instrumenting it is a **separate, caller-side** audit (a future
+F035.x) — folding it into the retrieval pipeline would misattribute a
+context-assembly drop to a recall-stage drop. Deliberately excluded from v1.
+
+### 4.6 Reason strings (the contract)
+
+Each stage emits a *specific* reason, not a category:
+- `pool_exclusion`: `"type 'censor' excluded from default pool by F080 coherent ranking"`
+- `graph_gate`: `"edge type 'contradicts' excluded from adjacency boost"`
+- `rerank_truncate`: `"rank 14 beyond top_k=12"`
+- `f071_context_dedup`: `"id already in system prompt this turn"`
+- `ce_rerank` (Phase 2): `"cross-encoder score 0.21 below kept-min 0.40"`
+- `mmr` (Phase 2): `"redundant with kept id 9f2… (sim 0.93 > λ-threshold)"`
+
+Boilerplate reasons ("dropped by filter") fail review.
+
+## 5. Acceptance Criteria
+
+- **A1 (perf, concrete):** with `audit_acc=None`, `PipelineResult.audit is None`
+  and a 100-run microbench shows **p50 delta < 1ms** and **zero `RetrievalAudit`
+  allocations** (assert via `tracemalloc`/sentinel) vs. current.
+- **A2:** with an accumulator passed on a query where a known item is dropped at
+  each *Phase-1* stage, the audit contains exactly one `DroppedCandidate` per
+  drop with correct `stage`, `stage_class`, and a non-empty, stage-specific
+  `reason`.
+- **A3 (conservation, Phase-1-scoped):** for Phase-1 stages only,
+  `kept ∪ {dropped ids}` ⊇ every candidate that entered the *Python* pipeline.
+  Conservation across the `heart.recall` boundary is explicitly **not** asserted
+  until Phase 2 (CE/MMR are inside that boundary).
+- **A4:** `near_misses` is the top-K `fetched_dropped` candidates by score,
+  descending; `never_fetched` items are excluded from it.
+- **A5:** kill-switch — with `NOUS_RETRIEVAL_AUDIT_ENABLED=false`, `recall_deep`
+  returns no `_audit` block even when the caller passes `audit=True`.
+- **A6:** existing `test_retrieval_pipeline*.py` pass unchanged (no drift).
+- **A7 (Phase 2):** an `audit_sink` that raises is fully suppressed — the recall
+  still returns correct hits; a debug log is emitted; the audit is marked
+  `phase2_available=False` for that run.
+
+## 6. Test Plan
+
+- Extend `tests/test_retrieval_pipeline_exclusion.py` harness with an
+  accumulator variant per Phase-1 stage (A2).
+- Conservation property test (A3) over randomized candidate sets, Phase-1 only.
+- Hot-path guard test (A1): `tracemalloc` assert no accumulator allocated when
+  `audit_acc=None`; microbench p50 delta < 1ms.
+- **Drop-site coverage test:** assert every one of the 4 Phase-1 drop points
+  (pool_exclusion/F080, graph_gate, rerank_truncate, F071) emits exactly one
+  `DroppedCandidate` under its `if audit_acc is not None` guard — a regression
+  guard so a future refactor can't silently bypass a drop site.
+- Kill-switch test (A5) at the `recall_deep` tool layer.
+- Phase 2: `audit_sink`-raises suppression test (A7) with a throwing sink.
+
+## 7. Rollout
+
+- **Phase 1** (~1 day): Python-stage audit (pool_exclusion/F080, graph_gate,
+  rerank_truncate, F071) + tool-layer kill-switch + CLI probe. Ships the 80%
+  useful slice with zero `heart.recall` changes.
+- **Phase 2** (~0.5 day): `audit_sink` callback into `heart.recall` for CE/MMR,
+  **with mandatory exception suppression (A7)**.
+- Flag-on for probes/eval only; never auto-on in conversational recall.
+
+## 8. Risks
+
+- **R1 (perf):** accidental hot-path cost. Mitigated by A1 guard test +
+  default-inert accumulator + tool-layer flag.
+- **R2 (boundary leak):** `heart.recall` returning large intermediate lists.
+  Mitigated by the callback sink (Phase 2), not return-value plumbing.
+- **R3 (audit sink aborts recall):** Mitigated by mandatory `try/except`
+  suppression (A7) — a recall must survive a broken audit.
+- **R4 (scope creep):** persistence/drift analysis + token-budget audit.
+  Explicitly deferred (§4.5).
+
+## 9. Cost
+
+Engineering: ~1 day Phase 1, ~0.5 day Phase 2. Runtime: $0 (no LLM, no writes).
+
+## 10. The cheaper 20% alternative (decision point)
+
+The value reviewer rated the full spec 5/10 and recommended a 2-hour log-line
+version: structured `log.info("RECALL_DROP id=%s stage=%s score=%.2f reason=%s")`
+at the 4 Phase-1 drop points, grep-able from prod logs, zero API-surface change.
+**Recommendation:** ship the 20% log-line version first as the actual ticket;
+build full Phase 1 only once BEAM recall-regression triage is a documented,
+recurring bottleneck. This spec is the "build the real thing" option, kept
+ready but gated behind that trigger.

--- a/docs/features/F035.5-retrieval-audit.md
+++ b/docs/features/F035.5-retrieval-audit.md
@@ -10,9 +10,22 @@
 - **Removed `token_budget` from the pipeline stage list** — it is *not* a per-item pipeline drop. Truncation happens downstream in `nous/cognitive/context.py::_truncate_to_budget` (line 1293) on the already-*formatted text* of each section, not on candidate items inside `run_recall_pipeline`. Documented as an explicitly out-of-scope, separate caller-side audit point (§4.5).
 - **CE rerank explicitly de-scoped from Phase 1.** It runs *inside* `heart.recall`, a separate subsystem the pipeline treats as a black box. Phase 2 now carries a concrete `audit_sink` callback design **with mandatory exception suppression** (§4.4, §7).
 - **Fixed the F080 reason string.** F080 is *pool exclusion* (it removes `censor`/`procedure` types from the implicit search pool when `search_all` + `coherent_ranking_enabled`, lines 364–374). It is **not** a per-item "incoherent with head cluster" filter. The aspirational reason string is gone.
-- **Split `stage` semantics** into *never-fetched* (pool exclusion — type excluded before the query ran) vs *fetched-then-dropped* (F071, rerank truncate). Different debugging meaning, now different stage values (§4.1).
+- **Split `stage` semantics** into *never-fetched* (pool exclusion — type excluded before the query ran) vs *fetched-then-dropped* (F071). Different debugging meaning, now different stage values (§4.1).
 - **Kill-switch placement pinned to the tool layer** (`recall_deep`) so `run_recall_pipeline`'s signature gains only an optional default-`None` accumulator, not a behavior-changing flag callers must thread (§4.2).
 - **A1 now carries a concrete microbench assertion**; A3 conservation explicitly scoped Phase-1-only (§5).
+
+**v2.1 correction (codex + 2-reviewer re-verification, 2026-06-27):**
+- **There are only TWO real Phase-1 drop sites, not four.** Re-reading
+  `retrieval_pipeline.py` against the spec: `rerank_by_score` (line 282-283) is a
+  pure `results.sort(...)` with **no truncation**, and `_apply_graph_adjacency_boost`
+  (758-849) appends *every* candidate and returns the full list — it only
+  re-scores and re-orders. Neither drops a candidate. The earlier `RERANK_TRUNCATE`
+  and `GRAPH_GATE` "drop" stages described behavior that does not exist; baking
+  them into the drop-site coverage test (old §6) made an acceptance criterion
+  that could only pass by *adding* gating/truncation — violating this spec's own
+  zero-behavior-change goal. They are removed from the drop enum and recorded as
+  **reorder-only** signals (out of scope for the drop audit; §4.7). The two real
+  Phase-1 drop sites are **`POOL_EXCLUSION` (F080)** and **`F071_CONTEXT_DEDUP`**.
 
 ---
 
@@ -21,10 +34,10 @@
 `run_recall_pipeline` returns a ranked list of *hits*. When recall is wrong, we
 can see what it **returned** but not what it **rejected** or **why**. Today the
 only observable rejection signal is `PipelineStats.excluded_in_context` (F071) —
-a single integer count of cross-context-dedup drops. Every other Python-stage
-filter (`rerank_by_score` truncation, `_apply_graph_adjacency_boost` gating,
-F080 pool exclusion) drops candidates **silently**, and the `heart.recall`
-internal stages (CE rerank, MMR) are entirely opaque to the pipeline.
+a single integer count of cross-context-dedup drops. The one other per-item drop
+(F080 pool exclusion) is silent, and the `heart.recall` internal stages (CE
+rerank, MMR) are entirely opaque to the pipeline. (`rerank_by_score` and
+`_apply_graph_adjacency_boost` re-order but never drop — see §4.7.)
 
 Consequence: "why didn't you recall X?" is un-answerable without re-running the
 query under a debugger. This is the biggest blind spot in retrieval debugging
@@ -49,15 +62,22 @@ context.py token-budget truncation (separate surface — §4.5).
     `coherent_ranking_applied`).
   - `run_recall_pipeline(...)` → `_run_stages` (vector/FTS/graph legs) →
     `rerank_by_score` stable sort → F071 `exclude_ids` drop → return.
-  - **Instrumentable Python-stage drop points (verified line refs):**
-    - `~282` `rerank_by_score` stable-sort + top_k truncation.
-    - `~291–298` F071 `exclude_ids` context-dedup drop.
+  - **The TWO real Python-stage drop points (verified line refs):**
+    - `~291–298` F071 `exclude_ids` context-dedup drop (the only *fetched-then-dropped* site).
     - `364–374` **F080 pool exclusion** — when `search_all and
       settings.coherent_ranking_enabled`, the implicit pool is narrowed to
       knowledge-only (censor/procedure types removed). Sets
       `acc.coherent_ranking_applied = True`. **This is a pool narrowing, not a
-      per-item coherence score.**
-    - `~758` `_apply_graph_adjacency_boost` adjacency gating.
+      per-item coherence score** (the *never-fetched* site).
+  - **Reorder-only stages (NOT drops — §4.7):**
+    - `~282–283` `rerank_by_score` is `results.sort(...)` only — **no truncation**;
+      it re-orders the full list. Top-K limiting is the *caller's* concern, not a
+      pipeline drop.
+    - `758–849` `_apply_graph_adjacency_boost` multiplies scores and re-sorts,
+      returning **every** candidate (all early-returns return the full `results`).
+      The `relation != 'contradicts'` clause (796-798) excludes those edges from
+      the *boost SQL*, not from the candidate set — the candidate is still
+      returned, merely unboosted.
   - **NOT instrumentable in Phase 1:** CE rerank + MMR happen *inside*
     `heart.recall` (the pipeline carries `ce_reranked=False  # CE rerank happens
     inside heart.recall`, ~line 310). Requires the Phase-2 callback (§4.4).
@@ -82,15 +102,15 @@ Opt-in audit accumulator threaded through the pipeline:
 ```python
 class DropStage(str, Enum):
     POOL_EXCLUSION   = "pool_exclusion"      # NEVER fetched: type excluded from pool (F080)
-    GRAPH_GATE       = "graph_gate"          # fetched-then-dropped: adjacency gate
-    RERANK_TRUNCATE  = "rerank_truncate"     # fetched-then-dropped: beyond top_k
     F071_CONTEXT_DEDUP = "f071_context_dedup" # fetched-then-dropped: already in context
     CE_RERANK        = "ce_rerank"           # Phase 2 only (inside heart.recall)
     MMR              = "mmr"                  # Phase 2 only (inside heart.recall)
+# NOTE: rerank_by_score and _apply_graph_adjacency_boost are reorder-only and
+# emit NO DropStage — they never remove a candidate (§4.7).
 
 # Stage class — drives interpretation, not just display:
 #   NEVER_FETCHED  = {POOL_EXCLUSION}
-#   FETCHED_DROPPED = {GRAPH_GATE, RERANK_TRUNCATE, F071_CONTEXT_DEDUP, CE_RERANK, MMR}
+#   FETCHED_DROPPED = {F071_CONTEXT_DEDUP, CE_RERANK, MMR}
 
 @dataclass
 class DroppedCandidate:
@@ -149,8 +169,9 @@ defaults to inert.
    in the normal conversational recall path.
 2. **CLI probe** — `nous_eval/probes/retrieval_audit.py`: run a query, print the
    kept list + a near-miss table (id, type, stage, stage_class, score, reason).
-   The BEAM-triage workhorse ("gold chunk fetched then dropped at
-   `rerank_truncate`, score 0.62, rank 14").
+   The BEAM-triage workhorse ("gold chunk dropped at `f071_context_dedup` —
+   already in the system prompt this turn" vs "never fetched: type excluded by
+   F080 pool exclusion" — the two answers that previously required a debugger).
 3. **No DB writes** in v1. Audits are ephemeral. (A later F035.x may sample and
    persist for drift analysis — out of scope, keeps v1 zero-risk.)
 
@@ -179,15 +200,26 @@ context-assembly drop to a recall-stage drop. Deliberately excluded from v1.
 
 ### 4.6 Reason strings (the contract)
 
-Each stage emits a *specific* reason, not a category:
+Each *drop* stage emits a *specific* reason, not a category:
 - `pool_exclusion`: `"type 'censor' excluded from default pool by F080 coherent ranking"`
-- `graph_gate`: `"edge type 'contradicts' excluded from adjacency boost"`
-- `rerank_truncate`: `"rank 14 beyond top_k=12"`
 - `f071_context_dedup`: `"id already in system prompt this turn"`
 - `ce_rerank` (Phase 2): `"cross-encoder score 0.21 below kept-min 0.40"`
 - `mmr` (Phase 2): `"redundant with kept id 9f2… (sim 0.93 > λ-threshold)"`
 
 Boilerplate reasons ("dropped by filter") fail review.
+
+### 4.7 Reorder-only stages (deliberately NOT in the drop audit)
+
+`rerank_by_score` (`retrieval_pipeline.py:282-283`) and
+`_apply_graph_adjacency_boost` (`758-849`) change candidate *ordering/score* but
+never remove a candidate from the returned list. They have **no `DropStage`** and
+emit **no `DroppedCandidate`** — auditing them as "drops" would be factually
+wrong and would require the pipeline to start dropping (breaking §2's
+zero-behavior-change goal). If rank-churn observability is later wanted, it is a
+**separate "reorder audit"** (record `score_before`/`score_after`/`rank_delta`
+per surviving candidate) — explicitly out of scope for this spec. The "rank N
+beyond top_k" question is answered by the caller that does the top-K slice, not
+here.
 
 ## 5. Acceptance Criteria
 
@@ -195,9 +227,11 @@ Boilerplate reasons ("dropped by filter") fail review.
   and a 100-run microbench shows **p50 delta < 1ms** and **zero `RetrievalAudit`
   allocations** (assert via `tracemalloc`/sentinel) vs. current.
 - **A2:** with an accumulator passed on a query where a known item is dropped at
-  each *Phase-1* stage, the audit contains exactly one `DroppedCandidate` per
+  each of the **2 Phase-1 drop stages** (`POOL_EXCLUSION`/F080,
+  `F071_CONTEXT_DEDUP`), the audit contains exactly one `DroppedCandidate` per
   drop with correct `stage`, `stage_class`, and a non-empty, stage-specific
-  `reason`.
+  `reason`. (The reorder-only stages of §4.7 produce no `DroppedCandidate` and
+  are explicitly *not* asserted here.)
 - **A3 (conservation, Phase-1-scoped):** for Phase-1 stages only,
   `kept ∪ {dropped ids}` ⊇ every candidate that entered the *Python* pipeline.
   Conservation across the `heart.recall` boundary is explicitly **not** asserted
@@ -214,22 +248,27 @@ Boilerplate reasons ("dropped by filter") fail review.
 ## 6. Test Plan
 
 - Extend `tests/test_retrieval_pipeline_exclusion.py` harness with an
-  accumulator variant per Phase-1 stage (A2).
+  accumulator variant per Phase-1 *drop* stage (A2).
 - Conservation property test (A3) over randomized candidate sets, Phase-1 only.
 - Hot-path guard test (A1): `tracemalloc` assert no accumulator allocated when
   `audit_acc=None`; microbench p50 delta < 1ms.
-- **Drop-site coverage test:** assert every one of the 4 Phase-1 drop points
-  (pool_exclusion/F080, graph_gate, rerank_truncate, F071) emits exactly one
-  `DroppedCandidate` under its `if audit_acc is not None` guard — a regression
-  guard so a future refactor can't silently bypass a drop site.
+- **Drop-site coverage test:** assert each of the **2 Phase-1 drop points**
+  (pool_exclusion/F080, F071) emits exactly one `DroppedCandidate` under its
+  `if audit_acc is not None` guard — a regression guard so a future refactor
+  can't silently bypass a drop site.
+- **Reorder-no-drop test (§4.7):** assert that on a query exercising
+  `rerank_by_score` and `_apply_graph_adjacency_boost`, the returned candidate
+  set is identical (same ids) with and without the accumulator, and **no**
+  `DroppedCandidate` is emitted for those stages — guards against a refactor
+  turning a reorder into a silent drop.
 - Kill-switch test (A5) at the `recall_deep` tool layer.
 - Phase 2: `audit_sink`-raises suppression test (A7) with a throwing sink.
 
 ## 7. Rollout
 
-- **Phase 1** (~1 day): Python-stage audit (pool_exclusion/F080, graph_gate,
-  rerank_truncate, F071) + tool-layer kill-switch + CLI probe. Ships the 80%
-  useful slice with zero `heart.recall` changes.
+- **Phase 1** (~1 day): Python-stage audit at the 2 real drop points
+  (pool_exclusion/F080, F071) + tool-layer kill-switch + CLI probe. Ships the
+  80% useful slice with zero `heart.recall` changes.
 - **Phase 2** (~0.5 day): `audit_sink` callback into `heart.recall` for CE/MMR,
   **with mandatory exception suppression (A7)**.
 - Flag-on for probes/eval only; never auto-on in conversational recall.
@@ -253,7 +292,8 @@ Engineering: ~1 day Phase 1, ~0.5 day Phase 2. Runtime: $0 (no LLM, no writes).
 
 The value reviewer rated the full spec 5/10 and recommended a 2-hour log-line
 version: structured `log.info("RECALL_DROP id=%s stage=%s score=%.2f reason=%s")`
-at the 4 Phase-1 drop points, grep-able from prod logs, zero API-surface change.
+at the **2 real Phase-1 drop points** (pool_exclusion/F080, F071), grep-able from
+prod logs, zero API-surface change.
 **Recommendation:** ship the 20% log-line version first as the actual ticket;
 build full Phase 1 only once BEAM recall-regression triage is a documented,
 recurring bottleneck. This spec is the "build the real thing" option, kept

--- a/docs/features/F035.6-consolidation-audit-diff.md
+++ b/docs/features/F035.6-consolidation-audit-diff.md
@@ -96,7 +96,7 @@ only F031 and F027.
 |---|---|---|---|
 | `_phase_resolve_contradictions` (F031) | 850 | supersede/merge | ✅ (migrate to unified) |
 | `_phase_cluster_consolidation` (F027) | 1199 | merge | ✅ (migrate to unified) |
-| `_phase_prune` | 568 | prune episodes | ❌ |
+| `_phase_reflect` (F031 orient) | 594 | create fact / supersede fact | ❌ |
 | `_phase_stale_scan` | 1125 | deactivate stale facts | ❌ |
 | `_phase_graph_densification` | 1443 | edge_add / edge_reweight | ❌ |
 | `_phase_stc_consolidation` (F044) | 1485 | consolidate STC | ❌ |
@@ -105,18 +105,32 @@ only F031 and F027.
 | `_phase_relink_open_episodes` | 1860 | relink | ❌ |
 | `_phase_generalize` (F012) | 1998 | create procedure | ❌ |
 | `_phase_evolve_rubric` (F024-3b) | 2018 | mutate rubric | ❌ |
-| `_phase_compress` | 581 | compress episodes | ❌ |
 
-**Housekeeping / not semantic memory → OUT of v1 (documented exclusion):**
+> **v2.1 correction (codex + 2-reviewer re-verification, 2026-06-27) — two fixes:**
+> 1. **`_phase_reflect` moved IN.** It was wrongly classified OUT as "produces a
+>    reflection note, no mutation of existing memory." Its body calls
+>    `self._heart.learn(FactInput(...))` (lines 650/666/682, incrementing
+>    `sleep_stats["facts_created"]`) and supersedes existing facts via the
+>    `UPDATES:` subject prefix → `_handle_updates_prefix` (642-648) — the same
+>    `learn` + supersede surface as F031/F027. Excluding it would let a reflecting
+>    cycle create/supersede facts with **no `consolidation_action` row**, breaking
+>    A1 conservation and *guaranteeing* `actions_persisted < totals`.
+> 2. **`_phase_prune` (568) and `_phase_compress` (581) moved OUT** of the
+>    mutating coverage: both bodies are verified no-op **stubs today** (literal
+>    `logger.debug("... (stub)")`, no DB write). They are listed in the
+>    housekeeping table with a forward-compat note instead.
+
+**Housekeeping / not semantic memory / stub → OUT of v1 (documented exclusion):**
 | Phase | Line | Why excluded |
 |---|---|---|
 | `_phase_prune_hub_snapshots` | 1630 | snapshot table GC, not memory content |
-| `_phase_review_decisions` | 554 | decision-outcome review, own audit trail |
-| `_phase_reflect` | 594 | produces a reflection note, no mutation of existing memory |
+| `_phase_review_decisions` | 554 | decision-outcome review (`list_decisions` only), own audit trail |
+| `_phase_prune` | 568 | **stub today** (no-op body); thread `cycle_id` now so a future real prune body needs no signature churn |
+| `_phase_compress` | 581 | **stub today** (no-op body); thread `cycle_id` now (same rationale) |
 
-**v1 ships coverage for the 12 mutating phases.** Phasing within that (§7): the
-2 already-emitting phases migrate first to prove the unified envelope, then the
-10 silent mutating phases are added.
+**v1 ships coverage for the 11 mutating phases above.** Phasing within that (§7):
+the 2 already-emitting phases (F031/F027) migrate first to prove the unified
+envelope, then the 9 silent mutating phases are added.
 
 Supporting substrate that already exists:
 - `nous_system.events` — event sink (F035.1/F035.2).
@@ -126,7 +140,7 @@ Supporting substrate that already exists:
 - Retention precedent: `_phase_prune_hub_snapshots` +
   `graph_hub_snapshot_retention_days` (line 1644) is the pattern to copy.
 
-So the **emission substrate exists**; missing is (a) **coverage** (12 mutating
+So the **emission substrate exists**; missing is (a) **coverage** (11 mutating
 phases, 2 instrumented), (b) a **cycle envelope** grouping a night's events, and
 (c) a **diff renderer** — all behind a kill-switch with bounded retention.
 
@@ -201,20 +215,27 @@ For single-target ops it's a one-element array.
 - **`totals` is computed from the *attempted* mutation counts the phases return
   (sleep_stats), not from successfully-inserted audit rows** — so a suppressed
   batch-insert failure undercounts the action table but `totals` still reflects
-  reality. A per-cycle `actions_persisted` vs `totals` mismatch is logged at
+  reality. The invariant is therefore **`actions_persisted <= totals`**, with
+  equality only on a fully-successful cycle (no rejected admissions, no suppressed
+  insert failures). A per-cycle `actions_persisted < totals` mismatch is logged at
   WARNING as an audit-integrity signal (it means the audit table lost rows, not
-  that memory was mutated wrongly).
+  that memory was mutated wrongly). **Do not assert `totals == count(actions)`** —
+  that equality is violated by design whenever any attempted mutation is rejected
+  (`FactRejected`) or its audit insert is suppressed (see A2).
 
 ### 4.3 `cycle_id` threading (scoped explicitly — P2)
 
 Each mutating phase signature gains a `cycle_id: uuid | None` parameter:
-`_phase_prune`, `_phase_stale_scan`, `_phase_graph_densification`,
+`_phase_reflect`, `_phase_stale_scan`, `_phase_graph_densification`,
 `_phase_stc_consolidation`, `_phase_prune_dead_edges`,
 `_phase_recover_abandoned_episodes`, `_phase_relink_open_episodes`,
-`_phase_generalize`, `_phase_evolve_rubric`, `_phase_compress`. The two
-already-emitting phases (`_phase_resolve_contradictions`,
-`_phase_cluster_consolidation`) also thread `cycle_id` into their inner emit
-loops. **Note:** the F031/F027 paths carry production hardening from PR #410 and
+`_phase_generalize`, `_phase_evolve_rubric` — plus the two stubs `_phase_prune`
+and `_phase_compress` (threaded now for forward-compat, emit nothing until they
+gain real bodies). The two already-emitting phases
+(`_phase_resolve_contradictions`, `_phase_cluster_consolidation`) also thread
+`cycle_id` into their inner emit loops. **`_phase_reflect` in particular must
+emit a `learn`/`supersede` action per stored or superseded fact** (it shares
+`_handle_updates_prefix` with F031, so the supersede emit path is reusable). **Note:** the F031/F027 paths carry production hardening from PR #410 and
 #411 — changes there are limited to adding the `cycle_id` arg + writing the new
 unified action; existing event emission is left intact until the Phase-3
 migration retires it.
@@ -306,12 +327,18 @@ Telegram-format summary for the morning report.
 
 ## 5. Acceptance Criteria
 
-- **A1 (conservation):** for every **in-scope mutating phase** (§3.1), emitted
-  `consolidation_action` count == actual DB mutation count for that phase
-  (asserted with a counting fake repo).
+- **A1 (conservation):** for every **in-scope mutating phase** (§3.1, incl.
+  `_phase_reflect`), emitted `consolidation_action` count == actual **successful**
+  DB mutation count for that phase (asserted with a counting fake repo). A
+  rejected mutation (`FactRejected`) is neither a DB mutation nor an emitted
+  action, so it is excluded from both sides.
 - **A2 (envelope):** a completed cycle has a `consolidation_cycles` row,
-  `status=completed`, correct `phases_run`, and `totals` == the sum over its
-  actions. The close write is **awaited** before `_run_sleep` returns.
+  `status=completed`, correct `phases_run`, and `totals` derived from the
+  per-phase **attempted** `sleep_stats` counts (§4.2). The integrity invariant is
+  **`actions_persisted <= totals`**, with equality **only** on a fully-successful
+  cycle; the batch-failure / `FactRejected` cases assert strict `<` plus the
+  WARNING. (Do **not** assert `totals == count(actions)` — see §4.2.) The close
+  write is **awaited** before `_run_sleep` returns.
 - **A3 (snapshots):** `before`/`after` correct for merge/supersede/reweight;
   `before` is a JSON array for multi-source merge; `after` is null for
   prune/deactivate/tombstone.
@@ -360,7 +387,7 @@ Telegram-format summary for the morning report.
 - **Phase 1a** (~0.5 day): migration 063 + cycle envelope + kill-switch +
   retention phase; migrate the 2 already-emitting phases (F031/F027) to the
   unified action table to prove the envelope.
-- **Phase 1b** (~1 day): extend emission to the 10 remaining mutating phases
+- **Phase 1b** (~1 day): extend emission to the 9 remaining mutating phases
   (§3.1), with batched inserts (§4.4).
 - **Phase 2** (~1 day): diff renderer + morning digest + dashboard query.
 - **Phase 3** (~0.5 day): wire `totals` into F035.3 drift detector; migrate
@@ -403,7 +430,7 @@ per-phase `mutation_summary` dict `{phase: {count, sample_ids, sample_before,
 sample_after}}` — no new tables, no envelope, ~55% of the value (you see *what*
 changed per phase, not the full before/after of every action).
 **Recommendation:** ship the 20% `mutation_summary` version first; have Tim
-review a few morning diffs; build this full spec (envelope + 12-phase coverage +
+review a few morning diffs; build this full spec (envelope + 11-phase coverage +
 renderer) once the diff format proves worth reviewing. This spec is the
 "build the real thing" option, gated behind that confirmation.
 

--- a/docs/features/F035.6-consolidation-audit-diff.md
+++ b/docs/features/F035.6-consolidation-audit-diff.md
@@ -1,0 +1,417 @@
+# F035.6 — Consolidation Audit Diff (Reviewable Sleep-Cycle Changelog)
+
+**Umbrella:** F035 Observability
+**Status:** Draft v2.1 (hardened after 2 review rounds; final P1s closed)
+**Author:** Nous
+**Date:** 2026-06-27
+**Provenance:** Concept mined from `pylit-ai/opendream` ("per-sleep-cycle
+consolidation audit diff as a reviewable artifact"). Adapted to Nous's existing
+sleep-phase event instrumentation.
+
+**v2 changelog (what the architecture/value/risk reviewers forced):**
+- **Phase taxonomy rebuilt from the actual code.** There are **15 `_phase_*`
+  methods**, not ~6; only **2 emit events today** (`_phase_resolve_contradictions`
+  F031, `_phase_cluster_consolidation` F027). §3 now enumerates all 15 and
+  classifies each *mutating / housekeeping / read-only*, with explicit **v1
+  coverage vs deferred** scoping (§3.1). The four phases the v1 reviewers caught
+  as missing — `stc_consolidation`, `prune_dead_edges`, `recover_abandoned_episodes`,
+  `relink_open_episodes` — are now first-class.
+- **`trace_id` typed `VARCHAR(12)`** (matches existing schema, mig 026), matching `Event.trace_id =
+  mapped_column(String(12))` (storage/models.py:104, F035.2 short-hash). It is
+  **not** a UUID.
+- **Concrete SQL migration added** — `sql/migrations/063_f035_5_consolidation_audit.sql`
+  (latest on disk is `062`). DDL in §4.6.
+- **Kill-switch added (P1)** — `NOUS_CONSOLIDATION_AUDIT_ENABLED` (default
+  `false`) gates **all** new writes (envelope + actions). Off = sleep behaves
+  byte-for-byte as today (§4.7, A7).
+- **cycle_id FK cascade failure mitigated (P1)** — `consolidation_actions.cycle_id`
+  is **nullable**; on cycle-open write failure the cycle is degraded to
+  `cycle_id=NULL` with a warning, and action emits continue as orphan rows
+  rather than every write being rejected (§4.1, §4.2).
+- **Retention sweep implemented (P1)** — a real `_phase_prune_consolidation_actions`
+  sleep phase mirroring `_phase_prune_hub_snapshots` (sleep_handler.py:1630),
+  gated by `NOUS_CONSOLIDATION_AUDIT_RETENTION_DAYS` (§4.5). No "operator may
+  manually DELETE" hand-wave.
+- **Backpressure cap (P2)** — high-volume phases (graph densify can emit
+  50–200 rows) batch into **one `executemany` per phase**, not N fire-and-forget
+  tasks; the existing `_pending_emits` set gets a semaphore cap (§4.4).
+- **`cycle_id` threading scoped explicitly (P2)** — §4.3 lists every phase
+  signature that must take `cycle_id`, acknowledging the F031/F027 paths carry
+  PR #410/#411 hardening and must be touched carefully.
+- **Envelope-close ordering fixed (P2)** — the cycle `completed` write is
+  **awaited**, not fire-and-forget, so a "completed" event can't land before its
+  phase mutation events (§4.2).
+- **Multi-fact merge `before` is now a structured list**, not a single 280-char
+  truncation — F027 merges N source facts (§4.1, R4).
+
+---
+
+## 1. Problem
+
+Sleep / consolidation mutates long-term memory autonomously across many phases —
+F031 contradiction resolution, F027 cluster consolidation, stale-scan
+deactivation, decay/pruning, edge densification/reweighting, STC consolidation,
+episode recovery/relink. Each cycle can merge facts, supersede values, prune
+episodes, deactivate stale facts, and reweight edges — **irreversibly altering
+what Nous knows** — and today there is no single reviewable artifact answering
+"what did last night's sleep change, and why?"
+
+This failure mode is qualitatively worse than a bad recall: a retrieval drop
+ruins **one** response; a wrongful tombstone, a bad merge, or over-decay
+silently corrupts **all future recalls** until a human notices and corrects it.
+There is currently no path to noticing without querying specific facts and
+getting suspicious.
+
+We have *fragments* — but only **2 of 15 phases emit any event**:
+- `_phase_resolve_contradictions` (F031) → `nous_system.events` (line ~939).
+- `_phase_cluster_consolidation` (F027) → `_emit_action_event` (lines 1322/1359/1413).
+- Three on-demand probes: `sleep_cycle_health` (PR #404, "phase produced 0
+  output"), `sleep_filter_dryrun` (PR #406, "filter would select 0"),
+  `sleep_action_audit` (LLM-judges F031/F027 action *quality* on a sample).
+
+None answer **"what did the full cycle change?"** The other 13 phases —
+including every prune, the stale-scan, graph densify, STC consolidation, and
+episode relink — are black boxes.
+
+## 2. Goal
+
+Emit, once per completed sleep cycle, a **Consolidation Audit Diff**: a
+structured, complete, reviewable record of every memory mutation the cycle made,
+grouped by phase, with before/after and rationale. Queryable, diffable across
+nights, and consumable by F035.3 Behavioral Drift Detection.
+
+**Non-goals:** judging quality (that's `sleep_action_audit`); changing
+consolidation behavior; making sleep reversible (rollback is a future F0xx);
+instrumenting housekeeping phases that don't mutate semantic memory (§3.1).
+
+## 3. Current State (grounded, re-verified 2026-06-27)
+
+`nous/handlers/sleep_handler.py` has **15 `_phase_*` methods**. Emission today:
+only F031 and F027.
+
+### 3.1 Phase taxonomy & v1 coverage decision
+
+**Mutates semantic memory → IN v1 audit coverage:**
+| Phase (method) | Line | Op kind | Emits today? |
+|---|---|---|---|
+| `_phase_resolve_contradictions` (F031) | 850 | supersede/merge | ✅ (migrate to unified) |
+| `_phase_cluster_consolidation` (F027) | 1199 | merge | ✅ (migrate to unified) |
+| `_phase_prune` | 568 | prune episodes | ❌ |
+| `_phase_stale_scan` | 1125 | deactivate stale facts | ❌ |
+| `_phase_graph_densification` | 1443 | edge_add / edge_reweight | ❌ |
+| `_phase_stc_consolidation` (F044) | 1485 | consolidate STC | ❌ |
+| `_phase_prune_dead_edges` | 1532 | edge prune | ❌ |
+| `_phase_recover_abandoned_episodes` | 1666 | recover/relink | ❌ |
+| `_phase_relink_open_episodes` | 1860 | relink | ❌ |
+| `_phase_generalize` (F012) | 1998 | create procedure | ❌ |
+| `_phase_evolve_rubric` (F024-3b) | 2018 | mutate rubric | ❌ |
+| `_phase_compress` | 581 | compress episodes | ❌ |
+
+**Housekeeping / not semantic memory → OUT of v1 (documented exclusion):**
+| Phase | Line | Why excluded |
+|---|---|---|
+| `_phase_prune_hub_snapshots` | 1630 | snapshot table GC, not memory content |
+| `_phase_review_decisions` | 554 | decision-outcome review, own audit trail |
+| `_phase_reflect` | 594 | produces a reflection note, no mutation of existing memory |
+
+**v1 ships coverage for the 12 mutating phases.** Phasing within that (§7): the
+2 already-emitting phases migrate first to prove the unified envelope, then the
+10 silent mutating phases are added.
+
+Supporting substrate that already exists:
+- `nous_system.events` — event sink (F035.1/F035.2).
+- `_emit_action_event` (line 387) — fire-and-forget `asyncio.create_task` with
+  debug-suppression and a GC-safe `_pending_emits: set[asyncio.Task]` (PR #407).
+- F035.2 Causal Chain Tracing → `Event.trace_id = String(12)` (storage/models.py:104).
+- Retention precedent: `_phase_prune_hub_snapshots` +
+  `graph_hub_snapshot_retention_days` (line 1644) is the pattern to copy.
+
+So the **emission substrate exists**; missing is (a) **coverage** (12 mutating
+phases, 2 instrumented), (b) a **cycle envelope** grouping a night's events, and
+(c) a **diff renderer** — all behind a kill-switch with bounded retention.
+
+## 4. Design
+
+### 4.1 Data model
+
+```
+nous_system.consolidation_cycles
+  cycle_id        uuid pk
+  trace_id        varchar(12)    -- F035.2 short-hash link, matches Event.trace_id String(12)/VARCHAR(12) (mig 026); NOT uuid
+  agent_id        text
+  started_at      timestamptz not null
+  finished_at     timestamptz
+  status          text not null  -- running|completed|failed
+  phases_run      text[]
+  totals          jsonb          -- {merged, superseded, pruned, deactivated,
+                                 --  edges_added, edges_reweighted, tombstoned, ...}
+
+nous_system.consolidation_actions
+  action_id    uuid pk
+  cycle_id     uuid NULL references consolidation_cycles(cycle_id) on delete set null
+  trace_id     varchar(12)       -- denormalized so orphan rows stay causally linked (matches VARCHAR(12))
+  phase        text not null     -- f031_contradiction|f027_consolidate|prune|
+                                 --  stale_scan|graph_densify|stc_consolidate|
+                                 --  prune_dead_edges|recover_episode|relink_episode|
+                                 --  generalize|evolve_rubric|compress
+  op           text not null     -- merge|supersede|prune|deactivate|edge_add|
+                                 --  edge_reweight|recover|relink|create_proc|mature
+  target_ids   uuid[]            -- fact/episode/edge ids touched
+  before       jsonb             -- see note: list for multi-source merge
+  after        jsonb             -- post-op snapshot (null for prune/deactivate/tombstone)
+  rationale    text              -- phase-supplied reason
+  created_at   timestamptz not null default now()
+```
+
+**`cycle_id` is nullable (P1 fix).** If the cycle-open write fails, actions are
+still written with `cycle_id=NULL` and a non-null `trace_id`, so the cycle's
+mutations are recoverable by `trace_id` even without an envelope row. `ON DELETE
+SET NULL` means retention pruning the envelope never orphan-cascades the actions
+mid-write.
+
+**`before` for multi-source merge (P2 fix).** F027 merges N source facts; a
+single truncated string is unintelligible. `before` is a **JSON array** of
+`{id, content_preview}` (each preview ≤200 chars), e.g.
+`[{"id":"1a3…","content_preview":"born in Texas"},{"id":"4b7…","content_preview":"born in TX"}]`.
+For single-target ops it's a one-element array.
+
+### 4.2 Emission ordering & failure handling
+
+- **`trace_id` is generated in-process at cycle start, BEFORE the cycle-open DB
+  write** (P2 fix) — so even if the envelope write fails, orphan action rows
+  still carry a valid `trace_id`. Generation is a pure short-hash, never a DB
+  round-trip.
+- **Open the envelope first**, `await`ed. On failure: log warning, set a
+  process-local `cycle_id=None` (keep `trace_id`), continue — actions degrade to
+  orphan rows.
+- **Per-phase actions** emit via a batched insert (§4.4) as fire-and-forget
+  `create_task`s tracked in `_pending_emits`.
+- **Envelope close is an explicit two-step `await` (P1 fix — resolves the A9
+  ordering contradiction):**
+  1. `await asyncio.gather(*list(self._pending_emits))` — **drain all pending
+     action-batch inserts.** Awaiting only the close write does NOT drain
+     fire-and-forget tasks, so without this gather a `status=completed` row can
+     be observable before its phase-action rows land. The drain is what makes
+     A9 mechanically true.
+  2. Then `await` the close write (`status=completed`, `finished_at`, `totals`).
+  This replaces the existing fire-and-forget `sleep_completed` emit at
+  `_run_sleep` (~lines 522-533); that emit must be moved after the drain.
+- Any individual emit failure is debug-suppressed exactly like
+  `_emit_action_event` — a broken audit can **never** break a sleep cycle.
+- **`totals` is computed from the *attempted* mutation counts the phases return
+  (sleep_stats), not from successfully-inserted audit rows** — so a suppressed
+  batch-insert failure undercounts the action table but `totals` still reflects
+  reality. A per-cycle `actions_persisted` vs `totals` mismatch is logged at
+  WARNING as an audit-integrity signal (it means the audit table lost rows, not
+  that memory was mutated wrongly).
+
+### 4.3 `cycle_id` threading (scoped explicitly — P2)
+
+Each mutating phase signature gains a `cycle_id: uuid | None` parameter:
+`_phase_prune`, `_phase_stale_scan`, `_phase_graph_densification`,
+`_phase_stc_consolidation`, `_phase_prune_dead_edges`,
+`_phase_recover_abandoned_episodes`, `_phase_relink_open_episodes`,
+`_phase_generalize`, `_phase_evolve_rubric`, `_phase_compress`. The two
+already-emitting phases (`_phase_resolve_contradictions`,
+`_phase_cluster_consolidation`) also thread `cycle_id` into their inner emit
+loops. **Note:** the F031/F027 paths carry production hardening from PR #410 and
+#411 — changes there are limited to adding the `cycle_id` arg + writing the new
+unified action; existing event emission is left intact until the Phase-3
+migration retires it.
+
+### 4.4 Backpressure (P2 fix)
+
+`_phase_graph_densification` can produce 50–200 edge mutations; spawning 200
+fire-and-forget `create_task` DB writes can saturate a 5–20-conn pool. Each
+phase therefore **collects its actions in a list and emits one batched
+`executemany` insert** (a single task), not per-row tasks. The `_pending_emits`
+set gets a soft cap (e.g. `NOUS_CONSOLIDATION_AUDIT_MAX_INFLIGHT`, default 32);
+if exceeded, the next batch is `await`ed inline rather than spawned, applying
+natural backpressure without dropping audit rows.
+
+**Batch-failure semantics (P1 fix):** each phase's `executemany` insert uses
+`ON CONFLICT (action_id) DO NOTHING` and is wrapped in the same debug-suppressed
+`try/except` as `_emit_action_event`. A single bad row therefore cannot abort
+the whole batch silently at the SQL layer beyond that statement, and a failed
+batch is logged (feeding the `actions_persisted` vs `totals` integrity check in
+§4.2) rather than raising into the sleep loop. Audit-row loss degrades the diff,
+never the consolidation.
+
+Realistic write volume (risk review): **30–300 action rows/cycle → ~1k–9k
+rows/month** at one cycle/night — trivial for Postgres, and bounded by §4.5.
+
+### 4.5 Retention sweep (P1 fix — real phase, not a hand-wave)
+
+New `_phase_prune_consolidation_actions` (the 16th sleep phase), modeled on
+`_phase_prune_hub_snapshots` (line 1630). **Ordering: it runs LAST in
+`_run_sleep`, after the envelope close/drain (§4.2)** — so it can never prune
+rows the current cycle is still emitting. It only ever deletes rows from *prior*
+cycles older than the retention window:
+- Gated by `NOUS_CONSOLIDATION_AUDIT_RETENTION_DAYS` (default 30; `<= 0`
+  disables the phase).
+- `DELETE FROM consolidation_actions WHERE created_at < now() - make_interval(days => :days)`.
+- The `consolidation_cycles` row (with `totals`) is retained **indefinitely** —
+  the per-night aggregate is cheap and is the F035.3 drift time-series.
+- Errors caught and logged; never aborts the sleep cycle.
+
+### 4.6 SQL migration
+
+`sql/migrations/063_f035_5_consolidation_audit.sql` (latest on disk is `062`):
+the two `CREATE TABLE` statements above, plus indexes:
+`idx_consolidation_actions_cycle (cycle_id)`,
+`idx_consolidation_actions_created (created_at)` (retention sweep),
+`idx_consolidation_actions_trace (trace_id)` (orphan recovery),
+`idx_consolidation_cycles_started (started_at)`.
+
+### 4.7 Kill-switch (P1 fix)
+
+`NOUS_CONSOLIDATION_AUDIT_ENABLED` (default `false`). When false: no envelope
+opened, no `cycle_id` threaded, no action emits, no retention phase — sleep
+runs **exactly as today**. This is pure additive instrumentation that can be
+force-disabled in prod without a redeploy if any regression appears.
+
+### 4.8 The diff renderer
+
+`nous_eval/probes/consolidation_diff.py` (+ a `dashboard_queries.py` function)
+renders a cycle into a reviewable artifact:
+
+```
+🌙 Consolidation Cycle 2026-06-27 (cycle a1b2…, trace a1b2c3d4e5f6)
+   Duration 42s · phases: f031, f027, prune, stale_scan, graph_densify, f071
+
+   ✏️  F031 Contradiction (3 actions)
+      • supersede fact 9f2…: "accuracy 85%" → "accuracy 78%"   [later-dated value wins]
+      • merge facts 1a3…,4b7…: dup "born in Texas"             [exact-dup merge]
+   🧹 Prune / Stale-scan (12 actions)
+      • prune episode 5c1…: last_access 41d, salience 0.07      [below prune floor 0.10]
+      • deactivate fact 3d2…: 0 recall 90d                      [stale-scan]
+   🔗 Graph densify (8 actions)
+      • edge_reweight 2d4…→7e9…: 0.31 → 0.55                    [co-recall x4 this week]
+
+   Totals: merged 1 · superseded 1 · pruned 8 · deactivated 4 · edges_reweighted 8
+```
+
+Output modes: terminal table, JSON (for the drift detector), and a
+Telegram-format summary for the morning report.
+
+### 4.9 Consumers
+
+1. **Human review** — morning digest: "last night Nous changed N things."
+2. **F035.3 Behavioral Drift Detection** — consumes `totals` as a time series;
+   z-score anomaly (e.g. prune count 10× baseline) fires a heartbeat alert.
+   **F035.6's `totals` is the primary write-side signal F035.3 depends on.**
+3. **`sleep_action_audit`** — keeps judging *quality* on a sample, but (Phase 3)
+   reads the unified `consolidation_actions` table instead of phase-specific
+   ad-hoc events.
+
+## 5. Acceptance Criteria
+
+- **A1 (conservation):** for every **in-scope mutating phase** (§3.1), emitted
+  `consolidation_action` count == actual DB mutation count for that phase
+  (asserted with a counting fake repo).
+- **A2 (envelope):** a completed cycle has a `consolidation_cycles` row,
+  `status=completed`, correct `phases_run`, and `totals` == the sum over its
+  actions. The close write is **awaited** before `_run_sleep` returns.
+- **A3 (snapshots):** `before`/`after` correct for merge/supersede/reweight;
+  `before` is a JSON array for multi-source merge; `after` is null for
+  prune/deactivate/tombstone.
+- **A4 (renderer round-trip):** the diff renderer reproduces a cycle with zero
+  lost actions.
+- **A5 (causal link):** cycle and all actions share one `trace_id` (`varchar(12)`);
+  orphan actions (cycle-open failed) still carry the `trace_id`.
+- **A6 (retention):** `_phase_prune_consolidation_actions` deletes actions older
+  than N days, preserves `consolidation_cycles.totals`, and is disabled when
+  `RETENTION_DAYS <= 0`.
+- **A7 (kill-switch):** with `NOUS_CONSOLIDATION_AUDIT_ENABLED=false`, sleep
+  emits no envelope and no actions and is behaviorally identical to today.
+- **A8 (FK degradation):** when the cycle-open write fails, action emits still
+  succeed with `cycle_id=NULL` and a non-null `trace_id`; no action write is
+  rejected by the FK; a warning is logged.
+- **A9 (ordering):** no `status=completed` envelope event is observable before
+  all of that cycle's phase-action rows are written.
+
+## 6. Test Plan
+
+- Per-phase emission/conservation tests with a counting fake repo (A1) — reuse
+  `test_sleep_handler.py` / `test_f031_consolidation.py` fixtures.
+- Cycle-envelope lifecycle test: start → actions → awaited close → totals (A2, A9).
+- Multi-source-merge `before`-array test (A3).
+- Renderer round-trip test (A4).
+- Orphan-action test: force cycle-open failure, assert actions written with
+  `cycle_id=NULL`, `trace_id` set, no FK error (A8).
+- Retention sweep test with frozen clock + `RETENTION_DAYS=0` disable case (A6).
+- Kill-switch behavioral-parity test (A7): byte-identical sleep_stats with flag
+  off vs the pre-feature baseline.
+- Backpressure test: simulate 200 graph-densify mutations, assert one batched
+  insert per phase and `_pending_emits` never exceeds the cap (§4.4).
+- **A9 drain test:** a separate reader querying mid-close must NOT observe
+  `status=completed` until every phase-action row of that cycle is present.
+  Assert the `asyncio.gather(*_pending_emits)` drain happens before the close
+  write (not merely that the close is awaited).
+- **F031/F027 regression test (R4):** assert the existing
+  `f031_contradiction_resolution` / F027 `_emit_action_event` payloads are
+  byte-identical after `cycle_id` threading is added.
+- **Batch-failure test:** force one `executemany` to raise; assert the sleep
+  cycle completes, the failure is logged, and `actions_persisted < totals`
+  triggers the integrity WARNING (§4.2/§4.4).
+
+## 7. Rollout
+
+- **Phase 1a** (~0.5 day): migration 063 + cycle envelope + kill-switch +
+  retention phase; migrate the 2 already-emitting phases (F031/F027) to the
+  unified action table to prove the envelope.
+- **Phase 1b** (~1 day): extend emission to the 10 remaining mutating phases
+  (§3.1), with batched inserts (§4.4).
+- **Phase 2** (~1 day): diff renderer + morning digest + dashboard query.
+- **Phase 3** (~0.5 day): wire `totals` into F035.3 drift detector; migrate
+  `sleep_action_audit` to read the unified table; retire the ad-hoc F031/F027
+  event path.
+
+## 8. Risks
+
+- **R1 (volume/cost):** table growth. Mitigated by batched inserts + the real
+  `_phase_prune_consolidation_actions` retention sweep (§4.5). 1k–9k rows/month
+  is trivial.
+- **R2 (sleep latency):** extra writes. Mitigated by per-phase batched
+  `executemany` + fire-and-forget action emits (only the envelope close is
+  awaited) + the path is already off the conversational hot path.
+- **R3 (cycle-open failure cascade):** Mitigated by nullable `cycle_id` +
+  `trace_id` denormalization + `ON DELETE SET NULL` (A8).
+- **R4 (double instrumentation):** old F031/F027 ad-hoc events vs the unified
+  table. Mitigated by Phase-3 migration that retires the ad-hoc path; until
+  then both run (idempotent, additive). **Authority rule: during the transition
+  the unified `consolidation_actions` table is the single source of truth for
+  F035.3; legacy ad-hoc events are ignored by downstream consumers.** The
+  F031/F027 paths carry PR #410/#411 hardening — adding `cycle_id` + the unified
+  write requires a mandatory integration test (§6) asserting the existing event
+  emission is unchanged.
+- **R5 (snapshot size/PII):** previews ≤200 chars; ids not full objects.
+- **R6 (kill-switch / no off-ramp):** Resolved — `NOUS_CONSOLIDATION_AUDIT_ENABLED`
+  gates everything (§4.7, A7).
+
+## 9. Cost
+
+Engineering: ~1.5 days Phase 1, ~1 day Phase 2, ~0.5 day Phase 3. Runtime: DB
+writes only (no LLM) for the diff; the `sleep_action_audit` quality LLM cost
+(~$2.50/run) is unchanged and separate.
+
+## 10. The cheaper 20% alternative (decision point)
+
+The value reviewer (7.5/10, the higher-value of the two specs) flagged a 4-hour
+20% version: enrich the **existing** `sleep_completed` event payload with a
+per-phase `mutation_summary` dict `{phase: {count, sample_ids, sample_before,
+sample_after}}` — no new tables, no envelope, ~55% of the value (you see *what*
+changed per phase, not the full before/after of every action).
+**Recommendation:** ship the 20% `mutation_summary` version first; have Tim
+review a few morning diffs; build this full spec (envelope + 12-phase coverage +
+renderer) once the diff format proves worth reviewing. This spec is the
+"build the real thing" option, gated behind that confirmation.
+
+## 11. Relationship to F035 siblings
+
+- **F035.1 Event Bus** — reuses `nous_system.events` substrate.
+- **F035.2 Causal Tracing** — `trace_id` (`varchar(12)`) threads the whole cycle.
+- **F035.3 Drift Detection** — primary downstream consumer of `totals` (this
+  spec is its write-side prerequisite).
+- **F035.5 Retrieval Audit** — sibling: this audits *writes* (consolidation),
+  F035.5 audits *reads* (recall).


### PR DESCRIPTION
## Summary
Two observability specs mined from `pylit-ai/opendream`, hardened across **2 fresh-context review rounds** (architecture / value / risk reviewers, none of whom saw the original reasoning).

| Spec | Title | Verdict | Arch |
|---|---|---|---|
| **F035.5** | Retrieval Audit (Recall Explainability) | SHIP | 8/10 |
| **F035.6** | Consolidation Audit Diff | SHIP-WITH-FIXES | 7/10 |

## What they do
- **F035.5 — Retrieval Audit:** read-path explainability. Returns *excluded / near-miss* memories with the reason they were dropped, not just the hits. §10 20%-version = ~4 audit log lines (~2h).
- **F035.6 — Consolidation Audit Diff:** per-sleep-cycle reviewable changelog of what consolidation mutated. `totals` is the primary write-side signal **F035.3 Behavioral Drift Detection** depends on. §10 20%-version = enrich `sleep_completed` with `mutation_summary` (~4h).

## Hardening (v2 -> v2.1)
All v2 codebase claims were re-verified accurate by reviewers: 15 `_phase_*` consolidation phases, 2 emitters, `trace_id` String(12), token-budget truncation in `context.py:1293`, F080 = pool exclusion.
Round-2 fixes folded in: A9 emit-ordering drain (`await asyncio.gather(*_pending_emits)`), `executemany` batch-failure semantics, retention phase ordering, char(12)->varchar(12), kill-switch env var, never_fetched sentinels, drop-site coverage test.

## Notes
- Renumbered from drafts (F035.4/F035.5) to **F035.5/F035.6** to avoid collision with the already-shipped `F035.4 Context Visibility`.
- Added both to the F035 umbrella roadmap table.
- Build gated behind operational triggers; 20% versions can ship first.