### PR TITLE
F035.6: surface F044 STC promotion + reinforcement in audit summary

### DIFF
--- a/nous/brain/tinyhippo_lite.py
+++ b/nous/brain/tinyhippo_lite.py
@@ -18,10 +18,26 @@ downstream consumer reads yet) and reports counts.
 
 from __future__ import annotations
 
+import logging
 from collections import Counter
 from typing import Any
 
 from sqlalchemy import text
+
+logger = logging.getLogger(__name__)
+
+# Keys produced by ``stc_promote_and_measure``; used to zero-fill a partial
+# result when promotion/telemetry fails after the (durable) recall flush.
+_STC_PROMOTE_KEYS = (
+    "f044_promoted",
+    "f044_n_edges",
+    "f044_n_tagged",
+    "f044_n_consolidated",
+    "f044_ltp_ge1",
+    "f044_ltp_ge2",
+    "f044_ltp_ge3",
+    "f044_reinforced_24h",
+)
 
 # F044 v1.1 — buffered recall-touch reinforcement. Edges among co-retrieved
 # results are "reactivated" by a recall (retrieval == STC reactivation). We
@@ -249,8 +265,21 @@ async def run_stc_consolidation(db: Any, agent_id: str, prp_threshold: int) -> d
     """
     async with db.session() as session:
         touched = await flush_recall_touches(session, agent_id)
-    async with db.session() as session:
-        stats = await stc_promote_and_measure(session, agent_id, prp_threshold)
-        await session.commit()
-    stats["f044_recall_touches_flushed"] = touched
+    # Capture the (already-committed, durable) flush count FIRST so a later
+    # promotion/telemetry failure can't discard it from the returned stats —
+    # otherwise the committed ltp writes would get no audit summary (codex P2).
+    # Promotion is idempotent and simply re-runs next cycle if it aborts here.
+    stats: dict[str, int] = {"f044_recall_touches_flushed": touched}
+    try:
+        async with db.session() as session:
+            stats.update(await stc_promote_and_measure(session, agent_id, prp_threshold))
+            await session.commit()
+    except Exception:
+        logger.warning(
+            "F044 STC promotion/telemetry failed after recall flush (touched=%d); "
+            "reporting flush count only, promotion retries next cycle",
+            touched, exc_info=True,
+        )
+        for k in _STC_PROMOTE_KEYS:
+            stats.setdefault(k, 0)
     return stats

--- a/nous/brain/tinyhippo_lite.py
+++ b/nous/brain/tinyhippo_lite.py
@@ -290,8 +290,13 @@ async def run_stc_consolidation(db: Any, agent_id: str, prp_threshold: int) -> d
             "reporting flush count only, promotion retries next cycle",
             touched, exc_info=True,
         )
-        for k in _STC_PROMOTE_KEYS:
-            stats.setdefault(k, 0)
+        # Zero-fill ONLY the committed-mutation counter (nothing was promoted —
+        # accurate). The telemetry SNAPSHOTS (f044_n_edges/n_tagged/n_consolidated/
+        # ltp_ge*/reinforced_24h) are deliberately OMITTED, not zeroed: fabricating
+        # "0 edges" for a cycle whose telemetry SELECT never ran (or rolled back)
+        # would corrupt the F035.3 drift time-series (codex P2). The phase returns
+        # before its telemetry logger.info on this path, so omission can't KeyError.
+        stats.setdefault("f044_promoted", 0)
         # Failure signal so the caller can mark the phase unsuccessful even
         # though the (durable) flush count is surfaced (codex P2). A BOOL, not an
         # int: it rides into the cycle totals, and ConsolidationAuditor._sum_totals

--- a/nous/brain/tinyhippo_lite.py
+++ b/nous/brain/tinyhippo_lite.py
@@ -293,7 +293,9 @@ async def run_stc_consolidation(db: Any, agent_id: str, prp_threshold: int) -> d
         for k in _STC_PROMOTE_KEYS:
             stats.setdefault(k, 0)
         # Failure signal so the caller can mark the phase unsuccessful even
-        # though the (durable) flush count is surfaced (codex P2). Excluded from
-        # the F035.6 audit allowlist like other diagnostic ``*_error`` keys.
-        stats["f044_stc_error"] = 1
+        # though the (durable) flush count is surfaced (codex P2). A BOOL, not an
+        # int: it rides into the cycle totals, and ConsolidationAuditor._sum_totals
+        # sums every non-bool int for `_attempted` — an int flag would be miscounted
+        # as an attempted mutation. Excluded from the STC audit allowlist regardless.
+        stats["f044_stc_error"] = True
     return stats

--- a/nous/brain/tinyhippo_lite.py
+++ b/nous/brain/tinyhippo_lite.py
@@ -282,4 +282,8 @@ async def run_stc_consolidation(db: Any, agent_id: str, prp_threshold: int) -> d
         )
         for k in _STC_PROMOTE_KEYS:
             stats.setdefault(k, 0)
+        # Failure signal so the caller can mark the phase unsuccessful even
+        # though the (durable) flush count is surfaced (codex P2). Excluded from
+        # the F035.6 audit allowlist like other diagnostic ``*_error`` keys.
+        stats["f044_stc_error"] = 1
     return stats

--- a/nous/brain/tinyhippo_lite.py
+++ b/nous/brain/tinyhippo_lite.py
@@ -84,7 +84,10 @@ async def flush_recall_touches(session: Any, agent_id: str, *, commit: bool = Tr
     Called at sleep (before the promotion gate). Each distinct edge is bumped by
     its buffered touch count. Only the sleeping agent's keys are drained — other
     agents' buffered touches survive for their own flush. Returns the number of
-    distinct edges reinforced.
+    edge rows the UPDATEs actually matched (a buffered edge deleted between recall
+    and sleep no longer matches, so it is NOT counted) — this is an audited F035.6
+    mutation counter, so it must reflect committed ``ltp_count`` writes, not the
+    drained buffer size.
 
     The buffer drain is in-process and only valid if the writes commit durably,
     so the commit lives INSIDE the restore-guarded block: any failure (an
@@ -105,13 +108,15 @@ async def flush_recall_touches(session: Any, agent_id: str, *, commit: bool = Tr
         _RECALL_TOUCH_BUFFER[key] -= n
         if _RECALL_TOUCH_BUFFER[key] <= 0:
             del _RECALL_TOUCH_BUFFER[key]
+    applied = 0
     try:
         for (agent, source_id, target_id, relation), n in items:
-            await session.execute(
+            result = await session.execute(
                 _LTP_INCREMENT_BY_SQL,
                 {"agent": agent, "source_id": source_id, "target_id": target_id,
                  "relation": relation, "n": int(n)},
             )
+            applied += result.rowcount or 0
         if commit:
             await session.commit()
     except BaseException:
@@ -121,7 +126,7 @@ async def flush_recall_touches(session: Any, agent_id: str, *, commit: bool = Tr
         for key, n in items:
             _RECALL_TOUCH_BUFFER[key] += n
         raise
-    return len(items)
+    return applied
 
 # Cumulative-reinforcement histogram buckets reported each cycle. The whole
 # bet hinges on this distribution shifting right over cycles; if edges stay at

--- a/nous/brain/tinyhippo_lite.py
+++ b/nous/brain/tinyhippo_lite.py
@@ -272,8 +272,13 @@ async def run_stc_consolidation(db: Any, agent_id: str, prp_threshold: int) -> d
     stats: dict[str, int] = {"f044_recall_touches_flushed": touched}
     try:
         async with db.session() as session:
-            stats.update(await stc_promote_and_measure(session, agent_id, prp_threshold))
+            promote_stats = await stc_promote_and_measure(session, agent_id, prp_threshold)
             await session.commit()
+        # Merge ONLY after the commit succeeds — if commit() raises, the promotion
+        # rowcounts/telemetry belong to a rolled-back transaction and must NOT be
+        # audited as committed mutations (codex P2). Keeping them in a local until
+        # here means the except path zero-fills instead of preserving stale values.
+        stats.update(promote_stats)
     except Exception:
         logger.warning(
             "F044 STC promotion/telemetry failed after recall flush (touched=%d); "

--- a/nous/handlers/sleep_handler.py
+++ b/nous/handlers/sleep_handler.py
@@ -1707,6 +1707,13 @@ class SleepHandler:
                 self._settings.tinyhippo_prp_threshold,
             )
             sleep_stats.update(stats)
+            # Promotion/telemetry failed after the durable recall flush: the
+            # flush count is in sleep_stats (so the F035.6 audit still records the
+            # reinforcement via _run_audited_phase, which fires regardless of this
+            # return), but the phase did NOT fully run — report failure so
+            # phases_completed doesn't claim stc_consolidation succeeded (codex P2).
+            if stats.get("f044_stc_error"):
+                return False
             # F044 Phase 8d (spec): homeostatic α-downscale of TAGGED edge
             # weights (consolidated exempt). Runs AFTER promotion (8c) so
             # freshly-promoted edges aren't penalized this cycle. Opt-in

--- a/nous/handlers/sleep_handler.py
+++ b/nous/handlers/sleep_handler.py
@@ -568,7 +568,12 @@ class SleepHandler:
                 success = await self._run_audited_phase(
                     "stc_consolidate", "consolidate",
                     lambda: self._phase_stc_consolidation(sleep_stats), sleep_stats,
-                    ("f044_downscaled",))
+                    # F044 per-cycle MUTATION counters only (UPDATE rowcounts):
+                    # promotions (consolidation_state), recall-buffer ltp writes,
+                    # and weight downscale. The f044_n_*/ltp_ge*/reinforced_24h
+                    # keys are STATE/WINDOW snapshots, not this-cycle mutations —
+                    # excluding them avoids recording a bogus 15k-edge "delta".
+                    ("f044_promoted", "f044_recall_touches_flushed", "f044_downscaled"))
                 if success:
                     phases_completed.append("stc_consolidation")
 

--- a/tests/test_consolidation_audit.py
+++ b/tests/test_consolidation_audit.py
@@ -318,6 +318,42 @@ async def test_audited_phase_ignores_diagnostic_counters():
 
 
 @pytest.mark.asyncio
+async def test_stc_phase_records_only_f044_mutations_not_telemetry():
+    # The stc_consolidate phase mixes per-cycle mutation rowcounts (promoted,
+    # recall_touches_flushed, downscaled) with large STATE/WINDOW snapshots
+    # (n_edges/n_tagged/ltp_ge*/reinforced_24h). Only the mutations belong in
+    # the audit summary; the snapshots would otherwise record a bogus delta.
+    db = _FakeDB()
+    handler = _make_handler(db, audit_enabled=True)
+    handler._auditor = _auditor(db)
+    await handler._auditor.open()
+    stats = {}
+
+    async def _phase():
+        stats.update({
+            "f044_promoted": 3,
+            "f044_recall_touches_flushed": 7,
+            "f044_downscaled": 0,            # no downscale this cycle
+            "f044_n_edges": 15381,           # snapshot — must be ignored
+            "f044_n_tagged": 14479,          # snapshot — must be ignored
+            "f044_ltp_ge1": 2688,            # snapshot — must be ignored
+            "f044_reinforced_24h": 436,      # 24h window — must be ignored
+        })
+        return True
+
+    await handler._run_audited_phase(
+        "stc_consolidate", "consolidate", _phase, stats,
+        ("f044_promoted", "f044_recall_touches_flushed", "f044_downscaled"),
+    )
+    await handler._auditor.close("completed", ["stc_consolidate"], stats)
+    assert len(db.actions) == 1
+    import json
+    assert json.loads(db.actions[0]["after"]) == {
+        "counts": {"f044_promoted": 3, "f044_recall_touches_flushed": 7}
+    }
+
+
+@pytest.mark.asyncio
 async def test_audited_phase_records_bool_flip():
     db = _FakeDB()
     handler = _make_handler(db, audit_enabled=True)

--- a/tests/test_f044_tinyhippo_lite.py
+++ b/tests/test_f044_tinyhippo_lite.py
@@ -64,10 +64,14 @@ async def test_run_stc_preserves_flush_count_on_promotion_failure(monkeypatch):
     stats = await run_stc_consolidation(_NoopDB(), _AGENT, prp_threshold=3)
 
     assert stats["f044_recall_touches_flushed"] == 7  # durable count preserved
-    assert stats["f044_promoted"] == 0                # rolled-back promotion
+    assert stats["f044_promoted"] == 0                # committed-mutation counter zero-filled
     assert stats["f044_stc_error"] is True              # failure signal for the phase
-    # every promote/telemetry key present (so the phase logger.info can't KeyError)
-    assert set(_STC_PROMOTE_KEYS).issubset(stats)
+    # telemetry SNAPSHOTS are OMITTED (not fake-zeroed) so the drift series isn't
+    # corrupted with "0 edges" for an unmeasured cycle (codex P2).
+    assert "f044_n_edges" not in stats
+    assert "f044_n_tagged" not in stats
+    assert "f044_ltp_ge1" not in stats
+    assert "f044_reinforced_24h" not in stats
 
 
 @pytest.mark.asyncio
@@ -104,6 +108,7 @@ async def test_run_stc_does_not_audit_promotion_when_commit_fails(monkeypatch):
     assert stats["f044_recall_touches_flushed"] == 5  # durable flush preserved
     assert stats["f044_promoted"] == 0                # rolled-back promotion zero-filled
     assert stats["f044_stc_error"] is True
+    assert "f044_n_edges" not in stats               # rolled-back telemetry omitted
 
 
 @pytest.mark.asyncio

--- a/tests/test_f044_tinyhippo_lite.py
+++ b/tests/test_f044_tinyhippo_lite.py
@@ -277,6 +277,23 @@ async def test_recall_touch_buffer_flushes_to_ltp(session):
 
 
 @pytest.mark.postgres_only
+async def test_flush_counts_only_matched_rows(session):
+    """codex P2: a buffered touch whose edge was deleted between recall and sleep
+    matches no row, so the audited flush count must exclude it (rowcount, not the
+    drained buffer size)."""
+    _RECALL_TOUCH_BUFFER.clear()
+    a, b = await _insert_edge(session, ltp=0, relation="related_to")
+    gone_src, gone_tgt = uuid4(), uuid4()  # never inserted
+    record_recall_touches([
+        (str(a), str(b), "related_to"),
+        (str(gone_src), str(gone_tgt), "related_to"),  # no live edge
+    ], _AGENT)
+    applied = await flush_recall_touches(session, _AGENT, commit=False)
+    assert applied == 1  # only the real edge was updated, not the 2 buffered
+    assert len(_RECALL_TOUCH_BUFFER) == 0
+
+
+@pytest.mark.postgres_only
 async def test_three_rederivations_then_gate_promotes(session):
     """End-to-end: an edge re-derived to the PRP threshold consolidates."""
     src, tgt = await _insert_edge(session, ltp=0)

--- a/tests/test_f044_tinyhippo_lite.py
+++ b/tests/test_f044_tinyhippo_lite.py
@@ -71,6 +71,42 @@ async def test_run_stc_preserves_flush_count_on_promotion_failure(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_run_stc_does_not_audit_promotion_when_commit_fails(monkeypatch):
+    """codex P2: if stc_promote_and_measure() succeeds but session.commit() raises,
+    the promotion rowcounts belong to a rolled-back txn and must be zero-filled —
+    never surfaced as committed mutations."""
+
+    class _CommitFailsSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def commit(self):
+            raise RuntimeError("serialization failure on commit")
+
+    class _CommitFailsDB:
+        def session(self):
+            return _CommitFailsSession()
+
+    async def _fake_flush(session, agent_id):
+        return 5
+
+    async def _fake_promote(session, agent_id, prp):
+        # rolled back by the failing commit — must NOT appear in audited stats
+        return {k: 0 for k in _STC_PROMOTE_KEYS} | {"f044_promoted": 9}
+
+    monkeypatch.setattr(_th, "flush_recall_touches", _fake_flush)
+    monkeypatch.setattr(_th, "stc_promote_and_measure", _fake_promote)
+
+    stats = await run_stc_consolidation(_CommitFailsDB(), _AGENT, prp_threshold=3)
+    assert stats["f044_recall_touches_flushed"] == 5  # durable flush preserved
+    assert stats["f044_promoted"] == 0                # rolled-back promotion zero-filled
+    assert stats["f044_stc_error"] == 1
+
+
+@pytest.mark.asyncio
 async def test_run_stc_success_path_merges_flush_and_promotion(monkeypatch):
     async def _fake_flush(session, agent_id):
         return 4

--- a/tests/test_f044_tinyhippo_lite.py
+++ b/tests/test_f044_tinyhippo_lite.py
@@ -65,6 +65,7 @@ async def test_run_stc_preserves_flush_count_on_promotion_failure(monkeypatch):
 
     assert stats["f044_recall_touches_flushed"] == 7  # durable count preserved
     assert stats["f044_promoted"] == 0                # rolled-back promotion
+    assert stats["f044_stc_error"] == 1              # failure signal for the phase
     # every promote/telemetry key present (so the phase logger.info can't KeyError)
     assert set(_STC_PROMOTE_KEYS).issubset(stats)
 
@@ -83,6 +84,7 @@ async def test_run_stc_success_path_merges_flush_and_promotion(monkeypatch):
     stats = await run_stc_consolidation(_NoopDB(), _AGENT, prp_threshold=3)
     assert stats["f044_recall_touches_flushed"] == 4
     assert stats["f044_promoted"] == 2
+    assert "f044_stc_error" not in stats  # no failure signal on the happy path
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_f044_tinyhippo_lite.py
+++ b/tests/test_f044_tinyhippo_lite.py
@@ -65,7 +65,7 @@ async def test_run_stc_preserves_flush_count_on_promotion_failure(monkeypatch):
 
     assert stats["f044_recall_touches_flushed"] == 7  # durable count preserved
     assert stats["f044_promoted"] == 0                # rolled-back promotion
-    assert stats["f044_stc_error"] == 1              # failure signal for the phase
+    assert stats["f044_stc_error"] is True              # failure signal for the phase
     # every promote/telemetry key present (so the phase logger.info can't KeyError)
     assert set(_STC_PROMOTE_KEYS).issubset(stats)
 
@@ -103,7 +103,7 @@ async def test_run_stc_does_not_audit_promotion_when_commit_fails(monkeypatch):
     stats = await run_stc_consolidation(_CommitFailsDB(), _AGENT, prp_threshold=3)
     assert stats["f044_recall_touches_flushed"] == 5  # durable flush preserved
     assert stats["f044_promoted"] == 0                # rolled-back promotion zero-filled
-    assert stats["f044_stc_error"] == 1
+    assert stats["f044_stc_error"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_f044_tinyhippo_lite.py
+++ b/tests/test_f044_tinyhippo_lite.py
@@ -14,16 +14,75 @@ from uuid import uuid4
 import pytest
 from sqlalchemy import text
 
+import nous.brain.tinyhippo_lite as _th
 from nous.brain.tinyhippo_lite import (
     _RECALL_TOUCH_BUFFER,
+    _STC_PROMOTE_KEYS,
     flush_recall_touches,
     homeostatic_downscale,
     increment_ltp_on_rederivation,
     record_recall_touches,
+    run_stc_consolidation,
     stc_promote_and_measure,
 )
 
 _AGENT = "f044-test-agent"
+
+
+class _NoopSession:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def commit(self):
+        return None
+
+
+class _NoopDB:
+    def session(self):
+        return _NoopSession()
+
+
+@pytest.mark.asyncio
+async def test_run_stc_preserves_flush_count_on_promotion_failure(monkeypatch):
+    """codex P2: if promotion/telemetry raises after the (durable) recall flush,
+    run_stc_consolidation must still surface f044_recall_touches_flushed (with the
+    rolled-back promotion keys zero-filled) rather than discarding the committed
+    reinforcement count by propagating the exception."""
+
+    async def _fake_flush(session, agent_id):
+        return 7
+
+    async def _fake_promote(session, agent_id, prp):
+        raise RuntimeError("promotion blew up after flush committed")
+
+    monkeypatch.setattr(_th, "flush_recall_touches", _fake_flush)
+    monkeypatch.setattr(_th, "stc_promote_and_measure", _fake_promote)
+
+    stats = await run_stc_consolidation(_NoopDB(), _AGENT, prp_threshold=3)
+
+    assert stats["f044_recall_touches_flushed"] == 7  # durable count preserved
+    assert stats["f044_promoted"] == 0                # rolled-back promotion
+    # every promote/telemetry key present (so the phase logger.info can't KeyError)
+    assert set(_STC_PROMOTE_KEYS).issubset(stats)
+
+
+@pytest.mark.asyncio
+async def test_run_stc_success_path_merges_flush_and_promotion(monkeypatch):
+    async def _fake_flush(session, agent_id):
+        return 4
+
+    async def _fake_promote(session, agent_id, prp):
+        return {k: 0 for k in _STC_PROMOTE_KEYS} | {"f044_promoted": 2}
+
+    monkeypatch.setattr(_th, "flush_recall_touches", _fake_flush)
+    monkeypatch.setattr(_th, "stc_promote_and_measure", _fake_promote)
+
+    stats = await run_stc_consolidation(_NoopDB(), _AGENT, prp_threshold=3)
+    assert stats["f044_recall_touches_flushed"] == 4
+    assert stats["f044_promoted"] == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Follow-up to #546. The `stc_consolidate` (F044 tinyHippo-Lite) audit summary only fired on `f044_downscaled`, so a sleep cycle that **promoted** edges (`tagged→consolidated`) or flushed **recall-touch** `ltp_count` writes — but did no downscale — produced no STC action row in the consolidation diff. Observed live in the first prod cycle (`5773fa93`): `f044_promoted` and reinforcement activity rode in `totals` but weren't a changelog action.

## Change
Widen the `stc_consolidate` mutation-counter allowlist to the three real per-cycle UPDATE rowcounts:
- `f044_promoted` — `consolidation_state` tagged→consolidated
- `f044_recall_touches_flushed` — `ltp_count` writes flushed from the recall buffer
- `f044_downscaled` — weight downscale (unchanged)

## What stays excluded (and why)
`f044_n_edges` / `f044_n_tagged` / `f044_n_consolidated` / `f044_ltp_ge1..3` / `f044_reinforced_24h` are **state/24h-window snapshots**, not this-cycle mutations (verified against `tinyhippo_lite.py`: the telemetry `SELECT count(*) FILTER ...` vs the `PROMOTE`/`LTP_INCREMENT`/`DOWNSCALE` `UPDATE`s). Since `_run_audited_phase` records the delta-from-0 each cycle, including a 15k-edge snapshot would record a bogus 15k "mutation" — exactly the phantom-row trap codex flagged in #546 round 4.

## Tests
New `test_stc_phase_records_only_f044_mutations_not_telemetry` feeds a realistic mixed stats dict and asserts only `{f044_promoted, f044_recall_touches_flushed}` are recorded. 62 audit+sleep tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
