### PR TITLE
fix(api): add __bool__ to _LazyProxy so /events/stats stops 500ing

### DIFF
--- a/nous/main.py
+++ b/nous/main.py
@@ -1062,6 +1062,15 @@ class _LazyProxy:
     def __getattr__(self, name):
         return getattr(self._resolve(), name)
 
+    def __bool__(self):
+        # Truthiness reflects whether the component is initialized. Without
+        # this, Python falls back to __len__, which raises on components that
+        # are not sized (e.g. SessionTimeoutMonitor) — breaking `if proxy`
+        # guards such as the one in /events/stats.
+        components = object.__getattribute__(self, "_components")
+        key = object.__getattribute__(self, "_key")
+        return components.get(key) is not None
+
     def __len__(self):
         return len(self._resolve())
 

--- a/tests/test_lazy_proxy.py
+++ b/tests/test_lazy_proxy.py
@@ -1,0 +1,41 @@
+"""Unit tests for the _LazyProxy component proxy in nous.main."""
+
+import pytest
+
+from nous.main import _lazy_component
+
+
+class _NoLen:
+    """Stand-in for a component (e.g. SessionTimeoutMonitor) that is not sized."""
+
+    def get_stats(self) -> dict:
+        return {"ok": True}
+
+
+def test_truthiness_when_initialized_does_not_call_len():
+    """`if proxy` must not fall back to __len__ on a component with no len()."""
+    components = {"session_monitor": _NoLen()}
+    proxy = _lazy_component(components, "session_monitor")
+
+    # Regression: previously raised TypeError ('object has no len()') because
+    # __bool__ was absent and Python fell back to __len__.
+    assert bool(proxy) is True
+    assert proxy and hasattr(proxy, "get_stats")
+    assert proxy.get_stats() == {"ok": True}
+
+
+def test_truthiness_false_before_initialization():
+    """A proxy for an uninitialized component is falsy (does not raise)."""
+    components: dict = {"session_monitor": None}
+    proxy = _lazy_component(components, "session_monitor")
+
+    assert bool(proxy) is False
+    assert not proxy
+
+
+def test_len_still_forwards_for_sized_components():
+    """Explicit len() still forwards to a sized underlying component."""
+    components = {"bus": [1, 2, 3]}
+    proxy = _lazy_component(components, "bus")
+
+    assert len(proxy) == 3


### PR DESCRIPTION
## Problem

`GET /events/stats` returns 500 in prod:

```
File "/app/nous/api/rest.py", line 2331, in events_stats
    if session_monitor and hasattr(session_monitor, "get_stats"):
File "/app/nous/main.py", line 1066, in __len__
    return len(self._resolve())
TypeError: object of type 'SessionTimeoutMonitor' has no len()
```

## Root cause

`_LazyProxy` (the deferred-component proxy in `nous/main.py`) defined `__len__` but **not** `__bool__`. Python's truthiness check on `if session_monitor` falls back to `__len__`, which resolves the real `SessionTimeoutMonitor` and calls `len()` on it — a non-sized object — raising `TypeError`. The sibling guards `if sleep_handler` and `if heartbeat_runner` immediately after had the same latent bug.

## Fix

Add `__bool__` to `_LazyProxy` that reads `components.get(key) is not None` directly (non-raising): falsy before lifespan init, truthy after. `__len__` is kept for genuine `len()` forwarding to sized components.

## Tests

New `tests/test_lazy_proxy.py` (3 tests):
- truthiness on an initialized, non-sized component no longer calls `__len__` (regression)
- proxy is falsy before initialization (no raise)
- explicit `len()` still forwards for sized components

All green. Verified end-to-end that the `events_stats` guards work with initialized + `None` components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMGSu4XRAEDffkHqnCR8CQ