### PR TITLE
F075 L3: date-window retrieval leg (land-dark)

### DIFF
--- a/docs/superpowers/plans/2026-07-01-date-window-retrieval-leg.md
+++ b/docs/superpowers/plans/2026-07-01-date-window-retrieval-leg.md
@@ -1,0 +1,740 @@
+# F075 Layer 3 — Date-Window Retrieval Leg Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a seed-independent, date-keyed retrieval leg to fact recall — parse a date window from the query, retrieve in-window facts ranked by cosine, and fuse them into the results via `_rrf_merge_n`.
+
+**Architecture:** A new `nous/heart/date_window.py` (a `DateWindow` value + a `DateWindowParser` with a regex pre-gate → Haiku fallback, budget-capped, cached, fail-open). `run_recall_pipeline` parses the window once per query when `NOUS_DATE_LEG_ENABLED=true` and threads it through `heart.recall` → `FactStore.search` → `FactStore._search`, where a date-window SQL leg is fused with the hybrid results by `_rrf_merge_n`. Off by default → byte-identical to today.
+
+**Tech Stack:** Python 3.12+, async SQLAlchemy/asyncpg, pgvector (`<=>`), pydantic-settings, pytest + pytest-asyncio, Anthropic Haiku via the existing `nous.api.anthropic_client` client.
+
+## Global Constraints
+
+- **Land-dark:** every new flag defaults OFF/inert. `NOUS_DATE_LEG_ENABLED=false` → recall output byte-identical to today.
+- **Every new boolean Settings field must be pinned in bare-MagicMock fixtures** (`tests/test_streaming.py::_make_mock_settings` + siblings) — a bare MagicMock returns a truthy child and defeats default-off. `date_leg_enabled` must be pinned `False`.
+- **Fail-open:** the parser never raises into the recall path — timeout / budget / error / no-date all return `None` → no leg → fused == vanilla.
+- **Fusion is position-based:** `_rrf_merge_n` ranks by list position, not score magnitude, so mixing the normalized hybrid list with a raw date-leg list is correct.
+- Ranking within the date window is **cosine-to-query**, never date-distance alone (the validated mechanism).
+- Validated params (do not change without re-measuring): window pad = 2 days, leg depth K = 15.
+
+---
+
+## File Structure
+
+- **Create** `nous/heart/date_window.py` — `DateWindow` dataclass + `DateWindowParser` (pre-gate, Haiku parse, in-process budget + TTL cache, fail-open).
+- **Modify** `nous/config.py` — 7 `date_leg_*` settings.
+- **Modify** `nous/heart/facts.py` — `_date_window_leg()` SQL helper; thread `date_window` into `search`/`_search`; fuse via `_rrf_merge_n`.
+- **Modify** `nous/heart/heart.py` — thread `date_window` through `recall` and the fact dispatch.
+- **Modify** `nous/api/retrieval_pipeline.py` — parse the window once (flag-gated) and pass into `heart.recall`.
+- **Create** `nous_eval/date_leg_rescue.py` — the rescue-metric dev harness.
+- **Tests:** `tests/heart/test_date_window.py`, `tests/heart/test_date_window_leg.py`, `tests/api/test_date_leg_pipeline.py`.
+
+---
+
+## Task 1: Config flags
+
+**Files:**
+- Modify: `nous/config.py`
+- Modify: `tests/test_streaming.py` (pin the bool in the mock)
+- Test: `tests/test_config.py`
+
+**Interfaces:**
+- Produces: `Settings.date_leg_enabled: bool`, `date_leg_model: str`, `date_leg_k: int`, `date_leg_pad_days: int`, `date_leg_timeout_seconds: float`, `date_leg_max_per_hour: int`, `date_leg_cache_ttl_days: int`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_config.py  (add)
+def test_date_leg_settings_defaults():
+    from nous.config import Settings
+    s = Settings()
+    assert s.date_leg_enabled is False
+    assert s.date_leg_model == "claude-haiku-4-5-20251001"
+    assert s.date_leg_k == 15
+    assert s.date_leg_pad_days == 2
+    assert s.date_leg_timeout_seconds == 2.0
+    assert s.date_leg_max_per_hour == 500
+    assert s.date_leg_cache_ttl_days == 30
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_config.py::test_date_leg_settings_defaults -v`
+Expected: FAIL — `AttributeError: 'Settings' object has no attribute 'date_leg_enabled'`.
+
+- [ ] **Step 3: Add the settings**
+
+In `nous/config.py`, add to the `Settings` class (near the other retrieval flags):
+```python
+    date_leg_enabled: bool = Field(
+        default=False,
+        description="F075 Layer 3: enable the date-window retrieval leg. "
+        "Off = byte-identical to today. Land-dark; flip after the A/B gate.",
+    )
+    date_leg_model: str = Field(
+        default="claude-haiku-4-5-20251001",
+        description="F075 L3: Haiku model for parsing the query's date window.",
+    )
+    date_leg_k: int = Field(
+        default=15, description="F075 L3: date-leg retrieval depth (validated).",
+    )
+    date_leg_pad_days: int = Field(
+        default=2, description="F075 L3: +/- days padding on the parsed window (validated).",
+    )
+    date_leg_timeout_seconds: float = Field(
+        default=2.0, description="F075 L3: parser timeout; breach fails open to no-date.",
+    )
+    date_leg_max_per_hour: int = Field(
+        default=500, description="F075 L3: per-hour Haiku budget cap on the parser.",
+    )
+    date_leg_cache_ttl_days: int = Field(
+        default=30, description="F075 L3: parsed-window in-process cache retention.",
+    )
+```
+
+- [ ] **Step 4: Pin the bool in the mock fixture**
+
+In `tests/test_streaming.py`, inside `_make_mock_settings` (and any sibling bare-MagicMock settings factory), add:
+```python
+    settings.date_leg_enabled = False
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_config.py::test_date_leg_settings_defaults tests/test_streaming.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add nous/config.py tests/test_config.py tests/test_streaming.py
+git commit -m "feat(config): add F075 L3 date-leg settings, land-dark"
+```
+
+---
+
+## Task 2: `DateWindow` + regex pre-gate (pure, no LLM)
+
+**Files:**
+- Create: `nous/heart/date_window.py`
+- Test: `tests/heart/test_date_window.py`
+
+**Interfaces:**
+- Produces: `DateWindow` (frozen dataclass: `start: datetime.date`, `end: datetime.date`); `has_temporal_signal(query: str) -> bool` (regex pre-gate; True means "worth an LLM parse").
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/heart/test_date_window.py
+import datetime
+from nous.heart.date_window import DateWindow, has_temporal_signal
+
+def test_temporal_signal_detects_month_year():
+    assert has_temporal_signal("What happened in late April 2026?") is True
+    assert has_temporal_signal("changes around mid-May") is True
+    assert has_temporal_signal("events on 2026-06-24") is True
+
+def test_temporal_signal_rejects_non_temporal():
+    assert has_temporal_signal("How does the calibration gate work?") is False
+    assert has_temporal_signal("summarize the trading bot design") is False
+
+def test_datewindow_is_frozen():
+    w = DateWindow(start=datetime.date(2026, 4, 20), end=datetime.date(2026, 4, 30))
+    assert w.start < w.end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/heart/test_date_window.py -v`
+Expected: FAIL — module does not exist (ImportError).
+
+- [ ] **Step 3: Implement `DateWindow` + `has_temporal_signal`**
+
+```python
+# nous/heart/date_window.py
+"""F075 Layer 3: parse a date window from a query for the date-window retrieval leg."""
+from __future__ import annotations
+
+import datetime
+import re
+from dataclasses import dataclass
+
+# Month names, 4-digit years, ISO dates, and vague-period words. A hit means the
+# query is worth a Haiku parse; a miss skips the LLM entirely (hot-path guard).
+_MONTHS = (r"jan(uary)?|feb(ruary)?|mar(ch)?|apr(il)?|may|jun(e)?|jul(y)?|"
+           r"aug(ust)?|sep(tember)?|oct(ober)?|nov(ember)?|dec(ember)?")
+_TEMPORAL_RE = re.compile(
+    r"\b(" + _MONTHS + r")\b"
+    r"|\b(19|20)\d{2}\b"                 # 4-digit year
+    r"|\d{4}-\d{2}-\d{2}"                # ISO date
+    r"|\b(yesterday|today|tomorrow|last|recent(ly)?|ago|"
+    r"early|mid|late|around|when|during|after|before|since)\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DateWindow:
+    start: datetime.date
+    end: datetime.date
+
+
+def has_temporal_signal(query: str) -> bool:
+    """Cheap pre-gate: True when the query plausibly references a time period."""
+    return bool(_TEMPORAL_RE.search(query or ""))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/heart/test_date_window.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add nous/heart/date_window.py tests/heart/test_date_window.py
+git commit -m "feat(heart): DateWindow + regex temporal pre-gate (F075 L3)"
+```
+
+---
+
+## Task 3: `DateWindowParser` — Haiku parse, budget, cache, fail-open
+
+**Files:**
+- Modify: `nous/heart/date_window.py`
+- Test: `tests/heart/test_date_window.py`
+
+**Interfaces:**
+- Consumes: `has_temporal_signal`, `DateWindow`; an LLM client exposing `async call(payload: dict)` returning an object whose `.content` is `list[dict]` with `{"type": "tool_use", "input": {...}}` blocks (the `nous.api.anthropic_client` contract).
+- Produces: `DateWindowParser(llm_client, settings)`, `async parse(query: str, today: datetime.date) -> DateWindow | None`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/heart/test_date_window.py  (add)
+import datetime
+import pytest
+from types import SimpleNamespace
+from nous.heart.date_window import DateWindowParser, DateWindow
+
+class _FakeClient:
+    def __init__(self, tool_input, raises=False, calls=None):
+        self._input = tool_input; self._raises = raises; self.calls = calls if calls is not None else []
+    async def call(self, payload):
+        self.calls.append(payload)
+        if self._raises:
+            raise RuntimeError("boom")
+        return SimpleNamespace(content=[{"type": "tool_use", "name": "emit_window", "input": self._input}])
+
+def _settings(**kw):
+    base = dict(date_leg_model="claude-haiku-4-5-20251001", date_leg_timeout_seconds=2.0,
+                date_leg_max_per_hour=500, date_leg_pad_days=2)
+    base.update(kw); return SimpleNamespace(**base)
+
+TODAY = datetime.date(2026, 7, 1)
+
+@pytest.mark.asyncio
+async def test_parse_returns_padded_window():
+    client = _FakeClient({"has_date": True, "start_date": "2026-04-20", "end_date": "2026-04-30"})
+    p = DateWindowParser(client, _settings())
+    w = await p.parse("what happened in late April 2026?", TODAY)
+    assert w == DateWindow(start=datetime.date(2026, 4, 18), end=datetime.date(2026, 5, 2))  # +/- 2 pad
+
+@pytest.mark.asyncio
+async def test_pregate_skips_llm_for_non_temporal():
+    client = _FakeClient({"has_date": True, "start_date": "2026-01-01", "end_date": "2026-01-02"})
+    p = DateWindowParser(client, _settings())
+    assert await p.parse("how does calibration work?", TODAY) is None
+    assert client.calls == []  # no LLM call
+
+@pytest.mark.asyncio
+async def test_has_date_false_returns_none():
+    client = _FakeClient({"has_date": False})
+    p = DateWindowParser(client, _settings())
+    assert await p.parse("something about last quarter's vibe", TODAY) is None
+
+@pytest.mark.asyncio
+async def test_fail_open_on_client_error():
+    client = _FakeClient(None, raises=True)
+    p = DateWindowParser(client, _settings())
+    assert await p.parse("events in April 2026", TODAY) is None
+
+@pytest.mark.asyncio
+async def test_cache_hit_skips_second_llm_call():
+    client = _FakeClient({"has_date": True, "start_date": "2026-04-20", "end_date": "2026-04-30"})
+    p = DateWindowParser(client, _settings())
+    q = "what happened in late April 2026?"
+    await p.parse(q, TODAY); await p.parse(q, TODAY)
+    assert len(client.calls) == 1  # second served from cache
+
+@pytest.mark.asyncio
+async def test_budget_cap_fails_open():
+    client = _FakeClient({"has_date": True, "start_date": "2026-04-20", "end_date": "2026-04-30"})
+    p = DateWindowParser(client, _settings(date_leg_max_per_hour=1))
+    await p.parse("events in April 2026", TODAY)          # uses the 1 budget
+    assert await p.parse("events in May 2026", TODAY) is None  # budget exhausted -> fail open
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/heart/test_date_window.py -k Parser -v` (and the new tests)
+Expected: FAIL — `DateWindowParser` not defined (ImportError).
+
+- [ ] **Step 3: Implement `DateWindowParser`**
+
+Append to `nous/heart/date_window.py`:
+```python
+import asyncio
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+_TOOL = {
+    "name": "emit_window",
+    "description": "Extract the time period a question asks about.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "has_date": {"type": "boolean"},
+            "start_date": {"type": "string", "description": "YYYY-MM-DD or empty"},
+            "end_date": {"type": "string", "description": "YYYY-MM-DD or empty"},
+        },
+        "required": ["has_date"],
+        "additionalProperties": False,
+    },
+}
+
+
+def _prompt(query: str, today: datetime.date) -> str:
+    return (
+        f"Today is {today.isoformat()}. Read the question and extract the TIME "
+        "PERIOD it asks about. If it references a date/month/period, has_date=true "
+        "and give start_date/end_date (YYYY-MM-DD) that generously bound it: "
+        "'late April 2026'->2026-04-20..2026-04-30; 'mid-May 2026'->2026-05-10.."
+        "2026-05-20; 'April 2026'->2026-04-01..2026-04-30; 'around June 25 2026'->"
+        "2026-06-22..2026-06-28. If no time reference, has_date=false.\n\n"
+        f"Question: {query}"
+    )
+
+
+def _parse_iso(x: object) -> datetime.date | None:
+    try:
+        return datetime.date.fromisoformat(str(x).strip())
+    except (ValueError, TypeError):
+        return None
+
+
+class DateWindowParser:
+    """Parse a padded DateWindow from a query. Fail-open, budgeted, cached."""
+
+    def __init__(self, llm_client, settings) -> None:
+        self._client = llm_client
+        self._settings = settings
+        self._cache: dict[str, DateWindow | None] = {}
+        self._budget_lock = asyncio.Lock()
+        self._calls: list[float] = []  # unix timestamps within the trailing hour
+
+    async def _within_budget(self) -> bool:
+        cap = int(getattr(self._settings, "date_leg_max_per_hour", 500))
+        now = time.monotonic()
+        async with self._budget_lock:
+            self._calls = [t for t in self._calls if now - t < 3600.0]
+            if len(self._calls) >= cap:
+                return False
+            self._calls.append(now)
+            return True
+
+    async def parse(self, query: str, today: datetime.date) -> DateWindow | None:
+        if not query or not has_temporal_signal(query):
+            return None
+        if query in self._cache:
+            return self._cache[query]
+        if not await self._within_budget():
+            logger.warning("date-leg parser budget exhausted; failing open")
+            return None
+        window = await self._parse_llm(query, today)
+        self._cache[query] = window
+        return window
+
+    async def _parse_llm(self, query: str, today: datetime.date) -> DateWindow | None:
+        payload = {
+            "model": self._settings.date_leg_model,
+            "max_tokens": 256,
+            "system": "",
+            "tools": [_TOOL],
+            "tool_choice": {"type": "tool", "name": "emit_window"},
+            "messages": [{"role": "user", "content": _prompt(query, today)}],
+        }
+        try:
+            resp = await asyncio.wait_for(
+                self._client.call(payload),
+                timeout=float(self._settings.date_leg_timeout_seconds),
+            )
+        except (asyncio.TimeoutError, Exception):  # fail-open on any error
+            logger.warning("date-leg parse failed; failing open", exc_info=True)
+            return None
+        data: dict = {}
+        for block in (getattr(resp, "content", None) or []):
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                data = block.get("input") or {}
+                break
+        if not data.get("has_date"):
+            return None
+        start, end = _parse_iso(data.get("start_date")), _parse_iso(data.get("end_date"))
+        if start is None or end is None or start > end:
+            return None
+        pad = datetime.timedelta(days=int(getattr(self._settings, "date_leg_pad_days", 2)))
+        return DateWindow(start=start - pad, end=end + pad)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/heart/test_date_window.py -v`
+Expected: PASS (all parser + pre-gate tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add nous/heart/date_window.py tests/heart/test_date_window.py
+git commit -m "feat(heart): DateWindowParser (Haiku, budgeted, cached, fail-open) (F075 L3)"
+```
+
+---
+
+## Task 4: `_date_window_leg` — in-window fact retrieval ranked by cosine
+
+**Files:**
+- Modify: `nous/heart/facts.py`
+- Test: `tests/heart/test_date_window_leg.py`
+
+**Interfaces:**
+- Consumes: `DateWindow`, a query embedding `list[float]`, an `AsyncSession`.
+- Produces: `FactStore._date_window_leg(session, embedding, window, limit) -> list[tuple[UUID, float]]` — in-window active dated facts ordered by cosine similarity to the embedding, score = cosine.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/heart/test_date_window_leg.py
+import datetime
+import pytest
+from nous.heart.date_window import DateWindow
+
+@pytest.mark.asyncio
+async def test_date_window_leg_returns_in_window_ranked(fact_store, seed_dated_facts):
+    # seed_dated_facts inserts: F_in (event_date 2026-04-25, embedding ~query),
+    # F_out (event_date 2026-06-01), F_undated (event_date NULL). Query embed ~F_in.
+    window = DateWindow(start=datetime.date(2026, 4, 20), end=datetime.date(2026, 4, 30))
+    async with fact_store.db.session() as s:
+        emb = await fact_store.embeddings.embed("calibration work in late April")
+        leg = await fact_store._date_window_leg(s, emb, window, limit=15)
+    ids = [row[0] for row in leg]
+    assert seed_dated_facts["F_in"] in ids
+    assert seed_dated_facts["F_out"] not in ids      # out of window
+    assert seed_dated_facts["F_undated"] not in ids  # no event_date
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/heart/test_date_window_leg.py::test_date_window_leg_returns_in_window_ranked -v`
+Expected: FAIL — `AttributeError: 'FactStore' object has no attribute '_date_window_leg'`.
+
+- [ ] **Step 3: Implement `_date_window_leg`**
+
+In `nous/heart/facts.py`, add a method on `FactStore` (near `_search`):
+```python
+    async def _date_window_leg(
+        self,
+        session: "AsyncSession",
+        embedding: list[float],
+        window: "DateWindow",
+        limit: int,
+    ) -> list[tuple["UUID", float]]:
+        """F075 L3: in-window active dated facts, ranked by cosine to the query.
+
+        Returns (id, cosine) tuples ordered best-first. Ranking is cosine-to-query
+        (relevance within the window), never date-distance alone.
+        """
+        qvec = "[" + ",".join(str(float(v)) for v in embedding) + "]"
+        sql = text("""
+            SELECT t.id, 1 - (t.embedding <=> CAST(:qvec AS vector)) AS score
+            FROM heart.facts t
+            WHERE t.agent_id = :agent_id
+              AND t.active = true
+              AND t.event_date IS NOT NULL
+              AND t.event_date BETWEEN :lo AND :hi
+              AND t.embedding IS NOT NULL
+            ORDER BY t.embedding <=> CAST(:qvec AS vector)
+            LIMIT :limit
+        """)
+        result = await session.execute(sql, {
+            "agent_id": self.agent_id, "qvec": qvec,
+            "lo": window.start, "hi": window.end, "limit": limit,
+        })
+        return [(row.id, float(row.score)) for row in result.all()]
+```
+Add the import at the top of `facts.py` if not present: `from nous.heart.date_window import DateWindow` (under TYPE_CHECKING is fine for the annotation; the method body doesn't construct one).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/heart/test_date_window_leg.py::test_date_window_leg_returns_in_window_ranked -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add nous/heart/facts.py tests/heart/test_date_window_leg.py
+git commit -m "feat(heart): _date_window_leg cosine-ranked in-window fact retrieval (F075 L3)"
+```
+
+---
+
+## Task 5: Fuse the date leg into `_search` via `_rrf_merge_n`
+
+**Files:**
+- Modify: `nous/heart/facts.py` (`search`, `_search`)
+- Test: `tests/heart/test_date_window_leg.py`
+
+**Interfaces:**
+- Consumes: `_date_window_leg`, `_rrf_merge_n`, `_resolve_rrf_k`.
+- Produces: `FactStore.search(..., date_window: DateWindow | None = None)` and `_search(..., date_window=None)`. When `date_window` and `embedding` are present, the hybrid result list is fused with the date leg via `_rrf_merge_n`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/heart/test_date_window_leg.py  (add)
+@pytest.mark.asyncio
+async def test_date_window_fusion_rescues_missed_fact(fact_store, seed_rescue_case):
+    # seed_rescue_case: a dated gold fact whose content does NOT lexically/semantically
+    # match a time-framed query, so vanilla ranks it outside `limit`, but it IS in the
+    # date window. Fusion must pull it into the returned top-`limit`.
+    q = seed_rescue_case["query"]; window = seed_rescue_case["window"]; gold = seed_rescue_case["gold"]
+    vanilla = await fact_store.search(q, limit=5)
+    fused = await fact_store.search(q, limit=5, date_window=window)
+    assert gold not in [f.id for f in vanilla]
+    assert gold in [f.id for f in fused]
+
+@pytest.mark.asyncio
+async def test_no_window_is_unchanged(fact_store, seed_rescue_case):
+    q = seed_rescue_case["query"]
+    a = await fact_store.search(q, limit=5)
+    b = await fact_store.search(q, limit=5, date_window=None)
+    assert [f.id for f in a] == [f.id for f in b]  # None window == today's behavior
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/heart/test_date_window_leg.py -k fusion -v`
+Expected: FAIL — `search()` got an unexpected keyword argument `date_window`.
+
+- [ ] **Step 3: Thread `date_window` + fuse**
+
+In `nous/heart/facts.py`:
+1. Add `date_window: "DateWindow | None" = None` to the `search` signature and pass it into `_search`:
+```python
+    async def search(self, query, limit=10, category=None, active_only=True,
+                     exclude_categories=None, session=None, variant_pairs=None,
+                     date_window=None):
+        if session is None:
+            async with self.db.session() as session:
+                return await self._search(query, limit, category, active_only,
+                                          exclude_categories, session, variant_pairs, date_window)
+        return await self._search(query, limit, category, active_only,
+                                  exclude_categories, session, variant_pairs, date_window)
+```
+2. Add `date_window=None` to `_search`'s signature, and after `results` is computed (facts.py:1696, before `if not results:`), fuse the leg:
+```python
+        # F075 L3: fuse the date-window leg (position-based RRF). Present only when
+        # the caller parsed a window and we have a query embedding. Empty leg is a
+        # no-op, so this preserves today's ordering when the window finds nothing.
+        if date_window is not None and embedding is not None:
+            from nous.heart.search import _rrf_merge_n, _resolve_rrf_k
+            date_leg = await self._date_window_leg(session, embedding, date_window, self.settings.date_leg_k)
+            if date_leg:
+                results = _rrf_merge_n([results, date_leg], _resolve_rrf_k(), limit)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/heart/test_date_window_leg.py -v`
+Expected: PASS (fusion rescues the gold; None-window is unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add nous/heart/facts.py tests/heart/test_date_window_leg.py
+git commit -m "feat(heart): fuse date-window leg into fact search via _rrf_merge_n (F075 L3)"
+```
+
+---
+
+## Task 6: Thread through `heart.recall` and wire the parser into `run_recall_pipeline`
+
+**Files:**
+- Modify: `nous/heart/heart.py` (`recall`, and the fact dispatch at ~:981)
+- Modify: `nous/api/retrieval_pipeline.py` (parse the window, pass into `heart.recall`)
+- Test: `tests/api/test_date_leg_pipeline.py`
+
+**Interfaces:**
+- Consumes: `DateWindowParser`, `Heart.recall`, `run_recall_pipeline`.
+- Produces: `Heart.recall(..., date_window: DateWindow | None = None)` passes `date_window` to `self.facts.search`. `run_recall_pipeline` parses the window once when `settings.date_leg_enabled` and threads it in.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/api/test_date_leg_pipeline.py
+import datetime
+import pytest
+
+@pytest.mark.asyncio
+async def test_pipeline_flag_off_is_byte_identical(pipeline_env):
+    # date_leg_enabled=False -> no parse, no leg, identical result ids
+    off = pipeline_env.settings(date_leg_enabled=False)
+    r1, _ = await pipeline_env.run("what changed in late April 2026?", off)
+    r2, _ = await pipeline_env.run_baseline("what changed in late April 2026?")
+    assert [x.id for x in r1] == [x.id for x in r2]
+
+@pytest.mark.asyncio
+async def test_pipeline_flag_on_parses_and_passes_window(pipeline_env, monkeypatch):
+    captured = {}
+    async def fake_recall(query, *a, date_window=None, **k):
+        captured["window"] = date_window
+        return []
+    monkeypatch.setattr(pipeline_env.heart, "recall", fake_recall)
+    on = pipeline_env.settings(date_leg_enabled=True)
+    await pipeline_env.run("what happened in late April 2026?", on)
+    assert isinstance(captured["window"], object) and captured["window"] is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/api/test_date_leg_pipeline.py -v`
+Expected: FAIL — `recall()` got an unexpected keyword `date_window` (and pipeline doesn't parse).
+
+- [ ] **Step 3: Thread `date_window` through `Heart.recall`**
+
+In `nous/heart/heart.py`, add `date_window: "DateWindow | None" = None` to `recall`'s signature (heart.py:835) and pass it to the fact branch (heart.py:981):
+```python
+                elif memory_type == "fact":
+                    result = await self.facts.search(
+                        query, fetch_limit, session=session,
+                        variant_pairs=variant_pairs, date_window=date_window,
+                    )
+```
+
+- [ ] **Step 4: Parse + pass in `run_recall_pipeline`**
+
+In `nous/api/retrieval_pipeline.py`, near the top of `run_recall_pipeline` (before stage execution), parse the window once and thread it into `heart.recall`. The parser needs an LLM client and settings; construct/reuse the background LLM client already available to the pipeline (mirror how contradiction detection obtains its Haiku client). Add:
+```python
+    date_window = None
+    if getattr(settings, "date_leg_enabled", False):
+        try:
+            from nous.heart.date_window import DateWindowParser
+            import datetime as _dt
+            parser = DateWindowParser(_get_background_llm_client(settings), settings)
+            date_window = await parser.parse(query, _dt.date.today())
+        except Exception:
+            logger.warning("date-leg parse errored in pipeline; continuing without", exc_info=True)
+            date_window = None
+```
+Then, at every `heart.recall(...)` call inside `_run_stages` for the fact path, pass `date_window=date_window`. (Thread `date_window` as a param of `_run_stages`, defaulting `None`, and forward it to `heart.recall`.)
+
+> Implementation note: `_get_background_llm_client` is the existing helper the pipeline/heart uses for Haiku calls (contradiction detection at `retrieval_pipeline.py` uses one — reuse that exact accessor; do not create a second client). If the pipeline holds the client differently, pass it in from the caller rather than constructing a new one.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/api/test_date_leg_pipeline.py -v`
+Expected: PASS (flag off = identical; flag on = window parsed + passed).
+
+- [ ] **Step 6: Run the recall snapshot test**
+
+Run: `uv run pytest tests/api/ -k "recall and snapshot" -v`
+Expected: PASS — `date_leg_enabled=False` default keeps `recall_deep` output byte-identical.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add nous/heart/heart.py nous/api/retrieval_pipeline.py tests/api/test_date_leg_pipeline.py
+git commit -m "feat(api): wire date-window parser into run_recall_pipeline, flag-gated (F075 L3)"
+```
+
+---
+
+## Task 7: Rescue-metric dev harness
+
+**Files:**
+- Create: `nous_eval/date_leg_rescue.py`
+- Test: `tests/nous_eval/test_date_leg_rescue.py`
+
+**Interfaces:**
+- Produces: `python -m nous_eval.date_leg_rescue --sample N` — samples dated facts, generates time-framed queries, compares vanilla vs vanilla+leg top-K, prints `rescued` / `lost` / `fused_top_k` counts. This is the dev instrument behind the A/B gate; it is NOT shipped in the prod image (lives under `nous_eval/`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/nous_eval/test_date_leg_rescue.py
+from nous_eval.date_leg_rescue import rrf_fuse
+
+def test_rrf_fuse_is_position_based():
+    # gold at rank 3 in vanilla, rank 1 in the leg -> fusion lifts it
+    vanilla = ["a", "b", "gold", "c"]
+    leg = ["gold", "x"]
+    fused = rrf_fuse(vanilla, leg)
+    assert fused.index("gold") < 2  # lifted into the head
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/nous_eval/test_date_leg_rescue.py -v`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the harness**
+
+Create `nous_eval/date_leg_rescue.py` with a pure `rrf_fuse(vanilla_ids, leg_ids, k=60)` (position-based RRF over two id lists, returns fused id list) plus an `async def main()` that reuses `_settings_for_eval_db`, `_build_heart_for_eval`, `DateWindowParser`, and `_date_window_leg` to run the rescue comparison over a sample of dated facts and print `n / vanilla_top_k / fused_top_k / rescued / lost`. (The `rrf_fuse` body is the same 8-line function validated in the 2026-07-01 probe.)
+```python
+def rrf_fuse(vanilla_ids, leg_ids, k=60):
+    score = {}
+    for rank, i in enumerate(vanilla_ids, 1):
+        score[i] = score.get(i, 0.0) + 1.0 / (k + rank)
+    for rank, i in enumerate(leg_ids, 1):
+        score[i] = score.get(i, 0.0) + 1.0 / (k + rank)
+    return [i for i, _ in sorted(score.items(), key=lambda kv: kv[1], reverse=True)]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/nous_eval/test_date_leg_rescue.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add nous_eval/date_leg_rescue.py tests/nous_eval/test_date_leg_rescue.py
+git commit -m "feat(eval): date-leg rescue-metric dev harness (F075 L3)"
+```
+
+---
+
+## Post-implementation: A/B gate (not a code task — operator step)
+
+Run before flipping `NOUS_DATE_LEG_ENABLED=true` in prod:
+1. `python -m nous_eval.date_leg_rescue --sample 40` on `:5433/nous_eval_prod` → assert `rescued > 0`, `lost == 0`.
+2. LongMemEval temporal-subset A/B (Opus generator, one variable = the flag), guardrail = no regression on non-temporal sources. Gate on temporal uplift + zero non-temporal regression. Record the numbers before flip.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §3.1 DateWindowParser → Tasks 2 (pre-gate) + 3 (Haiku/budget/cache/fail-open) ✅
+- §3.2 date-window fact retrieval → Task 4 ✅
+- §3.3 RRF fusion (Nth leg) → Task 5 ✅
+- §3.4 wiring point → Task 6 ✅
+- §5 config flags → Task 1 ✅
+- §6 zero-regression → Task 5 (`None`-window unchanged) + Task 6 (flag-off byte-identical) ✅
+- §7 measurement → Task 7 + the operator A/B step ✅
+- §2 bounds/non-goals → respected (facts-only, no coverage work, no Approach A).
+
+**Placeholder scan:** the only deferred detail is `_get_background_llm_client` in Task 6 Step 4 — flagged explicitly as "reuse the existing accessor the pipeline already uses for contradiction-detection Haiku calls; do not create a second client," which is a concrete instruction, not a TBD. The implementer must confirm the exact accessor name when they open `retrieval_pipeline.py`.
+
+**Type consistency:** `DateWindow(start, end)` used identically in Tasks 2–6; `_date_window_leg -> list[tuple[UUID, float]]` matches `_rrf_merge_n`'s `ranked_lists` element type; `date_window` param name consistent across `search`/`_search`/`recall`/`_run_stages`.

--- a/docs/superpowers/plans/2026-07-01-date-window-retrieval-leg.md
+++ b/docs/superpowers/plans/2026-07-01-date-window-retrieval-leg.md
@@ -25,9 +25,16 @@
 - **Modify** `nous/config.py` — 7 `date_leg_*` settings.
 - **Modify** `nous/heart/facts.py` — `_date_window_leg()` SQL helper; thread `date_window` into `search`/`_search`; fuse via `_rrf_merge_n`.
 - **Modify** `nous/heart/heart.py` — thread `date_window` through `recall` and the fact dispatch.
-- **Modify** `nous/api/retrieval_pipeline.py` — parse the window once (flag-gated) and pass into `heart.recall`.
+- **Modify** `nous/api/retrieval_pipeline.py` — parse the window once (flag-gated, via `heart.date_window_parser`) and pass into `heart.recall`.
+- **Modify** `nous/heart/heart.py` — `self.date_window_parser = None` in `__init__`.
+- **Modify** `nous/main.py` — construct `heart.date_window_parser = DateWindowParser(api_client, settings)` right after the `heart.facts.set_llm_client(...)` wiring at `main.py:212`.
 - **Create** `nous_eval/date_leg_rescue.py` — the rescue-metric dev harness.
-- **Tests:** `tests/heart/test_date_window.py`, `tests/heart/test_date_window_leg.py`, `tests/api/test_date_leg_pipeline.py`.
+- **Tests:** `tests/heart/test_date_window.py`, `tests/heart/test_date_window_leg.py`, `tests/test_date_leg_pipeline.py`, `tests/eval/test_date_leg_rescue.py`.
+
+**Pre-flight corrections applied (verified against code 2026-07-01):**
+- `FactStore` stores `self._settings` (optional, may be `None`) — NOT `self.settings`. All leg code guards `None`.
+- The heart-layer Haiku idiom is `nous.handlers.call_background_llm_structured(client, model, system_prompt, user_message, tool_name, tool_description, output_schema, max_tokens)` → returns the tool-input dict or `None` (fail-open built in). The shared client is the `api_client` (`LLMClient`) wired via `heart.facts.set_llm_client` at `main.py:212`. The parser reuses that same client, wrapped in `asyncio.wait_for` for the timeout.
+- Test layout is mostly flat (`tests/test_*.py`); `tests/heart/` and `tests/eval/` exist; `tests/api/` and `tests/nous_eval/` do NOT.
 
 ---
 
@@ -290,19 +297,15 @@ import time
 
 logger = logging.getLogger(__name__)
 
-_TOOL = {
-    "name": "emit_window",
-    "description": "Extract the time period a question asks about.",
-    "input_schema": {
-        "type": "object",
-        "properties": {
-            "has_date": {"type": "boolean"},
-            "start_date": {"type": "string", "description": "YYYY-MM-DD or empty"},
-            "end_date": {"type": "string", "description": "YYYY-MM-DD or empty"},
-        },
-        "required": ["has_date"],
-        "additionalProperties": False,
+_WINDOW_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "has_date": {"type": "boolean"},
+        "start_date": {"type": "string", "description": "YYYY-MM-DD or empty"},
+        "end_date": {"type": "string", "description": "YYYY-MM-DD or empty"},
     },
+    "required": ["has_date"],
+    "additionalProperties": False,
 }
 
 
@@ -358,28 +361,28 @@ class DateWindowParser:
         return window
 
     async def _parse_llm(self, query: str, today: datetime.date) -> DateWindow | None:
-        payload = {
-            "model": self._settings.date_leg_model,
-            "max_tokens": 256,
-            "system": "",
-            "tools": [_TOOL],
-            "tool_choice": {"type": "tool", "name": "emit_window"},
-            "messages": [{"role": "user", "content": _prompt(query, today)}],
-        }
+        # Reuse the heart-layer structured-call helper (adds the Claude Code
+        # preamble + cache_control, extracts the tool_use block, and returns
+        # None on any client error). Wrap in wait_for for the timeout.
+        from nous.handlers import call_background_llm_structured
         try:
-            resp = await asyncio.wait_for(
-                self._client.call(payload),
+            data = await asyncio.wait_for(
+                call_background_llm_structured(
+                    client=self._client,
+                    model=self._settings.date_leg_model,
+                    system_prompt="",
+                    user_message=_prompt(query, today),
+                    tool_name="emit_window",
+                    tool_description="Extract the time period a question asks about.",
+                    output_schema=_WINDOW_SCHEMA,
+                    max_tokens=256,
+                ),
                 timeout=float(self._settings.date_leg_timeout_seconds),
             )
-        except (asyncio.TimeoutError, Exception):  # fail-open on any error
+        except (asyncio.TimeoutError, Exception):  # fail-open on timeout/any error
             logger.warning("date-leg parse failed; failing open", exc_info=True)
             return None
-        data: dict = {}
-        for block in (getattr(resp, "content", None) or []):
-            if isinstance(block, dict) and block.get("type") == "tool_use":
-                data = block.get("input") or {}
-                break
-        if not data.get("has_date"):
+        if not data or not data.get("has_date"):
             return None
         start, end = _parse_iso(data.get("start_date")), _parse_iso(data.get("end_date"))
         if start is None or end is None or start > end:
@@ -549,7 +552,8 @@ In `nous/heart/facts.py`:
         # no-op, so this preserves today's ordering when the window finds nothing.
         if date_window is not None and embedding is not None:
             from nous.heart.search import _rrf_merge_n, _resolve_rrf_k
-            date_leg = await self._date_window_leg(session, embedding, date_window, self.settings.date_leg_k)
+            k_leg = self._settings.date_leg_k if self._settings else 15
+            date_leg = await self._date_window_leg(session, embedding, date_window, k_leg)
             if date_leg:
                 results = _rrf_merge_n([results, date_leg], _resolve_rrf_k(), limit)
 ```
@@ -571,9 +575,10 @@ git commit -m "feat(heart): fuse date-window leg into fact search via _rrf_merge
 ## Task 6: Thread through `heart.recall` and wire the parser into `run_recall_pipeline`
 
 **Files:**
-- Modify: `nous/heart/heart.py` (`recall`, and the fact dispatch at ~:981)
-- Modify: `nous/api/retrieval_pipeline.py` (parse the window, pass into `heart.recall`)
-- Test: `tests/api/test_date_leg_pipeline.py`
+- Modify: `nous/heart/heart.py` (`__init__` adds `self.date_window_parser = None`; `recall`, and the fact dispatch at ~:981)
+- Modify: `nous/main.py` (construct `heart.date_window_parser` after `main.py:212`)
+- Modify: `nous/api/retrieval_pipeline.py` (parse the window via `heart.date_window_parser`, pass into the fact recall)
+- Test: `tests/test_date_leg_pipeline.py`
 
 **Interfaces:**
 - Consumes: `DateWindowParser`, `Heart.recall`, `run_recall_pipeline`.
@@ -582,7 +587,7 @@ git commit -m "feat(heart): fuse date-window leg into fact search via _rrf_merge
 - [ ] **Step 1: Write the failing test**
 
 ```python
-# tests/api/test_date_leg_pipeline.py
+# tests/test_date_leg_pipeline.py
 import datetime
 import pytest
 
@@ -608,7 +613,7 @@ async def test_pipeline_flag_on_parses_and_passes_window(pipeline_env, monkeypat
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `uv run pytest tests/api/test_date_leg_pipeline.py -v`
+Run: `uv run pytest tests/test_date_leg_pipeline.py -v`
 Expected: FAIL — `recall()` got an unexpected keyword `date_window` (and pipeline doesn't parse).
 
 - [ ] **Step 3: Thread `date_window` through `Heart.recall`**
@@ -622,39 +627,46 @@ In `nous/heart/heart.py`, add `date_window: "DateWindow | None" = None` to `reca
                     )
 ```
 
-- [ ] **Step 4: Parse + pass in `run_recall_pipeline`**
+- [ ] **Step 4: Add the parser attribute to `Heart.__init__` and wire it in `main.py`**
 
-In `nous/api/retrieval_pipeline.py`, near the top of `run_recall_pipeline` (before stage execution), parse the window once and thread it into `heart.recall`. The parser needs an LLM client and settings; construct/reuse the background LLM client already available to the pipeline (mirror how contradiction detection obtains its Haiku client). Add:
+In `nous/heart/heart.py` `__init__`, add (near the other component attributes):
+```python
+        # F075 L3: date-window parser, wired in main.py (reuses the shared api_client).
+        self.date_window_parser = None
+```
+In `nous/main.py`, immediately after the F027 wiring line `heart.facts.set_llm_client(api_client, model=settings.contradiction_model)` (~line 212), add:
+```python
+    # F075 L3: Wire the date-window parser (reuses the shared api_client)
+    from nous.heart.date_window import DateWindowParser
+    heart.date_window_parser = DateWindowParser(api_client, settings)
+```
+
+- [ ] **Step 5: Parse + pass in `run_recall_pipeline`**
+
+In `nous/api/retrieval_pipeline.py`, near the top of `run_recall_pipeline` (before stage execution), parse the window once via the wired parser and thread it into the fact recall:
 ```python
     date_window = None
-    if getattr(settings, "date_leg_enabled", False):
-        try:
-            from nous.heart.date_window import DateWindowParser
-            import datetime as _dt
-            parser = DateWindowParser(_get_background_llm_client(settings), settings)
-            date_window = await parser.parse(query, _dt.date.today())
-        except Exception:
-            logger.warning("date-leg parse errored in pipeline; continuing without", exc_info=True)
-            date_window = None
+    parser = getattr(heart, "date_window_parser", None)
+    if getattr(settings, "date_leg_enabled", False) and parser is not None:
+        import datetime as _dt
+        date_window = await parser.parse(query, _dt.date.today())  # parser is fail-open
 ```
-Then, at every `heart.recall(...)` call inside `_run_stages` for the fact path, pass `date_window=date_window`. (Thread `date_window` as a param of `_run_stages`, defaulting `None`, and forward it to `heart.recall`.)
+Thread `date_window` as a param of `_run_stages` (default `None`) and forward it to the fact-branch `heart.recall(...)` call as `date_window=date_window`. The parser is fail-open (returns `None` on any error), so no try/except is needed here; `None` → no leg → today's behavior.
 
-> Implementation note: `_get_background_llm_client` is the existing helper the pipeline/heart uses for Haiku calls (contradiction detection at `retrieval_pipeline.py` uses one — reuse that exact accessor; do not create a second client). If the pipeline holds the client differently, pass it in from the caller rather than constructing a new one.
+- [ ] **Step 6: Run tests to verify they pass**
 
-- [ ] **Step 5: Run tests to verify they pass**
-
-Run: `uv run pytest tests/api/test_date_leg_pipeline.py -v`
+Run: `uv run pytest tests/test_date_leg_pipeline.py -v`
 Expected: PASS (flag off = identical; flag on = window parsed + passed).
 
-- [ ] **Step 6: Run the recall snapshot test**
+- [ ] **Step 7: Run the recall snapshot test**
 
-Run: `uv run pytest tests/api/ -k "recall and snapshot" -v`
+Run: `uv run pytest tests/ -k "recall and snapshot" -v`
 Expected: PASS — `date_leg_enabled=False` default keeps `recall_deep` output byte-identical.
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 8: Commit**
 
 ```bash
-git add nous/heart/heart.py nous/api/retrieval_pipeline.py tests/api/test_date_leg_pipeline.py
+git add nous/heart/heart.py nous/main.py nous/api/retrieval_pipeline.py tests/test_date_leg_pipeline.py
 git commit -m "feat(api): wire date-window parser into run_recall_pipeline, flag-gated (F075 L3)"
 ```
 
@@ -664,7 +676,7 @@ git commit -m "feat(api): wire date-window parser into run_recall_pipeline, flag
 
 **Files:**
 - Create: `nous_eval/date_leg_rescue.py`
-- Test: `tests/nous_eval/test_date_leg_rescue.py`
+- Test: `tests/eval/test_date_leg_rescue.py`
 
 **Interfaces:**
 - Produces: `python -m nous_eval.date_leg_rescue --sample N` — samples dated facts, generates time-framed queries, compares vanilla vs vanilla+leg top-K, prints `rescued` / `lost` / `fused_top_k` counts. This is the dev instrument behind the A/B gate; it is NOT shipped in the prod image (lives under `nous_eval/`).
@@ -672,7 +684,7 @@ git commit -m "feat(api): wire date-window parser into run_recall_pipeline, flag
 - [ ] **Step 1: Write the failing test**
 
 ```python
-# tests/nous_eval/test_date_leg_rescue.py
+# tests/eval/test_date_leg_rescue.py
 from nous_eval.date_leg_rescue import rrf_fuse
 
 def test_rrf_fuse_is_position_based():
@@ -685,7 +697,7 @@ def test_rrf_fuse_is_position_based():
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `uv run pytest tests/nous_eval/test_date_leg_rescue.py -v`
+Run: `uv run pytest tests/eval/test_date_leg_rescue.py -v`
 Expected: FAIL — module does not exist.
 
 - [ ] **Step 3: Implement the harness**
@@ -703,13 +715,13 @@ def rrf_fuse(vanilla_ids, leg_ids, k=60):
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `uv run pytest tests/nous_eval/test_date_leg_rescue.py -v`
+Run: `uv run pytest tests/eval/test_date_leg_rescue.py -v`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add nous_eval/date_leg_rescue.py tests/nous_eval/test_date_leg_rescue.py
+git add nous_eval/date_leg_rescue.py tests/eval/test_date_leg_rescue.py
 git commit -m "feat(eval): date-leg rescue-metric dev harness (F075 L3)"
 ```
 

--- a/docs/superpowers/specs/2026-07-01-date-window-retrieval-leg-design.md
+++ b/docs/superpowers/specs/2026-07-01-date-window-retrieval-leg-design.md
@@ -1,0 +1,139 @@
+# F075 Layer 3 — Date-Window Retrieval Leg (Design)
+
+**Status:** Design approved 2026-07-01. Ready for implementation planning.
+**Feature:** A seed-independent, date-keyed retrieval leg fused into the recall pipeline via RRF, to answer temporal queries whose gold the vector/keyword legs miss.
+
+---
+
+## 1. Motivation (why this, and why not the alternatives)
+
+A 2026-07-01 investigation established, with measurement on the prod-shape eval corpus (`:5433/nous_eval_prod`, agent `nous-default`), that **graph expansion does not improve retrieval**:
+
+- Graph-expanded results rank 13–28, never top-10 (n=20 probe).
+- A confirming probe rescored graph neighbors with the Path-A `seed_score × edge_weight` formula: **0/9 reachable golds cracked top-10** — scoring is not the cause.
+- An edge-semantics audit of all 15,771 edges: avg source↔target cosine 0.675; `related_to` is **72% of the graph** at cos 0.69; **~92% of edges connect same-topic content**; only ~8.5% are orthogonal. The graph is *precise but redundant* — it reconnects content the vector leg already retrieves.
+
+Conclusion: score-space normalization (audit "R2") and seed-score-for-decisions are dead ends. The lever is not scoring; it is a retrieval signal orthogonal to embeddings.
+
+The chosen target is **temporal / event-ordering** retrieval (the field's measured biggest gap: BEAM event-ordering wall, LongMemEval temporal). Of three mechanisms considered — (A) temporal-intent-gated chain traversal from seeds, (B) date-window retrieval leg, (C) anchor-and-expand — the deployed Nous advisor and a follow-up empirical test both selected **B**. Reason: A traverses *from vector-retrieved seeds*, but temporal queries fail vector seed retrieval (the 0/9 result), so A is built on the broken leg. B keys on `event_date` directly and is seed-independent.
+
+B is also the **already-scoped-but-unbuilt F075 Layer 3** (the `NOUS_DATE_AWARE_BOOST_*` config flags that ship today with no consumer).
+
+### Validated evidence (both on `:5433/nous_eval_prod`, n=22 each, synthetic time-framed queries vs dated-fact golds)
+
+| Test | date parsed | window ⊇ gold | vanilla top-10 | fused top-10 | rescued | lost |
+|---|---|---|---|---|---|---|
+| Oracle window (gold's date ±7d) | — | 22/22 | 15/22 | 21/22 | 6 | **0** |
+| Realistic (window parsed from query by Haiku) | 22/22 | 22/22 | 20/22 | 22/22 | 2 | **0** |
+
+Consistent across n=44: **rescue rate among vanilla-misses ~86–100%, zero regressions** (RRF fusion of a small/empty leg never demotes an existing hit). Haiku date-parsing was not a bottleneck (100% parse + window-contains-gold on time-referenced queries).
+
+---
+
+## 2. Scope
+
+**In scope (v1):** a date-window retrieval leg over `heart.facts`, fused via `_rrf_merge_n`, gated + land-dark, with an A/B measurement.
+
+**Bounded by (explicit, not hidden):**
+1. **Query realism** — only helps queries carrying a parseable time reference. No time reference → parser returns no date → leg inert → falls back to vanilla (safe).
+2. **Coverage cap** — only ~9.1% of facts (262/2890) carry `event_date`. B helps when the *answer* is dated. Widening reach depends on `event_date` extraction coverage (prior audit: ~45% `dated_event` miss) — tracked as a paired follow-on, not bundled here.
+3. Validated on synthetic queries, one corpus, n=44.
+
+**Non-goals (v1):** Approach A (entity-anchored chain traversal), multi-hop bridge, cross-episode `happened_before` chain generation, improving `event_date` extraction coverage. These are separate specs. A and multi-hop reuse the measurement + (for A) the fusion foundation built here.
+
+---
+
+## 3. Architecture
+
+A new retrieval leg parallel to the existing vector + keyword legs, fused by rank. Three components.
+
+### 3.1 DateWindowParser
+- **Input:** the raw query string.
+- **Output:** `DateWindow | None` = `{start: date, end: date}` or `None`.
+- **Pre-gate (cheap):** a regex/keyword pre-check for temporal signal (month names, 4-digit years, "yesterday/last week/in <month>/around/late/early/mid", ISO dates). If no signal → return `None` **without** an LLM call. Keeps the LLM off the hot path for the ~majority of non-temporal queries.
+- **LLM parse (Haiku):** on pre-gate hit, one forced-tool Haiku call (`{has_date, start_date, end_date}`), `system=""`, ~256 output tokens, anchored on "today" passed in. Validated at 100% on time-referenced queries.
+- **Cross-cutting:** per-hour budget cap (mirror `query_expansion_max_per_hour`), in-process cache with TTL (mirror `query_expansions`), `asyncio.wait_for` timeout. **Fail-open:** any timeout / budget breach / parse error / `has_date=false` → `None`.
+- **Padding:** the returned window is padded by `NOUS_DATE_LEG_PAD_DAYS` (default 2) at query time (PAD=2 validated).
+
+### 3.2 Date-window fact retrieval
+- **Input:** `DateWindow`, the query embedding, `agent_id`, `K = NOUS_DATE_LEG_K` (default 15).
+- **SQL:** `SELECT id FROM heart.facts WHERE agent_id=:a AND active AND event_date IS NOT NULL AND event_date BETWEEN :lo AND :hi ORDER BY embedding <=> :qvec LIMIT :k`.
+- Returns a **ranked list of fact IDs** (relevance-within-window). Ranking within the window by cosine is load-bearing — it is the "relevance floor AND date-proximity" the validated tests used; do **not** rank by date-distance alone.
+- The query embedding is the same vector the pipeline already computes for the vector leg (reuse it; do not re-embed).
+
+### 3.3 RRF fusion (Nth leg)
+- Feed the date-leg ranked list into **`_rrf_merge_n`** (`nous/heart/search.py:295`) as an additional ranked list alongside the existing vector + keyword lists.
+- Within-leg rank scoring with `k = NOUS_RRF_K` (60) gives k-dampening: the leg contributes `1/(k+rank)` per hit, so it lifts genuine matches without flooding top-K, and an empty leg is a no-op. No hand-tuned injection cap.
+
+### 3.4 Wiring point
+`heart.recall`'s hybrid fact path is where `_rrf_merge_n` fuses ranked lists (see `facts.py:1792` / `search.py`). The date leg is added there as one more ranked list when a `DateWindow` is present. Fact-only in v1. Determine at implementation time the cleanest thread for the parsed window + query embedding from `run_recall_pipeline` down to the fusion site (candidate: compute the window once in `run_recall_pipeline`, pass it into the fact search alongside the existing query).
+
+---
+
+## 4. Data flow
+
+```
+query
+  → DateWindowParser (regex pre-gate → Haiku; None if no temporal signal)
+  → if window: date-window SQL (event_date in [lo,hi], ranked by cosine, LIMIT K)
+  → _rrf_merge_n([vector_leg, keyword_leg, date_leg])   # date_leg absent → today's behavior
+  → existing rerank_by_score / graph / MMR / etc.
+  → results
+```
+
+---
+
+## 5. Configuration
+
+Repurpose the dead F075 Layer 3 flags; add leg-specific knobs. All land-dark.
+
+| Flag | default | purpose |
+|---|---|---|
+| `NOUS_DATE_LEG_ENABLED` | `false` | master switch. Off = byte-identical to today. |
+| `NOUS_DATE_LEG_MODEL` | `claude-haiku-4-5-20251001` | parser model |
+| `NOUS_DATE_LEG_K` | `15` | date-leg depth (validated) |
+| `NOUS_DATE_LEG_PAD_DAYS` | `2` | window padding (validated) |
+| `NOUS_DATE_LEG_TIMEOUT_SECONDS` | `2.0` | parser timeout; breach → fail-open |
+| `NOUS_DATE_LEG_MAX_PER_HOUR` | `500` | Haiku budget cap (mirror query-expansion) |
+| `NOUS_DATE_LEG_CACHE_TTL_DAYS` | `30` | parsed-window cache retention |
+
+The legacy `NOUS_DATE_AWARE_BOOST_*` flags are superseded; note their removal/repurpose in the plan.
+
+---
+
+## 6. Error handling & the zero-regression guarantee
+
+- Parser timeout / budget breach / error / no-date → `None` → **no date leg** → `_rrf_merge_n` receives the same lists as today → **fused == vanilla**. Proven: 0 losses across 44 cases.
+- Empty window result set → empty leg → same no-op.
+- All LLM I/O is fail-open; the leg never blocks or degrades the base retrieval.
+- Off by default; enabling it is A/B-gated.
+
+---
+
+## 7. Measurement plan
+
+**Unit-level (dev):** the rescue harness — sample dated facts, generate time-framed queries, compare vanilla vs vanilla+leg top-10; assert `rescued > 0` and `lost == 0`.
+
+**A/B gate (before flip):**
+- Corpus: LongMemEval temporal-reasoning subset (+ the prod-shape set as a non-temporal guardrail).
+- Generator: **Opus** (`--gen-model claude-opus-4-8`) — never a Sonnet/Haiku proxy (sign flips by generator).
+- One variable: `NOUS_DATE_LEG_ENABLED` off vs on.
+- Pass = temporal MRR / QA-accuracy uplift **and no regression on non-temporal sources** (the zero-regression property should hold end-to-end).
+- n ≥ 100 where the corpus allows; report any coverage-driven ceiling.
+
+---
+
+## 8. Follow-ons (separate specs, not this plan)
+
+1. **`event_date` extraction coverage** — lift the 9.1% dated fraction (the reach multiplier for this leg).
+2. **Approach A** — entity-anchored temporal chain traversal for point queries, once B validates that dates carry signal in prod A/B; reuses this measurement + fusion.
+3. **Multi-hop bridge** — reuses the additive-leg + measurement foundation.
+
+---
+
+## 9. Testing (TDD targets for the plan)
+
+- `DateWindowParser`: pre-gate rejects non-temporal queries with no LLM call; Haiku path parses "late April 2026" / "mid-May" / ISO dates; fail-open on timeout/budget/error/`has_date=false`; cache hit path.
+- Date-window SQL: window + `active` + `event_date NOT NULL` filter; cosine ordering; K limit; agent-scoped.
+- Fusion: date leg appended as an Nth list to `_rrf_merge_n`; empty leg → byte-identical to today; a strong in-window hit lifts into top-K.
+- End-to-end: `NOUS_DATE_LEG_ENABLED=false` → recall output unchanged (snapshot); `=true` → rescue on a seeded temporal fixture, zero loss.

--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -222,8 +222,9 @@ async def run_recall_pipeline(
     parser = getattr(heart, "date_window_parser", None)
     # Only the fact leg consumes the window, so skip the Haiku parse (latency +
     # budget) when facts aren't in scope, e.g. memory_types=["decision"] (codex P2).
-    # memory_types is None → "all" default → facts included.
-    _facts_in_scope = memory_types is None or "all" in memory_types or "fact" in memory_types
+    # `not memory_types` covers None AND [] — both default to "all" in _run_stages
+    # (`memory_types or ["all"]`), so facts are searched and the parse must run.
+    _facts_in_scope = not memory_types or "all" in memory_types or "fact" in memory_types
     if getattr(settings, "date_leg_enabled", False) and parser is not None and _facts_in_scope:
         import datetime as _dt
         date_window = await parser.parse(query, _dt.date.today())

--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -215,9 +215,18 @@ async def run_recall_pipeline(
         fired. Contradiction edges are surfaced via ``stats.contradiction_checks_ran``
         plus the per-result ``contradicts`` field.
     """
+    # F075 L3: parse the date window once per query when the leg is enabled.
+    # The parser is fail-open (returns None on timeout/error/no-date), so
+    # no try/except is needed; None → no leg → byte-identical to today.
+    date_window = None
+    parser = getattr(heart, "date_window_parser", None)
+    if getattr(settings, "date_leg_enabled", False) and parser is not None:
+        import datetime as _dt
+        date_window = await parser.parse(query, _dt.date.today())
+
     acc = await _run_stages(
         query, heart, brain, settings, limit, memory_types,
-        residual_activations, apply_mmr=apply_mmr,
+        residual_activations, apply_mmr=apply_mmr, date_window=date_window,
     )
 
     # Build flat PipelineResult list in stage order
@@ -338,6 +347,7 @@ async def _run_stages(
     memory_types: list[str] | None,
     residual_activations: dict[UUID, float] | None = None,
     apply_mmr: bool | None = None,
+    date_window: "object | None" = None,
 ) -> _PipelineAccumulator:
     acc = _PipelineAccumulator()
 
@@ -380,6 +390,7 @@ async def _run_stages(
                 query, limit=limit, types=heart_types,
                 residual_activations=residual_activations,  # F055
                 apply_mmr=apply_mmr,  # F030.2
+                date_window=date_window,  # F075 L3
             )
             acc.heart_results = list(heart_results or [])
 

--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -220,7 +220,11 @@ async def run_recall_pipeline(
     # no try/except is needed; None → no leg → byte-identical to today.
     date_window = None
     parser = getattr(heart, "date_window_parser", None)
-    if getattr(settings, "date_leg_enabled", False) and parser is not None:
+    # Only the fact leg consumes the window, so skip the Haiku parse (latency +
+    # budget) when facts aren't in scope, e.g. memory_types=["decision"] (codex P2).
+    # memory_types is None → "all" default → facts included.
+    _facts_in_scope = memory_types is None or "all" in memory_types or "fact" in memory_types
+    if getattr(settings, "date_leg_enabled", False) and parser is not None and _facts_in_scope:
         import datetime as _dt
         date_window = await parser.parse(query, _dt.date.today())
 

--- a/nous/config.py
+++ b/nous/config.py
@@ -236,6 +236,19 @@ class Settings(BaseSettings):
                 )
         return v
 
+    @field_validator("effort", mode="before")
+    @classmethod
+    def _normalize_effort_alias(cls, v: object) -> object:
+        """Map the human alias `extra` to the real Claude API tier `xhigh`.
+
+        The API has no `extra` effort value; operators reaching for
+        "extra high" set NOUS_EFFORT=extra. Resolve it here so the rest of
+        the code (and the API payload) only ever sees a valid tier.
+        """
+        if isinstance(v, str) and v.strip().lower() == "extra":
+            return "xhigh"
+        return v
+
     # F017: Staleness penalty
     staleness_penalty_enabled: bool = True
     staleness_half_life_days: int = 30
@@ -401,7 +414,12 @@ class Settings(BaseSettings):
     # Extended thinking
     thinking_mode: Literal["off", "adaptive", "manual"] = "off"
     thinking_budget: int = 10000  # budget_tokens for manual mode (min 1024)
-    effort: Literal["low", "medium", "high", "max"] = "high"
+    # Claude API effort tiers (output_config.effort). `xhigh` was added in
+    # Opus 4.7 (between high and max) and is the recommended tier for coding /
+    # agentic work on Opus 4.7/4.8. `extra` is not a real API value — it's a
+    # human-facing alias for "extra high" that we normalize to `xhigh` below
+    # so an operator's NOUS_EFFORT=extra loads instead of crashing startup.
+    effort: Literal["low", "medium", "high", "xhigh", "max"] = "high"
 
     # Context window override (0 = auto-detect from model name)
     context_window: int = Field(
@@ -1483,6 +1501,31 @@ class Settings(BaseSettings):
     date_aware_boost_window_pad_days: int = Field(
         default=30,
         description="F075 Layer 3: pad days around the inferred query date window.",
+    )
+    # F075 Layer 3 — Date-window retrieval leg (land-dark; flip after A/B gate)
+    date_leg_enabled: bool = Field(
+        default=False,
+        description="F075 Layer 3: enable the date-window retrieval leg. "
+        "Off = byte-identical to today. Land-dark; flip after the A/B gate.",
+    )
+    date_leg_model: str = Field(
+        default="claude-haiku-4-5-20251001",
+        description="F075 L3: Haiku model for parsing the query's date window.",
+    )
+    date_leg_k: int = Field(
+        default=15, description="F075 L3: date-leg retrieval depth (validated).",
+    )
+    date_leg_pad_days: int = Field(
+        default=2, description="F075 L3: +/- days padding on the parsed window (validated).",
+    )
+    date_leg_timeout_seconds: float = Field(
+        default=2.0, description="F075 L3: parser timeout; breach fails open to no-date.",
+    )
+    date_leg_max_per_hour: int = Field(
+        default=500, description="F075 L3: per-hour Haiku budget cap on the parser.",
+    )
+    date_leg_cache_ttl_days: int = Field(
+        default=30, description="F075 L3: parsed-window in-process cache retention.",
     )
     heart_graph_all_types_enabled: bool = Field(
         default=False,

--- a/nous/heart/date_window.py
+++ b/nous/heart/date_window.py
@@ -6,6 +6,7 @@ import datetime
 import logging
 import re
 import time
+from collections import OrderedDict
 from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
@@ -14,6 +15,8 @@ logger = logging.getLogger(__name__)
 # query is worth a Haiku parse; a miss skips the LLM entirely (hot-path guard).
 _MONTHS = (r"jan(uary)?|feb(ruary)?|mar(ch)?|apr(il)?|may|jun(e)?|jul(y)?|"
            r"aug(ust)?|sep(tember)?|oct(ober)?|nov(ember)?|dec(ember)?")
+# Deliberately generous (recall-over-precision): false-positives here are cheap since
+# the LLM parse is fail-open, budget-capped, and cached.
 _TEMPORAL_RE = re.compile(
     r"\b(" + _MONTHS + r")\b"
     r"|\b(19|20)\d{2}\b"                 # 4-digit year
@@ -22,6 +25,9 @@ _TEMPORAL_RE = re.compile(
     r"early|mid|late|around|when|during|after|before|since)\b",
     re.IGNORECASE,
 )
+
+# Hard cap: evict oldest entry when this limit is reached (OrderedDict.popitem(last=False)).
+_CACHE_MAX_ENTRIES = 2048
 
 
 @dataclass(frozen=True, slots=True)
@@ -72,7 +78,10 @@ class DateWindowParser:
     def __init__(self, llm_client, settings) -> None:
         self._client = llm_client
         self._settings = settings
-        self._cache: dict[str, DateWindow | None] = {}
+        # OrderedDict maps query -> (insertion_monotonic, DateWindow | None).
+        # Size-bounded at _CACHE_MAX_ENTRIES (evict oldest) and TTL-gated via
+        # date_leg_cache_ttl_days. ttl_days <= 0 means "never cache".
+        self._cache: OrderedDict[str, tuple[float, DateWindow | None]] = OrderedDict()
         self._budget_lock = asyncio.Lock()
         self._calls: list[float] = []  # unix timestamps within the trailing hour
 
@@ -86,16 +95,47 @@ class DateWindowParser:
             self._calls.append(now)
             return True
 
+    def _cache_get(self, query: str) -> tuple[bool, DateWindow | None]:
+        """Return (hit, value). Treats expired entries as misses (fail-open)."""
+        try:
+            ttl_days = int(getattr(self._settings, "date_leg_cache_ttl_days", 30))
+            if ttl_days <= 0:
+                return False, None  # "never cache" mode
+            entry = self._cache.get(query)
+            if entry is None:
+                return False, None
+            inserted_at, value = entry
+            if time.monotonic() - inserted_at > ttl_days * 86400:
+                del self._cache[query]
+                return False, None
+            return True, value
+        except Exception:
+            return False, None
+
+    def _cache_put(self, query: str, value: DateWindow | None) -> None:
+        """Insert into cache, evicting oldest when at cap (fail-open on error)."""
+        try:
+            ttl_days = int(getattr(self._settings, "date_leg_cache_ttl_days", 30))
+            if ttl_days <= 0:
+                return  # "never cache" mode
+            cap = _CACHE_MAX_ENTRIES
+            while len(self._cache) >= cap:
+                self._cache.popitem(last=False)  # evict oldest-inserted entry
+            self._cache[query] = (time.monotonic(), value)
+        except Exception:
+            pass
+
     async def parse(self, query: str, today: datetime.date) -> DateWindow | None:
         if not query or not has_temporal_signal(query):
             return None
-        if query in self._cache:
-            return self._cache[query]
+        hit, cached_value = self._cache_get(query)
+        if hit:
+            return cached_value
         if not await self._within_budget():
             logger.warning("date-leg parser budget exhausted; failing open")
             return None
         window = await self._parse_llm(query, today)
-        self._cache[query] = window
+        self._cache_put(query, window)
         return window
 
     async def _parse_llm(self, query: str, today: datetime.date) -> DateWindow | None:
@@ -125,8 +165,8 @@ class DateWindowParser:
         start, end = _parse_iso(data.get("start_date")), _parse_iso(data.get("end_date"))
         if start is None or end is None or start > end:
             return None
-        pad = datetime.timedelta(days=int(getattr(self._settings, "date_leg_pad_days", 2)))
         try:
+            pad = datetime.timedelta(days=int(getattr(self._settings, "date_leg_pad_days", 2)))
             return DateWindow(start=start - pad, end=end + pad)
         except OverflowError:
             return None

--- a/nous/heart/date_window.py
+++ b/nous/heart/date_window.py
@@ -95,24 +95,24 @@ class DateWindowParser:
             self._calls.append(now)
             return True
 
-    def _cache_get(self, query: str) -> tuple[bool, DateWindow | None]:
+    def _cache_get(self, key: str) -> tuple[bool, DateWindow | None]:
         """Return (hit, value). Treats expired entries as misses (fail-open)."""
         try:
             ttl_days = int(getattr(self._settings, "date_leg_cache_ttl_days", 30))
             if ttl_days <= 0:
                 return False, None  # "never cache" mode
-            entry = self._cache.get(query)
+            entry = self._cache.get(key)
             if entry is None:
                 return False, None
             inserted_at, value = entry
             if time.monotonic() - inserted_at > ttl_days * 86400:
-                del self._cache[query]
+                del self._cache[key]
                 return False, None
             return True, value
         except Exception:
             return False, None
 
-    def _cache_put(self, query: str, value: DateWindow | None) -> None:
+    def _cache_put(self, key: str, value: DateWindow | None) -> None:
         """Insert into cache, evicting oldest when at cap (fail-open on error)."""
         try:
             ttl_days = int(getattr(self._settings, "date_leg_cache_ttl_days", 30))
@@ -121,21 +121,25 @@ class DateWindowParser:
             cap = _CACHE_MAX_ENTRIES
             while len(self._cache) >= cap:
                 self._cache.popitem(last=False)  # evict oldest-inserted entry
-            self._cache[query] = (time.monotonic(), value)
+            self._cache[key] = (time.monotonic(), value)
         except Exception:
             pass
 
     async def parse(self, query: str, today: datetime.date) -> DateWindow | None:
         if not query or not has_temporal_signal(query):
             return None
-        hit, cached_value = self._cache_get(query)
+        # Cache key includes `today` so relative-date queries ("yesterday",
+        # "last week") don't return a stale window across day boundaries (codex P2):
+        # the same phrase resolves to a different window on a different day.
+        cache_key = f"{today.isoformat()}\x00{query}"
+        hit, cached_value = self._cache_get(cache_key)
         if hit:
             return cached_value
         if not await self._within_budget():
             logger.warning("date-leg parser budget exhausted; failing open")
             return None
         window = await self._parse_llm(query, today)
-        self._cache_put(query, window)
+        self._cache_put(cache_key, window)
         return window
 
     async def _parse_llm(self, query: str, today: datetime.date) -> DateWindow | None:

--- a/nous/heart/date_window.py
+++ b/nous/heart/date_window.py
@@ -1,9 +1,14 @@
 """F075 Layer 3: parse a date window from a query for the date-window retrieval leg."""
 from __future__ import annotations
 
+import asyncio
 import datetime
+import logging
 import re
+import time
 from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
 
 # Month names, 4-digit years, ISO dates, and vague-period words. A hit means the
 # query is worth a Haiku parse; a miss skips the LLM entirely (hot-path guard).
@@ -29,12 +34,6 @@ def has_temporal_signal(query: str) -> bool:
     """Cheap pre-gate: True when the query plausibly references a time period."""
     return bool(_TEMPORAL_RE.search(query or ""))
 
-
-import asyncio
-import logging
-import time
-
-logger = logging.getLogger(__name__)
 
 _WINDOW_SCHEMA = {
     "type": "object",
@@ -127,4 +126,7 @@ class DateWindowParser:
         if start is None or end is None or start > end:
             return None
         pad = datetime.timedelta(days=int(getattr(self._settings, "date_leg_pad_days", 2)))
-        return DateWindow(start=start - pad, end=end + pad)
+        try:
+            return DateWindow(start=start - pad, end=end + pad)
+        except OverflowError:
+            return None

--- a/nous/heart/date_window.py
+++ b/nous/heart/date_window.py
@@ -152,7 +152,10 @@ class DateWindowParser:
                 call_background_llm_structured(
                     client=self._client,
                     model=self._settings.date_leg_model,
-                    system_prompt="",
+                    # Non-empty system prompt: the helper wraps this in a cached
+                    # text block, and Anthropic rejects empty cached blocks (400),
+                    # which would fail every parse open to None (codex P1).
+                    system_prompt="You extract the specific time period a natural-language question refers to.",
                     user_message=_prompt(query, today),
                     tool_name="emit_window",
                     tool_description="Extract the time period a question asks about.",

--- a/nous/heart/date_window.py
+++ b/nous/heart/date_window.py
@@ -1,0 +1,30 @@
+"""F075 Layer 3: parse a date window from a query for the date-window retrieval leg."""
+from __future__ import annotations
+
+import datetime
+import re
+from dataclasses import dataclass
+
+# Month names, 4-digit years, ISO dates, and vague-period words. A hit means the
+# query is worth a Haiku parse; a miss skips the LLM entirely (hot-path guard).
+_MONTHS = (r"jan(uary)?|feb(ruary)?|mar(ch)?|apr(il)?|may|jun(e)?|jul(y)?|"
+           r"aug(ust)?|sep(tember)?|oct(ober)?|nov(ember)?|dec(ember)?")
+_TEMPORAL_RE = re.compile(
+    r"\b(" + _MONTHS + r")\b"
+    r"|\b(19|20)\d{2}\b"                 # 4-digit year
+    r"|\d{4}-\d{2}-\d{2}"                # ISO date
+    r"|\b(yesterday|today|tomorrow|last|recent(ly)?|ago|"
+    r"early|mid|late|around|when|during|after|before|since)\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DateWindow:
+    start: datetime.date
+    end: datetime.date
+
+
+def has_temporal_signal(query: str) -> bool:
+    """Cheap pre-gate: True when the query plausibly references a time period."""
+    return bool(_TEMPORAL_RE.search(query or ""))

--- a/nous/heart/date_window.py
+++ b/nous/heart/date_window.py
@@ -28,3 +28,103 @@ class DateWindow:
 def has_temporal_signal(query: str) -> bool:
     """Cheap pre-gate: True when the query plausibly references a time period."""
     return bool(_TEMPORAL_RE.search(query or ""))
+
+
+import asyncio
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+_WINDOW_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "has_date": {"type": "boolean"},
+        "start_date": {"type": "string", "description": "YYYY-MM-DD or empty"},
+        "end_date": {"type": "string", "description": "YYYY-MM-DD or empty"},
+    },
+    "required": ["has_date"],
+    "additionalProperties": False,
+}
+
+
+def _prompt(query: str, today: datetime.date) -> str:
+    return (
+        f"Today is {today.isoformat()}. Read the question and extract the TIME "
+        "PERIOD it asks about. If it references a date/month/period, has_date=true "
+        "and give start_date/end_date (YYYY-MM-DD) that generously bound it: "
+        "'late April 2026'->2026-04-20..2026-04-30; 'mid-May 2026'->2026-05-10.."
+        "2026-05-20; 'April 2026'->2026-04-01..2026-04-30; 'around June 25 2026'->"
+        "2026-06-22..2026-06-28. If no time reference, has_date=false.\n\n"
+        f"Question: {query}"
+    )
+
+
+def _parse_iso(x: object) -> datetime.date | None:
+    try:
+        return datetime.date.fromisoformat(str(x).strip())
+    except (ValueError, TypeError):
+        return None
+
+
+class DateWindowParser:
+    """Parse a padded DateWindow from a query. Fail-open, budgeted, cached."""
+
+    def __init__(self, llm_client, settings) -> None:
+        self._client = llm_client
+        self._settings = settings
+        self._cache: dict[str, DateWindow | None] = {}
+        self._budget_lock = asyncio.Lock()
+        self._calls: list[float] = []  # unix timestamps within the trailing hour
+
+    async def _within_budget(self) -> bool:
+        cap = int(getattr(self._settings, "date_leg_max_per_hour", 500))
+        now = time.monotonic()
+        async with self._budget_lock:
+            self._calls = [t for t in self._calls if now - t < 3600.0]
+            if len(self._calls) >= cap:
+                return False
+            self._calls.append(now)
+            return True
+
+    async def parse(self, query: str, today: datetime.date) -> DateWindow | None:
+        if not query or not has_temporal_signal(query):
+            return None
+        if query in self._cache:
+            return self._cache[query]
+        if not await self._within_budget():
+            logger.warning("date-leg parser budget exhausted; failing open")
+            return None
+        window = await self._parse_llm(query, today)
+        self._cache[query] = window
+        return window
+
+    async def _parse_llm(self, query: str, today: datetime.date) -> DateWindow | None:
+        # Reuse the heart-layer structured-call helper (adds the Claude Code
+        # preamble + cache_control, extracts the tool_use block, and returns
+        # None on any client error). Wrap in wait_for for the timeout.
+        from nous.handlers import call_background_llm_structured
+        try:
+            data = await asyncio.wait_for(
+                call_background_llm_structured(
+                    client=self._client,
+                    model=self._settings.date_leg_model,
+                    system_prompt="",
+                    user_message=_prompt(query, today),
+                    tool_name="emit_window",
+                    tool_description="Extract the time period a question asks about.",
+                    output_schema=_WINDOW_SCHEMA,
+                    max_tokens=256,
+                ),
+                timeout=float(self._settings.date_leg_timeout_seconds),
+            )
+        except (asyncio.TimeoutError, Exception):  # fail-open on timeout/any error
+            logger.warning("date-leg parse failed; failing open", exc_info=True)
+            return None
+        if not data or not data.get("has_date"):
+            return None
+        start, end = _parse_iso(data.get("start_date")), _parse_iso(data.get("end_date"))
+        if start is None or end is None or start > end:
+            return None
+        pad = datetime.timedelta(days=int(getattr(self._settings, "date_leg_pad_days", 2)))
+        return DateWindow(start=start - pad, end=end + pad)

--- a/nous/heart/date_window.py
+++ b/nous/heart/date_window.py
@@ -138,11 +138,17 @@ class DateWindowParser:
         if not await self._within_budget():
             logger.warning("date-leg parser budget exhausted; failing open")
             return None
-        window = await self._parse_llm(query, today)
-        self._cache_put(cache_key, window)
+        cacheable, window = await self._parse_llm(query, today)
+        # Only cache CONFIRMED parses (a window, or a genuine has_date=false /
+        # malformed response). A transient timeout/client error must NOT be cached,
+        # or one blip suppresses the leg for this query/day until the TTL (codex P2).
+        if cacheable:
+            self._cache_put(cache_key, window)
         return window
 
-    async def _parse_llm(self, query: str, today: datetime.date) -> DateWindow | None:
+    async def _parse_llm(self, query: str, today: datetime.date) -> tuple[bool, DateWindow | None]:
+        """Returns (cacheable, window). cacheable=False signals a transient
+        failure (timeout / client error) that must not be cached."""
         # Reuse the heart-layer structured-call helper (adds the Claude Code
         # preamble + cache_control, extracts the tool_use block, and returns
         # None on any client error). Wrap in wait_for for the timeout.
@@ -166,14 +172,17 @@ class DateWindowParser:
             )
         except (asyncio.TimeoutError, Exception):  # fail-open on timeout/any error
             logger.warning("date-leg parse failed; failing open", exc_info=True)
-            return None
-        if not data or not data.get("has_date"):
-            return None
+            return False, None  # transient — do not cache
+        if data is None:
+            # Helper returned None = client/helper failure (transient) — do not cache.
+            return False, None
+        if not data.get("has_date"):
+            return True, None  # confirmed no-date — cacheable
         start, end = _parse_iso(data.get("start_date")), _parse_iso(data.get("end_date"))
         if start is None or end is None or start > end:
-            return None
+            return True, None  # confirmed but malformed dates — cacheable
         try:
             pad = datetime.timedelta(days=int(getattr(self._settings, "date_leg_pad_days", 2)))
-            return DateWindow(start=start - pad, end=end + pad)
+            return True, DateWindow(start=start - pad, end=end + pad)
         except OverflowError:
-            return None
+            return True, None  # confirmed but unusable — cacheable

--- a/nous/heart/date_window.py
+++ b/nous/heart/date_window.py
@@ -21,8 +21,9 @@ _TEMPORAL_RE = re.compile(
     r"\b(" + _MONTHS + r")\b"
     r"|\b(19|20)\d{2}\b"                 # 4-digit year
     r"|\d{4}-\d{2}-\d{2}"                # ISO date
-    r"|\b(yesterday|today|tomorrow|last|recent(ly)?|ago|"
-    r"early|mid|late|around|when|during|after|before|since)\b",
+    r"|\b(yesterday|today|tomorrow|last|this|next|recent(ly)?|ago|"
+    r"early|mid|late|around|when|during|after|before|since|"
+    r"week|month|quarter)\b",  # this/next + period nouns: "this week", "next month" (codex P2)
     re.IGNORECASE,
 )
 

--- a/nous/heart/facts.py
+++ b/nous/heart/facts.py
@@ -1619,6 +1619,7 @@ class FactManager:
         exclude_categories: list[str] | None = None,
         session: AsyncSession | None = None,
         variant_pairs: list[tuple[str, list[float] | None]] | None = None,
+        date_window: "DateWindow | None" = None,
     ) -> list[FactSummary]:
         """Hybrid search over facts.
 
@@ -1626,11 +1627,13 @@ class FactManager:
             variant_pairs: F050 — when set with len > 1, routes through
                 hybrid_search_multi for RRF fusion across query variants.
                 Defaults to None (single-query path; backwards compatible).
+            date_window: F075 L3 — when set, fuses the date-window retrieval
+                leg into the results via _rrf_merge_n.
         """
         if session is None:
             async with self.db.session() as session:
-                return await self._search(query, limit, category, active_only, exclude_categories, session, variant_pairs)
-        return await self._search(query, limit, category, active_only, exclude_categories, session, variant_pairs)
+                return await self._search(query, limit, category, active_only, exclude_categories, session, variant_pairs, date_window)
+        return await self._search(query, limit, category, active_only, exclude_categories, session, variant_pairs, date_window)
 
     async def _search(
         self,
@@ -1641,6 +1644,7 @@ class FactManager:
         exclude_categories: list[str] | None,
         session: AsyncSession,
         variant_pairs: list[tuple[str, list[float] | None]] | None = None,
+        date_window: "DateWindow | None" = None,
     ) -> list[FactSummary]:
         # Generate query embedding
         embedding = None
@@ -1694,6 +1698,16 @@ class FactManager:
                 extra_params=extra_params,
                 limit=limit,
             )
+
+        # F075 L3: fuse the date-window leg (position-based RRF). Present only when
+        # the caller parsed a window and we have a query embedding. Empty leg is a
+        # no-op, so this preserves today's ordering when the window finds nothing.
+        if date_window is not None and embedding is not None:
+            from nous.heart.search import _rrf_merge_n, _resolve_rrf_k
+            k_leg = self._settings.date_leg_k if self._settings else 15
+            date_leg = await self._date_window_leg(session, embedding, date_window, k_leg)
+            if date_leg:
+                results = _rrf_merge_n([results, date_leg], _resolve_rrf_k(), limit)
 
         if not results:
             return []

--- a/nous/heart/facts.py
+++ b/nous/heart/facts.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from nous.config import Settings
     from nous.handlers import LLMClient
     from nous.heart.actionability import ActionabilityClassifier
+    from nous.heart.date_window import DateWindow
 
 logger = logging.getLogger(__name__)
 
@@ -1823,6 +1824,36 @@ class FactManager:
         summaries = self.apply_supersession_filter(summaries)
         self._fire_track_access([s.id for s in summaries])
         return summaries
+
+    async def _date_window_leg(
+        self,
+        session: "AsyncSession",
+        embedding: list[float],
+        window: "DateWindow",
+        limit: int,
+    ) -> list[tuple["UUID", float]]:
+        """F075 L3: in-window active dated facts, ranked by cosine to the query.
+
+        Returns (id, cosine) tuples ordered best-first. Ranking is cosine-to-query
+        (relevance within the window), never date-distance alone.
+        """
+        qvec = "[" + ",".join(str(float(v)) for v in embedding) + "]"
+        sql = text("""
+            SELECT t.id, 1 - (t.embedding <=> CAST(:qvec AS vector)) AS score
+            FROM heart.facts t
+            WHERE t.agent_id = :agent_id
+              AND t.active = true
+              AND t.event_date IS NOT NULL
+              AND t.event_date BETWEEN :lo AND :hi
+              AND t.embedding IS NOT NULL
+            ORDER BY t.embedding <=> CAST(:qvec AS vector)
+            LIMIT :limit
+        """)
+        result = await session.execute(sql, {
+            "agent_id": self.agent_id, "qvec": qvec,
+            "lo": window.start, "hi": window.end, "limit": limit,
+        })
+        return [(row.id, float(row.score)) for row in result.all()]
 
     # ------------------------------------------------------------------
     # list_all() — F021 dashboard browse mode

--- a/nous/heart/facts.py
+++ b/nous/heart/facts.py
@@ -1852,6 +1852,11 @@ class FactManager:
         (relevance within the window), never date-distance alone.
         """
         qvec = "[" + ",".join(str(float(v)) for v in embedding) + "]"
+        # Raise HNSW ef_search well above :limit: the agent/date/active predicates
+        # are post-applied to the approximate walk, so a selective date window can
+        # otherwise evict the in-window rows from the candidate set (codex P2).
+        # Mirrors _find_duplicate (facts.py:1200) and censor probe (censors.py:409).
+        await set_local_ef_search(session, 200)
         sql = text("""
             SELECT t.id, 1 - (t.embedding <=> CAST(:qvec AS vector)) AS score
             FROM heart.facts t

--- a/nous/heart/heart.py
+++ b/nous/heart/heart.py
@@ -16,6 +16,7 @@ from uuid import UUID
 from sqlalchemy import select
 
 if TYPE_CHECKING:
+    from nous.heart.date_window import DateWindow
     from nous.heart.query_expansion import QueryExpander
     from nous.heart.residual_activation import ResidualActivator
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -137,6 +138,10 @@ class Heart:
         # Wired via set_residual_activator() in main.py. None when flag is off;
         # _recall handles None as a no-op (boost branch skipped).
         self._residual_activator: "ResidualActivator | None" = None
+
+        # F075 L3: date-window parser, wired in main.py (reuses the shared api_client).
+        # None when flag is off or test fixture skipped wiring; recall handles None as a no-op.
+        self.date_window_parser = None
 
     # ------------------------------------------------------------------
     # Lifecycle (P2-2)
@@ -840,6 +845,7 @@ class Heart:
         session: AsyncSession | None = None,
         residual_activations: dict[UUID, float] | None = None,
         apply_mmr: bool | None = None,
+        date_window: "DateWindow | None" = None,
     ) -> list[RecallResult]:
         """Search across ALL memory types, return ranked results.
 
@@ -870,6 +876,7 @@ class Heart:
                     query, limit, types, session, residual_activations,
                     owns_session=True,
                     apply_mmr=apply_mmr,
+                    date_window=date_window,
                 )
         # Caller-provided session: caller owns transaction recovery. We do
         # NOT rollback after a sub-search failure (would silently discard
@@ -878,6 +885,7 @@ class Heart:
             query, limit, types, session, residual_activations,
             owns_session=False,
             apply_mmr=apply_mmr,
+            date_window=date_window,
         )
 
     def set_residual_activator(self, activator: "ResidualActivator | None") -> None:
@@ -922,6 +930,7 @@ class Heart:
         residual_activations: dict[UUID, float] | None = None,
         owns_session: bool = True,
         apply_mmr: bool | None = None,
+        date_window: "DateWindow | None" = None,
     ) -> list[RecallResult]:
         search_types = types or ["episode", "fact", "procedure", "censor"]
         fetch_limit = limit * 2  # Fetch more for merging
@@ -979,7 +988,8 @@ class Heart:
                     )
                 elif memory_type == "fact":
                     result = await self.facts.search(
-                        query, fetch_limit, session=session, variant_pairs=variant_pairs,
+                        query, fetch_limit, session=session,
+                        variant_pairs=variant_pairs, date_window=date_window,
                     )
                 elif memory_type == "procedure":
                     result = await self.procedures.search(

--- a/nous/main.py
+++ b/nous/main.py
@@ -211,6 +211,10 @@ async def create_components(settings: Settings) -> dict:
     # F027: Wire supersession classifier LLM client
     heart.facts.set_llm_client(api_client, model=settings.contradiction_model)
 
+    # F075 L3: Wire the date-window parser (reuses the shared api_client)
+    from nous.heart.date_window import DateWindowParser
+    heart.date_window_parser = DateWindowParser(api_client, settings)
+
     # F047: Wire actionability classifier + schedule backfill for NULL rows
     if settings.actionability_enabled:
         from nous.heart.actionability import ActionabilityClassifier

--- a/nous_eval/date_leg_rescue.py
+++ b/nous_eval/date_leg_rescue.py
@@ -1,0 +1,253 @@
+"""F075 L3 Task 7: rescue-metric dev harness for the date-window retrieval leg.
+
+Samples dated facts from the eval DB, generates time-framed Haiku queries,
+runs vanilla vs vanilla+leg recall, and reports rescued / lost counts.
+
+Usage::
+
+    python -m nous_eval.date_leg_rescue [--sample N] [--top-k K]
+
+This is a developer instrument — NOT shipped in the prod image. No unit tests
+are required for ``main()``.  The only unit-tested surface is ``rrf_fuse``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime
+import logging
+from typing import Any
+from uuid import UUID
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Pure function (unit-tested)
+# ---------------------------------------------------------------------------
+
+
+def rrf_fuse(vanilla_ids: list, leg_ids: list, k: int = 60) -> list:
+    """Position-based RRF fusion of two ranked id lists.
+
+    Each id contributes 1/(k + rank) from each list it appears in.  Ids are
+    merged and re-sorted by descending total score.  Equal ids are deduplicated
+    (higher contribution wins via accumulation).
+
+    Args:
+        vanilla_ids: Ordered ids from the main retrieval pipeline.
+        leg_ids:     Ordered ids from the date-window leg.
+        k:           RRF smoothing constant (default 60, validated).
+
+    Returns:
+        Fused list of ids, best-first.
+    """
+    score: dict[Any, float] = {}
+    for rank, i in enumerate(vanilla_ids, 1):
+        score[i] = score.get(i, 0.0) + 1.0 / (k + rank)
+    for rank, i in enumerate(leg_ids, 1):
+        score[i] = score.get(i, 0.0) + 1.0 / (k + rank)
+    return [i for i, _ in sorted(score.items(), key=lambda kv: kv[1], reverse=True)]
+
+
+# ---------------------------------------------------------------------------
+# Dev harness (not unit-tested — runtime-only)
+# ---------------------------------------------------------------------------
+
+
+async def _sample_dated_facts(
+    db: Any, agent_id: str, limit: int
+) -> list[dict]:
+    """Sample active facts with event_date from the eval DB."""
+    from sqlalchemy import text
+
+    sql = text("""
+        SELECT id, content, event_date
+        FROM heart.facts
+        WHERE agent_id = :agent_id
+          AND active = true
+          AND event_date IS NOT NULL
+          AND content IS NOT NULL
+          AND length(content) > 40
+        ORDER BY random()
+        LIMIT :limit
+    """)
+    async with db.session() as session:
+        result = await session.execute(sql, {"agent_id": agent_id, "limit": limit})
+        return [
+            {"id": row.id, "content": row.content, "event_date": row.event_date}
+            for row in result.all()
+        ]
+
+
+async def _generate_temporal_query(
+    client: Any, model: str, content: str, event_date: datetime.date
+) -> str:
+    """Ask Haiku to write a time-framed question about a fact."""
+    from nous.api.anthropic_client import create_client  # noqa: F401 (type hint only)
+
+    prompt = (
+        f"The following fact was recorded on {event_date.isoformat()}:\n\n"
+        f"{content}\n\n"
+        "Write a short question (one sentence) that a user would ask when trying "
+        "to recall this fact. The question MUST mention a specific date, month, "
+        "or time period so it has a clear temporal anchor. Do not use the word "
+        "'fact'. Reply with only the question, no preamble."
+    )
+    payload = {
+        "model": model,
+        "max_tokens": 128,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    try:
+        response = await asyncio.wait_for(client.call(payload), timeout=10.0)
+        for block in response.content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                return block["text"].strip()
+            # SDK-style objects
+            if hasattr(block, "type") and block.type == "text":
+                return block.text.strip()
+    except Exception:
+        logger.warning("query generation failed for content %r", content[:40], exc_info=True)
+    # Fallback: construct a simple query from content + date
+    return f"What happened around {event_date.strftime('%B %Y')}? ({content[:60]})"
+
+
+async def main() -> None:
+    """CLI entry point for the date-leg rescue metric harness."""
+    parser = argparse.ArgumentParser(description="Date-leg rescue-metric harness (F075 L3)")
+    parser.add_argument("--sample", type=int, default=20, help="Dated facts to sample")
+    parser.add_argument("--top-k", type=int, default=10, help="Retrieval top-K for comparison")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.WARNING)
+
+    # ── Build settings ──────────────────────────────────────────────────────
+    from nous.config import Settings
+    from nous.brain.embeddings import EmbeddingProvider
+    from nous.storage.database import Database
+    from nous_eval.config import EvalSettings
+    from nous_eval.retrieval_runner import _settings_for_eval_db, _build_heart_for_eval
+    from nous.api.retrieval_pipeline import run_recall_pipeline
+    from nous.heart.date_window import DateWindowParser
+    from nous.brain.brain import Brain
+
+    eval_settings = EvalSettings()
+    base_settings = Settings()
+    settings = _settings_for_eval_db(eval_settings, base_settings)
+
+    # Enable the date leg for the fused run
+    fused_settings = settings.model_copy(update={"date_leg_enabled": True})
+
+    # ── Connect to eval DB ──────────────────────────────────────────────────
+    db = Database(settings=settings)
+    await db.connect()
+
+    embedding_provider: EmbeddingProvider | None = None
+    if settings.openai_api_key:
+        embedding_provider = EmbeddingProvider(
+            api_key=settings.openai_api_key,
+            model=settings.embedding_model,
+            dimensions=settings.embedding_dimensions,
+        )
+
+    brain = Brain(database=db, settings=settings, embedding_provider=embedding_provider)
+
+    # ── LLM client for query generation + date-window parsing ──────────────
+    from nous.api.anthropic_client import create_client
+    api_client = create_client(settings)
+    await api_client.start()
+
+    try:
+        async with _build_heart_for_eval(db, settings) as heart:
+            # Wire the DateWindowParser so the fused pipeline can call it
+            heart.date_window_parser = DateWindowParser(api_client, fused_settings)
+
+            # ── Sample dated facts ──────────────────────────────────────────
+            facts = await _sample_dated_facts(db, settings.agent_id, args.sample)
+            if not facts:
+                print("No dated facts found in eval DB — run ingest first.")
+                return
+
+            n = len(facts)
+            rescued = 0
+            lost = 0
+            vanilla_hits = 0
+            fused_hits = 0
+            today = datetime.date.today()
+
+            print(f"Sampling {n} dated facts, top_k={args.top_k} …\n")
+
+            for fact in facts:
+                gold_id: UUID = fact["id"]
+                content: str = fact["content"]
+                event_date: datetime.date = fact["event_date"]
+
+                # Generate a temporal query about this fact
+                query = await _generate_temporal_query(
+                    api_client,
+                    settings.date_leg_model if hasattr(settings, "date_leg_model")
+                    else "claude-haiku-4-5-20251001",
+                    content,
+                    event_date,
+                )
+
+                # Vanilla run (date_leg_enabled=False)
+                vanilla_results, _ = await run_recall_pipeline(
+                    query=query,
+                    heart=heart,
+                    brain=brain,
+                    settings=settings,
+                    limit=args.top_k,
+                    memory_types=["fact"],
+                )
+                vanilla_ids = [r.id for r in vanilla_results]
+
+                # Date-window leg: parse window then retrieve in-window facts
+                date_window = await heart.date_window_parser.parse(query, today)
+                leg_ids: list[UUID] = []
+                if date_window is not None and embedding_provider is not None:
+                    embedding = await embedding_provider.embed(query)
+                    async with db.session() as session:
+                        leg_rows = await heart.facts._date_window_leg(
+                            session,
+                            embedding,
+                            date_window,
+                            limit=fused_settings.date_leg_k
+                            if hasattr(fused_settings, "date_leg_k") else 15,
+                        )
+                    leg_ids = [row[0] for row in leg_rows]
+
+                # Fuse
+                fused_ids = rrf_fuse(vanilla_ids, leg_ids)
+                top_fused = fused_ids[: args.top_k]
+
+                in_vanilla = gold_id in vanilla_ids
+                in_fused = gold_id in top_fused
+
+                if in_vanilla:
+                    vanilla_hits += 1
+                if in_fused:
+                    fused_hits += 1
+                if in_fused and not in_vanilla:
+                    rescued += 1
+                if in_vanilla and not in_fused:
+                    lost += 1
+
+            print(
+                f"{'n':>6}  {'vanilla_top_k':>13}  {'fused_top_k':>11}  "
+                f"{'rescued':>7}  {'lost':>4}"
+            )
+            print(
+                f"{n:>6}  {vanilla_hits:>13}  {fused_hits:>11}  "
+                f"{rescued:>7}  {lost:>4}"
+            )
+
+    finally:
+        await api_client.close()
+        await db.disconnect()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/nous_eval/date_leg_rescue.py
+++ b/nous_eval/date_leg_rescue.py
@@ -179,7 +179,6 @@ async def main() -> None:
             lost = 0
             vanilla_hits = 0
             fused_hits = 0
-            today = datetime.date.today()
 
             print(f"Sampling {n} dated facts, top_k={args.top_k} …\n")
 
@@ -208,24 +207,20 @@ async def main() -> None:
                 )
                 vanilla_ids = [r.id for r in vanilla_results]
 
-                # Date-window leg: parse window then retrieve in-window facts
-                date_window = await heart.date_window_parser.parse(query, today)
-                leg_ids: list[UUID] = []
-                if date_window is not None and embedding_provider is not None:
-                    embedding = await embedding_provider.embed(query)
-                    async with db.session() as session:
-                        leg_rows = await heart.facts._date_window_leg(
-                            session,
-                            embedding,
-                            date_window,
-                            limit=fused_settings.date_leg_k
-                            if hasattr(fused_settings, "date_leg_k") else 15,
-                        )
-                    leg_ids = [row[0] for row in leg_rows]
-
-                # Fuse
-                fused_ids = rrf_fuse(vanilla_ids, leg_ids)
-                top_fused = fused_ids[: args.top_k]
+                # Fused run through the REAL production path: fused_settings has
+                # date_leg_enabled=True, so run_recall_pipeline parses the window and
+                # FactManager._search fuses the date leg via _rrf_merge_n over the same
+                # fetch_limit*2 candidate pool production uses. Measuring the actual
+                # path (not a manual top-K rrf_fuse) keeps the A/B gate honest (codex P2).
+                fused_results, _ = await run_recall_pipeline(
+                    query=query,
+                    heart=heart,
+                    brain=brain,
+                    settings=fused_settings,
+                    limit=args.top_k,
+                    memory_types=["fact"],
+                )
+                top_fused = [r.id for r in fused_results]
 
                 in_vanilla = gold_id in vanilla_ids
                 in_fused = gold_id in top_fused

--- a/nous_eval/date_leg_rescue.py
+++ b/nous_eval/date_leg_rescue.py
@@ -139,6 +139,10 @@ async def main() -> None:
 
     # Enable the date leg for the fused run
     fused_settings = settings.model_copy(update={"date_leg_enabled": True})
+    # Force the vanilla baseline leg-free even when NOUS_DATE_LEG_ENABLED=true in
+    # the env (exactly the A/B case): otherwise the "vanilla" run_recall_pipeline
+    # would fire the leg itself and underreport rescues (codex P2).
+    baseline_settings = settings.model_copy(update={"date_leg_enabled": False})
 
     # ── Connect to eval DB ──────────────────────────────────────────────────
     db = Database(settings=settings)
@@ -193,12 +197,12 @@ async def main() -> None:
                     event_date,
                 )
 
-                # Vanilla run (date_leg_enabled=False)
+                # Vanilla run (date_leg_enabled=False — leg-free baseline)
                 vanilla_results, _ = await run_recall_pipeline(
                     query=query,
                     heart=heart,
                     brain=brain,
-                    settings=settings,
+                    settings=baseline_settings,
                     limit=args.top_k,
                     memory_types=["fact"],
                 )

--- a/tests/eval/test_date_leg_rescue.py
+++ b/tests/eval/test_date_leg_rescue.py
@@ -1,0 +1,17 @@
+"""Unit tests for nous_eval.date_leg_rescue (F075 L3 Task 7)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.eval
+
+from nous_eval.date_leg_rescue import rrf_fuse
+
+
+def test_rrf_fuse_is_position_based():
+    # gold at rank 3 in vanilla, rank 1 in the leg -> fusion lifts it
+    vanilla = ["a", "b", "gold", "c"]
+    leg = ["gold", "x"]
+    fused = rrf_fuse(vanilla, leg)
+    assert fused.index("gold") < 2  # lifted into the head

--- a/tests/heart/test_date_window.py
+++ b/tests/heart/test_date_window.py
@@ -54,6 +54,18 @@ async def test_pregate_skips_llm_for_non_temporal():
     assert client.calls == []  # no LLM call
 
 @pytest.mark.asyncio
+async def test_parser_system_prompt_is_non_empty():
+    # codex P1: an empty system text block is rejected by Anthropic's prompt cache
+    # (400), which would fail every parse open to None. Assert no system block is blank.
+    client = _FakeClient({"has_date": True, "start_date": "2026-04-20", "end_date": "2026-04-30"})
+    p = DateWindowParser(client, _settings())
+    await p.parse("what happened in late April 2026?", TODAY)
+    assert client.calls, "LLM was not called"
+    sys_blocks = client.calls[-1]["system"]
+    assert sys_blocks and all(b["text"].strip() for b in sys_blocks), \
+        "an empty system block would 400 on Anthropic's prompt cache"
+
+@pytest.mark.asyncio
 async def test_cache_key_includes_today_for_relative_queries():
     # codex P2: a relative query cached on one day must re-parse on the next —
     # "yesterday" resolves to a different window per `today`. Cache key includes today.

--- a/tests/heart/test_date_window.py
+++ b/tests/heart/test_date_window.py
@@ -8,6 +8,12 @@ def test_temporal_signal_detects_month_year():
     assert has_temporal_signal("changes around mid-May") is True
     assert has_temporal_signal("events on 2026-06-24") is True
 
+def test_temporal_signal_detects_this_next_period_phrases():
+    # codex P2: this/next determiners + bare period nouns must reach the parser.
+    assert has_temporal_signal("what happened this week?") is True
+    assert has_temporal_signal("what changed next month?") is True
+    assert has_temporal_signal("summarize this quarter") is True
+
 def test_temporal_signal_rejects_non_temporal():
     assert has_temporal_signal("How does the calibration gate work?") is False
     assert has_temporal_signal("summarize the trading bot design") is False

--- a/tests/heart/test_date_window.py
+++ b/tests/heart/test_date_window.py
@@ -54,6 +54,19 @@ async def test_pregate_skips_llm_for_non_temporal():
     assert client.calls == []  # no LLM call
 
 @pytest.mark.asyncio
+async def test_cache_key_includes_today_for_relative_queries():
+    # codex P2: a relative query cached on one day must re-parse on the next —
+    # "yesterday" resolves to a different window per `today`. Cache key includes today.
+    client = _FakeClient({"has_date": True, "start_date": "2026-07-01", "end_date": "2026-07-01"})
+    p = DateWindowParser(client, _settings())
+    q = "what happened yesterday?"
+    await p.parse(q, datetime.date(2026, 7, 2))
+    await p.parse(q, datetime.date(2026, 7, 2))   # same day -> cache hit, no new call
+    assert len(client.calls) == 1
+    await p.parse(q, datetime.date(2026, 7, 3))   # next day -> different key -> re-parse
+    assert len(client.calls) == 2
+
+@pytest.mark.asyncio
 async def test_has_date_false_returns_none():
     client = _FakeClient({"has_date": False})
     p = DateWindowParser(client, _settings())

--- a/tests/heart/test_date_window.py
+++ b/tests/heart/test_date_window.py
@@ -79,3 +79,18 @@ async def test_budget_cap_fails_open():
     p = DateWindowParser(client, _settings(date_leg_max_per_hour=1))
     await p.parse("events in April 2026", TODAY)          # uses the 1 budget
     assert await p.parse("events in May 2026", TODAY) is None  # budget exhausted -> fail open
+
+@pytest.mark.asyncio
+async def test_inverted_dates_return_none():
+    client = _FakeClient({"has_date": True, "start_date": "2026-04-30", "end_date": "2026-04-20"})
+    p = DateWindowParser(client, _settings())
+    assert await p.parse("events in April 2026", TODAY) is None
+
+@pytest.mark.asyncio
+async def test_none_result_is_cached():
+    client = _FakeClient({"has_date": False})
+    p = DateWindowParser(client, _settings())
+    q = "some vague temporal-ish query mentioning last quarter"
+    assert await p.parse(q, TODAY) is None
+    assert await p.parse(q, TODAY) is None
+    assert len(client.calls) == 1  # second call served from cache, no LLM

--- a/tests/heart/test_date_window.py
+++ b/tests/heart/test_date_window.py
@@ -79,6 +79,17 @@ async def test_cache_key_includes_today_for_relative_queries():
     assert len(client.calls) == 2
 
 @pytest.mark.asyncio
+async def test_transient_failure_is_not_cached():
+    # codex P2: a client error (transient) must NOT be cached as no-date — the same
+    # query must re-parse once the LLM recovers, not be suppressed until TTL.
+    client = _FakeClient(None, raises=True, calls=[])
+    p = DateWindowParser(client, _settings())
+    q = "events in April 2026"
+    assert await p.parse(q, TODAY) is None
+    assert await p.parse(q, TODAY) is None
+    assert len(client.calls) == 2  # transient failure not cached -> re-invoked
+
+@pytest.mark.asyncio
 async def test_has_date_false_returns_none():
     client = _FakeClient({"has_date": False})
     p = DateWindowParser(client, _settings())

--- a/tests/heart/test_date_window.py
+++ b/tests/heart/test_date_window.py
@@ -1,0 +1,15 @@
+import datetime
+from nous.heart.date_window import DateWindow, has_temporal_signal
+
+def test_temporal_signal_detects_month_year():
+    assert has_temporal_signal("What happened in late April 2026?") is True
+    assert has_temporal_signal("changes around mid-May") is True
+    assert has_temporal_signal("events on 2026-06-24") is True
+
+def test_temporal_signal_rejects_non_temporal():
+    assert has_temporal_signal("How does the calibration gate work?") is False
+    assert has_temporal_signal("summarize the trading bot design") is False
+
+def test_datewindow_is_frozen():
+    w = DateWindow(start=datetime.date(2026, 4, 20), end=datetime.date(2026, 4, 30))
+    assert w.start < w.end

--- a/tests/heart/test_date_window.py
+++ b/tests/heart/test_date_window.py
@@ -1,4 +1,6 @@
 import datetime
+import pytest
+from types import SimpleNamespace
 from nous.heart.date_window import DateWindow, has_temporal_signal
 
 def test_temporal_signal_detects_month_year():
@@ -13,3 +15,67 @@ def test_temporal_signal_rejects_non_temporal():
 def test_datewindow_is_frozen():
     w = DateWindow(start=datetime.date(2026, 4, 20), end=datetime.date(2026, 4, 30))
     assert w.start < w.end
+
+
+# ---------------------------------------------------------------------------
+# Task 3: DateWindowParser tests
+# ---------------------------------------------------------------------------
+from nous.heart.date_window import DateWindowParser
+
+
+class _FakeClient:
+    def __init__(self, tool_input, raises=False, calls=None):
+        self._input = tool_input; self._raises = raises; self.calls = calls if calls is not None else []
+    async def call(self, payload):
+        self.calls.append(payload)
+        if self._raises:
+            raise RuntimeError("boom")
+        return SimpleNamespace(content=[{"type": "tool_use", "name": "emit_window", "input": self._input}])
+
+def _settings(**kw):
+    base = dict(date_leg_model="claude-haiku-4-5-20251001", date_leg_timeout_seconds=2.0,
+                date_leg_max_per_hour=500, date_leg_pad_days=2)
+    base.update(kw); return SimpleNamespace(**base)
+
+TODAY = datetime.date(2026, 7, 1)
+
+@pytest.mark.asyncio
+async def test_parse_returns_padded_window():
+    client = _FakeClient({"has_date": True, "start_date": "2026-04-20", "end_date": "2026-04-30"})
+    p = DateWindowParser(client, _settings())
+    w = await p.parse("what happened in late April 2026?", TODAY)
+    assert w == DateWindow(start=datetime.date(2026, 4, 18), end=datetime.date(2026, 5, 2))  # +/- 2 pad
+
+@pytest.mark.asyncio
+async def test_pregate_skips_llm_for_non_temporal():
+    client = _FakeClient({"has_date": True, "start_date": "2026-01-01", "end_date": "2026-01-02"})
+    p = DateWindowParser(client, _settings())
+    assert await p.parse("how does calibration work?", TODAY) is None
+    assert client.calls == []  # no LLM call
+
+@pytest.mark.asyncio
+async def test_has_date_false_returns_none():
+    client = _FakeClient({"has_date": False})
+    p = DateWindowParser(client, _settings())
+    assert await p.parse("something about last quarter's vibe", TODAY) is None
+
+@pytest.mark.asyncio
+async def test_fail_open_on_client_error():
+    client = _FakeClient(None, raises=True)
+    p = DateWindowParser(client, _settings())
+    assert await p.parse("events in April 2026", TODAY) is None
+
+@pytest.mark.asyncio
+async def test_cache_hit_skips_second_llm_call():
+    client = _FakeClient({"has_date": True, "start_date": "2026-04-20", "end_date": "2026-04-30"})
+    p = DateWindowParser(client, _settings())
+    q = "what happened in late April 2026?"
+    await p.parse(q, TODAY); await p.parse(q, TODAY)
+    assert len(client.calls) == 1  # second served from cache
+
+@pytest.mark.asyncio
+async def test_budget_cap_fails_open():
+    client = _FakeClient({"has_date": True, "start_date": "2026-04-20", "end_date": "2026-04-30"})
+    p = DateWindowParser(client, _settings(date_leg_max_per_hour=1))
+    await p.parse("events in April 2026", TODAY)          # uses the 1 budget
+    assert await p.parse("events in May 2026", TODAY) is None  # budget exhausted -> fail open

--- a/tests/heart/test_date_window.py
+++ b/tests/heart/test_date_window.py
@@ -94,3 +94,30 @@ async def test_none_result_is_cached():
     assert await p.parse(q, TODAY) is None
     assert await p.parse(q, TODAY) is None
     assert len(client.calls) == 1  # second call served from cache, no LLM
+
+
+# ---------------------------------------------------------------------------
+# I-1: bounded cache + TTL flag
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_cache_size_bounded(monkeypatch):
+    """Cache must not grow past _CACHE_MAX_ENTRIES; oldest entry is evicted."""
+    import nous.heart.date_window as dw_mod
+    monkeypatch.setattr(dw_mod, "_CACHE_MAX_ENTRIES", 2)
+    client = _FakeClient({"has_date": True, "start_date": "2026-04-20", "end_date": "2026-04-30"})
+    p = DateWindowParser(client, _settings())
+    await p.parse("events in April 2026", TODAY)
+    await p.parse("events in May 2026", TODAY)
+    await p.parse("events in June 2026", TODAY)  # should evict oldest
+    assert len(p._cache) <= 2
+
+
+@pytest.mark.asyncio
+async def test_ttl_zero_disables_caching():
+    """date_leg_cache_ttl_days=0 means never cache; same query hits LLM every time."""
+    client = _FakeClient({"has_date": True, "start_date": "2026-04-20", "end_date": "2026-04-30"})
+    p = DateWindowParser(client, _settings(date_leg_cache_ttl_days=0))
+    q = "events in April 2026"
+    await p.parse(q, TODAY)
+    await p.parse(q, TODAY)
+    assert len(client.calls) == 2  # no cache hit when ttl=0

--- a/tests/heart/test_date_window_leg.py
+++ b/tests/heart/test_date_window_leg.py
@@ -98,3 +98,96 @@ async def test_date_window_leg_returns_in_window_ranked(
     assert seed_dated_facts["F_in"] in ids           # in window → included
     assert seed_dated_facts["F_out"] not in ids      # June → excluded
     assert seed_dated_facts["F_undated"] not in ids  # NULL event_date → excluded
+
+
+# ---------------------------------------------------------------------------
+# Task 5 fixtures + tests — fusion via _rrf_merge_n
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def seed_rescue_case(session, heart):
+    """Seed a scenario where vanilla search misses the gold fact but fusion rescues it.
+
+    Strategy:
+    - 6 crowder facts: embedding == query embedding (cosine = 1.0), no event_date.
+      This pushes them all into vanilla top-6, leaving gold at rank 6 (outside limit=5).
+    - 1 gold fact: embedding from different text (cosine ≈ 0), event_date in the window.
+      The date-window leg returns gold at rank 0; RRF fusion brings it into fused top-5.
+    - Both embedding AND content avoid FTS matches on the query so keyword results
+      are empty — pure vector ranking, fully deterministic.
+
+    Verified analytically:
+    - Vanilla _rrf_merge (empty keyword): crowder ranks 0-4 score 0.0162..0.0155,
+      crowder rank 5 scores 0.0153, gold at rank 6 scores 0.0152 → gold excluded.
+    - Fused _rrf_merge_n (vanilla list ++ date-leg): gold and c0 both score 0.01591
+      (tied), so all of {c0, gold, c1, c2, c3} appear in the fused top-5. ✓
+    """
+    agent_id = heart.facts.agent_id
+    embeddings = heart.facts.embeddings
+
+    query = "april window rescue query"
+    q_emb = await embeddings.embed(query)
+    gold_emb = await embeddings.embed("database initialization sequence")
+
+    from nous.storage.models import Fact
+
+    crowders = []
+    for i in range(6):
+        f = Fact(
+            id=uuid4(),
+            agent_id=agent_id,
+            content=f"background heartbeat check step {i}",
+            event_date=None,
+            embedding=q_emb,
+            active=True,
+            category="technical",
+        )
+        session.add(f)
+        crowders.append(f)
+
+    gold = Fact(
+        id=uuid4(),
+        agent_id=agent_id,
+        content="database initialization sequence",
+        event_date=datetime.date(2026, 4, 25),
+        embedding=gold_emb,
+        active=True,
+        category="technical",
+    )
+    session.add(gold)
+    await session.flush()
+
+    window = DateWindow(start=datetime.date(2026, 4, 20), end=datetime.date(2026, 4, 30))
+    return {"query": query, "window": window, "gold": gold.id}
+
+
+async def test_date_window_fusion_rescues_missed_fact(
+    fact_store, seed_rescue_case, session
+):
+    """Fusion of the date-window leg rescues a gold fact crowded out of vanilla top-5.
+
+    Passes session explicitly so that both search calls see the uncommitted seeded data.
+    Asserts the rescue mechanism is genuinely exercised (gold NOT in vanilla, IN fused).
+    """
+    q = seed_rescue_case["query"]
+    window = seed_rescue_case["window"]
+    gold = seed_rescue_case["gold"]
+
+    vanilla = await fact_store.search(q, limit=5, session=session)
+    fused = await fact_store.search(q, limit=5, date_window=window, session=session)
+
+    assert gold not in [f.id for f in vanilla], (
+        "gold should be crowded out of vanilla top-5 by the 6 crowders with cosine=1.0"
+    )
+    assert gold in [f.id for f in fused], (
+        "fusion of the date-window leg must lift gold into the fused top-5"
+    )
+
+
+async def test_no_window_is_unchanged(fact_store, seed_rescue_case, session):
+    """date_window=None leaves results byte-identical to no date_window argument."""
+    q = seed_rescue_case["query"]
+    a = await fact_store.search(q, limit=5, session=session)
+    b = await fact_store.search(q, limit=5, date_window=None, session=session)
+    assert [f.id for f in a] == [f.id for f in b]

--- a/tests/heart/test_date_window_leg.py
+++ b/tests/heart/test_date_window_leg.py
@@ -1,0 +1,100 @@
+"""F075 L3 Task 4: integration test for FactManager._date_window_leg.
+
+Postgres-only: uses the pgvector <=> operator which is not available in SQLite.
+Run with: NOUS_TEST_DB=postgres uv run pytest tests/heart/test_date_window_leg.py -v
+"""
+from __future__ import annotations
+
+import datetime
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from nous.heart.date_window import DateWindow
+from nous.storage.models import Fact
+
+pytestmark = [pytest.mark.postgres_only, pytest.mark.asyncio]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fact_store(heart):
+    """FactManager from the shared heart fixture (uses MockEmbeddingProvider)."""
+    return heart.facts
+
+
+@pytest_asyncio.fixture
+async def seed_dated_facts(session, heart):
+    """Insert three facts into the savepoint session and return their UUIDs.
+
+    F_in:      event_date=2026-04-25, embedding identical to query text
+    F_out:     event_date=2026-06-01  (out of the April window)
+    F_undated: event_date=NULL        (excluded by IS NOT NULL filter)
+    """
+    agent_id = heart.facts.agent_id
+    embeddings = heart.facts.embeddings
+
+    # Use the EXACT query text for F_in so MockEmbeddingProvider returns
+    # an identical vector → cosine similarity = 1.0 vs the query.
+    query_text = "calibration work in late April"
+    emb_in = await embeddings.embed(query_text)
+    emb_out = await embeddings.embed("June deployment notes")
+    emb_undated = await embeddings.embed("system architecture uses PostgreSQL")
+
+    f_in = Fact(
+        id=uuid4(),
+        agent_id=agent_id,
+        content=query_text,
+        event_date=datetime.date(2026, 4, 25),
+        embedding=emb_in,
+        active=True,
+        category="technical",
+    )
+    f_out = Fact(
+        id=uuid4(),
+        agent_id=agent_id,
+        content="June deployment notes",
+        event_date=datetime.date(2026, 6, 1),
+        embedding=emb_out,
+        active=True,
+        category="technical",
+    )
+    f_undated = Fact(
+        id=uuid4(),
+        agent_id=agent_id,
+        content="system architecture uses PostgreSQL",
+        event_date=None,
+        embedding=emb_undated,
+        active=True,
+        category="technical",
+    )
+
+    session.add(f_in)
+    session.add(f_out)
+    session.add(f_undated)
+    await session.flush()
+
+    return {"F_in": f_in.id, "F_out": f_out.id, "F_undated": f_undated.id}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_date_window_leg_returns_in_window_ranked(
+    fact_store, seed_dated_facts, session
+):
+    """_date_window_leg returns only in-window active dated facts, cosine-ranked."""
+    window = DateWindow(start=datetime.date(2026, 4, 20), end=datetime.date(2026, 4, 30))
+    emb = await fact_store.embeddings.embed("calibration work in late April")
+    leg = await fact_store._date_window_leg(session, emb, window, limit=15)
+    ids = [row[0] for row in leg]
+    assert seed_dated_facts["F_in"] in ids           # in window → included
+    assert seed_dated_facts["F_out"] not in ids      # June → excluded
+    assert seed_dated_facts["F_undated"] not in ids  # NULL event_date → excluded

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,6 +32,33 @@ class TestDAGTimeoutValidation:
         assert s.dag_node_max_timeout == 7200
 
 
+class TestEffortValidation:
+    """NOUS_EFFORT accepts the real Claude API tiers plus the `extra` alias."""
+
+    def test_xhigh_is_accepted(self, monkeypatch):
+        monkeypatch.setenv("NOUS_EFFORT", "xhigh")
+        s = Settings(_env_file=None)
+        assert s.effort == "xhigh"
+
+    def test_extra_alias_normalizes_to_xhigh(self, monkeypatch):
+        # `extra` was set in prod .env intending the extra-high tier; the
+        # Claude API has no `extra`, so it must resolve to `xhigh` at load
+        # time rather than crash startup or 400 at runtime.
+        monkeypatch.setenv("NOUS_EFFORT", "extra")
+        s = Settings(_env_file=None)
+        assert s.effort == "xhigh"
+
+    def test_invalid_effort_still_rejected(self, monkeypatch):
+        monkeypatch.setenv("NOUS_EFFORT", "bogus")
+        with pytest.raises(ValidationError):
+            Settings(_env_file=None)
+
+    def test_default_is_high(self, monkeypatch):
+        monkeypatch.delenv("NOUS_EFFORT", raising=False)
+        s = Settings(_env_file=None)
+        assert s.effort == "high"
+
+
 class TestContextBudgetOverridesParsing:
     """Audit ST-1: empty/blank NOUS_CONTEXT_BUDGET_OVERRIDES must not crash boot.
 
@@ -73,3 +100,15 @@ class TestContextBudgetOverridesParsing:
         monkeypatch.setenv("NOUS_CONTEXT_BUDGET_OVERRIDES", '{"total": -1}')
         with pytest.raises(ValidationError):
             Settings(_env_file=None)
+
+
+def test_date_leg_settings_defaults():
+    from nous.config import Settings
+    s = Settings()
+    assert s.date_leg_enabled is False
+    assert s.date_leg_model == "claude-haiku-4-5-20251001"
+    assert s.date_leg_k == 15
+    assert s.date_leg_pad_days == 2
+    assert s.date_leg_timeout_seconds == 2.0
+    assert s.date_leg_max_per_hour == 500
+    assert s.date_leg_cache_ttl_days == 30

--- a/tests/test_date_leg_pipeline.py
+++ b/tests/test_date_leg_pipeline.py
@@ -1,0 +1,221 @@
+"""F075 L3 Task 6: wiring test for the date-window retrieval leg pipeline integration.
+
+Verifies two wiring assertions with zero DB dependency:
+
+1. ``date_leg_enabled=False`` → ``heart.recall`` receives ``date_window=None``
+   AND the parser's ``parse`` method is never called (byte-identical to today).
+
+2. ``date_leg_enabled=True`` + a temporal query + a stub parser that returns a
+   ``DateWindow`` → ``heart.recall`` receives that exact ``DateWindow`` as
+   ``date_window``.
+
+The test drives ``run_recall_pipeline`` directly with a lightweight stub heart,
+brain, and settings (same pattern as ``tests/test_retrieval_pipeline.py``).
+"""
+from __future__ import annotations
+
+import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nous.api.retrieval_pipeline import run_recall_pipeline
+from nous.heart.date_window import DateWindow
+from nous.heart.schemas import RecallResult
+
+
+# ---------------------------------------------------------------------------
+# Minimal stubs (no DB, no network)
+# ---------------------------------------------------------------------------
+
+
+def _make_recall_results() -> list[RecallResult]:
+    return [
+        RecallResult(type="fact", id="11111111-1111-1111-1111-111111111111",
+                     summary="a fact", score=0.9),
+    ]
+
+
+class _FakeSession:
+    """Async context manager stand-in for brain.db.session()."""
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, *_):
+        return None
+    async def execute(self, _stmt):
+        class _R:
+            def scalars(self):
+                class _S:
+                    def all(self):
+                        return []
+                return _S()
+        return _R()
+
+
+def _make_brain():
+    brain = MagicMock()
+    brain.agent_id = "nous-test-agent"
+    brain.query = AsyncMock(return_value=[])
+    brain.neighbors = AsyncMock(return_value=[])
+    brain.db = MagicMock()
+    brain.db.session = MagicMock(return_value=_FakeSession())
+    return brain
+
+
+def _make_heart(*, parser=None):
+    heart = MagicMock()
+    heart.agent_id = "nous-test-agent"
+    heart.recall = AsyncMock(return_value=_make_recall_results())
+    heart.date_window_parser = parser
+    return heart
+
+
+def _make_settings(*, date_leg_enabled: bool = False):
+    """Minimal Settings SimpleNamespace with all flags the pipeline reads."""
+    return SimpleNamespace(
+        # F075 L3 flags under test
+        date_leg_enabled=date_leg_enabled,
+        # Graph / memory flags (all off to keep the test focused)
+        graph_recall_enabled=False,
+        cross_type_linking_enabled=False,
+        spreading_activation_enabled="false",
+        contradiction_detection=False,
+        graph_recall_decay=0.7,
+        graph_recall_max_expand=5,
+        graph_recall_max_neighbors=3,
+        heart_graph_all_types_enabled=False,
+        heart_graph_neighbors_per_seed=3,
+        # Other flags
+        episode_chunks_enabled=False,
+        episode_chunk_recall_limit=10,
+        coherent_ranking_enabled=False,
+        session_group_heart_section=False,
+        graph_adjacency_boost_enabled=False,
+        recall_exclude_context_ids=False,
+    )
+
+
+class _StubParser:
+    """Stub DateWindowParser that tracks parse() calls and returns a fixed window."""
+
+    def __init__(self, return_value):
+        self._return_value = return_value
+        self.call_count = 0
+
+    async def parse(self, query: str, today: datetime.date):
+        self.call_count += 1
+        return self._return_value
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pipeline_flag_off_passes_no_window_and_skips_parser():
+    """With date_leg_enabled=False the parser is never called and date_window=None."""
+    stub_parser = _StubParser(return_value=DateWindow(
+        start=datetime.date(2026, 4, 18),
+        end=datetime.date(2026, 5, 2),
+    ))
+    heart = _make_heart(parser=stub_parser)
+    brain = _make_brain()
+    settings = _make_settings(date_leg_enabled=False)
+
+    await run_recall_pipeline(
+        query="what changed in late April 2026?",
+        heart=heart,
+        brain=brain,
+        settings=settings,
+        limit=10,
+    )
+
+    # Parser.parse must never have been called
+    assert stub_parser.call_count == 0, "parser.parse was called when flag is off"
+
+    # heart.recall must have been called with date_window=None
+    assert heart.recall.called, "heart.recall was not called at all"
+    call_kwargs = heart.recall.call_args_list[-1].kwargs
+    assert call_kwargs.get("date_window") is None, (
+        f"expected date_window=None, got {call_kwargs.get('date_window')!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_flag_on_passes_window_from_parser():
+    """With date_leg_enabled=True the parser runs and heart.recall gets the DateWindow."""
+    expected_window = DateWindow(
+        start=datetime.date(2026, 4, 18),
+        end=datetime.date(2026, 5, 2),
+    )
+    stub_parser = _StubParser(return_value=expected_window)
+    heart = _make_heart(parser=stub_parser)
+    brain = _make_brain()
+    settings = _make_settings(date_leg_enabled=True)
+
+    await run_recall_pipeline(
+        query="what happened in late April 2026?",
+        heart=heart,
+        brain=brain,
+        settings=settings,
+        limit=10,
+    )
+
+    # Parser.parse must have been called exactly once
+    assert stub_parser.call_count == 1, (
+        f"expected parser.parse to be called once, got {stub_parser.call_count}"
+    )
+
+    # heart.recall must have been called with the expected DateWindow
+    assert heart.recall.called, "heart.recall was not called at all"
+    call_kwargs = heart.recall.call_args_list[-1].kwargs
+    assert call_kwargs.get("date_window") == expected_window, (
+        f"expected date_window={expected_window!r}, got {call_kwargs.get('date_window')!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_flag_on_no_parser_attribute_is_safe():
+    """date_leg_enabled=True but heart has no date_window_parser → no crash, no window."""
+    heart = _make_heart(parser=None)  # parser is None (wired but no-op)
+    brain = _make_brain()
+    settings = _make_settings(date_leg_enabled=True)
+
+    # Must not raise
+    await run_recall_pipeline(
+        query="what happened in late April 2026?",
+        heart=heart,
+        brain=brain,
+        settings=settings,
+        limit=10,
+    )
+
+    call_kwargs = heart.recall.call_args_list[-1].kwargs
+    assert call_kwargs.get("date_window") is None, (
+        "expected date_window=None when parser is None"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_flag_on_parser_returns_none_passes_none():
+    """When the parser fails open (returns None), heart.recall gets date_window=None."""
+    stub_parser = _StubParser(return_value=None)  # fail-open scenario
+    heart = _make_heart(parser=stub_parser)
+    brain = _make_brain()
+    settings = _make_settings(date_leg_enabled=True)
+
+    await run_recall_pipeline(
+        query="what happened in late April 2026?",
+        heart=heart,
+        brain=brain,
+        settings=settings,
+        limit=10,
+    )
+
+    assert stub_parser.call_count == 1
+    call_kwargs = heart.recall.call_args_list[-1].kwargs
+    assert call_kwargs.get("date_window") is None, (
+        "when parser returns None, date_window must be None (fail-open)"
+    )

--- a/tests/test_date_leg_pipeline.py
+++ b/tests/test_date_leg_pipeline.py
@@ -199,6 +199,32 @@ async def test_pipeline_flag_on_no_parser_attribute_is_safe():
 
 
 @pytest.mark.asyncio
+async def test_pipeline_skips_parse_when_facts_not_in_scope():
+    """codex P2: date_leg_enabled=True but memory_types=['decision'] → parser skipped.
+
+    The date leg only feeds fact search, so a decision-only recall must not pay the
+    Haiku parse latency/budget."""
+    stub_parser = _StubParser(return_value=DateWindow(
+        start=datetime.date(2026, 4, 18),
+        end=datetime.date(2026, 5, 2),
+    ))
+    heart = _make_heart(parser=stub_parser)
+    brain = _make_brain()
+    settings = _make_settings(date_leg_enabled=True)
+
+    await run_recall_pipeline(
+        query="what happened in late April 2026?",
+        heart=heart,
+        brain=brain,
+        settings=settings,
+        limit=10,
+        memory_types=["decision"],
+    )
+
+    assert stub_parser.call_count == 0, "parser ran for a decision-only recall (facts not in scope)"
+
+
+@pytest.mark.asyncio
 async def test_pipeline_flag_on_parser_returns_none_passes_none():
     """When the parser fails open (returns None), heart.recall gets date_window=None."""
     stub_parser = _StubParser(return_value=None)  # fail-open scenario

--- a/tests/test_date_leg_pipeline.py
+++ b/tests/test_date_leg_pipeline.py
@@ -225,6 +225,30 @@ async def test_pipeline_skips_parse_when_facts_not_in_scope():
 
 
 @pytest.mark.asyncio
+async def test_pipeline_empty_memory_types_still_parses():
+    """codex P2: memory_types=[] defaults to 'all' in _run_stages (facts searched),
+    so the parser must still run — the gate must treat [] like None."""
+    stub_parser = _StubParser(return_value=DateWindow(
+        start=datetime.date(2026, 4, 18),
+        end=datetime.date(2026, 5, 2),
+    ))
+    heart = _make_heart(parser=stub_parser)
+    brain = _make_brain()
+    settings = _make_settings(date_leg_enabled=True)
+
+    await run_recall_pipeline(
+        query="what happened in late April 2026?",
+        heart=heart,
+        brain=brain,
+        settings=settings,
+        limit=10,
+        memory_types=[],
+    )
+
+    assert stub_parser.call_count == 1, "empty memory_types should still parse (facts default in scope)"
+
+
+@pytest.mark.asyncio
 async def test_pipeline_flag_on_parser_returns_none_passes_none():
     """When the parser fails open (returns None), heart.recall gets date_window=None."""
     stub_parser = _StubParser(return_value=None)  # fail-open scenario

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -337,6 +337,7 @@ def _make_mock_settings():
     settings.tool_timeout = 120
     settings.keepalive_interval = 10
     settings.recall_exclude_context_ids = False  # F071: bare MagicMock truthy by default
+    settings.date_leg_enabled = False  # F075 L3: bare MagicMock truthy by default
     return settings
 
 


### PR DESCRIPTION
## Summary

Adds a **seed-independent, date-keyed fact-retrieval leg** — the F075 Layer 3 work that was scoped-but-unbuilt (the dead `NOUS_DATE_AWARE_*` flags). A Haiku parser extracts a date window from the query; in-window dated facts are retrieved by cosine and fused into fact search via the existing `_rrf_merge_n`. Ships **land-dark** behind `NOUS_DATE_LEG_ENABLED` (default `false` → recall output byte-identical).

### Why (investigation)
A 2026-07-01 investigation established, with measurement on the prod-shape eval corpus, that **graph expansion does not improve retrieval** — the edges are precise but redundant (edge-semantics audit: 72% `related_to` at cos 0.69, ~92% same-topic; graph-expanded golds pin at rank 13–28 by merit; scoring fixes "R2"/seed-score both null). The additive lever is a signal *orthogonal to embeddings* → temporal. A date-window leg was validated before building: **rescue rate ~86–100% among vanilla-misses, zero regressions across n=44**, with realistic Haiku date-parsing at 100% parse + window-hit.

## What it does
- `nous/heart/date_window.py`: `DateWindow` + regex temporal pre-gate + `DateWindowParser` (Haiku via `call_background_llm_structured`, budget-capped, TTL+size-bounded cache, **fail-open** on any error/timeout/overflow).
- `FactManager._date_window_leg`: in-window (`event_date BETWEEN`) active dated facts ranked by cosine-to-query.
- Fused into `FactManager._search` via `_rrf_merge_n` (position-based; empty/None leg = no-op).
- Wired through `run_recall_pipeline` → `heart.recall` (fact branch only), parser constructed in `main.py` reusing the shared `api_client`.
- `nous_eval/date_leg_rescue.py`: rescue-metric dev harness for the A/B gate.

## Safety
- **Land-dark / zero-regression:** flag off → parser never invoked, `date_window=None` at every recall hop, byte-identical output. Verified end-to-end.
- **Fail-open absolute:** no parse path raises into recall.
- Flag flip is gated on an A/B (rescue harness + LongMemEval temporal, **Opus generator**, no non-temporal regression) — see the design spec.

## Tests
34 feature tests pass (parser fail-open/budget/cache/TTL, SQL leg, RRF fusion + rescue on real Postgres, pipeline wiring off/on). Built via 7 TDD tasks, each per-task reviewed; final whole-branch review verdict: **READY TO MERGE**.

## Note for reviewers
Task 1's config commit also carries a small **pre-existing, out-of-feature** fix: adds `xhigh` to the `effort` Literal and normalizes `extra`→`xhigh` (prevents a `NOUS_EFFORT=extra` startup crash). Default unchanged.

Design: `docs/superpowers/specs/2026-07-01-date-window-retrieval-leg-design.md`
Plan: `docs/superpowers/plans/2026-07-01-date-window-retrieval-leg.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)