### PR TITLE
fix(eval): repair date-leg rescue harness + add --adversarial ceiling mode

### DIFF
--- a/nous_eval/date_leg_rescue.py
+++ b/nous_eval/date_leg_rescue.py
@@ -82,22 +82,42 @@ async def _sample_dated_facts(
 
 
 async def _generate_temporal_query(
-    client: Any, model: str, content: str, event_date: datetime.date
+    client: Any, model: str, content: str, event_date: datetime.date,
+    adversarial: bool = False,
 ) -> str:
-    """Ask Haiku to write a time-framed question about a fact."""
-    from nous.api.anthropic_client import create_client  # noqa: F401 (type hint only)
+    """Ask Haiku to write a time-framed question about a fact.
 
-    prompt = (
-        f"The following fact was recorded on {event_date.isoformat()}:\n\n"
-        f"{content}\n\n"
-        "Write a short question (one sentence) that a user would ask when trying "
-        "to recall this fact. The question MUST mention a specific date, month, "
-        "or time period so it has a clear temporal anchor. Do not use the word "
-        "'fact'. Reply with only the question, no preamble."
-    )
+    adversarial=False (default): a natural question (topic + date) — realistic.
+    adversarial=True: strips the topic so vanilla vector/keyword search cannot
+    find the gold from the wording, isolating the date leg's ceiling value on
+    pure-temporal queries.
+    """
+    if adversarial:
+        prompt = (
+            f"The following fact was recorded on {event_date.isoformat()}:\n\n"
+            f"{content}\n\n"
+            "Write a short question (one sentence) whose answer is this fact, but "
+            "that references ONLY the TIME PERIOD (e.g. 'in late June 2026', "
+            "'around mid-April 2026') and does NOT mention the fact's specific "
+            "topic, nouns, entities, or keywords. Phrase it so a keyword or vector "
+            "search on the question's wording would NOT surface the fact directly. "
+            "Reply with only the question, no preamble."
+        )
+    else:
+        prompt = (
+            f"The following fact was recorded on {event_date.isoformat()}:\n\n"
+            f"{content}\n\n"
+            "Write a short question (one sentence) that a user would ask when trying "
+            "to recall this fact. The question MUST mention a specific date, month, "
+            "or time period so it has a clear temporal anchor. Do not use the word "
+            "'fact'. Reply with only the question, no preamble."
+        )
     payload = {
         "model": model,
         "max_tokens": 128,
+        # The real anthropic client requires a "system" key; omitting it raised
+        # KeyError and silently degraded every query to the content-leaking fallback.
+        "system": "You write concise, time-anchored recall questions.",
         "messages": [{"role": "user", "content": prompt}],
     }
     try:
@@ -110,8 +130,9 @@ async def _generate_temporal_query(
                 return block.text.strip()
     except Exception:
         logger.warning("query generation failed for content %r", content[:40], exc_info=True)
-    # Fallback: construct a simple query from content + date
-    return f"What happened around {event_date.strftime('%B %Y')}? ({content[:60]})"
+    # Fallback: a purely time-anchored query. MUST NOT leak the fact content, or
+    # vanilla retrieval finds the gold trivially and rescue headroom collapses.
+    return f"What happened in {event_date.strftime('%B %Y')}?"
 
 
 async def main() -> None:
@@ -119,6 +140,9 @@ async def main() -> None:
     parser = argparse.ArgumentParser(description="Date-leg rescue-metric harness (F075 L3)")
     parser.add_argument("--sample", type=int, default=20, help="Dated facts to sample")
     parser.add_argument("--top-k", type=int, default=10, help="Retrieval top-K for comparison")
+    parser.add_argument("--adversarial", action="store_true",
+                        help="Strip the fact's topic from generated queries so vanilla "
+                             "misses — measures the date leg's ceiling on pure-temporal queries")
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.WARNING)
@@ -194,6 +218,7 @@ async def main() -> None:
                     else "claude-haiku-4-5-20251001",
                     content,
                     event_date,
+                    adversarial=args.adversarial,
                 )
 
                 # Vanilla run (date_leg_enabled=False — leg-free baseline)

--- a/tests/eval/test_date_leg_rescue.py
+++ b/tests/eval/test_date_leg_rescue.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import datetime
+from types import SimpleNamespace
+
 import pytest
 
 pytestmark = pytest.mark.eval
 
-from nous_eval.date_leg_rescue import rrf_fuse
+from nous_eval.date_leg_rescue import _generate_temporal_query, rrf_fuse
 
 
 def test_rrf_fuse_is_position_based():
@@ -15,3 +18,37 @@ def test_rrf_fuse_is_position_based():
     leg = ["gold", "x"]
     fused = rrf_fuse(vanilla, leg)
     assert fused.index("gold") < 2  # lifted into the head
+
+
+class _CaptureClient:
+    """Fake anthropic client that records the payload and returns a text block."""
+    def __init__(self, raises: bool = False):
+        self._raises = raises
+        self.payload = None
+
+    async def call(self, payload):
+        self.payload = payload
+        if self._raises:
+            raise RuntimeError("boom")
+        return SimpleNamespace(content=[{"type": "text", "text": "What happened in June 2026?"}])
+
+
+@pytest.mark.asyncio
+async def test_generate_temporal_query_payload_has_system_key():
+    # Regression: the real anthropic client requires payload["system"]; omitting it
+    # raised KeyError and silently degraded every query to the content-leaking fallback.
+    client = _CaptureClient()
+    q = await _generate_temporal_query(client, "m", "some fact about calibration", datetime.date(2026, 6, 1))
+    assert "system" in client.payload and client.payload["system"], "payload must carry a non-empty system"
+    assert q == "What happened in June 2026?"
+
+
+@pytest.mark.asyncio
+async def test_fallback_query_does_not_leak_fact_content():
+    # Regression: on gen failure the fallback MUST NOT echo the fact content, or vanilla
+    # finds the gold trivially and rescue headroom collapses.
+    client = _CaptureClient(raises=True)
+    content = "SECRETKEYWORD calibration Brier 0.192"
+    q = await _generate_temporal_query(client, "m", content, datetime.date(2026, 6, 1))
+    assert "SECRETKEYWORD" not in q and "calibration" not in q
+    assert "2026" in q


### PR DESCRIPTION
## Summary
The F075 L3 date-leg rescue harness (`nous_eval/date_leg_rescue.py`) was producing **invalid A/B numbers** and is fixed here.

Two bugs:
1. **`KeyError: 'system'`** — `_generate_temporal_query` built an Anthropic payload with no `system` key. The real client requires it, so every query-gen call raised, and the `except` fell back to a query that **leaked the fact's content** (`({content[:60]})`). Vanilla then found every gold → a fake *0-rescue-headroom* result. The `_FakeClient` in tests never exercised the real payload shape, so this slipped through.
2. Fix: add a non-empty `system` prompt; make the fallback **purely time-anchored** (no content echo).

Also adds **`--adversarial`** mode: strips the fact's topic from generated queries so vanilla misses, isolating the date leg's **ceiling** on pure-temporal queries.

## Measured results (nous_eval_prod, n=50)
| Query type | vanilla top-10 | fused top-10 | rescued | lost |
|---|---|---|---|---|
| Realistic (topic + date) | 50/50 | 50/50 | 0 | 0 |
| Adversarial ceiling (topic stripped) | 23/50 | 32/50 | 10 | 1 |

**Read:** the date leg is neutral on realistic (topic-bearing) temporal queries and a bounded win (+18pp, with 1 regression) only on pure-temporal ones. Does **not** yet justify flipping `NOUS_DATE_LEG_ENABLED=true`; the leg stays land-dark.

## Tests
`tests/eval/test_date_leg_rescue.py`: + regression tests for the system-key payload and the non-leaking fallback (3 passing). Dev-only (`nous_eval/`), no prod code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)