### PR TITLE
feat(retrieval): R2 hybrid chunk search — FTS leg over search_tsv (land-dark)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -521,6 +521,7 @@ DB connection vars are **unprefixed** (shared with docker-compose). All others u
 | `NOUS_EPISODE_CHUNK_SIZE` | `600` | F067 chunk size in chars (sliding window). |
 | `NOUS_EPISODE_CHUNK_OVERLAP` | `80` | F067 chunk overlap in chars to avoid splitting key tokens. |
 | `NOUS_EPISODE_CHUNK_RECALL_LIMIT` | `10` | F067 max chunks returned by the chunk-recall leg. |
+| `NOUS_CHUNK_HYBRID_SEARCH_ENABLED` | `false` | R2 (2026-07-02 MAB audit): RRF-fuse an FTS leg (the migration-050 `search_tsv` GIN index, previously unconsumed) with the vector leg in the F067 chunk-recall stage via the shared `heart.search.hybrid_search` helper. Also moves chunk scores from raw cosine onto the 1/k-normalized RRF [0,1] scale the coherent heart legs use (F080 deviant-leg renorm). Probe on the MAB CR corpus: gold-chunk in top-30 goes 1/5 → 4/5 (top-10: 0/5 → 1/5); compose with `NOUS_EPISODE_CHUNK_RECALL_LIMIT=30`. **Land-dark; flip after the retrieval A/B gate.** |
 | `NOUS_EPISODE_CHUNK_MIN_TRANSCRIPT_CHARS` | `50` | F067 minimum transcript length to chunk (shorter transcripts skip). |
 | `NOUS_RECALL_INCLUDE_PARENT_EPISODES` | `false` | F067 Phase 2. When true, `recall_deep` appends up to `recall_max_parent_episodes` parent episode summaries to its text output. **Validated on per-question isolation only; opt-in for prod.** |
 | `NOUS_RECALL_MAX_PARENT_EPISODES` | `2` | F067 cap on parent episode summaries appended (deduplicated). |

--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -423,6 +423,7 @@ async def _run_stages(
                 limit=min(
                     settings.episode_chunk_recall_limit, limit * 2
                 ),
+                settings=settings,
             )
         except Exception:
             # Match the sibling stages' pattern (spreading_activation,
@@ -989,19 +990,60 @@ async def _search_episode_chunks(
     query: str,
     agent_id: str,
     limit: int,
+    settings: "Settings | None" = None,
 ) -> list[tuple[UUID, str, float]]:
-    """F067: vector-similarity search over heart.episode_chunks.
+    """F067: search over heart.episode_chunks.
 
-    Returns ``[(id, content, similarity_score)]`` ordered by descending
-    similarity. Returns ``[]`` only when no embedder is wired (no way to
-    embed the query) or the query embeds to an empty vector. All other
-    failure modes — embed timeout, DB error, pgvector cast failure — RAISE
-    so the caller's try/except surfaces them via ``acc.stage_errors``
-    AND a WARN log. Silent fall-through to ``[]`` on embedder failure
-    would masquerade as "no matches" and hide real outages.
+    Default (``chunk_hybrid_search_enabled`` off): vector-only cosine search,
+    byte-identical to the original F067 leg; returns ``[]`` when no embedder
+    is wired or the query embeds to an empty vector.
+
+    R2 (flag on): RRF-fused vector + FTS legs via the shared
+    ``heart.search.hybrid_search`` helper (the FTS leg consumes the
+    ``search_tsv`` GIN index migration 050 provisioned for exactly this).
+    Scores are then on the 1/k-normalized RRF [0,1] scale the coherent heart
+    legs emit — not raw cosine (F080 deviant-leg renorm). With no embedder,
+    the hybrid path degrades to keyword-only instead of ``[]``.
+
+    Returns ``[(id, content, score, episode_id)]`` ordered by descending
+    score. All failure modes other than the missing-embedder cases — embed
+    timeout, DB error, pgvector cast failure — RAISE so the caller's
+    try/except surfaces them via ``acc.stage_errors`` AND a WARN log. Silent
+    fall-through to ``[]`` on embedder failure would masquerade as "no
+    matches" and hide real outages.
     """
     from sqlalchemy import text as sa_text
     embedder = getattr(heart, "_embeddings", None)
+
+    if getattr(settings, "chunk_hybrid_search_enabled", False):
+        from nous.heart import search as heart_search
+
+        query_vec = (await embedder.embed(query)) if embedder is not None else None
+        query_vec = query_vec or None  # empty embed → keyword-only fallback
+        async with heart.db.session() as s:
+            ranked = await heart_search.hybrid_search(
+                s,
+                "heart.episode_chunks",
+                query_vec,
+                query,
+                agent_id,
+                limit=limit,
+                active_filter=False,  # chunks have no active column
+            )
+            if not ranked:
+                return []
+            ids = [cid for cid, _ in ranked]
+            rows = (await s.execute(sa_text(
+                "SELECT id, content, episode_id FROM heart.episode_chunks "
+                "WHERE id = ANY(:ids)"
+            ), {"ids": ids})).all()
+        by_id = {r[0]: (r[1], r[2]) for r in rows}
+        return [
+            (cid, by_id[cid][0], float(score), by_id[cid][1])
+            for cid, score in ranked
+            if cid in by_id
+        ]
+
     if embedder is None:
         return []
     query_vec = await embedder.embed(query)

--- a/nous/config.py
+++ b/nous/config.py
@@ -1383,6 +1383,20 @@ class Settings(BaseSettings):
         default=10,
         description="F067 max chunks returned by the new chunk-recall leg before RRF merge.",
     )
+    chunk_hybrid_search_enabled: bool = Field(
+        default=False,
+        description=(
+            "R2 (2026-07-02 MAB audit): RRF-fuse an FTS leg (search_tsv GIN, "
+            "provisioned by migration 050 but unconsumed) with the vector leg "
+            "in the F067 chunk-recall stage, via the shared "
+            "heart.search.hybrid_search helper. Also moves chunk scores from "
+            "raw cosine onto the 1/k-normalized RRF [0,1] scale the coherent "
+            "heart legs use (F080 deviant-leg renorm). Vector-only chunk "
+            "search left 4/5 CR gold chunks at ranks 16-50; the one top-10 "
+            "hit was a token-only match — exactly what the FTS leg "
+            "generalizes. Land dark; flip after the retrieval A/B gate."
+        ),
+    )
     episode_chunk_min_transcript_chars: int = Field(
         default=50,
         description="F067 minimum transcript length to chunk (shorter transcripts are skipped).",

--- a/scripts/diag/probe_r2_gold_ranks.py
+++ b/scripts/diag/probe_r2_gold_ranks.py
@@ -1,0 +1,112 @@
+"""R2 A/B probe: gold-chunk ranks, vector-only vs hybrid chunk search.
+
+Read-only against the MAB eval corpus (nous_mab, agent
+mab-eval-prod_memory-8f18622a, 528 chunks). For each of the 5 CR probe
+questions from the 2026-07-02 root-cause doc, ranks all chunks with the
+production `_search_episode_chunks` in both flag states and reports the
+best gold-chunk rank per arm.
+
+Doc baseline (vector-only, text-embedding-3-large@1536): golds at ranks
+40 / 8 / 21 / 50 / 16 — 4/5 outside the top-10 recall limit.
+
+Usage (from repo root; OPENAI_API_KEY via .env):
+    uv run python scripts/diag/probe_r2_gold_ranks.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from sqlalchemy import text
+
+AGENT_ID = "mab-eval-prod_memory-8f18622a"
+EMBED_MODEL = "text-embedding-3-large"  # matches the stored corpus vectors
+EMBED_DIMS = 1536
+RECALL_LIMIT = 10  # prod default episode_chunk_recall_limit
+
+# (question, [ILIKE conditions identifying the gold chunk])
+PROBES = [
+    ("What type of music does Aki Takase play?", ["%carnatic%"]),
+    ("What is the country of citizenship of David Farragut?", ["%farragut%", "%denmark%"]),
+    ("Which country was Shaman King created in?", ["%shaman king%", "%greece%"]),
+    ("Who is the author of Hard Times?", ["%hard times%", "%luther king%"]),
+    ("Which religion is Henry of Blois affiliated with?", ["%blois%", "%church of scotland%"]),
+]
+
+
+async def main() -> None:
+    from nous.api.retrieval_pipeline import _search_episode_chunks
+    from nous.brain.embeddings import EmbeddingProvider
+    from nous.config import Settings
+    from nous.storage.database import Database
+
+    settings = Settings().model_copy(update={
+        "db_host": "127.0.0.1", "db_port": 5433, "db_name": "nous_mab",
+        "db_user": "nous", "db_password": "nous_eval",
+    })
+    db = Database(settings)
+    await db.connect()
+    embedder = EmbeddingProvider(
+        api_key=settings.openai_api_key, model=EMBED_MODEL, dimensions=EMBED_DIMS,
+    )
+    heart = SimpleNamespace(db=db, _embeddings=embedder, agent_id=AGENT_ID)
+
+    try:
+        async with db.session() as s:
+            total = (await s.execute(text(
+                "SELECT count(*) FROM heart.episode_chunks WHERE agent_id = :a"
+            ), {"a": AGENT_ID})).scalar()
+        print(f"corpus: {total} chunks, agent={AGENT_ID}")
+
+        report = []
+        for question, conds in PROBES:
+            where = " AND ".join("content ILIKE :c%d" % i for i in range(len(conds)))
+            params = {("c%d" % i): c for i, c in enumerate(conds)}
+            params["a"] = AGENT_ID
+            async with db.session() as s:
+                gold_ids = {r[0] for r in (await s.execute(text(
+                    f"SELECT id FROM heart.episode_chunks WHERE agent_id = :a AND {where}"
+                ), params)).all()}
+
+            row = {"question": question, "golds": len(gold_ids)}
+            for arm, flag in (("vector_only", False), ("hybrid", True)):
+                results = await _search_episode_chunks(
+                    heart=heart, query=question, agent_id=AGENT_ID, limit=total,
+                    settings=SimpleNamespace(chunk_hybrid_search_enabled=flag),
+                )
+                ranks = [i + 1 for i, r in enumerate(results) if r[0] in gold_ids]
+                best = ranks[0] if ranks else None
+                row[arm] = {
+                    "gold_rank": best,
+                    "in_top_%d" % RECALL_LIMIT: bool(best and best <= RECALL_LIMIT),
+                    # R1 composition: the proposed episode_chunk_recall_limit=30
+                    "in_top_30": bool(best and best <= 30),
+                }
+            report.append(row)
+            print(f"  {question[:55]:<55} gold@ vector={row['vector_only']['gold_rank']} "
+                  f"hybrid={row['hybrid']['gold_rank']}")
+
+        n = len(report)
+        v_hits = sum(1 for r in report if r["vector_only"]["in_top_%d" % RECALL_LIMIT])
+        h_hits = sum(1 for r in report if r["hybrid"]["in_top_%d" % RECALL_LIMIT])
+        v30 = sum(1 for r in report if r["vector_only"]["in_top_30"])
+        h30 = sum(1 for r in report if r["hybrid"]["in_top_30"])
+        print("\n=== SUMMARY ===")
+        print(json.dumps({
+            "recall_limit": RECALL_LIMIT,
+            "gold_in_top_k": {"vector_only": f"{v_hits}/{n}", "hybrid": f"{h_hits}/{n}"},
+            "gold_in_top_30": {"vector_only": f"{v30}/{n}", "hybrid": f"{h30}/{n}"},
+            "detail": report,
+        }, indent=2))
+    finally:
+        await db.disconnect()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/integration/test_r2_chunk_hybrid_e2e.py
+++ b/tests/integration/test_r2_chunk_hybrid_e2e.py
@@ -1,0 +1,125 @@
+"""R2 integration test: hybrid chunk search against real Postgres.
+
+Verifies the actual SQL (FTS leg over the migration-050 search_tsv GIN
+index, `= ANY(:ids)` content fetch) that the mocked unit tests in
+tests/test_r2_chunk_hybrid.py cannot exercise.
+
+Discrimination setup: the gold chunk contains a rare token but has NO
+embedding — invisible to the vector-only leg (``embedding IS NOT NULL``),
+findable only via FTS. Mirrors the MAB CR failure shape where the gold
+token was present verbatim but cosine rank was 16-50.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+
+def _eval_db_reachable() -> bool:
+    import socket
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.settimeout(1.0)
+            return s.connect_ex(("127.0.0.1", 5433)) == 0
+    except OSError:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _eval_db_reachable(),
+    reason="nous-eval-scratch container not reachable on 127.0.0.1:5433",
+)
+
+
+@pytest.fixture
+async def eval_db():
+    for k, v in {
+        "DB_HOST": "127.0.0.1", "DB_PORT": "5433", "DB_NAME": "nous_eval_scratch",
+        "DB_USER": "nous", "DB_PASSWORD": "nous_eval",
+        "NOUS_HEARTBEAT_ENABLED": "false", "NOUS_SUBTASK_ENABLED": "false",
+        "NOUS_SCHEDULE_ENABLED": "false", "NOUS_SLEEP_ENABLED": "false",
+        "NOUS_EVENT_BUS_ENABLED": "false",
+        "NOUS_ACTIONABILITY_BACKFILL_ON_STARTUP": "false",
+        "NOUS_TELEGRAM_BOT_TOKEN": "",
+    }.items():
+        os.environ.setdefault(k, v)
+
+    from nous.config import Settings
+    from nous.storage.database import Database
+
+    db = Database(Settings())
+    await db.connect()
+    yield db
+    await db.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_hybrid_finds_keyword_only_gold_chunk(eval_db):
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    from sqlalchemy import text
+
+    from nous.api.retrieval_pipeline import _search_episode_chunks
+
+    agent_id = f"r2-test-{uuid.uuid4().hex[:8]}"
+    episode_id = uuid.uuid4()
+    gold_id = uuid.uuid4()      # rare token, NO embedding → FTS-only
+    decoy_id = uuid.uuid4()     # embedded, no token
+
+    vec = "[" + ",".join(["0.01"] * 1536) + "]"
+
+    async with eval_db.session() as s:
+        await s.execute(text(
+            "INSERT INTO heart.episodes (id, agent_id, summary) "
+            "VALUES (:id, :a, 'r2 test episode')"
+        ), {"id": episode_id, "a": agent_id})
+        await s.execute(text(
+            "INSERT INTO heart.episode_chunks (id, agent_id, episode_id, chunk_index, content) "
+            "VALUES (:id, :a, :ep, 0, 'The zanzibarite kumquat ledger was moved to Reykjavik.')"
+        ), {"id": gold_id, "a": agent_id, "ep": episode_id})
+        await s.execute(text(
+            "INSERT INTO heart.episode_chunks (id, agent_id, episode_id, chunk_index, content, embedding) "
+            "VALUES (:id, :a, :ep, 1, 'Unrelated small talk about the weather.', CAST(:v AS vector))"
+        ), {"id": decoy_id, "a": agent_id, "ep": episode_id, "v": vec})
+        await s.commit()
+
+    embedder = MagicMock()
+    embedder.embed = AsyncMock(return_value=[0.01] * 1536)
+    heart = SimpleNamespace(db=eval_db, _embeddings=embedder, agent_id=agent_id)
+
+    try:
+        off = await _search_episode_chunks(
+            heart=heart, query="zanzibarite kumquat ledger", agent_id=agent_id,
+            limit=10, settings=SimpleNamespace(chunk_hybrid_search_enabled=False),
+        )
+        on = await _search_episode_chunks(
+            heart=heart, query="zanzibarite kumquat ledger", agent_id=agent_id,
+            limit=10, settings=SimpleNamespace(chunk_hybrid_search_enabled=True),
+        )
+    finally:
+        async with eval_db.session() as s:
+            await s.execute(text(
+                "DELETE FROM heart.episodes WHERE id = :id"  # chunks cascade
+            ), {"id": episode_id})
+            await s.commit()
+
+    # Vector-only: gold chunk (no embedding) is invisible
+    off_ids = [r[0] for r in off]
+    assert gold_id not in off_ids
+    assert decoy_id in off_ids
+
+    # Hybrid: FTS leg surfaces the gold chunk. (Ordering vs the decoy is
+    # legitimately vector_weight-dependent — a perfect-cosine decoy MAY
+    # outrank a keyword-only gold at the default 0.7 vector weight; the R2
+    # win is that the gold is retrievable at all.)
+    on_ids = [r[0] for r in on]
+    assert gold_id in on_ids
+
+    # 4-tuple shape with episode_id, scores on the normalized RRF [0,1] scale
+    gold_row = next(r for r in on if r[0] == gold_id)
+    assert gold_row[1].startswith("The zanzibarite")
+    assert 0.0 < gold_row[2] <= 1.0
+    assert gold_row[3] == episode_id

--- a/tests/test_r2_chunk_hybrid.py
+++ b/tests/test_r2_chunk_hybrid.py
@@ -1,0 +1,159 @@
+"""R2 (2026-07-02 MAB audit): hybrid chunk retrieval — unit tests.
+
+The F067 chunk leg is vector-only (`_search_episode_chunks`): a chunk
+literally containing a rare gold token gets no lexical boost, and 4/5 CR
+gold chunks ranked 16-50 by cosine (recall limit 10). Migration 050 already
+provisioned `search_tsv` + GIN on heart.episode_chunks "for keyword
+fallback / hybrid search" — with zero consumers until now.
+
+Flag `NOUS_CHUNK_HYBRID_SEARCH_ENABLED` (default OFF, land-dark): when on,
+the chunk leg RRF-fuses the vector and FTS legs via the shared
+`heart.search.hybrid_search` helper — which also moves chunk scores from
+raw cosine onto the same 1/k-normalized RRF [0,1] scale the coherent heart
+legs use (F080: only types sharing the SAME normalizer are comparable).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import contextlib
+
+import pytest
+
+from nous.api.retrieval_pipeline import _search_episode_chunks
+
+
+def _heart_shim(embedder, rows_by_query=None):
+    """Minimal heart stand-in: .db.session() ctx + ._embeddings + .agent_id."""
+    session = AsyncMock()
+    if rows_by_query is not None:
+        async def _execute(sql, params=None):
+            result = MagicMock()
+            result.all = MagicMock(return_value=rows_by_query(str(sql), params))
+            return result
+        session.execute = AsyncMock(side_effect=_execute)
+
+    db = MagicMock()
+
+    @contextlib.asynccontextmanager
+    async def _session_ctx():
+        yield session
+
+    db.session = _session_ctx
+    return SimpleNamespace(db=db, _embeddings=embedder, agent_id="test-agent"), session
+
+
+def _fake_embedder(vec=None):
+    e = MagicMock()
+    e.embed = AsyncMock(return_value=vec if vec is not None else [0.1] * 4)
+    return e
+
+
+def test_flag_defaults_off():
+    from nous.config import Settings
+
+    assert Settings.model_fields["chunk_hybrid_search_enabled"].default is False
+
+
+class TestFlagOff:
+    @pytest.mark.asyncio
+    async def test_vector_only_sql_unchanged(self):
+        """Flag OFF (or settings omitted) keeps the legacy vector-only query."""
+        captured = []
+
+        def rows(sql, params):
+            captured.append(sql)
+            return []
+
+        heart, _ = _heart_shim(_fake_embedder(), rows)
+        out = await _search_episode_chunks(
+            heart=heart, query="q", agent_id="test-agent", limit=10,
+            settings=SimpleNamespace(chunk_hybrid_search_enabled=False),
+        )
+        assert out == []
+        assert len(captured) == 1
+        assert "ORDER BY embedding" in captured[0]
+        assert "ts_rank" not in captured[0]
+
+    @pytest.mark.asyncio
+    async def test_no_embedder_returns_empty(self):
+        heart, _ = _heart_shim(None)
+        out = await _search_episode_chunks(
+            heart=heart, query="q", agent_id="test-agent", limit=10,
+            settings=SimpleNamespace(chunk_hybrid_search_enabled=False),
+        )
+        assert out == []
+
+
+class TestFlagOn:
+    @pytest.mark.asyncio
+    async def test_hybrid_search_called_and_rank_order_preserved(self, monkeypatch):
+        id_a, id_b = uuid4(), uuid4()
+        ep_a, ep_b = uuid4(), uuid4()
+        calls = {}
+
+        async def fake_hybrid(session, table, embedding, query_text, agent_id,
+                              limit=10, active_filter=True, **kw):
+            calls.update(table=table, embedding=embedding, query_text=query_text,
+                         agent_id=agent_id, limit=limit, active_filter=active_filter)
+            return [(id_b, 0.9), (id_a, 0.4)]  # b outranks a
+
+        monkeypatch.setattr("nous.heart.search.hybrid_search", fake_hybrid)
+
+        def rows(sql, params):
+            # content fetch — return in arbitrary (non-rank) order
+            return [(id_a, "content-a", ep_a), (id_b, "content-b", ep_b)]
+
+        heart, _ = _heart_shim(_fake_embedder([0.5] * 4), rows)
+        out = await _search_episode_chunks(
+            heart=heart, query="rare token query", agent_id="test-agent", limit=7,
+            settings=SimpleNamespace(chunk_hybrid_search_enabled=True),
+        )
+        assert calls["table"] == "heart.episode_chunks"
+        assert calls["active_filter"] is False
+        assert calls["agent_id"] == "test-agent"
+        assert calls["limit"] == 7
+        assert calls["embedding"] == [0.5] * 4
+        # 4-tuples in hybrid rank order, RRF scores passed through
+        assert out == [
+            (id_b, "content-b", 0.9, ep_b),
+            (id_a, "content-a", 0.4, ep_a),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_no_embedder_falls_back_to_keyword_only(self, monkeypatch):
+        """Flag ON without an embedder passes embedding=None → FTS-only leg
+        (vector-only path would return [])."""
+        cid, eid = uuid4(), uuid4()
+        seen = {}
+
+        async def fake_hybrid(session, table, embedding, query_text, agent_id,
+                              limit=10, active_filter=True, **kw):
+            seen["embedding"] = embedding
+            return [(cid, 0.7)]
+
+        monkeypatch.setattr("nous.heart.search.hybrid_search", fake_hybrid)
+
+        heart, _ = _heart_shim(None, lambda sql, params: [(cid, "kw-content", eid)])
+        out = await _search_episode_chunks(
+            heart=heart, query="rare gold token", agent_id="test-agent", limit=10,
+            settings=SimpleNamespace(chunk_hybrid_search_enabled=True),
+        )
+        assert seen["embedding"] is None
+        assert out == [(cid, "kw-content", 0.7, eid)]
+
+    @pytest.mark.asyncio
+    async def test_empty_hybrid_result_returns_empty(self, monkeypatch):
+        async def fake_hybrid(*a, **kw):
+            return []
+
+        monkeypatch.setattr("nous.heart.search.hybrid_search", fake_hybrid)
+        heart, session = _heart_shim(_fake_embedder())
+        out = await _search_episode_chunks(
+            heart=heart, query="q", agent_id="test-agent", limit=10,
+            settings=SimpleNamespace(chunk_hybrid_search_enabled=True),
+        )
+        assert out == []


### PR DESCRIPTION
## Problem (R2, 2026-07-02 MAB CR audit)

The F067 chunk-recall leg (`retrieval_pipeline.py::_search_episode_chunks`) is **vector-only** — a chunk literally containing a rare gold token gets no lexical boost. On the MAB Conflict-Resolution corpus, 4/5 gold chunks ranked 16–50 by cosine against a top-10 recall limit. Meanwhile migration 050 provisioned `search_tsv` (GENERATED tsvector) + a GIN index on `heart.episode_chunks` explicitly *"for keyword fallback / hybrid search"* — with **zero consumers**. This PR wires it.

## Change — `NOUS_CHUNK_HYBRID_SEARCH_ENABLED` (default OFF, land-dark)

When on, `_search_episode_chunks` RRF-fuses the vector and FTS legs via the shared, audited `heart.search.hybrid_search` helper (`active_filter=False` — chunks have no `active` column), then batch-fetches `content`/`episode_id` preserving fusion order. Two coupled effects, both intended:

1. **Keyword-bearing chunks become retrievable** (the R2 fix proper).
2. **Chunk scores move from raw cosine onto the 1/k-normalized RRF [0,1] scale** the coherent heart legs emit — this is the F080 "surgical deviant-leg renorm" for the chunk leg (per the reviewed F080 decision: only types sharing the SAME normalizer are comparable; blanket renorm was advisor-rejected, per-deviant-leg fixes are the sanctioned path).

Bonus: with no embedder wired, the hybrid path degrades to keyword-only instead of returning `[]`. **Flag OFF is byte-identical to the original vector-only leg.**

## Evidence — `scripts/diag/probe_r2_gold_ranks.py`

Read-only probe against the actual `nous_mab` corpus (528 chunks, `text-embedding-3-large@1536` matching the stored vectors), the 5 CR probe questions from the root-cause doc, production `_search_episode_chunks` in both flag states:

| Question | gold rank, vector-only | gold rank, hybrid |
|---|---|---|
| Aki Takase → Carnatic | 40 | **18** |
| Farragut → Denmark | 105 | 105 |
| Shaman King → Greece | 72 | **16** |
| Hard Times → MLK | 84 | **17** |
| Henry of Blois → Church of Scotland | 27 | **5** |

- Gold in top-10 (prod `episode_chunk_recall_limit=10`): 0/5 → **1/5**
- Gold in top-30 (composes with the R1 proposal `episode_chunk_recall_limit=30`, a pure config flip): 1/5 → **4/5**
- The flat question is `plainto_tsquery` AND-semantics: its gold chunk contains none of the query's other terms ("citizenship", "country"). Known limitation, not a regression.

## Flip gate

Stays dark until the retrieval A/B (post-S2 CR re-baseline — S2 landed in #552) confirms the win on the full question set. Recommended eval arm: `NOUS_CHUNK_HYBRID_SEARCH_ENABLED=true` × `NOUS_EPISODE_CHUNK_RECALL_LIMIT=30`.

## Tests

- 6 mocked unit tests: flag-off byte-identity (SQL shape), hybrid call contract (`table`, `active_filter=False`, limit threading), rank-order preservation through the content fetch, keyword-only fallback without embedder, empty-result path, Settings default OFF.
- 1 integration test against real Postgres (`--integration`, eval-scratch DB): a keyword-only gold chunk (rare token, NULL embedding) is invisible to the vector leg and retrieved by the hybrid leg; validates the real FTS SQL + `= ANY(:ids)` fetch + cascade cleanup.
- Full suite: zero new failures vs baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMGSu4XRAEDffkHqnCR8CQ