### PR TITLE
fix(embeddings): sub-batch embed_batch under OpenAI per-request caps

### DIFF
--- a/nous/brain/embeddings.py
+++ b/nous/brain/embeddings.py
@@ -33,6 +33,16 @@ _MAX_RETRIES = 3
 _RETRY_BACKOFF = (0.5, 1.0, 2.0)
 _DEFAULT_CACHE_SIZE = 1024
 
+# OpenAI embeddings per-request hard limits (API facts, not tuning knobs).
+# 2048 = max inputs per request. The char budget proxies the ~300k-token
+# per-request cap without a tokenizer dependency: 250k chars stays under
+# it even at the 1-token-per-char worst case (CJK); typical English text
+# (~4 chars/token) sits far below. A large transcript (~2000 chunks x
+# ~600 chars ~ 300k tokens) previously shipped as ONE request → HTTP 400
+# → callers like the F067 chunk path aborted and stored nothing.
+_MAX_BATCH_ITEMS = 2048
+_MAX_BATCH_CHARS = 250_000
+
 
 class EmbeddingProvider:
     """Async embedding generation using the OpenAI embeddings API."""
@@ -163,8 +173,12 @@ class EmbeddingProvider:
         """Generate embeddings for multiple texts.
 
         Cache-aware: only texts missing from the LRU are sent to the API
-        (one call for all misses, duplicates collapsed); results are
-        reassembled in input order.
+        (duplicates collapsed); results are reassembled in input order.
+        Misses are split into sub-batches respecting the OpenAI
+        per-request limits (_MAX_BATCH_ITEMS inputs, _MAX_BATCH_CHARS
+        chars) and sent sequentially; each sub-batch is cached as it
+        succeeds, so a mid-run failure doesn't re-pay completed requests
+        when the caller retries.
         """
         if not texts:
             return []
@@ -189,24 +203,52 @@ class EmbeddingProvider:
                 miss_texts.append(t)
 
         if miss_texts:
-            response = await self._post_with_retry({
-                "model": self.model,
-                "input": miss_texts,
-                "dimensions": self.dimensions,
-            })
-            data = response.json()["data"]
-            vectors = [item["embedding"] for item in sorted(data, key=lambda x: x["index"])]
-            # Guard BEFORE caching: a short/skipped-index response would
-            # misalign the zip and poison the LRU with wrong vectors that
-            # then silently serve dedup/recall until eviction (review P2).
-            if len(vectors) != len(miss_texts):
-                raise RuntimeError(
-                    f"embeddings API returned {len(vectors)} vectors "
-                    f"for {len(miss_texts)} inputs"
+            fetched: dict[str, list[float]] = {}
+            start = 0
+            n_batches = 0
+            while start < len(miss_texts):
+                # Greedy sub-batch: extend while both per-request limits
+                # hold. A single text over the char budget still ships as
+                # a batch of one (end starts past it) rather than looping.
+                end = start + 1
+                batch_chars = len(miss_texts[start])
+                while (
+                    end < len(miss_texts)
+                    and end - start < _MAX_BATCH_ITEMS
+                    and batch_chars + len(miss_texts[end]) <= _MAX_BATCH_CHARS
+                ):
+                    batch_chars += len(miss_texts[end])
+                    end += 1
+                sub_texts = miss_texts[start:end]
+                n_batches += 1
+
+                response = await self._post_with_retry({
+                    "model": self.model,
+                    "input": sub_texts,
+                    "dimensions": self.dimensions,
+                })
+                data = response.json()["data"]
+                vectors = [
+                    item["embedding"] for item in sorted(data, key=lambda x: x["index"])
+                ]
+                # Guard BEFORE caching: a short/skipped-index response would
+                # misalign the zip and poison the LRU with wrong vectors that
+                # then silently serve dedup/recall until eviction (review P2).
+                if len(vectors) != len(sub_texts):
+                    raise RuntimeError(
+                        f"embeddings API returned {len(vectors)} vectors "
+                        f"for {len(sub_texts)} inputs"
+                    )
+                for k, v in zip(miss_keys[start:end], vectors):
+                    fetched[k] = v
+                    self._cache_put(k, v)
+                start = end
+
+            if n_batches > 1:
+                logger.info(
+                    "embed_batch: %d texts split into %d sub-batches",
+                    len(miss_texts), n_batches,
                 )
-            fetched = dict(zip(miss_keys, vectors))
-            for k, v in fetched.items():
-                self._cache_put(k, v)
             out = [v if v is not None else fetched[k] for k, v in zip(keys, out)]
 
         return out  # type: ignore[return-value]

--- a/nous/brain/embeddings.py
+++ b/nous/brain/embeddings.py
@@ -34,14 +34,16 @@ _RETRY_BACKOFF = (0.5, 1.0, 2.0)
 _DEFAULT_CACHE_SIZE = 1024
 
 # OpenAI embeddings per-request hard limits (API facts, not tuning knobs).
-# 2048 = max inputs per request. The char budget proxies the ~300k-token
-# per-request cap without a tokenizer dependency: 250k chars stays under
-# it even at the 1-token-per-char worst case (CJK); typical English text
-# (~4 chars/token) sits far below. A large transcript (~2000 chunks x
-# ~600 chars ~ 300k tokens) previously shipped as ONE request → HTTP 400
-# → callers like the F067 chunk path aborted and stored nothing.
+# 2048 = max inputs per request. The byte budget bounds the ~300k-token
+# per-request cap without a tokenizer dependency: byte-level BPE maps
+# every token to a non-empty UTF-8 byte sequence, so tokens <= utf8
+# bytes — a hard invariant, unlike char counts (one emoji char can be
+# 3+ tokens; codex P2 on PR #554). Typical English text (~4 bytes/token)
+# sits far below. A large transcript (~2000 chunks x ~600 chars ~ 300k
+# tokens) previously shipped as ONE request → HTTP 400 → callers like
+# the F067 chunk path aborted and stored nothing.
 _MAX_BATCH_ITEMS = 2048
-_MAX_BATCH_CHARS = 250_000
+_MAX_BATCH_BYTES = 250_000
 
 
 class EmbeddingProvider:
@@ -175,8 +177,8 @@ class EmbeddingProvider:
         Cache-aware: only texts missing from the LRU are sent to the API
         (duplicates collapsed); results are reassembled in input order.
         Misses are split into sub-batches respecting the OpenAI
-        per-request limits (_MAX_BATCH_ITEMS inputs, _MAX_BATCH_CHARS
-        chars) and sent sequentially; each sub-batch is cached as it
+        per-request limits (_MAX_BATCH_ITEMS inputs, _MAX_BATCH_BYTES
+        UTF-8 bytes) and sent sequentially; each sub-batch is cached as it
         succeeds, so a mid-run failure doesn't re-pay completed requests
         when the caller retries.
         """
@@ -203,21 +205,24 @@ class EmbeddingProvider:
                 miss_texts.append(t)
 
         if miss_texts:
+            # UTF-8 byte lengths, not char counts: tokens <= utf8 bytes is
+            # the invariant that makes the budget a hard token bound.
+            byte_lens = [len(t.encode("utf-8", "replace")) for t in miss_texts]
             fetched: dict[str, list[float]] = {}
             start = 0
             n_batches = 0
             while start < len(miss_texts):
                 # Greedy sub-batch: extend while both per-request limits
-                # hold. A single text over the char budget still ships as
+                # hold. A single text over the byte budget still ships as
                 # a batch of one (end starts past it) rather than looping.
                 end = start + 1
-                batch_chars = len(miss_texts[start])
+                batch_bytes = byte_lens[start]
                 while (
                     end < len(miss_texts)
                     and end - start < _MAX_BATCH_ITEMS
-                    and batch_chars + len(miss_texts[end]) <= _MAX_BATCH_CHARS
+                    and batch_bytes + byte_lens[end] <= _MAX_BATCH_BYTES
                 ):
-                    batch_chars += len(miss_texts[end])
+                    batch_bytes += byte_lens[end]
                     end += 1
                 sub_texts = miss_texts[start:end]
                 n_batches += 1

--- a/tests/test_embed_batch_sub_batching.py
+++ b/tests/test_embed_batch_sub_batching.py
@@ -9,11 +9,13 @@ is the ~300k-token/request cap: the fix needs a size budget, not just a
 count cap.
 
 Fix: split misses into sub-batches capped at ``_MAX_BATCH_ITEMS`` (2048,
-the OpenAI input-count hard limit) AND ``_MAX_BATCH_CHARS`` (250k chars,
-a dependency-free proxy that stays under 300k tokens even at the
-1-token-per-char worst case), sequential requests, reassembled in input
-order. Each sub-batch is cached as it succeeds so a mid-run failure
-doesn't re-pay earlier requests on retry.
+the OpenAI input-count hard limit) AND ``_MAX_BATCH_BYTES`` (250k UTF-8
+bytes — a dependency-free HARD token bound: byte-level BPE maps every
+token to a non-empty byte sequence, so tokens <= utf8 bytes; char counts
+have no such bound, one emoji can be 3+ tokens — codex P2 on PR #554),
+sequential requests, reassembled in input order. Each sub-batch is
+cached as it succeeds so a mid-run failure doesn't re-pay earlier
+requests on retry.
 """
 
 from __future__ import annotations
@@ -57,8 +59,9 @@ def _expected(text: str) -> list[float]:
 class TestDefaults:
     def test_caps_match_openai_limits(self):
         assert embeddings_mod._MAX_BATCH_ITEMS == 2048
-        # 300k tokens/request at the 1-token-per-char worst case
-        assert 0 < embeddings_mod._MAX_BATCH_CHARS <= 300_000
+        # tokens <= utf8 bytes (byte-level BPE), so this bounds the
+        # 300k-token/request cap
+        assert 0 < embeddings_mod._MAX_BATCH_BYTES <= 300_000
 
 
 class TestCountCap:
@@ -86,12 +89,12 @@ class TestCountCap:
         assert result[-1] == _expected("t2048")
 
 
-class TestCharBudget:
+class TestByteBudget:
     @pytest.mark.asyncio
-    async def test_char_budget_splits_requests(self, monkeypatch):
+    async def test_byte_budget_splits_requests(self, monkeypatch):
         """The MAB failure shape: input count under the cap, total size over
         the token budget — MUST still split."""
-        monkeypatch.setattr(embeddings_mod, "_MAX_BATCH_CHARS", 10)
+        monkeypatch.setattr(embeddings_mod, "_MAX_BATCH_BYTES", 10)
         calls: list = []
         p = _content_keyed_provider(calls)
         result = await p.embed_batch(["aaaaa", "bbbbb", "cc"])
@@ -99,10 +102,25 @@ class TestCharBudget:
         assert result == [_expected("aaaaa"), _expected("bbbbb"), _expected("cc")]
 
     @pytest.mark.asyncio
+    async def test_budget_counts_utf8_bytes_not_chars(self, monkeypatch):
+        """codex P2 (PR #554): BPE can exceed 1 token per CHAR on non-Latin
+        text, so a char budget can still trip the 400. The safe invariant is
+        tokens <= UTF-8 BYTES. 'ééééé' is 5 chars but 10 bytes: a
+        char-counted budget of 10 would pack the next text into the same
+        request; a byte-counted one must split."""
+        monkeypatch.setattr(embeddings_mod, "_MAX_BATCH_BYTES", 10)
+        calls: list = []
+        p = _content_keyed_provider(calls)
+        multibyte = "é" * 5  # 5 chars, 10 UTF-8 bytes
+        result = await p.embed_batch([multibyte, "a"])
+        assert [c["input"] for c in calls] == [[multibyte], ["a"]]
+        assert result == [_expected(multibyte), _expected("a")]
+
+    @pytest.mark.asyncio
     async def test_oversized_single_text_sent_alone(self, monkeypatch):
         """A single text larger than the budget still ships as a batch of
         one — never dropped, never an infinite loop."""
-        monkeypatch.setattr(embeddings_mod, "_MAX_BATCH_CHARS", 10)
+        monkeypatch.setattr(embeddings_mod, "_MAX_BATCH_BYTES", 10)
         calls: list = []
         p = _content_keyed_provider(calls)
         big = "x" * 50

--- a/tests/test_embed_batch_sub_batching.py
+++ b/tests/test_embed_batch_sub_batching.py
@@ -1,0 +1,169 @@
+"""embed_batch sub-batching (2026-07-03 MAB large-transcript bug).
+
+``embed_batch`` sent ALL cache misses in ONE OpenAI embeddings request.
+A large transcript (~2000 chunks x ~600 chars ~ 300k tokens) blows the
+API's per-request token cap and returns HTTP 400 — the summarizer's F067
+chunk path catches the error and aborts, storing 0 chunks. Note the
+observed 400 fired BELOW the 2048 input-count cap, so the binding limit
+is the ~300k-token/request cap: the fix needs a size budget, not just a
+count cap.
+
+Fix: split misses into sub-batches capped at ``_MAX_BATCH_ITEMS`` (2048,
+the OpenAI input-count hard limit) AND ``_MAX_BATCH_CHARS`` (250k chars,
+a dependency-free proxy that stays under 300k tokens even at the
+1-token-per-char worst case), sequential requests, reassembled in input
+order. Each sub-batch is cached as it succeeds so a mid-run failure
+doesn't re-pay earlier requests on retry.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nous.brain import embeddings as embeddings_mod
+from nous.brain.embeddings import EmbeddingProvider
+
+
+def _content_keyed_provider(api_calls: list, cache_size: int = 4096) -> EmbeddingProvider:
+    """Provider whose fake vectors depend ONLY on text content.
+
+    The pre-existing test fake encodes the index-within-request, which
+    would mask cross-sub-batch reassembly bugs (index resets per request).
+    """
+    provider = EmbeddingProvider(api_key="test", cache_size=cache_size)
+
+    async def fake_post(payload):
+        api_calls.append(payload)
+        inp = payload["input"]
+        texts = [inp] if isinstance(inp, str) else inp
+        data = [
+            {"index": i, "embedding": [float(len(t)), float(ord(t[0]))]}
+            for i, t in enumerate(texts)
+        ]
+        response = MagicMock()
+        response.json = MagicMock(return_value={"data": data})
+        return response
+
+    provider._post_with_retry = fake_post
+    return provider
+
+
+def _expected(text: str) -> list[float]:
+    return [float(len(text)), float(ord(text[0]))]
+
+
+class TestDefaults:
+    def test_caps_match_openai_limits(self):
+        assert embeddings_mod._MAX_BATCH_ITEMS == 2048
+        # 300k tokens/request at the 1-token-per-char worst case
+        assert 0 < embeddings_mod._MAX_BATCH_CHARS <= 300_000
+
+
+class TestCountCap:
+    @pytest.mark.asyncio
+    async def test_items_over_cap_split_into_multiple_requests(self, monkeypatch):
+        monkeypatch.setattr(embeddings_mod, "_MAX_BATCH_ITEMS", 2)
+        calls: list = []
+        p = _content_keyed_provider(calls)
+        texts = ["aa", "bbb", "cccc", "ddddd", "e"]
+        result = await p.embed_batch(texts)
+        assert [len(c["input"]) for c in calls] == [2, 2, 1]
+        assert calls[0]["input"] == ["aa", "bbb"]
+        assert calls[2]["input"] == ["e"]
+        assert result == [_expected(t) for t in texts]
+
+    @pytest.mark.asyncio
+    async def test_default_cap_splits_2049_inputs(self):
+        """The real 2048 OpenAI cap: 2049 unique tiny texts → 2 requests."""
+        calls: list = []
+        p = _content_keyed_provider(calls, cache_size=0)
+        texts = [f"t{i}" for i in range(2049)]
+        result = await p.embed_batch(texts)
+        assert [len(c["input"]) for c in calls] == [2048, 1]
+        assert result[0] == _expected("t0")
+        assert result[-1] == _expected("t2048")
+
+
+class TestCharBudget:
+    @pytest.mark.asyncio
+    async def test_char_budget_splits_requests(self, monkeypatch):
+        """The MAB failure shape: input count under the cap, total size over
+        the token budget — MUST still split."""
+        monkeypatch.setattr(embeddings_mod, "_MAX_BATCH_CHARS", 10)
+        calls: list = []
+        p = _content_keyed_provider(calls)
+        result = await p.embed_batch(["aaaaa", "bbbbb", "cc"])
+        assert [c["input"] for c in calls] == [["aaaaa", "bbbbb"], ["cc"]]
+        assert result == [_expected("aaaaa"), _expected("bbbbb"), _expected("cc")]
+
+    @pytest.mark.asyncio
+    async def test_oversized_single_text_sent_alone(self, monkeypatch):
+        """A single text larger than the budget still ships as a batch of
+        one — never dropped, never an infinite loop."""
+        monkeypatch.setattr(embeddings_mod, "_MAX_BATCH_CHARS", 10)
+        calls: list = []
+        p = _content_keyed_provider(calls)
+        big = "x" * 50
+        result = await p.embed_batch(["aa", big, "bb"])
+        assert [c["input"] for c in calls] == [["aa"], [big], ["bb"]]
+        assert result == [_expected("aa"), _expected(big), _expected("bb")]
+
+
+class TestCrossBatchSemantics:
+    @pytest.mark.asyncio
+    async def test_reassembly_preserves_input_order_across_sub_batches(self, monkeypatch):
+        monkeypatch.setattr(embeddings_mod, "_MAX_BATCH_ITEMS", 2)
+        calls: list = []
+        p = _content_keyed_provider(calls)
+        # duplicates + a warm cache hit interleaved with cold misses
+        await p.embed("warm")
+        texts = ["c1", "warm", "c2", "c1", "c3", "c4", "c5"]
+        result = await p.embed_batch(texts)
+        # unique misses c1..c5 → sub-batches of 2, 2, 1; no re-embed of warm
+        assert [len(c["input"]) for c in calls[1:]] == [2, 2, 1]
+        assert result == [_expected(t) for t in texts]
+
+    @pytest.mark.asyncio
+    async def test_mid_run_failure_keeps_earlier_sub_batch_cached(self, monkeypatch):
+        monkeypatch.setattr(embeddings_mod, "_MAX_BATCH_ITEMS", 2)
+        calls: list = []
+        p = _content_keyed_provider(calls)
+        real_post = p._post_with_retry
+
+        async def failing_second(payload):
+            if calls:  # first request succeeds, second fails
+                raise RuntimeError("api down")
+            return await real_post(payload)
+
+        p._post_with_retry = failing_second
+        with pytest.raises(RuntimeError, match="api down"):
+            await p.embed_batch(["k1", "k2", "k3"])
+        # first sub-batch landed in the LRU: retry serves k1/k2 without API
+        p._post_with_retry = real_post
+        await p.embed_batch(["k1", "k2", "k3"])
+        assert [c["input"] for c in calls[1:]] == [["k3"]]
+
+    @pytest.mark.asyncio
+    async def test_short_response_in_later_sub_batch_raises(self, monkeypatch):
+        """The review-P2 misalignment guard must run PER sub-batch."""
+        monkeypatch.setattr(embeddings_mod, "_MAX_BATCH_ITEMS", 2)
+        p = _content_keyed_provider([])
+        real_post = p._post_with_retry
+        request_n = 0
+
+        async def short_second(payload):
+            nonlocal request_n
+            request_n += 1
+            if request_n < 2:
+                return await real_post(payload)
+            response = MagicMock()
+            response.json = MagicMock(return_value={"data": [
+                {"index": 0, "embedding": [1.0, 0.0]},
+            ]})
+            return response
+
+        p._post_with_retry = short_second
+        with pytest.raises(RuntimeError, match="returned 1 vectors for 2"):
+            await p.embed_batch(["m1", "m2", "m3", "m4"])


### PR DESCRIPTION
## Problem

`EmbeddingProvider.embed_batch` (nous/brain/embeddings.py) sends **all** cache misses in a single OpenAI embeddings request. A large transcript (~2000 chunks × ~600 chars ≈ 300k tokens) trips the API's per-request limits → HTTP 400 → the F067 chunk path (`episode_summarizer.py:364`) catches the failure and aborts, storing **0 chunks** (observed on the 2026-07-03 MAB large-context run).

Both limits reproduced **live** against the API pre-fix:
- 2500 inputs → `400 Invalid 'input': array length must be 2048 or less.`
- 2000 × 1500-char inputs → `400 Requested 750000 tokens, max 300000 tokens per request`

Note: the observed ~2000-input failure is **below** the 2048 count cap — the binding constraint is the ~300k-token/request cap, so a count-only split would not have fixed it.

## Fix

At the provider seam (covers all six callers — episode_summarizer F067 chunks, cognitive dedup, procedure_learner, ingest_document, F050 variants, backfill script — with no caller changes):

- Greedy sub-batches capped at `_MAX_BATCH_ITEMS = 2048` (API input-count hard limit) **and** `_MAX_BATCH_CHARS = 250_000` (dependency-free proxy for the token cap; safe under 300k tokens even at the 1-token-per-char worst case — live probe confirmed ~4 chars/token on real transcript-shaped text, so typical sub-batches sit at ~62k tokens)
- Sequential requests; existing retry semantics per request unchanged
- Per-sub-batch misalignment guard (review-P2 zip-poisoning protection preserved)
- Each sub-batch cached as it succeeds → a mid-run failure doesn't re-pay completed requests when the caller retries
- Single text over the char budget still ships as a batch of one (no drop, no loop)
- Constants, not env vars: these encode OpenAI API facts, not tuning knobs

## Validation (independent of the eval harness)

- **Live A/B**: pre-fix single request 400s on both failure modes; fixed `embed_batch` returns 2000 × 1536-dim vectors on the 750k-token corpus (split into sub-batches under the hood)
- 8 new tests (`tests/test_embed_batch_sub_batching.py`): count-cap split incl. real 2049→[2048,1] default, char-budget split (the MAB failure shape: count under cap, size over), oversized-single-text batch-of-one, cross-sub-batch reassembly in input order with warm-cache + duplicates interleaved, mid-run-failure cache retention, per-sub-batch short-response guard
- Pre-existing suites green: `test_memory_integrity_fixes` (D2/S7 cache), `test_f025_chunked`, `test_f050_integration`, `test_procedure_learner`, `test_heartbeat_intelligent` — 179 passed total

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMGSu4XRAEDffkHqnCR8CQ