### PR TITLE
fix(retrieval): resolve real content in spreading-activation results + TTL-cache density gate

### DIFF
--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 
 import difflib
 import logging
+import time
+import weakref
 from dataclasses import dataclass, field, replace
 from datetime import UTC, date, datetime
 from typing import TYPE_CHECKING, Literal
@@ -39,6 +41,16 @@ if TYPE_CHECKING:
     from nous.heart.schemas import RecallResult
 
 logger = logging.getLogger(__name__)
+
+# Spreading-activation density gate: TTL cache per Brain instance.
+# Density only moves at sleep-cycle cadence (densifier/pruning), so paying
+# the graph_edges aggregate on EVERY recall with decision hits is pure
+# overhead now that prod density sits above the auto-mode threshold.
+# WeakKeyDictionary so a torn-down Brain frees its entry.
+_DENSITY_GATE_TTL_SECONDS = 300.0
+_density_gate_cache: "weakref.WeakKeyDictionary[object, tuple[float, float]]" = (
+    weakref.WeakKeyDictionary()
+)
 
 
 # ---------------------------------------------------------------------------
@@ -606,20 +618,34 @@ async def _run_stages(
 
             # F022 Phase 4: density-gated spreading activation
             use_spreading = False
-            if settings.spreading_activation_enabled != "false":
+            mode = str(settings.spreading_activation_enabled).lower()
+            if mode == "true":
+                # Forced on — no need to pay the density aggregate query.
+                use_spreading = True
+            elif mode != "false":
+                # auto — density-gated, TTL-cached per Brain instance.
                 try:
                     from nous.brain.spreading_activation import (
                         compute_graph_density,
                         should_use_spreading_activation,
                     )
 
-                    async with brain.db.session() as sa_session:
-                        density = await compute_graph_density(
-                            sa_session, brain.agent_id
-                        )
-                        use_spreading = should_use_spreading_activation(
-                            settings, density
-                        )
+                    now_ts = time.monotonic()
+                    cached = _density_gate_cache.get(brain)
+                    if (
+                        cached is not None
+                        and now_ts - cached[1] < _DENSITY_GATE_TTL_SECONDS
+                    ):
+                        density = cached[0]
+                    else:
+                        async with brain.db.session() as sa_session:
+                            density = await compute_graph_density(
+                                sa_session, brain.agent_id
+                            )
+                        _density_gate_cache[brain] = (density, now_ts)
+                    use_spreading = should_use_spreading_activation(
+                        settings, density
+                    )
                 except Exception:
                     logger.debug("Density check failed, using 1-hop")
                     acc.stage_errors["spreading_density_check"] = (
@@ -642,23 +668,45 @@ async def _run_stages(
                             sa_session, brain.agent_id, seeds, settings
                         )
                         seed_ids = {s[0] for s in seeds}
-                        for nid, ntype, activation in activated:
-                            if (
-                                nid not in seed_ids
-                                and nid not in seen_ids
-                                and activation > 0.1
-                            ):
-                                graph_expanded.append(
-                                    NeighborResult(
-                                        id=nid,
-                                        node_type=ntype,
-                                        description=f"[{ntype}] {str(nid)[:8]}",
-                                        edge_relation="spreading_activation",
-                                        edge_weight=activation,
-                                        created_at=datetime.now(UTC),
-                                    )
+                        hits = [
+                            (nid, ntype, activation)
+                            for nid, ntype, activation in activated
+                            if nid not in seed_ids
+                            and nid not in seen_ids
+                            and activation > 0.1
+                        ]
+                        # Resolve real content + created_at (shared with
+                        # brain._neighbors). Ids the resolver omits —
+                        # inactive facts/procedures, missing rows — are
+                        # DROPPED rather than surfaced as "[<ntype>] <uuid>"
+                        # placeholders that ship no information to the LLM
+                        # yet consume ranking slots.
+                        ids_by_type: dict[str, list[UUID]] = {}
+                        for nid, ntype, _activation in hits:
+                            ids_by_type.setdefault(ntype, []).append(nid)
+                        descriptions = (
+                            await brain._resolve_node_descriptions(
+                                sa_session, ids_by_type
+                            )
+                            if ids_by_type
+                            else {}
+                        )
+                        for nid, ntype, activation in hits:
+                            resolved = descriptions.get(nid)
+                            if resolved is None or not resolved[0]:
+                                continue
+                            desc, created = resolved
+                            graph_expanded.append(
+                                NeighborResult(
+                                    id=nid,
+                                    node_type=ntype,
+                                    description=desc,
+                                    edge_relation="spreading_activation",
+                                    edge_weight=activation,
+                                    created_at=created or datetime.now(UTC),
                                 )
-                                seen_ids.add(nid)
+                            )
+                            seen_ids.add(nid)
                     acc.spreading_activation_used = True
                 except Exception:
                     logger.debug(

--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -720,7 +720,17 @@ async def _run_stages(
                             )
                             seen_ids.add(nid)
                             n_appended += 1
-                    acc.spreading_activation_used = True
+                    if n_appended > 0:
+                        acc.spreading_activation_used = True
+                    else:
+                        # Every activated node was dropped by resolution
+                        # (inactive/foreign/dangling). Fall back to 1-hop
+                        # rather than shipping an empty graph expansion.
+                        logger.debug(
+                            "Spreading resolved 0 of %d hits; using 1-hop",
+                            len(hits),
+                        )
+                        use_spreading = False
                 except Exception:
                     logger.debug(
                         "Spreading activation failed, falling back to 1-hop"

--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -42,6 +42,14 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Spreading-activation result window: at most this many activated nodes are
+# appended per recall (the CTE's historic LIMIT). The CTE is over-fetched at
+# 2x so rows dropped by content resolution (inactive/foreign/dangling —
+# codex P2 round 5, PR #555) backfill from lower-ranked valid nodes instead
+# of consuming the window.
+_SPREADING_RESULT_CAP = 20
+_SPREADING_OVERFETCH_LIMIT = 40
+
 # Spreading-activation density gate: TTL cache per Brain instance.
 # Density only moves at sleep-cycle cadence (densifier/pruning), so paying
 # the graph_edges aggregate on EVERY recall with decision hits is pure
@@ -665,7 +673,8 @@ async def _run_stages(
                             for d in decision_results[: settings.graph_recall_max_expand]
                         ]
                         activated = await spreading_activation_search(
-                            sa_session, brain.agent_id, seeds, settings
+                            sa_session, brain.agent_id, seeds, settings,
+                            limit=_SPREADING_OVERFETCH_LIMIT,
                         )
                         seed_ids = {s[0] for s in seeds}
                         hits = [
@@ -691,7 +700,10 @@ async def _run_stages(
                             if ids_by_type
                             else {}
                         )
+                        n_appended = 0
                         for nid, ntype, activation in hits:
+                            if n_appended >= _SPREADING_RESULT_CAP:
+                                break
                             resolved = descriptions.get(nid)
                             if resolved is None or not resolved[0]:
                                 continue
@@ -707,6 +719,7 @@ async def _run_stages(
                                 )
                             )
                             seen_ids.add(nid)
+                            n_appended += 1
                     acc.spreading_activation_used = True
                 except Exception:
                     logger.debug(

--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -1393,35 +1393,33 @@ class Brain:
         results = []
         for r in rows:
             ntype, rel, weight, method = edge_map[r.neighbor_id]
-            # F080 / Audit BR-1 (codex P1): an inactive/superseded procedure OR
-            # fact was filtered out of the description resolution above (both
-            # queries carry `active = true`). Drop it rather than surfacing an
-            # archived skill / superseded fact as a "[type] <uuid>" placeholder
-            # that would also consume a post-LIMIT ranking slot.
-            if ntype in ("procedure", "fact") and r.neighbor_id not in descriptions:
+            # F080 / Audit BR-1 (codex P1) + codex P2 round 3 (PR #555): an
+            # id absent from the resolver map is an inactive/superseded
+            # fact or procedure (active=true filters), a foreign-agent node
+            # (agent_id filters — graph_edges endpoints are polymorphic and
+            # not FK-protected), or a dangling edge. Drop ALL of them rather
+            # than surfacing a "[type] <uuid>" placeholder that ships no
+            # information yet consumes a post-LIMIT ranking slot.
+            if r.neighbor_id not in descriptions:
                 continue
-            if r.neighbor_id in descriptions:
-                desc, created = descriptions[r.neighbor_id]
-                # Defensive: keep placeholder if resolved description is empty
-                # (DB rows with NULL/empty content shouldn't crash retrieval).
-                if not desc:
-                    if ntype in _NOT_NULL_CONTENT_TYPES:
-                        logger.warning(
-                            "brain._neighbors: empty/NULL content on "
-                            "%s id=%s (column is declared NOT NULL — "
-                            "data integrity issue)",
-                            ntype, r.neighbor_id,
-                        )
-                    desc = f"[{ntype}] {r.neighbor_id}"
-                if created is None:
+            desc, created = descriptions[r.neighbor_id]
+            # Defensive: keep placeholder if resolved description is empty
+            # (DB rows with NULL/empty content shouldn't crash retrieval).
+            if not desc:
+                if ntype in _NOT_NULL_CONTENT_TYPES:
                     logger.warning(
-                        "brain._neighbors: NULL created_at on %s id=%s "
-                        "(column has server_default — possible migration bug)",
+                        "brain._neighbors: empty/NULL content on "
+                        "%s id=%s (column is declared NOT NULL — "
+                        "data integrity issue)",
                         ntype, r.neighbor_id,
                     )
-                    created = datetime.now(UTC)
-            else:
                 desc = f"[{ntype}] {r.neighbor_id}"
+            if created is None:
+                logger.warning(
+                    "brain._neighbors: NULL created_at on %s id=%s "
+                    "(column has server_default — possible migration bug)",
+                    ntype, r.neighbor_id,
+                )
                 created = datetime.now(UTC)
             results.append(NeighborResult(
                 id=r.neighbor_id,

--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -1507,14 +1507,21 @@ class Brain:
         # a live Path-A resurrection of dead skills via auto_linked edges).
         if ids_by_type.get("procedure"):
             p_result = await session.execute(
-                select(Procedure.id, Procedure.description, Procedure.created_at)
+                select(
+                    Procedure.id,
+                    Procedure.name,
+                    Procedure.description,
+                    Procedure.created_at,
+                )
                 .where(Procedure.id.in_(ids_by_type["procedure"]))
                 .where(Procedure.active == True)  # noqa: E712
             )
             for p in p_result.all():
-                # Procedure.description is nullable — fall back to placeholder
-                # so consumers don't get None.
-                desc_text = p.description or f"[procedure] {p.id}"
+                # Procedure.description is nullable — fall back to the NAME
+                # (NOT NULL; matches how recall formats descriptionless
+                # procedures), then to a placeholder so consumers never get
+                # None (codex P2, PR #555).
+                desc_text = p.description or p.name or f"[procedure] {p.id}"
                 descriptions[p.id] = (desc_text, p.created_at)
 
         return descriptions

--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -1450,6 +1450,11 @@ class Brain:
         ``active=false`` is a soft-delete / supersession marker) and are simply
         ABSENT from the returned map — callers must treat a missing id as
         "drop this node".
+
+        Every lookup is agent-scoped (codex P2 round 2, PR #555):
+        ``graph_edges`` endpoints are polymorphic and not FK-protected, so a
+        miswritten edge can point at another agent's node — foreign content
+        must never resolve.
         """
         descriptions: dict[UUID, tuple[str, datetime | None]] = {}
 
@@ -1459,6 +1464,7 @@ class Brain:
             dec_result = await session.execute(
                 select(Decision.id, Decision.description, Decision.created_at)
                 .where(Decision.id.in_(ids_by_type["decision"]))
+                .where(Decision.agent_id == self.agent_id)
             )
             for d in dec_result.all():
                 descriptions[d.id] = (d.description, d.created_at)
@@ -1476,6 +1482,7 @@ class Brain:
                 select(Fact.id, Fact.content, Fact.created_at)
                 .where(Fact.id.in_(ids_by_type["fact"]))
                 .where(Fact.active == True)  # noqa: E712
+                .where(Fact.agent_id == self.agent_id)
             )
             for f in f_result.all():
                 descriptions[f.id] = (f.content, f.created_at)
@@ -1487,6 +1494,7 @@ class Brain:
             e_result = await session.execute(
                 select(Episode.id, Episode.summary, Episode.created_at)
                 .where(Episode.id.in_(ids_by_type["episode"]))
+                .where(Episode.agent_id == self.agent_id)
             )
             for e in e_result.all():
                 descriptions[e.id] = (e.summary, e.created_at)
@@ -1496,6 +1504,7 @@ class Brain:
             c_result = await session.execute(
                 select(EpisodeChunk.id, EpisodeChunk.content, EpisodeChunk.created_at)
                 .where(EpisodeChunk.id.in_(ids_by_type["chunk"]))
+                .where(EpisodeChunk.agent_id == self.agent_id)
             )
             for c in c_result.all():
                 descriptions[c.id] = (c.content, c.created_at)
@@ -1515,6 +1524,7 @@ class Brain:
                 )
                 .where(Procedure.id.in_(ids_by_type["procedure"]))
                 .where(Procedure.active == True)  # noqa: E712
+                .where(Procedure.agent_id == self.agent_id)
             )
             for p in p_result.all():
                 # Procedure.description is nullable — fall back to the NAME

--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -1348,6 +1348,12 @@ class Brain:
             )
             .subquery()
         )
+        # Over-fetch 3x (mirrors hybrid_search's limit_expanded and the
+        # spreading-branch over-fetch): the resolver below drops rows whose
+        # endpoints are inactive/foreign/dangling (codex P2 round 7,
+        # PR #555), and Path A windows are small (limit=3) — without the
+        # buffer a few bad high-weight edges starve the window. Results are
+        # capped back to ``limit`` after resolution.
         union_q = (
             select(
                 ranked.c.neighbor_id,
@@ -1358,7 +1364,7 @@ class Brain:
             )
             .where(ranked.c.rn == 1)
             .order_by(func.coalesce(ranked.c.edge_weight, -1.0).desc(), ranked.c.neighbor_id)
-            .limit(limit)
+            .limit(limit * 3)
         )
         result = await session.execute(union_q)
         rows = result.all()
@@ -1392,6 +1398,8 @@ class Brain:
         _NOT_NULL_CONTENT_TYPES = {"fact", "episode", "chunk"}
         results = []
         for r in rows:
+            if len(results) >= limit:
+                break
             ntype, rel, weight, method = edge_map[r.neighbor_id]
             # F080 / Audit BR-1 (codex P1) + codex P2 round 3 (PR #555): an
             # id absent from the resolver map is an inactive/superseded

--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
-from sqlalchemy import case, delete, func, select, text
+from sqlalchemy import case, delete, func, or_, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -1487,12 +1487,21 @@ class Brain:
 
         # Episode: heart.episodes.summary (matches _ENTITY_CONFIG fallback;
         # structured_summary preferred at densifier time but plain summary
-        # is always populated).
+        # is always populated). Mirrors the episode recall contract
+        # (episodes.py HT-1 filter; codex P2 round 4, PR #555): ongoing
+        # (active=true) OR genuinely-closed (ended_at IS NOT NULL), never
+        # deactivated-noise or abandoned rows — graph edges to suppressed
+        # episodes must not resurface them past normal recall's filters.
         if ids_by_type.get("episode"):
             e_result = await session.execute(
                 select(Episode.id, Episode.summary, Episode.created_at)
                 .where(Episode.id.in_(ids_by_type["episode"]))
                 .where(Episode.agent_id == self.agent_id)
+                .where(or_(
+                    Episode.active == True,  # noqa: E712
+                    Episode.ended_at.is_not(None),
+                ))
+                .where(Episode.outcome.is_distinct_from("abandoned"))
             )
             for e in e_result.all():
                 descriptions[e.id] = (e.summary, e.created_at)

--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -1464,13 +1464,18 @@ class Brain:
         """
         descriptions: dict[UUID, tuple[str, datetime | None]] = {}
 
-        # Decision: existing behavior, kept verbatim so consumers that only
-        # use decision neighbors observe no change.
+        # Decision: mirrors Brain._query's default suppression of abandoned
+        # decisions (outcome='failure' AND confidence=0.0 — codex P2 round 8,
+        # PR #555) so graph traversal cannot reintroduce noise decisions
+        # that normal brain search hides.
         if ids_by_type.get("decision"):
             dec_result = await session.execute(
                 select(Decision.id, Decision.description, Decision.created_at)
                 .where(Decision.id.in_(ids_by_type["decision"]))
                 .where(Decision.agent_id == self.agent_id)
+                .where(
+                    ~((Decision.outcome == "failure") & (Decision.confidence == 0.0))
+                )
             )
             for d in dec_result.all():
                 descriptions[d.id] = (d.description, d.created_at)

--- a/nous/brain/brain.py
+++ b/nous/brain/brain.py
@@ -1381,71 +1381,7 @@ class Brain:
         for r in rows:
             ids_by_type[r.neighbor_type].append(r.neighbor_id)
 
-        descriptions: dict[UUID, tuple[str, datetime]] = {}
-
-        # Decision: existing behavior, kept verbatim so consumers that only
-        # use decision neighbors observe no change.
-        if ids_by_type.get("decision"):
-            dec_result = await session.execute(
-                select(Decision.id, Decision.description, Decision.created_at)
-                .where(Decision.id.in_(ids_by_type["decision"]))
-            )
-            for d in dec_result.all():
-                descriptions[d.id] = (d.description, d.created_at)
-
-        # Fact: heart.facts.content
-        # Audit BR-1 (2026-06-09): only ACTIVE facts. For facts, active=false
-        # is a soft-delete / supersession marker (F027), so superseded and
-        # contradiction-resolved facts must never resurface as graph neighbors
-        # via Path A or decision 1-hop expansion — mirrors the F080 procedure
-        # fix below. (Episodes/chunks are intentionally NOT filtered here:
-        # episode active=false is the normal *closed* lifecycle state, and
-        # episode_chunks has no soft-delete column.)
-        if ids_by_type.get("fact"):
-            f_result = await session.execute(
-                select(Fact.id, Fact.content, Fact.created_at)
-                .where(Fact.id.in_(ids_by_type["fact"]))
-                .where(Fact.active == True)  # noqa: E712
-            )
-            for f in f_result.all():
-                descriptions[f.id] = (f.content, f.created_at)
-
-        # Episode: heart.episodes.summary (matches _ENTITY_CONFIG fallback;
-        # structured_summary preferred at densifier time but plain summary
-        # is always populated).
-        if ids_by_type.get("episode"):
-            e_result = await session.execute(
-                select(Episode.id, Episode.summary, Episode.created_at)
-                .where(Episode.id.in_(ids_by_type["episode"]))
-            )
-            for e in e_result.all():
-                descriptions[e.id] = (e.summary, e.created_at)
-
-        # Chunk: heart.episode_chunks.content (F067 raw transcript fragment).
-        if ids_by_type.get("chunk"):
-            c_result = await session.execute(
-                select(EpisodeChunk.id, EpisodeChunk.content, EpisodeChunk.created_at)
-                .where(EpisodeChunk.id.in_(ids_by_type["chunk"]))
-            )
-            for c in c_result.all():
-                descriptions[c.id] = (c.content, c.created_at)
-
-        # Procedure: heart.procedures.description. F080: only ACTIVE procedures —
-        # archived/superseded skills (active=false, set by name-dedup) must never
-        # be surfaced as graph neighbors. Inactive ids are simply absent from
-        # ``descriptions`` and dropped in the results loop below (this also fixes
-        # a live Path-A resurrection of dead skills via auto_linked edges).
-        if ids_by_type.get("procedure"):
-            p_result = await session.execute(
-                select(Procedure.id, Procedure.description, Procedure.created_at)
-                .where(Procedure.id.in_(ids_by_type["procedure"]))
-                .where(Procedure.active == True)  # noqa: E712
-            )
-            for p in p_result.all():
-                # Procedure.description is nullable — fall back to placeholder
-                # so consumers don't get None.
-                desc_text = p.description or f"[procedure] {p.id}"
-                descriptions[p.id] = (desc_text, p.created_at)
+        descriptions = await self._resolve_node_descriptions(session, ids_by_type)
 
         # Build results
         # Node types where the content column is declared NOT NULL in models.py
@@ -1498,6 +1434,90 @@ class Brain:
             ))
 
         return results
+
+    async def _resolve_node_descriptions(
+        self,
+        session: AsyncSession,
+        ids_by_type: dict[str, list[UUID]],
+    ) -> dict[UUID, tuple[str, datetime | None]]:
+        """Resolve real content + created_at for graph node ids, batched per type.
+
+        Shared by ``_neighbors`` and the spreading-activation branch in
+        ``run_recall_pipeline`` so every graph consumer surfaces real memory
+        content instead of ``"[<ntype>] <uuid>"`` placeholders.
+
+        Inactive facts and procedures are filtered out (for those types,
+        ``active=false`` is a soft-delete / supersession marker) and are simply
+        ABSENT from the returned map — callers must treat a missing id as
+        "drop this node".
+        """
+        descriptions: dict[UUID, tuple[str, datetime | None]] = {}
+
+        # Decision: existing behavior, kept verbatim so consumers that only
+        # use decision neighbors observe no change.
+        if ids_by_type.get("decision"):
+            dec_result = await session.execute(
+                select(Decision.id, Decision.description, Decision.created_at)
+                .where(Decision.id.in_(ids_by_type["decision"]))
+            )
+            for d in dec_result.all():
+                descriptions[d.id] = (d.description, d.created_at)
+
+        # Fact: heart.facts.content
+        # Audit BR-1 (2026-06-09): only ACTIVE facts. For facts, active=false
+        # is a soft-delete / supersession marker (F027), so superseded and
+        # contradiction-resolved facts must never resurface as graph neighbors
+        # via Path A or decision 1-hop expansion — mirrors the F080 procedure
+        # fix below. (Episodes/chunks are intentionally NOT filtered here:
+        # episode active=false is the normal *closed* lifecycle state, and
+        # episode_chunks has no soft-delete column.)
+        if ids_by_type.get("fact"):
+            f_result = await session.execute(
+                select(Fact.id, Fact.content, Fact.created_at)
+                .where(Fact.id.in_(ids_by_type["fact"]))
+                .where(Fact.active == True)  # noqa: E712
+            )
+            for f in f_result.all():
+                descriptions[f.id] = (f.content, f.created_at)
+
+        # Episode: heart.episodes.summary (matches _ENTITY_CONFIG fallback;
+        # structured_summary preferred at densifier time but plain summary
+        # is always populated).
+        if ids_by_type.get("episode"):
+            e_result = await session.execute(
+                select(Episode.id, Episode.summary, Episode.created_at)
+                .where(Episode.id.in_(ids_by_type["episode"]))
+            )
+            for e in e_result.all():
+                descriptions[e.id] = (e.summary, e.created_at)
+
+        # Chunk: heart.episode_chunks.content (F067 raw transcript fragment).
+        if ids_by_type.get("chunk"):
+            c_result = await session.execute(
+                select(EpisodeChunk.id, EpisodeChunk.content, EpisodeChunk.created_at)
+                .where(EpisodeChunk.id.in_(ids_by_type["chunk"]))
+            )
+            for c in c_result.all():
+                descriptions[c.id] = (c.content, c.created_at)
+
+        # Procedure: heart.procedures.description. F080: only ACTIVE procedures —
+        # archived/superseded skills (active=false, set by name-dedup) must never
+        # be surfaced as graph neighbors. Inactive ids are simply absent from
+        # ``descriptions`` and dropped by the caller (this also fixes
+        # a live Path-A resurrection of dead skills via auto_linked edges).
+        if ids_by_type.get("procedure"):
+            p_result = await session.execute(
+                select(Procedure.id, Procedure.description, Procedure.created_at)
+                .where(Procedure.id.in_(ids_by_type["procedure"]))
+                .where(Procedure.active == True)  # noqa: E712
+            )
+            for p in p_result.all():
+                # Procedure.description is nullable — fall back to placeholder
+                # so consumers don't get None.
+                desc_text = p.description or f"[procedure] {p.id}"
+                descriptions[p.id] = (desc_text, p.created_at)
+
+        return descriptions
 
     # ------------------------------------------------------------------
     # top_hubs() — F065 god-node surfacing

--- a/nous/brain/spreading_activation.py
+++ b/nous/brain/spreading_activation.py
@@ -81,11 +81,15 @@ async def spreading_activation_search(
     agent_id: str,
     seed_nodes: list[tuple[UUID, str, float]],
     settings: Settings,
+    limit: int = 20,
 ) -> list[tuple[UUID, str, float]]:
     """Run spreading activation CTE and return activated nodes.
 
     Args:
         seed_nodes: List of (node_id, node_type, score) from vector search
+        limit: max activated rows returned. Callers that post-filter the
+            results (e.g. the pipeline's content-resolution drop, PR #555)
+            should over-fetch so dropped rows don't consume the window.
 
     Returns:
         List of (node_id, node_type, total_activation) sorted by activation desc
@@ -98,6 +102,7 @@ async def spreading_activation_search(
         "decay": settings.spreading_activation_decay,
         "max_depth": settings.spreading_activation_max_depth,
         "agent_id": agent_id,
+        "result_limit": int(limit),
     }
     for i, (nid, ntype, score) in enumerate(seed_nodes):
         values_parts.append(f"(CAST(:id_{i} AS UUID), CAST(:type_{i} AS VARCHAR), CAST(:score_{i} AS FLOAT))")
@@ -136,7 +141,7 @@ async def spreading_activation_search(
         FROM activation
         GROUP BY id, node_type
         ORDER BY total_activation DESC
-        LIMIT 20
+        LIMIT :result_limit
     """)
 
     result = await session.execute(sql, params)

--- a/tests/test_resolve_node_descriptions.py
+++ b/tests/test_resolve_node_descriptions.py
@@ -95,6 +95,29 @@ async def test_descriptionless_procedure_resolves_to_name(brain, session):
 
 
 @pytest.mark.asyncio
+async def test_foreign_agent_nodes_do_not_resolve(brain, session):
+    """Codex P2 round 2 (PR #555): graph_edges endpoints are polymorphic and
+    not FK-protected — a miswritten edge can point at ANOTHER agent's node.
+    The resolver must agent-scope every lookup so foreign content is never
+    surfaced (absent from the map => dropped by callers)."""
+    foreign = Fact(
+        id=uuid.uuid4(),
+        agent_id="some-other-agent",
+        content="foreign agent secret fact",
+        active=True,
+        created_at=datetime(2026, 1, 5, tzinfo=UTC),
+    )
+    session.add(foreign)
+    await session.flush()
+
+    resolved = await brain._resolve_node_descriptions(
+        session, {"fact": [foreign.id]}
+    )
+
+    assert foreign.id not in resolved
+
+
+@pytest.mark.asyncio
 async def test_empty_input_returns_empty_map(brain, session):
     resolved = await brain._resolve_node_descriptions(session, {})
     assert resolved == {}

--- a/tests/test_resolve_node_descriptions.py
+++ b/tests/test_resolve_node_descriptions.py
@@ -164,6 +164,53 @@ async def test_neighbors_drops_all_unresolved_node_types(brain, session):
 
 
 @pytest.mark.asyncio
+async def test_episode_lifecycle_filters_applied(brain, session):
+    """Codex P2 round 4 (PR #555): the resolver must mirror the episode
+    recall contract (episodes.py HT-1 filter): include ongoing
+    (active=true) OR genuinely-closed (ended_at IS NOT NULL) episodes,
+    exclude deactivated-noise (active=false, ended_at NULL) and
+    outcome='abandoned' rows — otherwise spreading/Path-A resurface
+    episodes normal recall suppresses."""
+    closed = Episode(
+        id=uuid.uuid4(),
+        agent_id=brain.agent_id,
+        title="closed episode",
+        summary="genuinely closed episode summary",
+        active=False,
+        ended_at=datetime(2026, 1, 6, tzinfo=UTC),
+        created_at=datetime(2026, 1, 5, tzinfo=UTC),
+    )
+    noise = Episode(
+        id=uuid.uuid4(),
+        agent_id=brain.agent_id,
+        title="deactivated noise",
+        summary="trivial-session noise summary",
+        active=False,
+        ended_at=None,
+        created_at=datetime(2026, 1, 5, tzinfo=UTC),
+    )
+    abandoned = Episode(
+        id=uuid.uuid4(),
+        agent_id=brain.agent_id,
+        title="abandoned episode",
+        summary="abandoned episode summary",
+        active=True,
+        outcome="abandoned",
+        created_at=datetime(2026, 1, 5, tzinfo=UTC),
+    )
+    session.add_all([closed, noise, abandoned])
+    await session.flush()
+
+    resolved = await brain._resolve_node_descriptions(
+        session, {"episode": [closed.id, noise.id, abandoned.id]}
+    )
+
+    assert closed.id in resolved, "closed episodes are the ones worth recalling"
+    assert noise.id not in resolved, "deactivated-noise episodes must not resolve"
+    assert abandoned.id not in resolved, "abandoned episodes must not resolve"
+
+
+@pytest.mark.asyncio
 async def test_empty_input_returns_empty_map(brain, session):
     resolved = await brain._resolve_node_descriptions(session, {})
     assert resolved == {}

--- a/tests/test_resolve_node_descriptions.py
+++ b/tests/test_resolve_node_descriptions.py
@@ -15,7 +15,7 @@ import pytest_asyncio
 
 from nous.brain.brain import Brain
 from nous.brain.schemas import ReasonInput, RecordInput
-from nous.storage.models import Episode, Fact, GraphEdge, Procedure
+from nous.storage.models import Decision, Episode, Fact, GraphEdge, Procedure
 
 
 @pytest_asyncio.fixture
@@ -263,6 +263,44 @@ async def test_neighbors_backfills_past_dropped_rows(brain, session):
         "the dropped high-weight foreign edge must not starve the window; "
         "the valid lower-weight neighbor must backfill"
     )
+
+
+@pytest.mark.asyncio
+async def test_abandoned_decisions_do_not_resolve(brain, session):
+    """Codex P2 round 8 (PR #555): ``Brain._query`` suppresses abandoned
+    decisions (outcome='failure' AND confidence=0.0) by default
+    (brain.py filter_clauses). The resolver must mirror that predicate so
+    spreading/Path-A cannot reintroduce abandoned/noise decisions that
+    normal brain search hides."""
+    abandoned = Decision(
+        id=uuid.uuid4(),
+        agent_id=brain.agent_id,
+        description="abandoned decision",
+        category="process",
+        stakes="low",
+        outcome="failure",
+        confidence=0.0,
+        created_at=datetime(2026, 1, 5, tzinfo=UTC),
+    )
+    real_failure = Decision(
+        id=uuid.uuid4(),
+        agent_id=brain.agent_id,
+        description="genuine failed decision",
+        category="process",
+        stakes="low",
+        outcome="failure",
+        confidence=0.8,
+        created_at=datetime(2026, 1, 5, tzinfo=UTC),
+    )
+    session.add_all([abandoned, real_failure])
+    await session.flush()
+
+    resolved = await brain._resolve_node_descriptions(
+        session, {"decision": [abandoned.id, real_failure.id]}
+    )
+
+    assert abandoned.id not in resolved
+    assert resolved[real_failure.id][0] == "genuine failed decision"
 
 
 @pytest.mark.asyncio

--- a/tests/test_resolve_node_descriptions.py
+++ b/tests/test_resolve_node_descriptions.py
@@ -15,7 +15,7 @@ import pytest_asyncio
 
 from nous.brain.brain import Brain
 from nous.brain.schemas import ReasonInput, RecordInput
-from nous.storage.models import Fact
+from nous.storage.models import Fact, Procedure
 
 
 @pytest_asyncio.fixture
@@ -67,6 +67,31 @@ async def test_resolves_content_and_drops_inactive_fact(brain, session):
     assert isinstance(resolved[active.id][1], datetime)
     assert inactive.id not in resolved
     assert resolved[decision.id][0] == "resolver decision"
+
+
+@pytest.mark.asyncio
+async def test_descriptionless_procedure_resolves_to_name(brain, session):
+    """Codex P2 (PR #555): ``Procedure.description`` is optional — a NULL
+    description must fall back to the procedure NAME (matching how normal
+    recall formats descriptionless procedures), not a ``[procedure] <uuid>``
+    placeholder that re-introduces the non-informative content this
+    resolver exists to remove."""
+    proc = Procedure(
+        id=uuid.uuid4(),
+        agent_id=brain.agent_id,
+        name="deploy-checklist",
+        description=None,
+        active=True,
+        created_at=datetime(2026, 1, 5, tzinfo=UTC),
+    )
+    session.add(proc)
+    await session.flush()
+
+    resolved = await brain._resolve_node_descriptions(
+        session, {"procedure": [proc.id]}
+    )
+
+    assert resolved[proc.id][0] == "deploy-checklist"
 
 
 @pytest.mark.asyncio

--- a/tests/test_resolve_node_descriptions.py
+++ b/tests/test_resolve_node_descriptions.py
@@ -15,7 +15,7 @@ import pytest_asyncio
 
 from nous.brain.brain import Brain
 from nous.brain.schemas import ReasonInput, RecordInput
-from nous.storage.models import Fact, Procedure
+from nous.storage.models import Episode, Fact, GraphEdge, Procedure
 
 
 @pytest_asyncio.fixture
@@ -115,6 +115,52 @@ async def test_foreign_agent_nodes_do_not_resolve(brain, session):
     )
 
     assert foreign.id not in resolved
+
+
+@pytest.mark.asyncio
+async def test_neighbors_drops_all_unresolved_node_types(brain, session):
+    """Codex P2 round 3 (PR #555): after agent-scoping, an unresolved
+    decision/episode/chunk must be DROPPED by ``_neighbors`` like
+    facts/procedures already are — not emitted as a ``[type] <uuid>``
+    placeholder that surfaces a foreign/dangling node as a recall
+    candidate."""
+    d1 = await brain.record(
+        RecordInput(
+            description="edge source decision",
+            confidence=0.8,
+            category="architecture",
+            stakes="low",
+            reasons=[ReasonInput(type="analysis", text="neighbors drop test")],
+        ),
+        session=session,
+    )
+    foreign_episode = Episode(
+        id=uuid.uuid4(),
+        agent_id="some-other-agent",
+        title="foreign episode",
+        summary="foreign agent episode summary",
+        created_at=datetime(2026, 1, 5, tzinfo=UTC),
+    )
+    session.add(foreign_episode)
+    await session.flush()
+    # Current-agent edge whose endpoint points at another agent's episode
+    # (polymorphic, not FK-protected — this can exist).
+    session.add(GraphEdge(
+        source_id=d1.id,
+        target_id=foreign_episode.id,
+        source_type="decision",
+        target_type="episode",
+        agent_id=brain.agent_id,
+        relation="related_to",
+        weight=0.9,
+    ))
+    await session.flush()
+
+    results = await brain.neighbors(d1.id, session=session)
+
+    assert all(r.id != foreign_episode.id for r in results), (
+        "foreign-agent episode must be dropped, not surfaced as a placeholder"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_resolve_node_descriptions.py
+++ b/tests/test_resolve_node_descriptions.py
@@ -1,0 +1,75 @@
+"""Tests for ``Brain._resolve_node_descriptions``.
+
+The per-type content-resolution block extracted from ``Brain._neighbors``
+so the spreading-activation branch in ``run_recall_pipeline`` can share it
+instead of fabricating ``[<ntype>] <uuid8>`` placeholder descriptions.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+
+from nous.brain.brain import Brain
+from nous.brain.schemas import ReasonInput, RecordInput
+from nous.storage.models import Fact
+
+
+@pytest_asyncio.fixture
+async def brain(db, settings):
+    """Brain without embeddings (keyword-only mode)."""
+    b = Brain(database=db, settings=settings)
+    yield b
+    await b.close()
+
+
+@pytest.mark.asyncio
+async def test_resolves_content_and_drops_inactive_fact(brain, session):
+    """Active facts + decisions resolve to real content with real created_at;
+    inactive (superseded) facts are absent from the map entirely."""
+    active = Fact(
+        id=uuid.uuid4(),
+        agent_id=brain.agent_id,
+        content="active fact content",
+        active=True,
+        created_at=datetime(2026, 1, 5, tzinfo=UTC),
+    )
+    inactive = Fact(
+        id=uuid.uuid4(),
+        agent_id=brain.agent_id,
+        content="superseded fact content",
+        active=False,
+        created_at=datetime(2026, 1, 5, tzinfo=UTC),
+    )
+    session.add_all([active, inactive])
+    await session.flush()
+
+    decision = await brain.record(
+        RecordInput(
+            description="resolver decision",
+            confidence=0.8,
+            category="architecture",
+            stakes="low",
+            reasons=[ReasonInput(type="analysis", text="resolver test")],
+        ),
+        session=session,
+    )
+
+    resolved = await brain._resolve_node_descriptions(
+        session,
+        {"fact": [active.id, inactive.id], "decision": [decision.id]},
+    )
+
+    assert resolved[active.id][0] == "active fact content"
+    assert isinstance(resolved[active.id][1], datetime)
+    assert inactive.id not in resolved
+    assert resolved[decision.id][0] == "resolver decision"
+
+
+@pytest.mark.asyncio
+async def test_empty_input_returns_empty_map(brain, session):
+    resolved = await brain._resolve_node_descriptions(session, {})
+    assert resolved == {}

--- a/tests/test_resolve_node_descriptions.py
+++ b/tests/test_resolve_node_descriptions.py
@@ -211,6 +211,61 @@ async def test_episode_lifecycle_filters_applied(brain, session):
 
 
 @pytest.mark.asyncio
+async def test_neighbors_backfills_past_dropped_rows(brain, session):
+    """Codex P2 round 7 (PR #555): the union SQL capped rows at ``limit``
+    BEFORE the resolver drop, so a bad high-weight edge (foreign/dangling
+    endpoint) starved small windows (Path A uses limit=3). ``_neighbors``
+    must over-fetch and cap after resolution so valid lower-weight
+    neighbors backfill."""
+    d1 = await brain.record(
+        RecordInput(
+            description="backfill source decision",
+            confidence=0.8,
+            category="architecture",
+            stakes="low",
+            reasons=[ReasonInput(type="analysis", text="backfill test")],
+        ),
+        session=session,
+    )
+    foreign_episode = Episode(
+        id=uuid.uuid4(),
+        agent_id="some-other-agent",
+        title="foreign high-weight target",
+        summary="foreign summary",
+        created_at=datetime(2026, 1, 5, tzinfo=UTC),
+    )
+    valid_fact = Fact(
+        id=uuid.uuid4(),
+        agent_id=brain.agent_id,
+        content="valid lower-weight neighbor fact",
+        active=True,
+        created_at=datetime(2026, 1, 5, tzinfo=UTC),
+    )
+    session.add_all([foreign_episode, valid_fact])
+    await session.flush()
+    session.add_all([
+        GraphEdge(
+            source_id=d1.id, target_id=foreign_episode.id,
+            source_type="decision", target_type="episode",
+            agent_id=brain.agent_id, relation="related_to", weight=0.9,
+        ),
+        GraphEdge(
+            source_id=d1.id, target_id=valid_fact.id,
+            source_type="decision", target_type="fact",
+            agent_id=brain.agent_id, relation="related_to", weight=0.5,
+        ),
+    ])
+    await session.flush()
+
+    results = await brain.neighbors(d1.id, limit=1, session=session)
+
+    assert [r.id for r in results] == [valid_fact.id], (
+        "the dropped high-weight foreign edge must not starve the window; "
+        "the valid lower-weight neighbor must backfill"
+    )
+
+
+@pytest.mark.asyncio
 async def test_empty_input_returns_empty_map(brain, session):
     resolved = await brain._resolve_node_descriptions(session, {})
     assert resolved == {}

--- a/tests/test_retrieval_pipeline.py
+++ b/tests/test_retrieval_pipeline.py
@@ -867,6 +867,66 @@ class TestSpreadingContentResolution:
         )
 
     @pytest.mark.asyncio
+    async def test_spreading_overfetches_and_caps_after_resolution(self):
+        """Codex P2 round 5 (PR #555): the CTE's hard LIMIT ran BEFORE the
+        resolution drop, so dropped rows consumed the window. The pipeline
+        must over-fetch (limit=40) and cap appended results at 20 AFTER
+        resolution, so drops backfill from lower-ranked valid nodes."""
+        # 30 resolvable hits: first 10 unresolvable (dropped), next 20 resolve.
+        hits = [(UUID(int=1000 + i), "fact", 0.9 - i * 0.01) for i in range(30)]
+        resolved = {
+            nid: (f"content {i}", datetime(2026, 1, 5, tzinfo=UTC))
+            for i, (nid, _t, _a) in enumerate(hits)
+            if i >= 10
+        }
+        heart, brain = self._spreading_fixtures(resolved=resolved)
+        settings = _make_settings(spreading_activation_enabled="true")
+        search_mock = AsyncMock(return_value=hits)
+
+        with patch(
+            "nous.brain.spreading_activation.spreading_activation_search",
+            search_mock,
+        ):
+            results, stats = await run_recall_pipeline(
+                query="anything", heart=heart, brain=brain,
+                settings=settings, limit=10,
+            )
+
+        assert stats.spreading_activation_used is True
+        # Over-fetch wiring: the CTE limit must be raised above the 20 cap.
+        assert search_mock.await_args.kwargs.get("limit") == 40
+        spread_ids = [r.id for r in results if r.source == "spreading_activation"]
+        # All 20 resolvable hits surface — the 10 dropped rows did not
+        # consume the cap.
+        assert len(spread_ids) == 20
+        assert set(spread_ids) == set(resolved.keys())
+
+    @pytest.mark.asyncio
+    async def test_spreading_cap_bounds_appended_results(self):
+        """Even when everything resolves, at most 20 spreading results append."""
+        hits = [(UUID(int=2000 + i), "fact", 0.9 - i * 0.01) for i in range(30)]
+        resolved = {
+            nid: (f"content {i}", datetime(2026, 1, 5, tzinfo=UTC))
+            for i, (nid, _t, _a) in enumerate(hits)
+        }
+        heart, brain = self._spreading_fixtures(resolved=resolved)
+        settings = _make_settings(spreading_activation_enabled="true")
+
+        with patch(
+            "nous.brain.spreading_activation.spreading_activation_search",
+            AsyncMock(return_value=hits),
+        ):
+            results, _stats = await run_recall_pipeline(
+                query="anything", heart=heart, brain=brain,
+                settings=settings, limit=10,
+            )
+
+        spread_ids = [r.id for r in results if r.source == "spreading_activation"]
+        assert len(spread_ids) == 20
+        # Highest-activation resolvable hits win the cap (order preserved).
+        assert spread_ids == [nid for nid, _t, _a in hits[:20]]
+
+    @pytest.mark.asyncio
     async def test_true_mode_skips_density_query(self):
         heart, brain = self._spreading_fixtures(resolved={})
         settings = _make_settings(spreading_activation_enabled="true")

--- a/tests/test_retrieval_pipeline.py
+++ b/tests/test_retrieval_pipeline.py
@@ -218,11 +218,13 @@ def _make_settings(
     episode_chunks_enabled=False,
     episode_chunk_recall_limit=10,
     coherent_ranking_enabled=False,
+    spreading_activation_density_threshold=3.0,
 ):
     return SimpleNamespace(
         graph_recall_enabled=graph_recall_enabled,
         cross_type_linking_enabled=cross_type_linking_enabled,
         spreading_activation_enabled=spreading_activation_enabled,
+        spreading_activation_density_threshold=spreading_activation_density_threshold,
         contradiction_detection=contradiction_detection,
         graph_recall_decay=graph_recall_decay,
         graph_recall_max_expand=graph_recall_max_expand,
@@ -787,6 +789,132 @@ class TestPathAStage2b:
         assert count >= 1, (
             f"expected heart_graph_memory_neighbors counter to increment, "
             f"got {stats.n_stage_errors}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Spreading-activation branch: content resolution + density-gate caching
+# ---------------------------------------------------------------------------
+
+
+SPREAD_FACT_ID = UUID("77777777-7777-7777-7777-777777777777")
+
+
+class TestSpreadingContentResolution:
+    """The spreading branch must resolve real node content via
+    ``Brain._resolve_node_descriptions`` (shared with ``_neighbors``) instead
+    of fabricating ``[<ntype>] <uuid8>`` placeholder descriptions, and must
+    drop nodes the resolver does not return (inactive/missing rows)."""
+
+    def _spreading_fixtures(self, *, resolved):
+        heart = _make_heart(recall_results=[])
+        brain = _make_brain(
+            neighbors_by_node={},
+            contradictions=[],
+            decision_results=_make_decision_summaries(),
+        )
+        brain._resolve_node_descriptions = AsyncMock(return_value=resolved)
+        return heart, brain
+
+    @pytest.mark.asyncio
+    async def test_spreading_results_carry_real_content(self):
+        resolved_at = datetime(2026, 1, 5, tzinfo=UTC)
+        heart, brain = self._spreading_fixtures(
+            resolved={
+                SPREAD_FACT_ID: ("real fact content about pgvector", resolved_at)
+            },
+        )
+        settings = _make_settings(spreading_activation_enabled="true")
+
+        with patch(
+            "nous.brain.spreading_activation.spreading_activation_search",
+            AsyncMock(return_value=[(SPREAD_FACT_ID, "fact", 0.6)]),
+        ), patch(
+            "nous.brain.spreading_activation.compute_graph_density",
+            AsyncMock(return_value=5.0),
+        ):
+            results, stats = await run_recall_pipeline(
+                query="anything", heart=heart, brain=brain,
+                settings=settings, limit=10,
+            )
+
+        assert stats.spreading_activation_used is True
+        spread = next(r for r in results if r.id == SPREAD_FACT_ID)
+        assert spread.source == "spreading_activation"
+        assert spread.description == "real fact content about pgvector"
+
+    @pytest.mark.asyncio
+    async def test_spreading_drops_unresolvable_nodes(self):
+        heart, brain = self._spreading_fixtures(resolved={})
+        settings = _make_settings(spreading_activation_enabled="true")
+
+        with patch(
+            "nous.brain.spreading_activation.spreading_activation_search",
+            AsyncMock(return_value=[(SPREAD_FACT_ID, "fact", 0.6)]),
+        ), patch(
+            "nous.brain.spreading_activation.compute_graph_density",
+            AsyncMock(return_value=5.0),
+        ):
+            results, stats = await run_recall_pipeline(
+                query="anything", heart=heart, brain=brain,
+                settings=settings, limit=10,
+            )
+
+        assert stats.spreading_activation_used is True
+        assert all(r.id != SPREAD_FACT_ID for r in results), (
+            "unresolvable spreading node must be dropped, not surfaced as a "
+            "placeholder"
+        )
+
+    @pytest.mark.asyncio
+    async def test_true_mode_skips_density_query(self):
+        heart, brain = self._spreading_fixtures(resolved={})
+        settings = _make_settings(spreading_activation_enabled="true")
+        density_mock = AsyncMock(return_value=5.0)
+
+        with patch(
+            "nous.brain.spreading_activation.spreading_activation_search",
+            AsyncMock(return_value=[]),
+        ), patch(
+            "nous.brain.spreading_activation.compute_graph_density",
+            density_mock,
+        ):
+            await run_recall_pipeline(
+                query="anything", heart=heart, brain=brain,
+                settings=settings, limit=10,
+            )
+
+        assert density_mock.await_count == 0, (
+            "forced-on mode must not pay the density aggregate query"
+        )
+
+    @pytest.mark.asyncio
+    async def test_auto_mode_density_gate_cached_across_recalls(self):
+        heart, brain = self._spreading_fixtures(resolved={})
+        settings = _make_settings(
+            spreading_activation_enabled="auto",
+            spreading_activation_density_threshold=3.0,
+        )
+        density_mock = AsyncMock(return_value=5.0)
+
+        with patch(
+            "nous.brain.spreading_activation.spreading_activation_search",
+            AsyncMock(return_value=[]),
+        ), patch(
+            "nous.brain.spreading_activation.compute_graph_density",
+            density_mock,
+        ):
+            await run_recall_pipeline(
+                query="anything", heart=heart, brain=brain,
+                settings=settings, limit=10,
+            )
+            await run_recall_pipeline(
+                query="anything", heart=heart, brain=brain,
+                settings=settings, limit=10,
+            )
+
+        assert density_mock.await_count == 1, (
+            "density gate must be TTL-cached per Brain instance across recalls"
         )
 
 

--- a/tests/test_retrieval_pipeline.py
+++ b/tests/test_retrieval_pipeline.py
@@ -860,7 +860,9 @@ class TestSpreadingContentResolution:
                 settings=settings, limit=10,
             )
 
-        assert stats.spreading_activation_used is True
+        # Zero hits resolved -> the pipeline falls back to 1-hop (round-6
+        # refinement), so spreading is reported unused for this recall.
+        assert stats.spreading_activation_used is False
         assert all(r.id != SPREAD_FACT_ID for r in results), (
             "unresolvable spreading node must be dropped, not surfaced as a "
             "placeholder"
@@ -925,6 +927,38 @@ class TestSpreadingContentResolution:
         assert len(spread_ids) == 20
         # Highest-activation resolvable hits win the cap (order preserved).
         assert spread_ids == [nid for nid, _t, _a in hits[:20]]
+
+    @pytest.mark.asyncio
+    async def test_spreading_zero_resolved_falls_back_to_one_hop(self):
+        """If every spreading hit is dropped by resolution (inactive/foreign/
+        dangling), fall back to 1-hop expansion instead of returning an empty
+        graph expansion. Pre-PR#555 this state was unreachable (placeholders
+        always appended); the drop made it real."""
+        heart, brain = self._spreading_fixtures(resolved={})
+        one_hop = NeighborResult(
+            id=UUID(int=3001),
+            node_type="decision",
+            description="one-hop fallback neighbor",
+            edge_relation="supports",
+            edge_weight=0.8,
+            created_at=datetime(2026, 1, 5, tzinfo=UTC),
+        )
+        brain.neighbors = AsyncMock(return_value=[one_hop])
+        settings = _make_settings(spreading_activation_enabled="true")
+
+        with patch(
+            "nous.brain.spreading_activation.spreading_activation_search",
+            AsyncMock(return_value=[(SPREAD_FACT_ID, "fact", 0.6)]),
+        ):
+            results, stats = await run_recall_pipeline(
+                query="anything", heart=heart, brain=brain,
+                settings=settings, limit=10,
+            )
+
+        assert any(r.id == one_hop.id for r in results), (
+            "1-hop fallback must fire when spreading resolves nothing"
+        )
+        assert stats.spreading_activation_used is False
 
     @pytest.mark.asyncio
     async def test_true_mode_skips_density_query(self):


### PR DESCRIPTION
## Why now

Spreading activation is **active in prod today**: the auto-mode density gate (`compute_graph_density`, exclusion-filtered) measured **3.3253 ≥ 3.0** on 2026-07-11 (20,457 qualifying edges / 6,152 nodes, read-only probe). The 2026-06-29 "dead at density 2.745" verdict is superseded by graph growth. That flipped two latent bugs in the Stage-4 spreading branch LIVE:

1. **Placeholder descriptions in LLM-facing output.** The spreading branch built `NeighborResult`s with `description=f"[{ntype}] {str(nid)[:8]}"` — literal `[fact] 1a2b3c4d` text flows through `_graph_expanded_to_pipeline` into `recall_deep` output. Zero information, but the rows still consume ranking slots.
2. **A full `graph_edges` aggregate on every recall.** The density gate ran `compute_graph_density` (aggregate over 22k+ edges) on every recall with decision hits.

## What this does

- **Extract `Brain._resolve_node_descriptions`** from `_neighbors` (verbatim move: per-type batched SELECTs, active-only facts/procedures, NOT-NULL integrity logging) and share it with the spreading branch.
- **Spreading results now carry real content + real `created_at`** (was faked as `datetime.now()`). Ids the resolver omits — inactive/superseded facts, archived procedures, missing rows — are **dropped**, closing an inactive-fact resurrection hole spreading had (it never touched the tables where `active` lives).
- **TTL-cache the density gate** (300 s, `WeakKeyDictionary` keyed per Brain instance — density only moves at sleep-cycle cadence). Forced-on mode (`"true"`) skips the density query entirely.

## Deliberately out of scope

- **Score space.** Spreading emits `SUM(activation)` (unbounded, no cycle guard in the CTE) into the global rerank — a known deviant-leg issue tracked as item 1.2 of `docs/plans/2026-07-11-memory-simplification-plan.md`. Fixing it here would be an eval-gated ranking change and would confound the planned spreading re-evaluation A/B.
- **Keep/remove decision on spreading itself.** Pending re-eval on the current graph (plan item 0.2). This PR makes that re-eval honest: the prior negative A/B measured spreading *with* placeholder garbage in its output.
- No flag changes, no migrations.

## Tests (TDD, repro-first)

- 4 mock-based pipeline tests (`TestSpreadingContentResolution`): real content surfaces, unresolvable nodes dropped, forced-on mode skips density, auto-mode density cached across recalls — each watched fail first (`'[fact] 77777777'` repro).
- 2 DB-backed resolver tests (`tests/test_resolve_node_descriptions.py`): active/inactive fact + decision resolution, empty-input.
- `recall_deep` byte-identical snapshot test unchanged and green.
- Touched-path suites (`test_retrieval_pipeline*`, `test_tools`, `test_dashboard_queries`, `test_graph_constants`, `test_brain`, `test_spreading_activation`) diffed against the unmodified baseline: **identical failure sets** (all pre-existing local SQLite-env failures; CI/Postgres is the gate).

Note: 3 pre-existing `test_spreading_activation.py` tests fail on SQLite (`::float` cast) because they're missing the `postgres_only` marker — untouched here, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMGSu4XRAEDffkHqnCR8CQ
