### PR TITLE
feat(retrieval): plan 1.2 - bounded spreading scores + seed-score threading for graph legs

### DIFF
--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -1286,7 +1286,11 @@ def _score_memory_neighbor(n: "NeighborResult", settings: "Settings") -> float:
             if (n.extraction_method or "heuristic") == "inferred"
             else 1.0
         )
-        return n.seed_score * n.edge_weight * penalty
+        # Clamp the edge term at 1.0 — graph_edges.weight has no DB CHECK,
+        # so a >1 edge would push a seed-scored neighbor above the
+        # direct-hit scale, reintroducing the inflation plan 1.2 removes
+        # (codex PR #558 P2; mirrors the spreading-CTE clamp).
+        return n.seed_score * min(n.edge_weight, 1.0) * penalty
     return _f065_provenance_penalty(n, n.edge_weight, settings.graph_recall_decay, settings)
 
 

--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -804,6 +804,7 @@ async def _run_stages(
 
         if not use_spreading:
             # Fall back to 1-hop expansion
+            seen_hop: dict[UUID, "NeighborResult"] = {}
             for dec in decision_results[: settings.graph_recall_max_expand]:
                 if dec.score is None:
                     continue
@@ -814,9 +815,30 @@ async def _run_stages(
                         limit=settings.graph_recall_max_neighbors,
                     )
                     for n in neighbors:
-                        if n.id not in seen_ids:
-                            graph_expanded.append(n)
-                            seen_ids.add(n.id)
+                        prev = seen_hop.get(n.id)
+                        if prev is n:
+                            # Aliasing guard — see Stage 2.
+                            continue
+                        # Plan 1.2: thread the expanding decision's score
+                        # (guaranteed non-None here by the guard above).
+                        n.seed_score = dec.score
+                        if n.id in seen_ids:
+                            # prev is None when the id is a seed decision or
+                            # a spreading leftover — skip without compare.
+                            if (
+                                prev is not None
+                                and getattr(settings, "graph_neighbor_seed_score_enabled", False)
+                                and _score_memory_neighbor(n, settings)
+                                > _score_memory_neighbor(prev, settings)
+                            ):
+                                prev.seed_score = n.seed_score
+                                prev.edge_weight = n.edge_weight
+                                prev.edge_relation = n.edge_relation
+                                prev.extraction_method = n.extraction_method
+                            continue
+                        graph_expanded.append(n)
+                        seen_hop[n.id] = n
+                        seen_ids.add(n.id)
                 except Exception:
                     logger.debug(
                         "Graph expansion failed for decision %s", dec.id

--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -473,7 +473,7 @@ async def _run_stages(
         and settings.graph_recall_enabled
         and settings.cross_type_linking_enabled
     ):
-        seen_graph_ids: set[UUID] = set()
+        seen_graph: dict[UUID, "NeighborResult"] = {}
         for hr in acc.heart_results[:3]:
             if hr.type in ("fact", "episode"):
                 try:
@@ -491,9 +491,36 @@ async def _run_stages(
                         neighbor_type="decision",
                     )
                     for n in neighbors:
-                        if n.node_type == "decision" and n.id not in seen_graph_ids:
-                            acc.heart_graph_decisions.append(n)
-                            seen_graph_ids.add(n.id)
+                        if n.node_type != "decision":
+                            continue
+                        prev = seen_graph.get(n.id)
+                        if prev is n:
+                            # Aliasing guard: the same object reached again
+                            # (shared instances from mocks) must not have
+                            # its stored seed_score overwritten below.
+                            continue
+                        # Plan 1.2: thread the seed's retrieval score
+                        # (nullable — None stays None so the scorer's
+                        # legacy fallback fires; never coerce to 0.0).
+                        n.seed_score = hr.score
+                        if prev is not None:
+                            # Best-composed-path replacement (same rule as
+                            # Stage 2b :578-596) is part of the seed-score
+                            # mechanism — flag-gated so flag-off dedup
+                            # stays first-seed-wins, byte-identical to the
+                            # pre-plan-1.2 behavior.
+                            if (
+                                getattr(settings, "graph_neighbor_seed_score_enabled", False)
+                                and _score_memory_neighbor(n, settings)
+                                > _score_memory_neighbor(prev, settings)
+                            ):
+                                prev.seed_score = n.seed_score
+                                prev.edge_weight = n.edge_weight
+                                prev.edge_relation = n.edge_relation
+                                prev.extraction_method = n.extraction_method
+                            continue
+                        acc.heart_graph_decisions.append(n)
+                        seen_graph[n.id] = n
                 except Exception:
                     # 3a: log (was silent) so a graph-expansion outage is
                     # diagnosable, not just counted. Still non-fatal.
@@ -1198,13 +1225,15 @@ def _f065_provenance_penalty(
 def _heart_graph_to_pipeline(
     heart_graph: list["NeighborResult"], settings: "Settings"
 ) -> list[PipelineResult]:
-    decay = settings.graph_recall_decay
     return [
         PipelineResult(
             id=n.id,
             type="decision",  # Only decision neighbors are appended at this stage
             description=n.description,
-            score=_f065_provenance_penalty(n, n.edge_weight, decay, settings),
+            # Plan 1.2: shared Path-A scorer — seed×edge×penalty when the
+            # seed-score flag is on and Stage 2 threaded seed_score; exact
+            # legacy edge×decay×penalty otherwise.
+            score=_score_memory_neighbor(n, settings),
             source="graph_expanded",
             edge_relation=n.edge_relation,
             # Stage origin tag — the formatter uses this to bucket
@@ -1294,13 +1323,17 @@ def _decisions_to_pipeline(
 def _graph_expanded_to_pipeline(
     graph_expanded: list["NeighborResult"], settings: "Settings"
 ) -> list[PipelineResult]:
-    decay = settings.graph_recall_decay
     return [
         PipelineResult(
             id=n.id,
             type=n.node_type,  # type: ignore[arg-type]
             description=n.description,
-            score=_f065_provenance_penalty(n, n.edge_weight, decay, settings),
+            # Plan 1.2: shared Path-A scorer. 1-hop rows (Stage 4 threads
+            # seed_score=dec.score) score seed×edge×penalty under the flag;
+            # spreading rows keep seed_score=None by design (their activation
+            # already composes the seed per hop, bounded by the MAX
+            # aggregation) and fall through to the legacy activation×decay.
+            score=_score_memory_neighbor(n, settings),
             source=(
                 "spreading_activation"
                 if n.edge_relation == "spreading_activation"

--- a/nous/brain/schemas.py
+++ b/nous/brain/schemas.py
@@ -176,8 +176,10 @@ class NeighborResult(BaseModel):
     # or for rows that somehow slip through the migration with NULL.
     extraction_method: str = "heuristic"
     # Retrieval score of the SEED this neighbor was expanded from (Path A
-    # graph-neighbor scoring fix). Set by run_recall_pipeline Stage 2b when
-    # the neighbor is collected; consumed by _heart_graph_memory_to_pipeline
-    # when graph_neighbor_seed_score_enabled. None for neighbors built outside
-    # that path (e.g. decision expansion, spreading activation).
+    # graph-neighbor scoring fix). Set by run_recall_pipeline when the
+    # neighbor is collected (Stage 2b since Path A; Stage 2 decision
+    # expansion and Stage 4 1-hop since plan 1.2); consumed by the pipeline
+    # converters via _score_memory_neighbor when
+    # graph_neighbor_seed_score_enabled. Spreading-activation rows keep None
+    # BY DESIGN — their activation already composes the seed score per hop.
     seed_score: float | None = None

--- a/nous/brain/spreading_activation.py
+++ b/nous/brain/spreading_activation.py
@@ -98,7 +98,15 @@ async def spreading_activation_search(
             PR #556). Traversal still passes THROUGH excluded nodes.
 
     Returns:
-        List of (node_id, node_type, total_activation) sorted by activation desc
+        List of (node_id, node_type, activation) sorted by activation desc.
+        Aggregation across paths is MAX (bounded best-path), not SUM: each
+        path's activation is seed_score × ∏(weight × decay) ≤ 1 when weights
+        ≤ 1, so MAX keeps results on the seeds' [0,1] score scale and makes
+        undirected-traversal cycles score-harmless. (Plan 1.2 — SUM let
+        multi-path/cyclic nodes exceed 1.0 and dominate the RRF-sorted
+        merge.) The per-hop weight term is clamped to 1.0 in the CTE:
+        ``brain.graph_edges.weight`` has no DB CHECK, so the bound is
+        enforced here rather than assumed of every writer.
     """
     if not seed_nodes:
         return []
@@ -134,7 +142,7 @@ async def spreading_activation_search(
             SELECT
                 CASE WHEN e.source_id = a.id THEN e.target_id ELSE e.source_id END,
                 CASE WHEN e.source_id = a.id THEN e.target_type ELSE e.source_type END,
-                a.activation * COALESCE(e.weight, 1.0) * :decay,
+                a.activation * LEAST(COALESCE(e.weight, 1.0), 1.0) * :decay,
                 a.depth + 1
             FROM activation a
             JOIN brain.graph_edges e
@@ -147,7 +155,7 @@ async def spreading_activation_search(
                 AND {excl_e}
                 AND e.agent_id = :agent_id
         )
-        SELECT id, node_type, SUM(activation) AS total_activation
+        SELECT id, node_type, MAX(activation) AS total_activation
         FROM activation
         {exclude_clause}
         GROUP BY id, node_type

--- a/nous/brain/spreading_activation.py
+++ b/nous/brain/spreading_activation.py
@@ -142,7 +142,13 @@ async def spreading_activation_search(
             SELECT
                 CASE WHEN e.source_id = a.id THEN e.target_id ELSE e.source_id END,
                 CASE WHEN e.source_id = a.id THEN e.target_type ELSE e.source_type END,
-                a.activation * LEAST(COALESCE(e.weight, 1.0), 1.0) * :decay,
+                -- Clamp the weight term at 1.0 (no DB CHECK on
+                -- graph_edges.weight). CASE, not LEAST: the suite's default
+                -- SQLite backend has no LEAST() (codex PR #558 P2).
+                a.activation
+                    * CASE WHEN COALESCE(e.weight, 1.0) > 1.0 THEN 1.0
+                           ELSE COALESCE(e.weight, 1.0) END
+                    * :decay,
                 a.depth + 1
             FROM activation a
             JOIN brain.graph_edges e

--- a/tests/test_f065_pipeline_penalty.py
+++ b/tests/test_f065_pipeline_penalty.py
@@ -158,6 +158,20 @@ class TestSeedScoreScoring:
         [res2] = _heart_graph_to_pipeline([n2], settings_on)
         assert res2.score == pytest.approx(0.8 * 0.7)
 
+    def test_seed_score_path_clamps_edge_weight_above_one(self) -> None:
+        """graph_edges.weight has no DB CHECK <= 1; a rogue 1.3 edge must not
+        push a seed-scored neighbor above the direct-hit scale (codex PR #558
+        P2 — mirrors the spreading-CTE clamp)."""
+        settings = Settings(
+            graph_neighbor_seed_score_enabled=True,
+            graph_recall_decay=0.7,
+        )
+        n = _neighbor(weight=1.3, seed_score=0.9)
+        [res] = _heart_graph_to_pipeline([n], settings)
+        assert res.score == pytest.approx(0.9 * 1.0), (
+            "edge term must clamp at 1.0, not multiply seed by 1.3"
+        )
+
     def test_graph_expanded_to_pipeline_uses_seed_score_for_one_hop(self) -> None:
         """1-hop expansion rows (seed_score threaded) score seed×edge×penalty
         under the flag; spreading rows (seed_score None, edge_weight = bounded

--- a/tests/test_f065_pipeline_penalty.py
+++ b/tests/test_f065_pipeline_penalty.py
@@ -29,15 +29,19 @@ def _neighbor(
     method: str = "heuristic",
     relation: str = "related_to",
     weight: float = 1.0,
+    seed_score: float | None = None,
+    node_type: str = "decision",
+    description: str = "x",
 ) -> NeighborResult:
     return NeighborResult(
         id=uuid.uuid4(),
-        node_type="decision",
-        description="x",
+        node_type=node_type,
+        description=description,
         edge_relation=relation,
         edge_weight=weight,
         created_at=datetime.now(UTC),
         extraction_method=method,
+        seed_score=seed_score,
     )
 
 
@@ -116,3 +120,64 @@ class TestPipelineHelpers:
         hg = _heart_graph_to_pipeline([inferred], settings)
         assert ge[0].score == pytest.approx(0.85 * decay)
         assert hg[0].score == pytest.approx(0.85 * decay)
+
+
+class TestSeedScoreScoring:
+    """Plan 1.2: Stage 2 / Stage 4 converters join Path A's seed-anchored
+    scale via the shared _score_memory_neighbor — seed × edge × penalty
+    when graph_neighbor_seed_score_enabled and the loop threaded a
+    seed_score; exact legacy formula otherwise."""
+
+    def test_heart_graph_to_pipeline_uses_seed_score_when_flag_on(self) -> None:
+        settings = Settings(
+            graph_neighbor_seed_score_enabled=True,
+            graph_inferred_edge_penalty=0.5,
+            graph_recall_decay=0.7,
+        )
+        n = _neighbor(method="inferred", weight=0.8, seed_score=0.9)
+        [res] = _heart_graph_to_pipeline([n], settings)
+        assert res.score == pytest.approx(0.9 * 0.8 * 0.5)
+
+    def test_heart_graph_to_pipeline_legacy_when_flag_off_or_no_seed(self) -> None:
+        """Flag off, or seed_score None (spreading rows / legacy callers),
+        must reproduce the pre-plan-1.2 formula edge × decay × penalty
+        exactly — the byte-identical flag-off invariant."""
+        settings = Settings(
+            graph_neighbor_seed_score_enabled=False,
+            graph_recall_decay=0.7,
+        )
+        n = _neighbor(weight=0.8, seed_score=0.9)
+        [res] = _heart_graph_to_pipeline([n], settings)
+        assert res.score == pytest.approx(0.8 * 0.7)
+
+        settings_on = Settings(
+            graph_neighbor_seed_score_enabled=True,
+            graph_recall_decay=0.7,
+        )
+        n2 = _neighbor(weight=0.8, seed_score=None)
+        [res2] = _heart_graph_to_pipeline([n2], settings_on)
+        assert res2.score == pytest.approx(0.8 * 0.7)
+
+    def test_graph_expanded_to_pipeline_uses_seed_score_for_one_hop(self) -> None:
+        """1-hop expansion rows (seed_score threaded) score seed×edge×penalty
+        under the flag; spreading rows (seed_score None, edge_weight = bounded
+        activation) keep activation × decay."""
+        settings = Settings(
+            graph_neighbor_seed_score_enabled=True,
+            graph_recall_decay=0.7,
+        )
+        one_hop = _neighbor(
+            node_type="fact", description="f", weight=0.7, seed_score=0.6,
+        )
+        spreading = _neighbor(
+            node_type="fact", description="f2",
+            relation="spreading_activation", weight=0.4,
+        )
+        res = {
+            r.description: r
+            for r in _graph_expanded_to_pipeline([one_hop, spreading], settings)
+        }
+        assert res["f"].score == pytest.approx(0.6 * 0.7)
+        # Spreading branch: observed once the converter swap lands (Step 4);
+        # pins the forward regression that spreading stays on activation×decay.
+        assert res["f2"].score == pytest.approx(0.4 * 0.7)

--- a/tests/test_retrieval_pipeline.py
+++ b/tests/test_retrieval_pipeline.py
@@ -1392,3 +1392,235 @@ class TestExports:
         assert s.n_graph_expanded == 0
         assert s.n_stage_errors == {}
         assert s.contradiction_edges == []
+
+
+# ---------------------------------------------------------------------------
+# Plan 1.2 — seed_score threading for Stage 2 (heart-graph decisions) and
+# Stage 4 (1-hop expansion), and the flag-off byte-identical invariant.
+# ---------------------------------------------------------------------------
+
+
+class TestPlan12SeedScoreThreading:
+    """The converters are unit-tested in test_f065_pipeline_penalty.py; these
+    tests exercise the WIRING — the loop-level seed_score assignment — which
+    is the silent-inert failure class (converters swapped but loops never
+    thread the score)."""
+
+    @pytest.mark.asyncio
+    async def test_stage2_and_stage4_thread_seed_score_flag_on(self):
+        """E2E: a heart fact seed (0.9) with a decision neighbor (edge 0.8)
+        must produce a heart_graph result scored 0.72; a brain decision seed
+        (0.75) with a 1-hop neighbor (edge 0.7) must produce a graph_expanded
+        result scored 0.525."""
+        from uuid import uuid4
+
+        fact_seed = uuid4()
+        stage2_nbr = uuid4()
+        dec_seed = uuid4()
+        stage4_nbr = uuid4()
+        now = datetime.now(UTC)
+
+        recall = [
+            RecallResult(type="fact", id=fact_seed, summary="seed fact", score=0.9),
+        ]
+        decisions = [
+            DecisionSummary(
+                id=dec_seed, description="seed decision", confidence=0.8,
+                category="architecture", stakes="low", outcome="pending",
+                score=0.75, created_at=now,
+            ),
+        ]
+        neighbors_by_node = {
+            fact_seed: [
+                NeighborResult(
+                    id=stage2_nbr, node_type="decision",
+                    description="stage2 decision neighbor",
+                    edge_relation="evidence_for", edge_weight=0.8,
+                    created_at=now,
+                ),
+            ],
+            dec_seed: [
+                NeighborResult(
+                    id=stage4_nbr, node_type="fact",
+                    description="stage4 one-hop neighbor",
+                    edge_relation="related_to", edge_weight=0.7,
+                    created_at=now,
+                ),
+            ],
+        }
+        heart = _make_heart(recall_results=recall)
+        brain = _make_brain(
+            neighbors_by_node=neighbors_by_node,
+            contradictions=[], decision_results=decisions,
+        )
+        settings = _make_settings()
+        settings.graph_neighbor_seed_score_enabled = True
+        settings.graph_inferred_edge_penalty = 1.0
+
+        results, _ = await run_recall_pipeline(
+            query="anything", heart=heart, brain=brain,
+            settings=settings, limit=20,
+        )
+        by_id = {r.id: r for r in results}
+        assert abs(by_id[stage2_nbr].score - 0.9 * 0.8) < 1e-6, (
+            f"Stage 2 neighbor must score seed(0.9)*edge(0.8), "
+            f"got {by_id[stage2_nbr].score}"
+        )
+        assert by_id[stage2_nbr].metadata.get("stage_origin") == "heart_graph"
+        assert abs(by_id[stage4_nbr].score - 0.75 * 0.7) < 1e-6, (
+            f"Stage 4 neighbor must score dec(0.75)*edge(0.7), "
+            f"got {by_id[stage4_nbr].score}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_stage2_duplicate_flag_on_best_composed_path_wins(self):
+        """Two heart seeds reach the SAME decision: keep the best composed
+        (seed x edge) path — 0.4x0.9=0.36 beats 0.9x0.3=0.27; never the
+        phantom 0.9x0.9. Fresh objects per seed (shared instances hit the
+        aliasing guard by design)."""
+        from uuid import uuid4
+
+        weak_seed = uuid4()
+        strong_seed = uuid4()
+        dup_dec = uuid4()
+        now = datetime.now(UTC)
+
+        def _dec_nbr(weight):
+            return NeighborResult(
+                id=dup_dec, node_type="decision", description="shared decision",
+                edge_relation="evidence_for", edge_weight=weight,
+                created_at=now,
+            )
+
+        recall = [
+            RecallResult(type="fact", id=weak_seed, summary="weak", score=0.4),
+            RecallResult(type="episode", id=strong_seed, summary="strong", score=0.9),
+        ]
+        heart = _make_heart(recall_results=recall)
+        brain = _make_brain(
+            neighbors_by_node={
+                weak_seed: [_dec_nbr(0.9)], strong_seed: [_dec_nbr(0.3)],
+            },
+            contradictions=[], decision_results=[],
+        )
+        settings = _make_settings()
+        settings.graph_neighbor_seed_score_enabled = True
+        settings.graph_inferred_edge_penalty = 1.0
+
+        results, _ = await run_recall_pipeline(
+            query="anything", heart=heart, brain=brain,
+            settings=settings, limit=20,
+        )
+        dup = next(r for r in results if r.id == dup_dec)
+        assert abs(dup.score - 0.36) < 1e-6, (
+            f"best composed path 0.4x0.9=0.36 must win, got {dup.score}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_stage2_duplicate_flag_off_first_seed_wins_byte_identical(self):
+        """Flag OFF: the dedup must stay first-seed-wins (no best-path
+        replacement) so flag-off output — score AND edge metadata — stays
+        byte-identical to pre-plan-1.2 behavior (the external A/B control
+        arm depends on this)."""
+        from uuid import uuid4
+
+        first_seed = uuid4()
+        second_seed = uuid4()
+        dup_dec = uuid4()
+        now = datetime.now(UTC)
+
+        def _dec_nbr(weight, relation):
+            return NeighborResult(
+                id=dup_dec, node_type="decision", description="shared decision",
+                edge_relation=relation, edge_weight=weight,
+                created_at=now,
+            )
+
+        recall = [
+            RecallResult(type="fact", id=first_seed, summary="first", score=0.4),
+            RecallResult(type="fact", id=second_seed, summary="second", score=0.9),
+        ]
+        heart = _make_heart(recall_results=recall)
+        brain = _make_brain(
+            neighbors_by_node={
+                # Second path has the higher legacy score (0.9 edge) — under
+                # flag-off it must NOT replace the first (0.5 edge) path.
+                first_seed: [_dec_nbr(0.5, "evidence_for")],
+                second_seed: [_dec_nbr(0.9, "informed_by")],
+            },
+            contradictions=[], decision_results=[],
+        )
+        settings = _make_settings()  # seed-score flag ABSENT -> off
+
+        results, _ = await run_recall_pipeline(
+            query="anything", heart=heart, brain=brain,
+            settings=settings, limit=20,
+        )
+        dup = next(r for r in results if r.id == dup_dec)
+        # Legacy formula on the FIRST path: edge(0.5) x decay(0.7) = 0.35.
+        assert abs(dup.score - 0.5 * 0.7) < 1e-6, (
+            f"flag-off dedup must stay first-seed-wins (0.35), got {dup.score}"
+        )
+        assert dup.edge_relation == "evidence_for", (
+            "flag-off must keep the first path's edge metadata"
+        )
+
+    @pytest.mark.asyncio
+    async def test_stage4_seed_decision_neighbor_skipped_without_compare(self):
+        """A 1-hop neighbor whose id IS another seed decision (already in
+        seen_ids, never in seen_hop) must be skipped without a compare and
+        without crashing; the loop keeps collecting other neighbors."""
+        from uuid import uuid4
+
+        dec_a = uuid4()
+        dec_b = uuid4()
+        normal_nbr = uuid4()
+        now = datetime.now(UTC)
+
+        decisions = [
+            DecisionSummary(
+                id=dec_a, description="decision A", confidence=0.8,
+                category="architecture", stakes="low", outcome="pending",
+                score=0.75, created_at=now,
+            ),
+            DecisionSummary(
+                id=dec_b, description="decision B", confidence=0.7,
+                category="tooling", stakes="low", outcome="pending",
+                score=0.6, created_at=now,
+            ),
+        ]
+        neighbors_by_node = {
+            dec_a: [
+                # This neighbor IS seed decision B — must be skipped.
+                NeighborResult(
+                    id=dec_b, node_type="decision", description="decision B",
+                    edge_relation="related_to", edge_weight=0.9,
+                    created_at=now,
+                ),
+                NeighborResult(
+                    id=normal_nbr, node_type="fact", description="normal",
+                    edge_relation="related_to", edge_weight=0.7,
+                    created_at=now,
+                ),
+            ],
+        }
+        heart = _make_heart(recall_results=[])
+        brain = _make_brain(
+            neighbors_by_node=neighbors_by_node,
+            contradictions=[], decision_results=decisions,
+        )
+        settings = _make_settings()
+        settings.graph_neighbor_seed_score_enabled = True
+        settings.graph_inferred_edge_penalty = 1.0
+
+        results, _ = await run_recall_pipeline(
+            query="anything", heart=heart, brain=brain,
+            settings=settings, limit=20,
+        )
+        graph_rows = [r for r in results if r.source == "graph_expanded"]
+        graph_ids = {r.id for r in graph_rows}
+        assert normal_nbr in graph_ids, "loop must continue past the seed-id skip"
+        assert dec_b not in graph_ids, (
+            "a neighbor that IS a seed decision must not re-enter via 1-hop"
+        )
+

--- a/tests/test_spreading_activation.py
+++ b/tests/test_spreading_activation.py
@@ -307,3 +307,98 @@ async def test_spreading_excludes_supersedes_edges(brain, session):
     ids = {r[0] for r in activated}
     assert b.id in ids, "a normal edge must be traversed"
     assert c.id not in ids, "a supersedes edge must NOT be traversed by spreading activation"
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_spreading_activation_is_bounded_best_path(brain, session):
+    """Plan 1.2: cross-path aggregation is MAX, not SUM. A diamond
+    (seed→A→C, seed→B→C, all weight 1.0, decay 0.5, depth 2) must give C
+    activation = one best path (1.0 × 0.5 × 0.5 = 0.25), NOT the 0.5 a
+    SUM over both paths would produce. Also pins the global bound: no
+    activation may exceed the max seed score (SUM additionally inflated
+    seeds themselves via undirected cycle returns — seed would score 1.5)."""
+    from sqlalchemy import text
+
+    from nous.brain.schemas import RecordInput
+
+    def _inp(d):
+        return RecordInput(description=d, confidence=0.8, category="architecture",
+                           stakes="low", reasons=_reasons())
+
+    seed = await brain.record(_inp("Diamond seed decision for bounded path test"), session=session)
+    a = await brain.record(_inp("Diamond left intermediate decision node"), session=session)
+    b = await brain.record(_inp("Diamond right intermediate decision node"), session=session)
+    c = await brain.record(_inp("Diamond sink decision reachable via two paths"), session=session)
+
+    async def _edge(s_id, t_id):
+        await session.execute(text(
+            "INSERT INTO brain.graph_edges (source_id,target_id,source_type,target_type,"
+            "agent_id,relation,weight,auto_linked,extraction_method) "
+            "VALUES (:s,:t,'decision','decision',:a,'related_to',1.0,true,'deterministic')"),
+            {"s": str(s_id), "t": str(t_id), "a": brain.agent_id})
+
+    await _edge(seed.id, a.id)
+    await _edge(seed.id, b.id)
+    await _edge(a.id, c.id)
+    await _edge(b.id, c.id)
+    await session.flush()
+
+    # Explicit kwargs: exact-magnitude assertions must not inherit .env drift.
+    settings = Settings(
+        spreading_activation_decay=0.5, spreading_activation_max_depth=2,
+    )
+    activated = await spreading_activation_search(
+        session, brain.agent_id, [(seed.id, "decision", 1.0)], settings,
+    )
+    by_id = {r[0]: r[2] for r in activated}
+    assert by_id[c.id] == pytest.approx(0.25), (
+        "C must score its best single path (MAX), not the sum of both paths"
+    )
+    assert all(act <= 1.0 + 1e-9 for act in by_id.values()), (
+        "no activation may exceed the max seed score"
+    )
+    # Seed's own activation must stay its seed score, not seed + cycle returns.
+    assert by_id[seed.id] == pytest.approx(1.0)
+
+
+@pytest.mark.postgres_only
+@pytest.mark.asyncio
+async def test_spreading_activation_max_across_mixed_depths(brain, session):
+    """Plan 1.2: MAX must also hold across DIFFERENT-length paths to the
+    same node. seed→X directly (0.5) plus seed→A→X (0.25): X scores 0.5
+    (best path), not 0.75 (SUM)."""
+    from sqlalchemy import text
+
+    from nous.brain.schemas import RecordInput
+
+    def _inp(d):
+        return RecordInput(description=d, confidence=0.8, category="architecture",
+                           stakes="low", reasons=_reasons())
+
+    seed = await brain.record(_inp("Mixed depth seed decision for max test"), session=session)
+    a = await brain.record(_inp("Mixed depth intermediate decision node"), session=session)
+    x = await brain.record(_inp("Mixed depth sink reachable at two depths"), session=session)
+
+    async def _edge(s_id, t_id):
+        await session.execute(text(
+            "INSERT INTO brain.graph_edges (source_id,target_id,source_type,target_type,"
+            "agent_id,relation,weight,auto_linked,extraction_method) "
+            "VALUES (:s,:t,'decision','decision',:a,'related_to',1.0,true,'deterministic')"),
+            {"s": str(s_id), "t": str(t_id), "a": brain.agent_id})
+
+    await _edge(seed.id, x.id)
+    await _edge(seed.id, a.id)
+    await _edge(a.id, x.id)
+    await session.flush()
+
+    settings = Settings(
+        spreading_activation_decay=0.5, spreading_activation_max_depth=2,
+    )
+    activated = await spreading_activation_search(
+        session, brain.agent_id, [(seed.id, "decision", 1.0)], settings,
+    )
+    by_id = {r[0]: r[2] for r in activated}
+    assert by_id[x.id] == pytest.approx(0.5), (
+        "X must take its best (depth-1) path, not accumulate the depth-2 one"
+    )


### PR DESCRIPTION
﻿> ## Merge authorized by owner 2026-07-12
> The retrieval A/B runs post-merge in a separate session (owner directive). Codex: 3 rounds, 2 real P2s fixed (LEAST portability; edge-term clamp in the seed-score path), final round clean on d531ffa.

## Problem — the last two score-space-deviant graph legs

After F080's verdict (the merge is NOT globally incoherent — facts/episodes/decisions/procedures share the 1/k-normalized RRF [0,1] scale; only deviant legs need surgical renorm) and the chunk-leg fix (#553, land-dark), two graph legs remained off-scale:

1. **Spreading activation** summed activation across paths: each path already composes `seed_score × ∏(weight × decay) ≤ 1`, so the cross-path `SUM` was the only violation — multi-path and *cyclic* nodes (traversal is undirected with no visited-set; a depth-2 cycle returns to the seed) could exceed 1.0 and dominate the RRF-sorted merge.
2. **Stage 2 heart-graph decisions and Stage 4 1-hop expansion** scored `edge_weight × decay × penalty` — a structural ceiling of ~0.70 on a scale where direct hits reach 1.0, and disconnected from how good the *seed* was. Path A (Stage 2b) already fixed this with seed-anchored scoring (`_score_memory_neighbor`, flag `NOUS_GRAPH_NEIGHBOR_SEED_SCORE_ENABLED`, ON in prod); these two legs never joined.

## Fix (design FORGE 97ec2098; plan + 3-agent review in docs/superpowers/plans/2026-07-12-plan12-graph-seed-score.md)

- **`SUM(activation)` → `MAX(activation)`** in the spreading CTE — bounded best-path, cycles become score-harmless. Unconditional (no flag, per the #556 owner directive: no dark landing for spreading behavior). The per-hop weight term is clamped `LEAST(COALESCE(weight,1.0),1.0)` since `graph_edges.weight` has no DB CHECK.
- **Seed-score threading**: Stage 2 threads `hr.score`, Stage 4 threads `dec.score` (nullable — None falls through to the legacy formula), mirroring Path A's pattern including best-composed-path duplicate handling. Both graph converters now use the shared `_score_memory_neighbor`.
- **Flag-off is byte-identical**: the scorer's fallback is the exact legacy expression, and the best-path dedup replacement is flag-gated (flag-off duplicates stay first-seed-wins) — pinned by `test_stage2_duplicate_flag_off_first_seed_wins_byte_identical`. The A/B control arm is uncontaminated.
- Spreading rows keep `seed_score=None` by design — their activation already composes the seed per hop; they score `activation × decay`, now bounded ≤ 1.

## What changes in prod on deploy (reviewer findings, stated for the A/B reader)

- `NOUS_GRAPH_NEIGHBOR_SEED_SCORE_ENABLED` is **ON in prod**, and prod `recall_deep` runs with `rerank_by_score=True` (chunks enabled → `tools.py:947-959`), so the new Stage-2/4 scores **globally reorder** the merged list; the prod-ON adjacency boost then multiplies and re-sorts on top. Graph decision neighbors move from a ~0.70 ceiling to `seed × edge` (up to ~1.0) and can displace direct heart hits — that is the intended, measurable effect.
- **Spreading itself is inert in prod day-one** (auto mode, density 2.745 < 3.0 threshold, pinned off per the F053 rollout), so `SUM→MAX` has no immediate prod effect.
- **A/B measurement request**: report spreading result-count and depth histogram before/after, not just MRR — under MAX + the kept 0.1 activation floor, depth-2 survival requires `seed × w₁ × w₂ > 0.4`, so weak chains drop to near-1-hop behavior by design; that should be visible in the eval, not assumed. (Seed scales verified coherent: both decision and fact seeds are 1/k-normalized RRF in [0,1]; top-3 fact seeds ≈ 0.86–1.0 → depth-2 activations ≈ 0.22–0.25 clear the floor.)

## Tests

- Diamond + mixed-depth Postgres tests pin MAX semantics (exact values: C=0.25 not 0.5; X=0.5 not 0.75; seed stays 1.0, no cycle inflation).
- Converter unit tests (flag-on seed×edge×penalty; flag-off/None exact legacy) in `test_f065_pipeline_penalty.py`.
- E2E wiring tests (the converters-swapped-but-loops-never-thread failure class), flag-on best-composed-path dedup, flag-off first-seed-wins byte-identical pin, Stage 4 seed-decision skip path — in `test_retrieval_pipeline.py`.
- Full suite in CI mode: 4,956 passed; the 6 local failures are the known dirty-dev-DB artifacts, byte-identical on origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMGSu4XRAEDffkHqnCR8CQ


