### PR TITLE
fix: enumerative backfill includes closed episodes — active is lifecycle, not liveness (#557 lesson)

### DIFF
--- a/scripts/backfill_enumerative_facts.py
+++ b/scripts/backfill_enumerative_facts.py
@@ -84,8 +84,11 @@ async def select_backfill_episodes(session, agent_id: str, since, limit: int):
               -- _end() sets active=False on every properly CLOSED episode,
               -- which are exactly the transcripts this backfill remediates.
               -- Include open (active) and closed (ended_at set) episodes;
-              -- exclude only never-ended deactivated orphans.
+              -- exclude never-ended deactivated orphans and abandoned
+              -- episodes (F060.2 sets ended_at on those too — mirror the
+              -- recall predicate at nous/heart/episodes.py:531).
               AND (active = true OR ended_at IS NOT NULL)
+              AND outcome IS DISTINCT FROM 'abandoned'
               AND transcript IS NOT NULL
               AND length(transcript) > 0
               {since_clause}

--- a/scripts/backfill_enumerative_facts.py
+++ b/scripts/backfill_enumerative_facts.py
@@ -80,7 +80,12 @@ async def select_backfill_episodes(session, agent_id: str, since, limit: int):
             SELECT id, transcript
             FROM heart.episodes
             WHERE agent_id = :agent_id
-              AND active = true
+              -- #557 liveness lesson: episodes.active is a LIFECYCLE flag —
+              -- _end() sets active=False on every properly CLOSED episode,
+              -- which are exactly the transcripts this backfill remediates.
+              -- Include open (active) and closed (ended_at set) episodes;
+              -- exclude only never-ended deactivated orphans.
+              AND (active = true OR ended_at IS NOT NULL)
               AND transcript IS NOT NULL
               AND length(transcript) > 0
               {since_clause}

--- a/tests/test_write_path_adjudication.py
+++ b/tests/test_write_path_adjudication.py
@@ -2270,7 +2270,16 @@ async def test_select_backfill_episodes_includes_closed_episodes(session):
         ended_at=None,
         active=False,  # deactivated without ever closing — excluded
     )
-    session.add_all([ep_closed, ep_open, ep_orphan])
+    ep_abandoned = Episode(
+        agent_id=agent_id,
+        summary="Abandoned episode",
+        transcript="Stale fact 1.\nStale fact 2.\nStale fact 3.",
+        started_at=now,
+        ended_at=now,  # F060.2 stamps ended_at on abandonment too
+        active=False,
+        outcome="abandoned",  # excluded, mirroring the recall predicate
+    )
+    session.add_all([ep_closed, ep_open, ep_orphan, ep_abandoned])
     await session.flush()
 
     rows = await select_backfill_episodes(session, agent_id, None, 0)
@@ -2279,6 +2288,7 @@ async def test_select_backfill_episodes_includes_closed_episodes(session):
     assert ep_closed.id in ids, "closed episode (the normal case) must be included"
     assert ep_open.id in ids, "open episode must still be included"
     assert ep_orphan.id not in ids, "never-ended deactivated orphan must stay excluded"
+    assert ep_abandoned.id not in ids, "abandoned episode must stay excluded (F060.2)"
 
 
 @pytest.mark.postgres_only

--- a/tests/test_write_path_adjudication.py
+++ b/tests/test_write_path_adjudication.py
@@ -2234,6 +2234,54 @@ async def test_select_backfill_episodes_filters_empty_transcripts(session):
 
 
 @pytest.mark.postgres_only
+async def test_select_backfill_episodes_includes_closed_episodes(session):
+    """#557 liveness lesson: episodes.active is a LIFECYCLE flag — _end() sets
+    active=False on every properly closed episode (episodes.py:235). Closed
+    episodes are exactly the ones with complete transcripts the backfill
+    exists to remediate; filtering `active = true` selected only OPEN episodes
+    and silently skipped the whole corpus. Closed (ended) episodes must be
+    included; never-ended deactivated orphans stay excluded."""
+    from scripts.backfill_enumerative_facts import select_backfill_episodes
+    from nous.storage.models import Episode
+
+    agent_id = f"test-enum-closed-{uuid4().hex[:8]}"
+    now = datetime.now(timezone.utc)
+
+    ep_closed = Episode(
+        agent_id=agent_id,
+        summary="Properly closed episode",
+        transcript="Fact one.\nFact two.\nFact three.",
+        started_at=now,
+        ended_at=now,
+        active=False,  # lifecycle close, NOT soft-delete
+    )
+    ep_open = Episode(
+        agent_id=agent_id,
+        summary="Still-open episode",
+        transcript="Live fact 1.\nLive fact 2.\nLive fact 3.",
+        started_at=now,
+        active=True,
+    )
+    ep_orphan = Episode(
+        agent_id=agent_id,
+        summary="Never-ended deactivated orphan",
+        transcript="Orphan fact 1.\nOrphan fact 2.\nOrphan fact 3.",
+        started_at=now,
+        ended_at=None,
+        active=False,  # deactivated without ever closing — excluded
+    )
+    session.add_all([ep_closed, ep_open, ep_orphan])
+    await session.flush()
+
+    rows = await select_backfill_episodes(session, agent_id, None, 0)
+    ids = {r.id for r in rows}
+
+    assert ep_closed.id in ids, "closed episode (the normal case) must be included"
+    assert ep_open.id in ids, "open episode must still be included"
+    assert ep_orphan.id not in ids, "never-ended deactivated orphan must stay excluded"
+
+
+@pytest.mark.postgres_only
 async def test_select_backfill_episodes_orders_oldest_first(session):
     """select_backfill_episodes: returns episodes ordered oldest-first (started_at ASC)."""
     from scripts.backfill_enumerative_facts import select_backfill_episodes


### PR DESCRIPTION
## Summary

F084's `backfill_enumerative_facts.py` filtered episodes with `AND active = true` — but `episodes.active` is a **lifecycle** flag: `_end()` sets `active=False` on every properly closed episode (`nous/heart/episodes.py:235`). The backfill therefore selected only still-open episodes and silently skipped the entire closed corpus it exists to remediate (operator dry-runs returned 0 episodes). This is the #557 liveness lesson recurring.

**Fix:** `(active = true OR ended_at IS NOT NULL)` — open and closed episodes included; never-ended deactivated orphans stay excluded.

## Test plan

- New PG regression test `test_select_backfill_episodes_includes_closed_episodes`: closed (ended, active=False) episode INCLUDED, open episode included, never-ended deactivated orphan excluded — fails on the old filter, passes on the fix.
- Full `tests/test_write_path_adjudication.py`: 88 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMGSu4XRAEDffkHqnCR8CQ