### PR TITLE
fix: backfill_supersession chain-depth histogram accepts ISO-string watermark

### DIFF
--- a/scripts/backfill_supersession.py
+++ b/scripts/backfill_supersession.py
@@ -149,12 +149,20 @@ async def run_sweep(
     return counters
 
 
-async def _chain_depth_histogram(session, agent_id: str, watermark: str) -> Counter:
+async def _chain_depth_histogram(
+    session, agent_id: str, watermark: str | datetime
+) -> Counter:
     """Return a Counter of chain depths for winners touched this run.
 
     Uses the DB trigger-updated updated_at to identify losers written in this
     run, then walks each winner's downstream chain recursively.
     """
+    # The run watermark is kept as an ISO STRING for printing (the rollback
+    # key), but asyncpg refuses str for a timestamptz bind — normalize to a
+    # datetime here so the report can never crash after resolutions have
+    # already been committed (field bug: rc=2 with only the printout lost).
+    if isinstance(watermark, str):
+        watermark = datetime.fromisoformat(watermark)
     # Find distinct winners from this run.
     winner_sql = text("""
         SELECT DISTINCT superseded_by AS winner_id

--- a/tests/test_write_path_adjudication.py
+++ b/tests/test_write_path_adjudication.py
@@ -3903,6 +3903,29 @@ async def test_backfill_keep_both_seen_set_terminates(heart, monkeypatch):
     assert result["keep_both"] == 1
 
 
+@pytest.mark.postgres_only
+async def test_chain_depth_histogram_accepts_iso_string_watermark(heart):
+    """Field bug (sh_6k run): the run watermark is an ISO STRING (kept that way
+    for the printed rollback key) but was bound directly into the histogram's
+    timestamptz query — asyncpg raises TypeError, rc=2 AFTER all resolutions
+    were committed (only the report printout was lost). The helper must accept
+    both str and datetime watermarks."""
+    from collections import Counter
+    from datetime import UTC, datetime
+    from uuid import uuid4
+
+    from scripts.backfill_supersession import _chain_depth_histogram
+
+    unique_agent = f"hist-{uuid4().hex[:8]}"
+    wm_dt = datetime.now(UTC)
+    async with heart.db.session() as s:
+        # str watermark (the exact shape _run_backfill passes) must not raise.
+        hist_str = await _chain_depth_histogram(s, unique_agent, wm_dt.isoformat())
+        # datetime watermark keeps working.
+        hist_dt = await _chain_depth_histogram(s, unique_agent, wm_dt)
+    assert hist_str == hist_dt == Counter()
+
+
 # ---------------------------------------------------------------------------
 # Codex round-4 P1: stale-pair guard in resolve_key_conflict_pair
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Field bug from the Gate-1 repair run (sh_6k): the chain-depth histogram added in #564 passes the run watermark to asyncpg as an ISO string instead of a datetime → `TypeError` / rc=2 **after** all resolutions were already committed, so only the report printout was lost (no data impact). Reported by the operator, who patched locally with `datetime.fromisoformat(watermark)` — this upstreams the same semantics: `_chain_depth_histogram` now accepts `str | datetime` and normalizes at the bind site.

Sweep: every other `.isoformat()` watermark in `scripts/` is print-only (rollback keys), not query-bound — no siblings.

Regression test pins both call shapes (str + datetime); red-first verified against the pre-fix code (exact DBAPIError reproduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdLp1gY3GQjNhtAFkJDkDz