### PR TITLE
feat: Identity dashboard view — agent identity section editor + Tier-1 user-profile fact editor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -633,6 +633,9 @@ The dashboard is a Svelte SPA under `dashboard-app/`. Build with `cd dashboard-a
 | GET | `/decisions/{id}` | Decision detail |
 | GET | `/episodes` | List recent episodes |
 | GET | `/facts?q=query` | Search facts |
+| PUT | `/facts/{fact_id}` | Edit a Tier-1 fact via supersession (new versioned fact, re-embedded; reports merged_into_existing on dedup-swallow) |
+| DELETE | `/facts/{fact_id}` | Deactivate (soft-delete) a Tier-1 fact |
+| GET | `/profile/facts` | Tier-1 user-profile facts (preference/person/rule), prompt-order |
 | GET | `/censors` | Active censors |
 | PUT | `/censors/{id}` | Update censor fields (trigger_action, action_instruction, unblock_pattern) |
 | GET | `/procedures` | List procedures |

--- a/dashboard-app/src/App.svelte
+++ b/dashboard-app/src/App.svelte
@@ -18,6 +18,7 @@
   import Rubric from './views/Rubric.svelte';
   import Density from './views/Density.svelte';
   import Consolidation from './views/Consolidation.svelte';
+  import Identity from './views/Identity.svelte';
 
   // ── Router ────────────────────────────────────────────────────
   initRouter();
@@ -193,6 +194,8 @@
     <DagView />
   {:else if $currentRoute === 'subtasks'}
     <Subtasks />
+  {:else if $currentRoute === 'identity'}
+    <Identity />
   {/if}
 </main>
 

--- a/dashboard-app/src/lib/router.test.ts
+++ b/dashboard-app/src/lib/router.test.ts
@@ -7,7 +7,8 @@ describe('router', () => {
   it('defaults to overview when hash empty', () => { initRouter(); expect(get(currentRoute)).toBe('overview'); });
   it('reads the hash route', () => { location.hash = '#/cache'; initRouter(); expect(get(currentRoute)).toBe('cache'); });
   it('falls back to overview on unknown route', () => { location.hash = '#/nope'; initRouter(); expect(get(currentRoute)).toBe('overview'); });
-  it('lists all 15 routes', () => { expect(ROUTES.length).toBe(15); });
+  it('lists all 17 routes', () => { expect(ROUTES.length).toBe(17); });
+  it('includes the identity route', () => { expect(ROUTES).toContain('identity'); });
   it('unknown fragment (e.g. skip-link #main-content) leaves current route unchanged', () => {
     // Navigate to a known route first
     location.hash = '#/cache';

--- a/dashboard-app/src/lib/router.ts
+++ b/dashboard-app/src/lib/router.ts
@@ -3,6 +3,7 @@ import { writable } from 'svelte/store';
 export const ROUTES = [
   'overview','graph','browser','decisions','activity','heartbeat','observability',
   'health','admission','rubric','execution','cache','density','consolidation','dag','subtasks',
+  'identity',
 ] as const;
 export type RouteName = typeof ROUTES[number];
 

--- a/dashboard-app/src/lib/types/api.ts
+++ b/dashboard-app/src/lib/types/api.ts
@@ -1171,3 +1171,25 @@ export interface ConsolidationCycleDetail {
   cycle: ConsolidationCycle | null;
   actions: ConsolidationAction[];
 }
+
+// ── Identity view (GET /identity, PUT /identity/{section}, /profile/facts, /facts/{id}) ──
+
+/** Full response from GET /identity. */
+export interface IdentityResponse {
+  agent_id: string;
+  is_initiated: boolean | null;
+  sections: Record<string, string>;
+}
+
+/** Response from PUT /facts/{fact_id} — supersede-edit of a Tier-1 fact. */
+export interface FactUpdateResponse {
+  status: 'superseded' | 'merged_into_existing';
+  new_fact_id: string;
+  stored_content?: string;
+}
+
+/** Response from GET /profile/facts. */
+export interface ProfileFactsResponse {
+  facts: BrowserFact[];  // superset cast — endpoint omits some BrowserFact fields; view reads none of them
+  total: number;
+}

--- a/dashboard-app/src/lib/ui/Nav.svelte
+++ b/dashboard-app/src/lib/ui/Nav.svelte
@@ -95,6 +95,11 @@
       label: 'Subtasks',
       icon: '<path fill-rule="evenodd" d="M3 4a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1H4a1 1 0 01-1-1V4zm9 0a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1V4zM3 12a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1H4a1 1 0 01-1-1v-3zm9 0a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-3z" clip-rule="evenodd"/>',
     },
+    {
+      id: 'identity',
+      label: 'Identity',
+      icon: '<path d="M10 2a4 4 0 100 8 4 4 0 000-8zM3 18a7 7 0 0114 0H3z"/>',
+    },
   ];
 </script>
 

--- a/dashboard-app/src/views/Identity.svelte
+++ b/dashboard-app/src/views/Identity.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  // Placeholder — Task 4 fills this view with the identity-section editor
+  // and the Tier-1 user-profile fact editor.
+</script>
+
+<h1>Identity</h1>

--- a/dashboard-app/src/views/Identity.svelte
+++ b/dashboard-app/src/views/Identity.svelte
@@ -1,6 +1,533 @@
 <script lang="ts">
-  // Placeholder — Task 4 fills this view with the identity-section editor
-  // and the Tier-1 user-profile fact editor.
+  import { onMount } from 'svelte';
+  import { apiGet, apiSend } from '../lib/api';
+  import DataTable from '../lib/ui/DataTable.svelte';
+  import type {
+    IdentityResponse,
+    ProfileFactsResponse,
+    FactUpdateResponse,
+    BrowserFact,
+  } from '../lib/types/api';
+
+  // ── Panel 1: Agent Identity ───────────────────────────────────────────────
+
+  // Order matches nous/identity/manager.py SECTIONS (status is internal, excluded).
+  const SECTIONS = ['character', 'values', 'protocols', 'preferences', 'boundaries', 'environment'];
+
+  // Drafts bound to the textareas; originals track the last-loaded value so Save
+  // can gate on "unchanged". Both seeded from GET /identity (''.for absent sections).
+  let sectionDrafts = $state<Record<string, string>>({});
+  let sectionOriginal = $state<Record<string, string>>({});
+  let sectionStatus = $state<Record<string, 'idle' | 'saving' | 'saved' | 'error'>>({});
+  let sectionMsg = $state<Record<string, string>>({});
+  let identityError = $state<string | null>(null);
+
+  async function loadIdentity() {
+    identityError = null;
+    try {
+      const data = await apiGet<IdentityResponse>('/identity');
+      for (const name of SECTIONS) {
+        const val = data.sections[name] ?? '';
+        sectionDrafts[name] = val;
+        sectionOriginal[name] = val;
+      }
+    } catch (e) {
+      identityError = e instanceof Error ? e.message : 'Failed to load identity';
+    }
+  }
+
+  async function saveSection(name: string) {
+    const content = (sectionDrafts[name] ?? '').trim();
+    if (!content) return;
+    if (!confirm(`Overwrite the "${name}" identity section? There is no undo UI.`)) return;
+    sectionStatus[name] = 'saving';
+    sectionMsg[name] = 'Saving…';
+    try {
+      await apiSend(`/identity/${name}`, { content, updated_by: 'dashboard' });
+      sectionStatus[name] = 'saved';
+      sectionMsg[name] = 'Saved';
+      await loadIdentity(); // refresh originals so Save re-gates on unchanged
+    } catch (e) {
+      sectionStatus[name] = 'error';
+      sectionMsg[name] = e instanceof Error ? e.message : 'Error';
+    }
+  }
+
+  // ── Panel 2: User Profile Facts (Tier-1) ──────────────────────────────────
+
+  let includeInactive = $state(false);
+  let factsData = $state<ProfileFactsResponse | null>(null);
+  let loadingFacts = $state(false);
+  let errorFacts = $state<string | null>(null);
+
+  // Per-row edit state (Browser.svelte censor idiom).
+  let factDrafts = $state<Record<string, string>>({});
+  let factStatus = $state<Record<string, 'idle' | 'saving' | 'saved' | 'error'>>({});
+  let factMsg = $state<Record<string, string>>({});
+  // Panel-level notice — used for the merged_into_existing case, where the row is
+  // about to disappear so a per-row message would vanish with it.
+  let factsPanelMsg = $state<string | null>(null);
+
+  function truncate(s: string, n: number): string {
+    if (!s) return '';
+    return s.length > n ? s.slice(0, n) + '…' : s;
+  }
+
+  async function loadFacts() {
+    loadingFacts = true;
+    errorFacts = null;
+    try {
+      const params = new URLSearchParams({ limit: '200' });
+      if (includeInactive) params.set('active', 'false');
+      factsData = await apiGet<ProfileFactsResponse>(`/profile/facts?${params}`);
+    } catch (e) {
+      errorFacts = e instanceof Error ? e.message : 'Failed to load facts';
+    } finally {
+      loadingFacts = false;
+    }
+  }
+
+  // Precompute display fields — DataTable renders row[c.key] verbatim (no formatters).
+  const factRows = $derived(
+    (factsData?.facts ?? []).map((f: BrowserFact) => ({
+      ...f,
+      content_display: truncate(f.content, 120),
+      confidence_display: f.confidence.toFixed(2),
+      active_display: f.active ? 'yes' : 'no',
+    })),
+  );
+
+  function initFactDraft(row: BrowserFact) {
+    if (factDrafts[row.id] === undefined) factDrafts[row.id] = row.content;
+  }
+
+  // Clear per-row edit state after a mutation — never leave a row editable against
+  // a retired id (edit gives the fact a NEW id; deactivate removes it). Reloading
+  // the list re-keys DataTable's rows, which collapses the stale expanded row.
+  function clearFactRow(id: string) {
+    delete factDrafts[id];
+    delete factStatus[id];
+    delete factMsg[id];
+  }
+
+  async function saveFact(row: BrowserFact) {
+    const draft = (factDrafts[row.id] ?? '').trim();
+    if (!draft) return;
+    factStatus[row.id] = 'saving';
+    factMsg[row.id] = 'Saving…';
+    factsPanelMsg = null;
+    try {
+      const resp = await apiSend<FactUpdateResponse>(
+        `/facts/${row.id}`,
+        { content: draft, subject: row.subject, confidence: row.confidence },
+        'PUT',
+      );
+      if (resp.status === 'merged_into_existing') {
+        factsPanelMsg =
+          'Your edit matched an existing fact — the old entry was retired and linked to it. Stored: "' +
+          truncate(resp.stored_content ?? '', 120) +
+          '"';
+      }
+      clearFactRow(row.id);
+      await loadFacts();
+    } catch (e) {
+      factStatus[row.id] = 'error';
+      factMsg[row.id] = e instanceof Error ? e.message : 'Error';
+    }
+  }
+
+  async function deactivateFact(row: BrowserFact) {
+    if (!confirm('Deactivate this fact? It will be soft-deleted and no longer shown to the agent.')) return;
+    factStatus[row.id] = 'saving';
+    factMsg[row.id] = 'Deactivating…';
+    factsPanelMsg = null;
+    try {
+      await apiSend(`/facts/${row.id}`, undefined, 'DELETE');
+      clearFactRow(row.id);
+      await loadFacts();
+    } catch (e) {
+      factStatus[row.id] = 'error';
+      factMsg[row.id] = e instanceof Error ? e.message : 'Error';
+    }
+  }
+
+  onMount(() => {
+    loadIdentity();
+    loadFacts();
+  });
 </script>
 
-<h1>Identity</h1>
+<header class="view-head">
+  <div>
+    <h1>Identity</h1>
+    <p class="subtitle">Agent identity sections and Tier-1 user-profile facts</p>
+  </div>
+</header>
+
+<!-- ═══════════════════════ AGENT IDENTITY ═══════════════════════ -->
+<section class="panel">
+  <h2>Agent Identity</h2>
+
+  {#if identityError}
+    <p class="status-msg error">{identityError}</p>
+  {/if}
+
+  <div class="section-grid">
+    {#each SECTIONS as name}
+      <div class="section-card">
+        <label class="section-label" for={`identity-${name}`}>{name}</label>
+        <textarea
+          id={`identity-${name}`}
+          rows={8}
+          bind:value={sectionDrafts[name]}
+        ></textarea>
+        <div class="card-actions">
+          <button
+            class="btn btn-sm"
+            onclick={() => saveSection(name)}
+            disabled={
+              sectionStatus[name] === 'saving' ||
+              !(sectionDrafts[name] ?? '').trim() ||
+              (sectionDrafts[name] ?? '') === (sectionOriginal[name] ?? '')
+            }
+          >
+            {sectionStatus[name] === 'saving' ? 'Saving…' : 'Save'}
+          </button>
+          {#if sectionMsg[name]}
+            <span
+              class="save-status"
+              class:save-ok={sectionStatus[name] === 'saved'}
+              class:save-err={sectionStatus[name] === 'error'}
+            >
+              {sectionMsg[name]}
+            </span>
+          {/if}
+        </div>
+      </div>
+    {/each}
+  </div>
+
+  <p class="info-note">
+    Identity edits reach the agent's prompt within ~60s. Editing <strong>preferences</strong>
+    also changes which User Profile facts below are shown to the agent (overlap dedup).
+  </p>
+</section>
+
+<!-- ═══════════════════════ USER PROFILE FACTS ═══════════════════════ -->
+<section class="panel">
+  <h2>User Profile Facts (Tier-1)</h2>
+
+  <div class="controls-bar">
+    <label class="check-label">
+      <input
+        type="checkbox"
+        bind:checked={includeInactive}
+        onchange={() => loadFacts()}
+      />
+      Include inactive
+    </label>
+  </div>
+
+  {#if factsPanelMsg}
+    <p class="info-note info-highlight">{factsPanelMsg}</p>
+  {/if}
+
+  {#if loadingFacts}
+    <p class="status-msg">Loading…</p>
+  {:else if errorFacts}
+    <p class="status-msg error">{errorFacts}</p>
+  {:else if factsData}
+    {#if factRows.length === 0}
+      <p class="empty">No Tier-1 profile facts found.</p>
+    {:else}
+      <DataTable
+        columns={[
+          { key: 'subject',            label: 'Subject' },
+          { key: 'category',           label: 'Category' },
+          { key: 'content_display',    label: 'Content' },
+          { key: 'confidence_display', label: 'Confidence' },
+          { key: 'active_display',     label: 'Active' },
+        ]}
+        rows={factRows}
+        rowKey={(r: BrowserFact) => r.id}
+        onrowclick={(row: BrowserFact) => initFactDraft(row)}
+      >
+        {#snippet detail(row: BrowserFact)}
+          <div class="detail-grid">
+            <span class="dl">Subject</span><span>{row.subject ?? '—'}</span>
+            <span class="dl">Category</span><span>{row.category ?? '—'}</span>
+            <span class="dl">Confidence</span><span>{row.confidence.toFixed(2)}</span>
+            <span class="dl">Active</span><span>{row.active ? 'yes' : 'no'}</span>
+            <span class="dl">ID</span><span class="mono">{row.id}</span>
+          </div>
+
+          <!-- Edit = supersede (new versioned fact); Deactivate = soft delete -->
+          <div
+            class="fact-edit"
+            onclick={(e) => e.stopPropagation()}
+            onkeydown={(e) => e.stopPropagation()}
+            role="presentation"
+          >
+            <textarea
+              class="fact-textarea"
+              rows={4}
+              bind:value={factDrafts[row.id]}
+            ></textarea>
+            <div class="fact-actions">
+              <button
+                class="btn btn-sm"
+                onclick={() => saveFact(row)}
+                disabled={factStatus[row.id] === 'saving' || !(factDrafts[row.id] ?? '').trim()}
+              >
+                {factStatus[row.id] === 'saving' ? 'Saving…' : 'Save'}
+              </button>
+              <button
+                class="btn btn-sm btn-danger"
+                onclick={() => deactivateFact(row)}
+                disabled={factStatus[row.id] === 'saving'}
+              >
+                Deactivate
+              </button>
+              {#if factMsg[row.id]}
+                <span
+                  class="save-status"
+                  class:save-ok={factStatus[row.id] === 'saved'}
+                  class:save-err={factStatus[row.id] === 'error'}
+                >
+                  {factMsg[row.id]}
+                </span>
+              {/if}
+            </div>
+          </div>
+        {/snippet}
+      </DataTable>
+    {/if}
+  {/if}
+
+  <p class="info-note">
+    Editing a fact <strong>supersedes</strong> it: a new versioned fact is created with a new id
+    and re-embedded, and the old one is retired. Deactivate <strong>soft-deletes</strong> it.
+    Both changes reach the agent on its next turn.
+  </p>
+</section>
+
+<style>
+  .view-head {
+    margin-bottom: 1.25rem;
+  }
+
+  h1 {
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--text);
+    margin: 0 0 0.125rem;
+  }
+
+  .subtitle {
+    font-size: 0.8125rem;
+    color: var(--muted);
+    margin: 0;
+  }
+
+  /* ── Panels ── */
+  .panel {
+    margin-bottom: 2rem;
+  }
+
+  h2 {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--text);
+    margin: 0 0 0.875rem;
+  }
+
+  /* ── Identity section cards ── */
+  .section-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 1rem;
+  }
+
+  .section-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.875rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm, 6px);
+  }
+
+  .section-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--muted);
+  }
+
+  textarea {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0.5rem 0.625rem;
+    background: var(--bg, var(--surface));
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm, 6px);
+    color: var(--text);
+    font-family: inherit;
+    font-size: 0.8125rem;
+    line-height: 1.5;
+    resize: vertical;
+  }
+
+  textarea:focus {
+    outline: none;
+    border-color: var(--accent, #22d3ee);
+  }
+
+  .card-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+  }
+
+  /* ── Controls bar ── */
+  .controls-bar {
+    display: flex;
+    gap: 0.75rem;
+    margin-bottom: 0.875rem;
+    flex-wrap: wrap;
+  }
+
+  .check-label {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.8125rem;
+    color: var(--text);
+    cursor: pointer;
+  }
+
+  /* ── Buttons ── */
+  .btn {
+    padding: 0.4375rem 0.875rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm, 6px);
+    color: var(--text);
+    font-size: 0.875rem;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .btn:hover:not(:disabled) {
+    border-color: var(--accent, #22d3ee);
+    color: var(--accent, #22d3ee);
+  }
+
+  .btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .btn-sm {
+    padding: 0.3125rem 0.625rem;
+    font-size: 0.8125rem;
+  }
+
+  .btn-danger:hover:not(:disabled) {
+    border-color: var(--red, #ef4444);
+    color: var(--red, #ef4444);
+  }
+
+  /* ── Info notes ── */
+  .info-note {
+    font-size: 0.8125rem;
+    color: var(--muted);
+    margin: 0.875rem 0 0;
+    line-height: 1.5;
+  }
+
+  .info-highlight {
+    color: var(--text);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm, 6px);
+    padding: 0.625rem 0.75rem;
+    margin-bottom: 0.875rem;
+  }
+
+  /* ── Status messages ── */
+  .status-msg {
+    color: var(--muted);
+    font-size: 0.9375rem;
+    padding: 2rem;
+    text-align: center;
+  }
+
+  .status-msg.error {
+    color: var(--red, #ef4444);
+  }
+
+  .empty {
+    color: var(--muted);
+    font-size: 0.875rem;
+    padding: 2rem 0;
+    text-align: center;
+  }
+
+  .save-status {
+    font-size: 0.75rem;
+    color: var(--muted);
+  }
+
+  .save-status.save-ok {
+    color: #4ade80;
+  }
+
+  .save-status.save-err {
+    color: #f87171;
+  }
+
+  /* ── Detail grid (inside expanded rows) ── */
+  :global(.detail-grid) {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.25rem 0.875rem;
+    font-size: 0.8125rem;
+    padding: 0.5rem 0;
+  }
+
+  :global(.dl) {
+    color: var(--muted);
+    font-weight: 600;
+    white-space: nowrap;
+    align-self: start;
+  }
+
+  :global(.mono) {
+    font-family: monospace;
+    font-size: 0.75rem;
+  }
+
+  /* ── Fact edit controls ── */
+  .fact-edit {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-top: 0.625rem;
+    padding-top: 0.625rem;
+    border-top: 1px solid var(--border);
+  }
+
+  .fact-textarea {
+    font-size: 0.8125rem;
+  }
+
+  .fact-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    flex-wrap: wrap;
+  }
+</style>

--- a/dashboard-app/src/views/Identity.test.ts
+++ b/dashboard-app/src/views/Identity.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import Identity from './Identity.svelte';
+
+// Render smoke for the Identity view: mocks fetch so both panels load and a
+// section save round-trips to the right endpoint. Doubles as the Task-4 manual
+// smoke's frontend half (the API half is tests/test_profile_facts_api.py).
+
+const IDENTITY = {
+  agent_id: 'test-agent',
+  is_initiated: true,
+  sections: { character: 'Curious and precise', values: 'Honesty above all' },
+};
+
+const FACTS = {
+  facts: [
+    {
+      id: 'fact-1',
+      content: 'Tim prefers Celsius for temperature readings',
+      category: 'preference',
+      subject: 'Tim',
+      confidence: 0.8,
+      active: true,
+      tags: [],
+      superseded_by: null,
+      actionable: null,
+      event_date: null,
+      source: null,
+      source_episode_id: null,
+      learned_at: '2026-01-01T00:00:00Z',
+      created_at: '2026-01-01T00:00:00Z',
+    },
+  ],
+  total: 1,
+};
+
+function jsonResp(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as Response;
+}
+
+let calls: Array<{ url: string; method: string; body: unknown }>;
+
+function installFetch() {
+  calls = [];
+  const fetchMock = vi.fn(async (url: string, opts?: RequestInit) => {
+    const method = opts?.method ?? 'GET';
+    const body = opts?.body ? JSON.parse(opts.body as string) : undefined;
+    calls.push({ url, method, body });
+    if (url.startsWith('/identity/') && method === 'PUT') {
+      return jsonResp({ status: 'updated', section: url.split('/').pop() });
+    }
+    if (url === '/identity') return jsonResp(IDENTITY);
+    if (url.startsWith('/profile/facts')) return jsonResp(FACTS);
+    if (url.startsWith('/facts/') && method === 'PUT') {
+      return jsonResp({ status: 'superseded', new_fact_id: 'fact-2' });
+    }
+    throw new Error(`unexpected ${method} ${url}`);
+  });
+  vi.stubGlobal('fetch', fetchMock);
+}
+
+describe('Identity view', () => {
+  beforeEach(() => {
+    installFetch();
+    vi.stubGlobal('confirm', () => true);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('renders both panels, seeds identity sections, and lists profile facts', async () => {
+    render(Identity);
+
+    expect(await screen.findByText('Agent Identity')).toBeTruthy();
+    expect(screen.getByText('User Profile Facts (Tier-1)')).toBeTruthy();
+
+    // Section textarea seeded from GET /identity (findByDisplayValue retries
+    // until the async load flushes to the bound textarea).
+    const character = (await screen.findByDisplayValue('Curious and precise')) as HTMLTextAreaElement;
+    expect(character.getAttribute('id')).toBe('identity-character');
+
+    // Fact content (truncated display field) is listed.
+    expect(await screen.findByText('Tim prefers Celsius for temperature readings')).toBeTruthy();
+  });
+
+  it('saving an edited identity section PUTs to /identity/{section}', async () => {
+    render(Identity);
+    const character = (await screen.findByLabelText('character')) as HTMLTextAreaElement;
+
+    await fireEvent.input(character, { target: { value: 'Curious, precise, and kind' } });
+    // Save button lives in the same card as the character textarea.
+    const card = character.closest('.section-card')!;
+    const saveBtn = card.querySelector('button')! as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(false);
+
+    await fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      const put = calls.find((c) => c.url === '/identity/character' && c.method === 'PUT');
+      expect(put).toBeTruthy();
+      expect(put!.body).toMatchObject({ content: 'Curious, precise, and kind', updated_by: 'dashboard' });
+    });
+  });
+});

--- a/nous/api/rest.py
+++ b/nous/api/rest.py
@@ -542,6 +542,100 @@ def create_app(
             logger.error("list_profile_facts failed: %s", e)
             return JSONResponse({"error": str(e)}, status_code=500)
 
+    async def update_fact(request: Request) -> JSONResponse:
+        """PUT /facts/{fact_id} — edit a Tier-1 fact's content via supersession.
+
+        Nous never edits fact content in place: the old fact is deactivated
+        with superseded_by set, the replacement is re-embedded. If the new
+        content dedups into a DIFFERENT existing fact (native cosine gate),
+        heart confirms that fact instead of storing the edit — we report that
+        honestly as merged_into_existing (never a silent false success).
+        """
+        from uuid import UUID as _UUID
+
+        from nous.heart import FactInput
+
+        try:
+            fact_id = _UUID(request.path_params["fact_id"])
+        except ValueError:
+            return JSONResponse({"error": "invalid fact id"}, status_code=400)
+        try:
+            body = await request.json()
+        except Exception:
+            return JSONResponse({"error": "invalid JSON body"}, status_code=400)
+        content = (body.get("content") or "").strip()
+        if not content:
+            return JSONResponse({"error": "content is required"}, status_code=400)
+        min_chars = settings.fact_min_content_chars
+        if min_chars and len(content) < min_chars:
+            return JSONResponse(
+                {"error": f"content too short (min {min_chars} chars)"}, status_code=400
+            )
+        body_category = (body.get("category") or "").strip() or None
+        if body_category is not None and body_category not in TIER1_FACT_CATEGORIES:
+            return JSONResponse(
+                {"error": f"category must be one of {TIER1_FACT_CATEGORIES}"}, status_code=400
+            )
+        try:
+            target = await heart.get_current_fact(fact_id)
+        except ValueError:
+            return JSONResponse({"error": "fact not found"}, status_code=404)
+        if str(target.id) != str(fact_id):
+            return JSONResponse(
+                {"error": "already_superseded", "current_fact_id": str(target.id)},
+                status_code=409,
+            )
+        if target.category not in TIER1_FACT_CATEGORIES:
+            return JSONResponse({"error": "not_profile_fact"}, status_code=409)
+        new_input = FactInput(
+            content=content,
+            category=body_category or target.category,
+            subject=body.get("subject") if "subject" in body else target.subject,
+            confidence=body.get("confidence") if body.get("confidence") is not None else target.confidence,
+        )
+        try:
+            new_fact = await heart.supersede_fact(fact_id, new_input)
+        except ValueError:
+            return JSONResponse({"error": "fact not found"}, status_code=404)
+        except Exception as e:
+            logger.error("update_fact failed: %s", e)
+            return JSONResponse({"error": str(e)}, status_code=500)
+        if (new_fact.content or "").strip() != content:
+            return JSONResponse({
+                "status": "merged_into_existing",
+                "new_fact_id": str(new_fact.id),
+                "stored_content": new_fact.content,
+            })
+        return JSONResponse({"status": "superseded", "new_fact_id": str(new_fact.id)})
+
+    async def delete_fact(request: Request) -> JSONResponse:
+        """DELETE /facts/{fact_id} — soft-delete (deactivate) a Tier-1 fact."""
+        from uuid import UUID as _UUID
+
+        try:
+            fact_id = _UUID(request.path_params["fact_id"])
+        except ValueError:
+            return JSONResponse({"error": "invalid fact id"}, status_code=400)
+        try:
+            target = await heart.get_current_fact(fact_id)
+        except ValueError:
+            return JSONResponse({"error": "fact not found"}, status_code=404)
+        if str(target.id) != str(fact_id):
+            return JSONResponse(
+                {"error": "already_superseded", "current_fact_id": str(target.id)},
+                status_code=409,
+            )
+        if target.category not in TIER1_FACT_CATEGORIES:
+            return JSONResponse({"error": "not_profile_fact"}, status_code=409)
+        try:
+            await heart.deactivate_fact(fact_id)
+        except ValueError:
+            return JSONResponse({"error": "fact not found"}, status_code=404)
+        except Exception as e:
+            logger.error("delete_fact failed: %s", e)
+            return JSONResponse({"error": str(e)}, status_code=500)
+        return JSONResponse({"status": "deactivated"})
+
     async def list_chunks(request: Request) -> JSONResponse:
         """GET /chunks?q=&episode_id=&limit=&offset= — browse F067 episode chunks.
 
@@ -2639,6 +2733,8 @@ def create_app(
         Route("/decisions/{id}", get_decision),
         Route("/episodes", list_episodes),
         Route("/profile/facts", list_profile_facts),
+        Route("/facts/{fact_id}", update_fact, methods=["PUT"]),
+        Route("/facts/{fact_id}", delete_fact, methods=["DELETE"]),
         Route("/facts", search_facts),
         Route("/chunks", list_chunks),
         Route("/censors/{id}", update_censor, methods=["PUT"]),

--- a/nous/api/rest.py
+++ b/nous/api/rest.py
@@ -54,6 +54,7 @@ from nous.api.models import Attachment
 from nous.api.runner import AgentRunner
 from nous.brain import Brain
 from nous.cognitive import CognitiveLayer
+from nous.cognitive.context import TIER1_FACT_CATEGORIES
 from nous.config import Settings
 from nous.events import Event, EventBus
 from nous.heart import Heart
@@ -512,6 +513,33 @@ def create_app(
                 })
         except Exception as e:
             logger.error("Search/browse facts error: %s", e)
+            return JSONResponse({"error": str(e)}, status_code=500)
+
+    async def list_profile_facts(request: Request) -> JSONResponse:
+        """GET /profile/facts — Tier-1 user-profile facts (preference/person/rule).
+
+        Same accessor + ordering (confidence DESC, learned_at DESC) as the
+        system-prompt User Profile section, so the dashboard shows exactly
+        what the agent can draw from.
+        """
+        try:
+            limit = int(request.query_params.get("limit", "100"))
+            if limit < 1:
+                raise ValueError
+        except ValueError:
+            return JSONResponse({"error": "invalid limit"}, status_code=400)
+        active_only = request.query_params.get("active", "true").lower() != "false"
+        try:
+            facts = await heart.list_facts_by_category(
+                categories=TIER1_FACT_CATEGORIES,
+                active_only=active_only,
+                limit=limit,
+            )
+            return JSONResponse(
+                {"facts": [f.model_dump(mode="json") for f in facts], "total": len(facts)}
+            )
+        except Exception as e:
+            logger.error("list_profile_facts failed: %s", e)
             return JSONResponse({"error": str(e)}, status_code=500)
 
     async def list_chunks(request: Request) -> JSONResponse:
@@ -2610,6 +2638,7 @@ def create_app(
         Route("/decisions/{id}/review", review_decision, methods=["POST"]),
         Route("/decisions/{id}", get_decision),
         Route("/episodes", list_episodes),
+        Route("/profile/facts", list_profile_facts),
         Route("/facts", search_facts),
         Route("/chunks", list_chunks),
         Route("/censors/{id}", update_censor, methods=["PUT"]),

--- a/nous/api/rest.py
+++ b/nous/api/rest.py
@@ -553,6 +553,8 @@ def create_app(
         """
         from uuid import UUID as _UUID
 
+        from sqlalchemy import text as sa_text
+
         from nous.heart import FactInput
 
         try:
@@ -577,30 +579,62 @@ def create_app(
                 {"error": f"category must be one of {TIER1_FACT_CATEGORIES}"}, status_code=400
             )
         try:
-            target = await heart.get_current_fact(fact_id)
-        except ValueError:
-            return JSONResponse({"error": "fact not found"}, status_code=404)
-        if str(target.id) != str(fact_id):
-            return JSONResponse(
-                {"error": "already_superseded", "current_fact_id": str(target.id)},
-                status_code=409,
-            )
-        if target.category not in TIER1_FACT_CATEGORIES:
-            return JSONResponse({"error": "not_profile_fact"}, status_code=409)
-        new_input = FactInput(
-            content=content,
-            category=body_category or target.category,
-            subject=body.get("subject") if "subject" in body else target.subject,
-            confidence=body.get("confidence") if body.get("confidence") is not None else target.confidence,
-        )
-        try:
-            new_fact = await heart.supersede_fact(fact_id, new_input)
-        except ValueError:
-            return JSONResponse({"error": "fact not found"}, status_code=404)
+            # One session for the whole check-then-write: a per-fact advisory
+            # xact lock serializes concurrent edits of the same fact so the
+            # loser re-reads under the lock and hits the advertised 409
+            # (codex r1: both requests could pass the current-id check before
+            # either committed). Lock is transaction-scoped — released on
+            # commit/rollback with the session.
+            async with database.session() as session:
+                await session.execute(
+                    sa_text("SELECT pg_advisory_xact_lock(hashtextextended(:key, 0))"),
+                    {"key": f"nous_fact_edit:{fact_id}"},
+                )
+                try:
+                    target = await heart.get_current_fact(fact_id, session=session)
+                except ValueError:
+                    return JSONResponse({"error": "fact not found"}, status_code=404)
+                if str(target.id) != str(fact_id):
+                    return JSONResponse(
+                        {"error": "already_superseded", "current_fact_id": str(target.id)},
+                        status_code=409,
+                    )
+                if target.category not in TIER1_FACT_CATEGORIES:
+                    return JSONResponse({"error": "not_profile_fact"}, status_code=409)
+                # Exact-content pre-check (codex r1): an edit that exactly
+                # matches ANOTHER active fact dedup-confirms it, so the
+                # content-inequality signal below cannot see the merge —
+                # detect it up front.
+                exact_row = await session.execute(
+                    sa_text(
+                        "SELECT id FROM heart.facts "
+                        "WHERE agent_id = :a AND content = :c AND active AND id != :fid "
+                        "LIMIT 1"
+                    ),
+                    {"a": settings.agent_id, "c": content, "fid": str(fact_id)},
+                )
+                exact_dupe_id = exact_row.scalar_one_or_none()
+                new_input = FactInput(
+                    content=content,
+                    category=body_category or target.category,
+                    subject=body.get("subject") if "subject" in body else target.subject,
+                    confidence=body.get("confidence") if body.get("confidence") is not None else target.confidence,
+                )
+                try:
+                    new_fact = await heart.supersede_fact(fact_id, new_input, session=session)
+                except ValueError:
+                    return JSONResponse({"error": "fact not found"}, status_code=404)
+                await session.commit()
+            # Injected-session supersede skips its own post-commit vocab
+            # invalidation (facts.py contract: commit owner invalidates).
+            heart.facts.invalidate_entity_vocab()
         except Exception as e:
             logger.error("update_fact failed: %s", e)
             return JSONResponse({"error": str(e)}, status_code=500)
-        if (new_fact.content or "").strip() != content:
+        merged = (new_fact.content or "").strip() != content or (
+            exact_dupe_id is not None and str(new_fact.id) == str(exact_dupe_id)
+        )
+        if merged:
             return JSONResponse({
                 "status": "merged_into_existing",
                 "new_fact_id": str(new_fact.id),
@@ -612,25 +646,37 @@ def create_app(
         """DELETE /facts/{fact_id} — soft-delete (deactivate) a Tier-1 fact."""
         from uuid import UUID as _UUID
 
+        from sqlalchemy import text as sa_text
+
         try:
             fact_id = _UUID(request.path_params["fact_id"])
         except ValueError:
             return JSONResponse({"error": "invalid fact id"}, status_code=400)
         try:
-            target = await heart.get_current_fact(fact_id)
-        except ValueError:
-            return JSONResponse({"error": "fact not found"}, status_code=404)
-        if str(target.id) != str(fact_id):
-            return JSONResponse(
-                {"error": "already_superseded", "current_fact_id": str(target.id)},
-                status_code=409,
-            )
-        if target.category not in TIER1_FACT_CATEGORIES:
-            return JSONResponse({"error": "not_profile_fact"}, status_code=409)
-        try:
-            await heart.deactivate_fact(fact_id)
-        except ValueError:
-            return JSONResponse({"error": "fact not found"}, status_code=404)
+            # Same per-fact advisory xact lock + single session as update_fact
+            # so a DELETE racing a PUT on the same fact serializes and the
+            # loser sees the already_superseded/missing state (codex r1).
+            async with database.session() as session:
+                await session.execute(
+                    sa_text("SELECT pg_advisory_xact_lock(hashtextextended(:key, 0))"),
+                    {"key": f"nous_fact_edit:{fact_id}"},
+                )
+                try:
+                    target = await heart.get_current_fact(fact_id, session=session)
+                except ValueError:
+                    return JSONResponse({"error": "fact not found"}, status_code=404)
+                if str(target.id) != str(fact_id):
+                    return JSONResponse(
+                        {"error": "already_superseded", "current_fact_id": str(target.id)},
+                        status_code=409,
+                    )
+                if target.category not in TIER1_FACT_CATEGORIES:
+                    return JSONResponse({"error": "not_profile_fact"}, status_code=409)
+                try:
+                    await heart.deactivate_fact(fact_id, session=session)
+                except ValueError:
+                    return JSONResponse({"error": "fact not found"}, status_code=404)
+                await session.commit()
         except Exception as e:
             logger.error("delete_fact failed: %s", e)
             return JSONResponse({"error": str(e)}, status_code=500)

--- a/tests/test_profile_facts_api.py
+++ b/tests/test_profile_facts_api.py
@@ -7,6 +7,11 @@ from httpx import ASGITransport, AsyncClient
 
 from nous.heart import FactInput, Heart
 
+# Codex r2: the fixtures use Postgres-specific SQL (nous_system schema, ::jsonb,
+# vector casts, advisory locks) — skip cleanly under the default sqlite backend
+# instead of erroring (conftest skips postgres_only when NOUS_TEST_DB != postgres).
+pytestmark = pytest.mark.postgres_only
+
 _PROFILE_AGENT = f"test-profile-{_uuid.uuid4().hex[:8]}"
 
 

--- a/tests/test_profile_facts_api.py
+++ b/tests/test_profile_facts_api.py
@@ -1,0 +1,127 @@
+"""REST tests for /profile/facts + /facts/{id} edit endpoints (dashboard identity UI)."""
+import uuid as _uuid
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from nous.heart import FactInput, Heart
+
+_PROFILE_AGENT = f"test-profile-{_uuid.uuid4().hex[:8]}"
+
+
+# ---------------------------------------------------------------------------
+# Isolated fixtures — unique agent id so committed facts on the session-scoped
+# Postgres don't persist/dedup-collide across re-runs (tests-P1-2).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def settings():
+    # conftest's settings fixture is a bare Settings() with no test-critical
+    # overrides, so construct directly and pin a unique agent id.
+    from nous.config import Settings
+
+    return Settings().model_copy(update={"agent_id": _PROFILE_AGENT})
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _ensure_agent(db):
+    from sqlalchemy import text
+
+    async with db.session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO nous_system.agents (id, name, config) "
+                "VALUES (:id, :n, '{}'::jsonb) ON CONFLICT (id) DO NOTHING"
+            ),
+            {"id": _PROFILE_AGENT, "n": "Profile API Test Agent"},
+        )
+        await session.commit()
+
+
+@pytest_asyncio.fixture
+async def heart(db, mock_embeddings, settings):
+    h = Heart(db, settings, embedding_provider=mock_embeddings)
+    yield h
+    await h.close()
+
+
+@pytest_asyncio.fixture
+async def brain(db, settings):
+    from nous.brain.brain import Brain
+
+    b = Brain(database=db, settings=settings)
+    yield b
+    await b.close()
+
+
+@pytest_asyncio.fixture
+async def cognitive(brain, heart, settings):
+    from nous.cognitive import CognitiveLayer
+
+    return CognitiveLayer(brain, heart, settings, identity_prompt="You are Nous.")
+
+
+@pytest_asyncio.fixture
+async def identity_manager(db, settings):
+    from nous.identity.manager import IdentityManager
+
+    return IdentityManager(db, settings.agent_id)
+
+
+def _build_app(brain, heart, cognitive, db, settings, identity_manager):
+    from unittest.mock import AsyncMock
+
+    from nous.api.rest import create_app
+    from nous.api.runner import AgentRunner
+
+    mock_runner = AsyncMock(spec=AgentRunner)
+    return create_app(
+        mock_runner, brain, heart, cognitive, db, settings,
+        identity_manager=identity_manager,
+    )
+
+
+@pytest.fixture
+def app(brain, heart, cognitive, db, settings, identity_manager):
+    return _build_app(brain, heart, cognitive, db, settings, identity_manager)
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# GET /profile/facts (Task 1)
+# ---------------------------------------------------------------------------
+
+
+class TestProfileFactsEndpoint:
+    @pytest.mark.asyncio
+    async def test_returns_tier1_categories_only(self, client, heart, db):
+        async with db.session() as session:
+            await heart.learn(FactInput(content="Tim prefers Celsius for temperature readings", category="preference", subject="Tim"), session=session)
+            await heart.learn(FactInput(content="Tim lives in Silver Spring Maryland United States", category="person", subject="Tim"), session=session)
+            await heart.learn(FactInput(content="Postgres seventeen with pgvector extension is the datastore", category="technical", subject="stack"), session=session)
+            await session.commit()
+        resp = await client.get("/profile/facts")
+        assert resp.status_code == 200
+        data = resp.json()
+        cats = {f["category"] for f in data["facts"]}
+        assert cats == {"preference", "person"}  # exact — agent is module-unique
+        assert data["total"] == len(data["facts"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_limit_active_and_validation(self, client, heart, db):
+        resp = await client.get("/profile/facts?limit=1")
+        assert resp.status_code == 200
+        assert len(resp.json()["facts"]) <= 1
+        # include-inactive path (tests-P3 coverage)
+        resp = await client.get("/profile/facts?active=false")
+        assert resp.status_code == 200
+        resp = await client.get("/profile/facts?limit=notanumber")
+        assert resp.status_code == 400

--- a/tests/test_profile_facts_api.py
+++ b/tests/test_profile_facts_api.py
@@ -95,6 +95,40 @@ async def client(app):
         yield c
 
 
+async def _make_client_for_heart(heart, db, settings):
+    """Build an AsyncClient over a create_app wired to the given heart."""
+    from nous.brain.brain import Brain
+    from nous.cognitive import CognitiveLayer
+    from nous.identity.manager import IdentityManager
+
+    brain = Brain(database=db, settings=settings)
+    cognitive = CognitiveLayer(brain, heart, settings, identity_prompt="You are Nous.")
+    identity_manager = IdentityManager(db, settings.agent_id)
+    app = _build_app(brain, heart, cognitive, db, settings, identity_manager)
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+async def _insert_fact_raw(db, agent_id, content, category, subject):
+    """Insert an active fact directly (bypassing dedup) with the const embedding
+    [1.0, 0.0, ...] so it collides under a constant-embedding Heart."""
+    from sqlalchemy import text
+
+    fid = _uuid.uuid4()
+    emb = "[" + ",".join(["1.0"] + ["0.0"] * 1535) + "]"
+    async with db.session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO heart.facts (id, agent_id, content, category, subject, "
+                "confidence, embedding, active, learned_at) "
+                "VALUES (:id, :aid, :content, :cat, :subj, 1.0, CAST(:emb AS vector), true, NOW())"
+            ),
+            {"id": fid, "aid": agent_id, "content": content, "cat": category, "subj": subject, "emb": emb},
+        )
+        await session.commit()
+    return fid
+
+
 # ---------------------------------------------------------------------------
 # GET /profile/facts (Task 1)
 # ---------------------------------------------------------------------------
@@ -125,3 +159,119 @@ class TestProfileFactsEndpoint:
         assert resp.status_code == 200
         resp = await client.get("/profile/facts?limit=notanumber")
         assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# PUT / DELETE /facts/{id} (Task 2)
+# ---------------------------------------------------------------------------
+
+
+class TestFactEditEndpoints:
+    @pytest.mark.asyncio
+    async def test_put_supersedes_and_new_content_listed(self, client, heart, db):
+        async with db.session() as session:
+            old = await heart.learn(FactInput(content="Tim prefers Fahrenheit for all temperature readings", category="preference", subject="Tim-temp", confidence=0.8), session=session)
+            await session.commit()
+        resp = await client.put(f"/facts/{old.id}", json={
+            "content": "Tim prefers Celsius for all temperature readings",
+            "subject": "Tim-temp",
+        })
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "superseded"
+        assert body["new_fact_id"] != str(old.id)
+        listing = (await client.get("/profile/facts")).json()
+        by_id = {f["id"]: f for f in listing["facts"]}
+        new = by_id[body["new_fact_id"]]
+        assert new["content"] == "Tim prefers Celsius for all temperature readings"
+        assert new["category"] == "preference"      # inherited from target (no body category)
+        assert abs(new["confidence"] - 0.8) < 1e-6  # preserved, NOT clobbered to 1.0
+        assert str(old.id) not in by_id             # old is inactive
+
+    @pytest.mark.asyncio
+    async def test_put_validation_and_scope(self, client, heart, db):
+        import uuid as _u
+        assert (await client.put("/facts/not-a-uuid", json={"content": "x" * 40})).status_code == 400
+        assert (await client.put(f"/facts/{_u.uuid4()}", json={})).status_code == 400  # no content
+        # unknown fact -> 404 (NOTE: weak-red — a missing route is also 404; the
+        # red signal for this task is the 200-path test above)
+        assert (await client.put(f"/facts/{_u.uuid4()}", json={"content": "Valid replacement content over thirty characters"})).status_code == 404
+        # bad body category -> 400
+        async with db.session() as session:
+            f = await heart.learn(FactInput(content="Tim reviews all plans before implementation begins", category="rule", subject="scope-r"), session=session)
+            await session.commit()
+        assert (await client.put(f"/facts/{f.id}", json={"content": "Valid replacement content over thirty characters", "category": "technical"})).status_code == 400
+        # non-Tier-1 TARGET -> 409
+        async with db.session() as session:
+            t = await heart.learn(FactInput(content="Postgres runs with the pgvector extension enabled always", category="technical", subject="scope-t"), session=session)
+            await session.commit()
+        assert (await client.put(f"/facts/{t.id}", json={"content": "Valid replacement content over thirty characters"})).status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_put_too_short_content_400_not_500(self, client, heart, db, settings):
+        floor = settings.fact_min_content_chars
+        if not floor:
+            pytest.skip("min-content floor disabled in this environment")
+        async with db.session() as session:
+            old = await heart.learn(FactInput(content="Tim always reviews plans before implementation starts", category="rule", subject="Tim-rule"), session=session)
+            await session.commit()
+        resp = await client.put(f"/facts/{old.id}", json={"content": "x" * (floor - 1)})
+        assert resp.status_code == 400
+        assert "error" in resp.json()
+
+    @pytest.mark.asyncio
+    async def test_delete_deactivates_and_scope(self, client, heart, db):
+        import uuid as _u
+        async with db.session() as session:
+            f = await heart.learn(FactInput(content="Tim enjoys weekend hiking in national parks nearby", category="person", subject="Tim-hike"), session=session)
+            t = await heart.learn(FactInput(content="The build pipeline uses uv for dependency management", category="technical", subject="scope-d"), session=session)
+            await session.commit()
+        assert (await client.delete("/facts/not-a-uuid")).status_code == 400
+        assert (await client.delete(f"/facts/{_u.uuid4()}")).status_code == 404
+        assert (await client.delete(f"/facts/{t.id}")).status_code == 409  # non-Tier-1 target
+        resp = await client.delete(f"/facts/{f.id}")
+        assert resp.status_code == 200
+        listing = (await client.get("/profile/facts")).json()
+        assert str(f.id) not in [x["id"] for x in listing["facts"]]
+
+
+class TestMergedIntoExisting:
+    """devil-P1: an edit whose content dedups to a THIRD active fact must be
+    reported honestly, never as a plain success."""
+
+    @pytest_asyncio.fixture
+    async def const_heart(self, db, settings):
+        class _ConstEmbeddings:
+            dimensions = 1536
+
+            async def embed(self, text: str):
+                return [1.0] + [0.0] * 1535
+
+            async def embed_batch(self, texts):
+                return [[1.0] + [0.0] * 1535 for _ in texts]
+
+            async def close(self):
+                pass
+
+        h = Heart(db, settings, embedding_provider=_ConstEmbeddings())
+        yield h
+        await h.close()
+
+    @pytest.mark.asyncio
+    async def test_edit_colliding_with_third_fact_reports_merge(self, db, settings, const_heart):
+        client = await _make_client_for_heart(const_heart, db, settings)
+        async with db.session() as session:
+            a = await const_heart.learn(FactInput(content="Tim prefers coffee brewed strong in the morning", category="preference", subject="merge-a"), session=session)
+            await session.commit()
+        # With constant embeddings every learn after the first collides. Insert B
+        # via raw SQL so two distinct active facts exist despite identical vectors.
+        b_id = await _insert_fact_raw(db, settings.agent_id, "Tim drinks tea in the afternoon most days", "preference", "merge-b")
+        resp = await client.put(f"/facts/{a.id}", json={"content": "Completely different edited wording goes right here"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "merged_into_existing"
+        assert body["new_fact_id"] == str(b_id)
+        assert body["stored_content"] == "Tim drinks tea in the afternoon most days"
+        # old fact retired either way
+        listing = (await client.get("/profile/facts")).json()
+        assert str(a.id) not in [x["id"] for x in listing["facts"]]

--- a/tests/test_profile_facts_api.py
+++ b/tests/test_profile_facts_api.py
@@ -311,3 +311,54 @@ class TestAlreadySuperseded:
         assert resp.status_code == 409
         assert resp.json()["error"] == "already_superseded"
         assert resp.json()["current_fact_id"] == new_id
+
+
+class TestCodexRound1Contracts:
+    """Codex r1 P2s: exact-duplicate edits must report merged_into_existing
+    (content equality masks the dedup-confirm), and concurrent stale edits on
+    the same fact must serialize (advisory xact lock) so the loser gets the
+    advertised 409 instead of double-superseding."""
+
+    @pytest.mark.asyncio
+    async def test_exact_duplicate_edit_reports_merge(self, client, heart, db):
+        # Hash-seeded mock embeddings: identical content -> identical vector ->
+        # cosine 1.0 >= threshold, so the dedup-confirm path fires
+        # deterministically without a constant-embedding stub.
+        dupe_content = "Tim keeps his calendar blocked for focus time on Fridays"
+        async with db.session() as session:
+            a = await heart.learn(
+                FactInput(content="Tim prefers asynchronous communication over meetings", category="preference", subject="codex-a"),
+                session=session,
+            )
+            b = await heart.learn(
+                FactInput(content=dupe_content, category="preference", subject="codex-b"),
+                session=session,
+            )
+            await session.commit()
+        resp = await client.put(f"/facts/{a.id}", json={"content": dupe_content})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "merged_into_existing"
+        assert body["new_fact_id"] == str(b.id)
+        assert body["stored_content"] == dupe_content
+        listing = (await client.get("/profile/facts")).json()
+        assert str(a.id) not in [x["id"] for x in listing["facts"]]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_edits_serialize_one_wins(self, client, heart, db):
+        import asyncio
+
+        async with db.session() as session:
+            a = await heart.learn(
+                FactInput(content="Tim writes project notes in markdown files locally", category="preference", subject="codex-race"),
+                session=session,
+            )
+            await session.commit()
+        r1, r2 = await asyncio.gather(
+            client.put(f"/facts/{a.id}", json={"content": "Tim writes project notes in Obsidian vaults nowadays"}),
+            client.put(f"/facts/{a.id}", json={"content": "Tim writes project notes in Notion databases nowadays"}),
+        )
+        codes = sorted([r1.status_code, r2.status_code])
+        assert codes == [200, 409], f"expected one winner + one stale 409, got {codes}"
+        loser = r1 if r1.status_code == 409 else r2
+        assert loser.json()["error"] == "already_superseded"

--- a/tests/test_profile_facts_api.py
+++ b/tests/test_profile_facts_api.py
@@ -275,3 +275,39 @@ class TestMergedIntoExisting:
         # old fact retired either way
         listing = (await client.get("/profile/facts")).json()
         assert str(a.id) not in [x["id"] for x in listing["facts"]]
+
+
+class TestAlreadySuperseded:
+    """rev2-branch P2-1: the 409 already_superseded branch (stale-tab double
+    submit on a retired id) is part of the public contract — pin it."""
+
+    @pytest.mark.asyncio
+    async def test_put_and_delete_on_superseded_fact_409(self, client, heart, db):
+        async with db.session() as session:
+            a = await heart.learn(
+                FactInput(
+                    content="Tim schedules deep work in the early morning hours",
+                    category="preference",
+                    subject="chain-a",
+                ),
+                session=session,
+            )
+            await session.commit()
+        first = await client.put(
+            f"/facts/{a.id}",
+            json={"content": "Tim schedules deep work in the late evening hours"},
+        )
+        assert first.status_code == 200
+        new_id = first.json()["new_fact_id"]
+        # Stale-tab double submit against the retired id: PUT then DELETE.
+        resp = await client.put(
+            f"/facts/{a.id}",
+            json={"content": "Another perfectly valid replacement content string here"},
+        )
+        assert resp.status_code == 409
+        assert resp.json()["error"] == "already_superseded"
+        assert resp.json()["current_fact_id"] == new_id
+        resp = await client.delete(f"/facts/{a.id}")
+        assert resp.status_code == 409
+        assert resp.json()["error"] == "already_superseded"
+        assert resp.json()["current_fact_id"] == new_id


### PR DESCRIPTION
## What

A new **Identity** view in the dashboard SPA (`/dashboard/v2/#/identity`) with two panels:

1. **Agent Identity** — view/edit the six identity sections (`character`, `values`, `protocols`, `preferences`, `boundaries`, `environment`) stored in `nous_system.agent_identity`. Saves go through the existing `PUT /identity/{section}` (versioned via `IdentityManager.update_section`); each save is `confirm()`-gated since there is no rollback UI (versions ARE kept in the DB chain).
2. **User Profile Facts (Tier-1)** — view/edit/deactivate `preference`/`person`/`rule` facts, in the same order the system prompt's User Profile section uses. Include-inactive toggle.

## New REST endpoints (facts had no mutation surface)

| Method | Path | Semantics |
|---|---|---|
| GET | `/profile/facts` | Tier-1 facts via `heart.list_facts_by_category` (prompt order: confidence DESC, learned_at DESC) |
| PUT | `/facts/{fact_id}` | Edit via **supersession** — old fact deactivated + `superseded_by` set, replacement re-embedded, NEW id returned. Tier-1 targets only (409 otherwise); 409 `already_superseded` on stale ids; category/subject/confidence inherited from the target unless supplied; min-content floor pre-validated to a clean 400 |
| DELETE | `/facts/{fact_id}` | Soft-delete via `heart.deactivate_fact`. Same Tier-1 target scoping |

### The merge-honest contract (important)

`supersede` runs the edit through `_learn` with dedup active: if the edited content lands ≥ `NOUS_FACT_NATIVE_COSINE_THRESHOLD` (prod: **0.80**) similar to a *different* active fact, heart confirms that fact instead of storing the edit (verified trace: facts.py:757-838 confirm path under `check_contradictions=False`). The endpoint detects this (returned content ≠ submitted content) and returns `{"status": "merged_into_existing", "new_fact_id", "stored_content"}` instead of a false success; the UI surfaces it. Pinned by a deterministic test using a constant-embedding Heart. Heart-core dedup semantics deliberately untouched (sleep/F031/F027 callers).

## Notes for the operator

- **Side effects per fact edit:** one embedding call, possibly one Haiku F047 actionability call, `fact_learned` + `fact_superseded` events. Identity edits reach the live prompt within ~60s (TTL cache); editing the `preferences` identity section also changes which profile facts the prompt shows (PR #569 per-line dedup coupling) — the UI states both.
- **Auth:** the REST API has no auth (pre-existing posture — `PUT /identity/{section}` was already open); these endpoints match it.
- `dist/` is not committed; the Docker `dashboard` stage builds the SPA.

## Validation

- Plan 3-agent reviewed (correctness / devil's advocate / test quality); the devil's dedup-swallow P1 was re-verified in code before the contract was designed around it. Whole-branch final review: READY FOR PR, 0 blocking findings.
- Backend: `test_profile_facts_api.py` 8/8 (module-local unique-agent fixtures; includes merge-contract + 409 already_superseded tests); `test_rest.py` + `test_identity_api.py` 25/25 no regressions. Full-suite delta vs main = exactly the new Postgres-only module's sqlite errors; failed/passed/skipped identical.
- Frontend: vitest 24/24 (includes an Identity.svelte render test with mocked fetch), `svelte-check` 0 errors, build green. **This branch also fixes a pre-existing baseline failure:** `router.test.ts` asserted 15 routes while main had 16.
- **Manual smoke substitution (stated per review):** the full app was not booted live (it starts the Telegram bot / heartbeat / background LLM calls — outward-facing side effects). Instead, per the plan's sanctioned fallback: httpx integration tests against a real `create_app` + Postgres for the API half, and the mocked-fetch render test for the view half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)