### PR TITLE
fix: tier-1 backfill — durable-language guard (prod dry-run findings), scoped mechanical, --db-* alias fix

### DIFF
--- a/scripts/backfill_tier1_integrity.py
+++ b/scripts/backfill_tier1_integrity.py
@@ -119,8 +119,10 @@ EVENT_NOISE_PATTERNS_AB = (EVENT_NOISE_PATTERN_A, EVENT_NOISE_PATTERN_B)
 # receipt marker. Preference/directive language suppresses an A or B match;
 # the asymmetric cost rules here: a kept noise row is one stray profile line,
 # a demoted genuine preference is exactly the data the profile exists for.
+# `likes` (verb) / `would like` only — bare `like` is usually the preposition
+# ("a draft like last week's summary") and must not shield noise (codex #573).
 DURABLE_LANGUAGE_GUARD = re.compile(
-    r"\b(prefers?|wants?|likes?|always|never|must|going forward|from now on|standing)\b",
+    r"\b(prefers?|wants?|likes|would like|always|never|must|going forward|from now on|standing)\b",
     re.IGNORECASE,
 )
 # C: dated-logistics (flight codes, m/d dates, clock times, tomorrow, weekdays).

--- a/scripts/backfill_tier1_integrity.py
+++ b/scripts/backfill_tier1_integrity.py
@@ -112,11 +112,16 @@ EVENT_NOISE_PATTERN_B = re.compile(
     re.IGNORECASE,
 )
 EVENT_NOISE_PATTERNS_AB = (EVENT_NOISE_PATTERN_A, EVENT_NOISE_PATTERN_B)
-# Standing-directive guard for B (codex r3): a rule can be WORDED as a request
-# ("The user asked to always verify the date...") — standing-rule language
-# suppresses a B match so genuine directives survive the scrub.
-STANDING_RULE_GUARD = re.compile(
-    r"\b(always|never|must|going forward|from now on|standing)\b", re.IGNORECASE
+# Durable-language guard for A AND B (codex r3, WIDENED after the prod dry-run
+# 2026-07-24): the first prod regex dry-run surfaced genuine delivery-routing
+# PREFERENCES matching A ("User prefers sailing forecasts sent to Gmail only",
+# "User wants all reports ... sent to both inboxes") — `sent to` is not only a
+# receipt marker. Preference/directive language suppresses an A or B match;
+# the asymmetric cost rules here: a kept noise row is one stray profile line,
+# a demoted genuine preference is exactly the data the profile exists for.
+DURABLE_LANGUAGE_GUARD = re.compile(
+    r"\b(prefers?|wants?|likes?|always|never|must|going forward|from now on|standing)\b",
+    re.IGNORECASE,
 )
 # C: dated-logistics (flight codes, m/d dates, clock times, tomorrow, weekdays).
 EVENT_NOISE_PATTERN_C = re.compile(
@@ -130,17 +135,16 @@ def classify_event_noise_ab(content: str) -> bool:
     """True if the fact reads as a delivery event (A) or a request/action the
     user or assistant took (B) — session events, not durable user profile.
 
-    A B-match is suppressed when the content carries standing-rule language
-    (always/never/must/going forward/...) — a directive worded as a request is
-    still a directive (codex r3). A (delivery events) is NOT guarded: 'the
-    forecast was always sent to X' is still a delivery event.
+    Both A and B matches are suppressed when the content carries durable
+    preference/directive language (prefers/wants/always/never/...): the prod
+    dry-run proved delivery-routing preferences match A, and a directive
+    worded as a request matches B. Kept-noise costs one stray line; a demoted
+    genuine preference is the exact data the profile exists to hold.
     """
     if not content:
         return False
-    if EVENT_NOISE_PATTERN_A.search(content):
-        return True
-    if EVENT_NOISE_PATTERN_B.search(content):
-        return not STANDING_RULE_GUARD.search(content)
+    if any(p.search(content) for p in EVENT_NOISE_PATTERNS_AB):
+        return not DURABLE_LANGUAGE_GUARD.search(content)
     return False
 
 
@@ -221,9 +225,16 @@ async def _require_capture(session, *, phase: str) -> None:
 
 async def phase_mechanical(session, *, agent_id: str, dry_run: bool) -> dict:
     """tier-1 `rule` rows from contradiction_resolution / cluster_consolidation
-    -> technical (lessons / doc atoms by construction)."""
+    -> technical.
+
+    Scoped to subject='lesson_learned' (2026-07-24 prod dry-run): the blanket
+    version would have demoted a genuine delivery preference stored as a
+    contradiction_resolution rule ("User wants all reports ... sent to both
+    inboxes"). Rows with other subjects flow to the Haiku phase instead.
+    """
     predicate = (
-        "agent_id = :a AND category = 'rule' AND source = ANY(:srcs)"
+        "agent_id = :a AND category = 'rule' AND source = ANY(:srcs) "
+        "AND subject = 'lesson_learned'"
     )
     params = {"a": agent_id, "srcs": list(_MECHANICAL_SOURCES)}
     n = (
@@ -469,17 +480,23 @@ async def phase_verify(session, *, agent_id: str) -> dict:
 # --- CLI -------------------------------------------------------------------
 
 def _build_settings(args) -> Settings:
-    """Settings() with any provided --db-* overrides (init kwargs beat env)."""
+    """Settings() with any provided --db-* overrides.
+
+    The DB fields carry validation_alias="DB_HOST" etc. (unprefixed env vars,
+    per config convention), so init kwargs MUST use the ALIAS names — the
+    snake_case field names are silently ignored by pydantic when an alias is
+    set (2026-07-24 prod-run bug: --db-host had no effect).
+    """
     overrides: dict[str, object] = {}
-    for value, field in (
-        (args.db_host, "db_host"),
-        (args.db_port, "db_port"),
-        (args.db_user, "db_user"),
-        (args.db_password, "db_password"),
-        (args.db_name, "db_name"),
+    for value, alias in (
+        (args.db_host, "DB_HOST"),
+        (args.db_port, "DB_PORT"),
+        (args.db_user, "DB_USER"),
+        (args.db_password, "DB_PASSWORD"),
+        (args.db_name, "DB_NAME"),
     ):
         if value is not None:
-            overrides[field] = value
+            overrides[alias] = value
     return Settings(**overrides)
 
 

--- a/tests/test_backfill_tier1_integrity.py
+++ b/tests/test_backfill_tier1_integrity.py
@@ -74,12 +74,32 @@ def test_ab_contact_fact_email_was_not_demoted():
 
 
 def test_ab_standing_directive_worded_as_request_survives():
-    """codex r3: a directive can be WORDED as a request — standing-rule
-    language suppresses the B match. A (delivery) is deliberately unguarded."""
+    """codex r3 (widened after the prod dry-run): durable preference/directive
+    language suppresses BOTH A and B matches — a directive worded as a request
+    is still a directive, and a recurring-delivery statement reads as a
+    routing preference."""
     assert not classify_event_noise_ab("The user asked to always verify the current date before scheduling")
     assert not classify_event_noise_ab("Tim requested that reports must never include raw credentials")
     assert not classify_event_noise_ab("The user asked that going forward summaries be sent as HTML")
     # plain requests still demote
     assert classify_event_noise_ab("The user asked for the weather forecast for Annapolis")
-    # A is unguarded: a delivery event with 'always' is still a delivery event
-    assert classify_event_noise_ab("The report was sent to the personal Gmail as always")
+    assert not classify_event_noise_ab("The report was sent to the personal Gmail as always")
+
+
+def test_ab_delivery_routing_preferences_survive():
+    """Regression from the FIRST PROD DRY-RUN (2026-07-24): pattern A's
+    'sent to' matched genuine delivery-routing preferences. The durable-
+    language guard (prefers/wants/...) now suppresses A matches too."""
+    assert not classify_event_noise_ab(
+        "User prefers sailing forecasts sent to Gmail only (Tfatykhov@gmail.com), not other channels."
+    )
+    assert not classify_event_noise_ab(
+        "User wants all reports and research deliverables sent to both their personal and work email inboxes."
+    )
+    assert not classify_event_noise_ab(
+        "User wants forecast emails sent to personal inbox with a cc to work email."
+    )
+    # plain receipts (no durable language) still demote
+    assert classify_event_noise_ab("The Annapolis Weekend Forecast email was sent to timur_fatykhov@fanniemae.com.")
+    assert classify_event_noise_ab("The forecast was sent to timandeugene@gmail.com.")
+    assert classify_event_noise_ab("The user sent a list of fixes at 17:24 UTC.")

--- a/tests/test_backfill_tier1_integrity.py
+++ b/tests/test_backfill_tier1_integrity.py
@@ -103,3 +103,11 @@ def test_ab_delivery_routing_preferences_survive():
     assert classify_event_noise_ab("The Annapolis Weekend Forecast email was sent to timur_fatykhov@fanniemae.com.")
     assert classify_event_noise_ab("The forecast was sent to timandeugene@gmail.com.")
     assert classify_event_noise_ab("The user sent a list of fixes at 17:24 UTC.")
+
+
+def test_ab_preposition_like_does_not_shield_noise():
+    """codex #573: bare 'like' is usually the preposition — it must not
+    suppress a genuine noise match; verb forms (likes / would like) do."""
+    assert classify_event_noise_ab("The user asked for a draft like last week's summary")
+    assert not classify_event_noise_ab("Tim likes concise answers with code samples")
+    assert not classify_event_noise_ab("Tim would like reports sent to his work inbox")


### PR DESCRIPTION
Follow-up to #572, driven by the FIRST supervised prod dry-run (no mutations were applied — dry-run only):

1. **Durable-language guard on A+B.** The regex dry-run's own sample output showed 3/10 AB hits were genuine delivery-routing preferences ("User prefers sailing forecasts sent to Gmail only...", "User wants all reports ... sent to both inboxes") — pattern A's `sent to` matches routing preferences, not just receipts. `DURABLE_LANGUAGE_GUARD` (prefers/wants/likes/always/never/must/going forward/standing) now suppresses both A and B. Asymmetric cost argument: kept noise = one stray profile line; demoted preference = exactly the data the profile exists for. All three prod false positives are pinned as regression tests; plain receipts still demote.
2. **`mechanical` scoped to `subject='lesson_learned'`.** The dry-run also showed a genuine preference stored as a `contradiction_resolution` rule row; the blanket source-level demotion would have taken it. Non-lesson subjects flow to the Haiku phase (which already covers those sources).
3. **`--db-*` args were inert:** the DB Settings fields use `validation_alias` (`DB_HOST` etc.), so pydantic ignores snake_case init kwargs — overrides now pass alias names. (Discovered when `--db-host` fell back to the .env docker hostname.)

Tests: 11/11 pure-function suite including the new regression cases and a deliberate expectation flip ("sent ... as always" now reads as a routing preference, documented inline).

The prod backfill remains NOT applied — it runs after this merges, dry-run first per phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)