### PR TITLE
fix(run_python): enforce the timeout for real, drop the useless builtins allowlist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,7 +363,8 @@ DB connection vars are **unprefixed** (shared with docker-compose). All others u
 | `NOUS_INLINE_SUBTASK_TIMEOUT` | `90` | Default timeout for inline (await_result) subtasks |
 | `NOUS_FRAME_DEFAULT_MODELS` | `{}` | JSON map of frame type to default model (falls back to `NOUS_BACKGROUND_MODEL`) |
 | `NOUS_PROGRAMMATIC_TOOLS_ENABLED` | `true` | Enable run_python tool for client-side code execution |
-| `NOUS_PROGRAMMATIC_TOOLS_TIMEOUT` | `10` | Timeout in seconds for run_python code execution |
+| `NOUS_PROGRAMMATIC_TOOLS_TIMEOUT` | `10` | Timeout in seconds for run_python code execution. Enforced in-thread by a `sys.settrace` deadline hook, so Python-level runaway code (`while True: pass`) is actually interrupted; a blocking C-level call still cannot be interrupted and holds its slot until it returns. |
+| `NOUS_PROGRAMMATIC_TOOLS_MAX_CONCURRENT` | `4` | Max concurrent run_python executions. Excess calls are rejected with an error instead of stacking threads inside the API process. |
 | `NOUS_CONTEXT_WINDOW` | auto | Override model context window size in tokens (0 = auto-detect from model name) |
 | `NOUS_ANTI_HALLUCINATION_PROMPT` | `true` | Inject "don't guess, re-fetch" safety prompt into system context |
 | `NOUS_TOOL_PRUNING_ENABLED` | `true` | Enable 4-tier tool result pruning pipeline |

--- a/nous/api/tools.py
+++ b/nous/api/tools.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import copy
 import json
 import logging
+import sys
+import threading
 import time
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
@@ -3238,14 +3240,50 @@ def register_subtask_tools(
 # Programmatic tool calling (012.3)
 # ---------------------------------------------------------------------------
 
-SAFE_BUILTINS = {
-    "len", "list", "dict", "set", "str", "int", "float", "bool",
-    "print", "range", "enumerate", "zip", "sorted", "filter",
-    "map", "max", "min", "sum", "any", "all", "isinstance",
-    "repr", "round", "abs", "type", "tuple",
-}
-
 _MAX_WRITES = 5
+
+# Seconds the awaiting coroutine waits past the script deadline before giving
+# up on the worker thread. The in-thread trace hook normally raises at the
+# deadline, so this grace only matters when the thread is stuck below Python
+# level (a blocking C call), which no in-process mechanism can interrupt.
+_TIMEOUT_GRACE = 2.0
+
+# Trace-hook check interval — number of traced events between deadline checks.
+# Keeps the per-line overhead down without letting an overrun go unnoticed.
+_DEADLINE_CHECK_EVERY = 64
+
+_active_runs = 0
+_active_runs_lock = threading.Lock()
+
+
+class ScriptDeadlineExceeded(BaseException):
+    """Raised inside the run_python worker thread when its deadline passes.
+
+    Derives from BaseException, not Exception, so ordinary agent code using
+    `try/except Exception` cannot swallow its own timeout.
+    """
+
+
+def run_python_active_runs() -> int:
+    """Number of run_python executions currently occupying a worker thread."""
+    with _active_runs_lock:
+        return _active_runs
+
+
+def _acquire_run_slot(max_concurrent: int) -> bool:
+    """Take a concurrency slot if one is free."""
+    global _active_runs
+    with _active_runs_lock:
+        if _active_runs >= max_concurrent:
+            return False
+        _active_runs += 1
+        return True
+
+
+def _release_run_slot() -> None:
+    global _active_runs
+    with _active_runs_lock:
+        _active_runs -= 1
 
 
 def create_programmatic_tools(
@@ -3344,10 +3382,11 @@ def create_programmatic_tools(
         def _print(*args: object) -> None:
             output_buf.write(" ".join(str(a) for a in args) + "\n")
 
-        safe_builtins = {k: getattr(builtins, k) for k in SAFE_BUILTINS if hasattr(builtins, k)}
-
         namespace: dict[str, Any] = {
-            "__builtins__": safe_builtins,
+            # Full builtins: the allowlist that used to live here bought no
+            # security (the same agent holds an unrestricted `bash` tool) and
+            # broke harmless code — `import`, `except Exception`, class bodies.
+            "__builtins__": builtins,
             # Nous memory functions
             "recall_deep": _recall_deep,
             "recall_recent": _recall_recent,
@@ -3355,7 +3394,7 @@ def create_programmatic_tools(
             "learn_fact": _learn_fact,
             "print": _print,
             "result": None,
-            # Safe stdlib modules (pre-injected — import statement is disabled)
+            # Pre-injected for convenience — `import` also works.
             "json": json,
             "re": re,
             "math": math,
@@ -3366,16 +3405,60 @@ def create_programmatic_tools(
             "statistics": statistics,
         }
 
-        def _run() -> None:
-            exec(compile(code, "<nous_script>", "exec"), namespace)
+        # Deadline enforcement inside the worker thread. asyncio.wait_for only
+        # cancels the *await* — the thread keeps running — so a pure-Python
+        # spin loop (`while True: pass`) would otherwise hold a thread (and the
+        # GIL) inside the API process forever. A trace hook fires on every line
+        # of the executing script and raises once the deadline passes.
+        countdown = [_DEADLINE_CHECK_EVERY]
 
-        logger.info("run_python | %d chars\n%s", len(code), code)
+        def _tracer(frame, event, arg):  # noqa: ANN001, ANN202 - CPython trace signature
+            countdown[0] -= 1
+            if countdown[0] <= 0:
+                countdown[0] = _DEADLINE_CHECK_EVERY
+                if time.monotonic() >= deadline:
+                    raise ScriptDeadlineExceeded(f"execution timed out ({timeout}s)")
+            return _tracer
+
+        def _run() -> None:
+            try:
+                sys.settrace(_tracer)
+                exec(compile(code, "<nous_script>", "exec"), namespace)
+            finally:
+                sys.settrace(None)
+                _release_run_slot()
+
+        max_concurrent = settings.programmatic_tools_max_concurrent
+        if not _acquire_run_slot(max_concurrent):
+            logger.warning(
+                "run_python rejected: %d/%d concurrent executions in flight",
+                run_python_active_runs(), max_concurrent,
+            )
+            return {
+                "content": [{
+                    "type": "text",
+                    "text": (
+                        f"Error: too many concurrent run_python executions "
+                        f"({max_concurrent} max) — retry shortly"
+                    ),
+                }],
+                "is_error": True,
+            }
+
+        logger.info(
+            "run_python | %d chars | %d/%d slots in use\n%s",
+            len(code), run_python_active_runs(), max_concurrent, code,
+        )
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
         try:
             # await run_in_executor releases the event loop so DB coroutines
             # scheduled via run_coroutine_threadsafe can actually execute.
-            await asyncio.wait_for(loop.run_in_executor(executor, _run), timeout=timeout)
-        except asyncio.TimeoutError:
+            # The grace covers the trace hook's own check interval; the hook,
+            # not this wait_for, is what actually stops the script.
+            await asyncio.wait_for(
+                loop.run_in_executor(executor, _run), timeout=timeout + _TIMEOUT_GRACE
+            )
+        except (asyncio.TimeoutError, ScriptDeadlineExceeded):
             # is_error per MCP (#179): lets downstream consumers (runner
             # tool_result block, compaction bulk-failure detection)
             # distinguish a real execution failure from a successful run
@@ -3403,14 +3486,19 @@ def create_programmatic_tools(
 _RUN_PYTHON_SCHEMA: dict[str, Any] = {
     "type": "object",
     "description": (
-        "Execute Python code with Nous memory functions and safe stdlib in scope. "
+        "Execute Python code with Nous memory functions in scope. "
+        "Full Python: import, try/except, class and function definitions, open() all work. "
         "Memory functions: recall_deep(query, limit=5), recall_recent(hours=24, limit=5), "
         "list_tasks(status=None), learn_fact(content, category, subject, confidence). "
-        "Stdlib available: json, re, math, datetime, collections, itertools, functools, statistics. "
+        "Pre-imported for convenience (no import needed): json, re, math, datetime, "
+        "collections, itertools, functools, statistics — anything else, just import it. "
         "Use this to batch multiple memory lookups, filter results, and return only what's needed — "
         "reducing token usage compared to separate tool calls. "
         "Set result = <value> to return structured data. Use print() to emit text output. "
-        "Max runtime is configurable (default 10s). Max 5 learn_fact calls per execution."
+        "Runs in-process on a worker thread with a wall-clock deadline (default 10s): "
+        "Python-level code is interrupted when it expires and the call returns a timeout error, "
+        "so keep work short and shell out to `bash` for anything long-running. "
+        "Max 5 learn_fact calls per execution."
     ),
     "properties": {
         "code": {

--- a/nous/api/tools.py
+++ b/nous/api/tools.py
@@ -3420,11 +3420,32 @@ def create_programmatic_tools(
                     raise ScriptDeadlineExceeded(f"execution timed out ({timeout}s)")
             return _tracer
 
+        # P1 Fix 1: Block sys.settrace bypass (slot leak). Monkey-patch
+        # sys.settrace and sys.setprofile to reinstall our tracer and
+        # then silently ignore the script's call.
+        _original_settrace = sys.settrace
+        _original_setprofile = sys.setprofile
+
+        def _settrace_shim(func):
+            # Reinstall our deadline tracer after the script's call
+            _original_settrace(_tracer)
+
+        def _setprofile_shim(func):
+            # No-op for setprofile, but keep tracer alive
+            pass
+
         def _run() -> None:
             try:
+                # Install our tracer
                 sys.settrace(_tracer)
+                # Replace sys.settrace/setprofile with shims in this thread
+                sys.settrace = _settrace_shim
+                sys.setprofile = _setprofile_shim
                 exec(compile(code, "<nous_script>", "exec"), namespace)
             finally:
+                # Restore original functions
+                sys.settrace = _original_settrace
+                sys.setprofile = _original_setprofile
                 sys.settrace(None)
                 _release_run_slot()
 
@@ -3471,6 +3492,20 @@ def create_programmatic_tools(
             return {
                 "content": [{"type": "text", "text": f"Error: {type(e).__name__}: {e}"}],
                 "is_error": True,
+            }
+        except BaseException as exc:
+            # P1 Fix 2: Translate SystemExit/KeyboardInterrupt to is_error.
+            # ScriptDeadlineExceeded is a BaseException so `except Exception`
+            # can't swallow it. But SystemExit/KeyboardInterrupt are also
+            # BaseException subclasses and would escape past the Exception
+            # catch, propagate through ToolDispatcher.dispatch, and crash
+            # the API process. Catch and translate to is_error.
+            return {
+                "is_error": True,
+                "content": [{
+                    "type": "text",
+                    "text": f"Error: script raised {type(exc).__name__}: {exc}"
+                }],
             }
         finally:
             executor.shutdown(wait=False, cancel_futures=True)

--- a/nous/config.py
+++ b/nous/config.py
@@ -975,6 +975,15 @@ class Settings(BaseSettings):
     # 012.3: Programmatic tool calling
     programmatic_tools_enabled: bool = True
     programmatic_tools_timeout: int = 10
+    programmatic_tools_max_concurrent: int = Field(
+        4,
+        ge=1,
+        description=(
+            "Max concurrent run_python executions. Each run occupies a thread in "
+            "the API process; a run that ignores its deadline (blocking C call) "
+            "keeps its slot until it returns, bounding the blast radius."
+        ),
+    )
 
     # 012.2: Subtask execution guardrails (configurable constants)
     subtask_tool_call_limit: int = 20

--- a/tests/test_run_python.py
+++ b/tests/test_run_python.py
@@ -740,3 +740,61 @@ class TestRunPythonFrameAccess:
         from nous.api.runner import FRAME_TOOLS
 
         assert "run_python" not in FRAME_TOOLS["initiation"]
+
+
+# ---------------------------------------------------------------------------
+# P1 bug fix tests (settrace bypass + BaseException handling)
+# ---------------------------------------------------------------------------
+
+
+class TestP1Fixes:
+    """Tests for P1 bugs fixed post-PR-575 initial review."""
+
+    async def test_settrace_bypass_blocked(self, run_python_tool):
+        """Script calling sys.settrace(None) then spinning must still timeout.
+
+        P1 Fix 1: Without the shim, settrace(None) uninstalls the deadline
+        hook and the thread spins forever, holding its concurrency slot.
+        """
+        code = """
+import sys
+sys.settrace(None)  # Attempt to bypass deadline tracer
+while True:
+    pass  # Infinite spin
+"""
+        result = await run_python_tool(code)
+        # Must return timeout error, not hang
+        assert result["is_error"] is True
+        assert "timed out" in result["content"][0]["text"]
+
+        # Slot must be released after timeout
+        from nous.api.tools import run_python_active_runs
+        await asyncio.sleep(0.5)  # Grace for thread cleanup
+        assert run_python_active_runs() == 0
+
+    async def test_system_exit_is_error(self, run_python_tool):
+        """Script calling sys.exit() must return is_error, not crash.
+
+        P1 Fix 2: SystemExit is a BaseException, so it escapes `except Exception`.
+        Without the BaseException catch, it would propagate through
+        ToolDispatcher.dispatch and crash the API process.
+        """
+        code = """
+import sys
+sys.exit(1)
+"""
+        result = await run_python_tool(code)
+        assert result["is_error"] is True
+        assert "SystemExit" in result["content"][0]["text"]
+
+    async def test_keyboard_interrupt_is_error(self, run_python_tool):
+        """Script raising KeyboardInterrupt must return is_error, not crash.
+
+        P1 Fix 2: KeyboardInterrupt is also a BaseException.
+        """
+        code = """
+raise KeyboardInterrupt("user interrupted")
+"""
+        result = await run_python_tool(code)
+        assert result["is_error"] is True
+        assert "KeyboardInterrupt" in result["content"][0]["text"]

--- a/tests/test_run_python.py
+++ b/tests/test_run_python.py
@@ -7,11 +7,14 @@ memory operations, filter results, and return shaped data — reducing
 token consumption compared to separate tool calls.
 """
 
-import pytest
+import asyncio
+import threading
+import time
 from unittest.mock import AsyncMock, MagicMock
 
-from nous.config import Settings
+import pytest
 
+from nous.config import Settings
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -115,6 +118,16 @@ class TestRunPythonConfig:
         s = Settings(programmatic_tools_enabled=False, programmatic_tools_timeout=30)
         assert s.programmatic_tools_enabled is False
         assert s.programmatic_tools_timeout == 30
+
+    def test_default_max_concurrent(self):
+        """programmatic_tools_max_concurrent defaults to 4."""
+        s = Settings()
+        assert s.programmatic_tools_max_concurrent == 4
+
+    def test_max_concurrent_must_be_positive(self):
+        """A cap below 1 would disable the tool outright — reject it."""
+        with pytest.raises(ValueError):
+            Settings(programmatic_tools_max_concurrent=0)
 
 
 # ---------------------------------------------------------------------------
@@ -247,54 +260,74 @@ class TestRunPythonSafeBuiltins:
 
 
 # ---------------------------------------------------------------------------
-# Blocked builtins tests
+# Full-builtins tests (the SAFE_BUILTINS allowlist was removed)
 # ---------------------------------------------------------------------------
 
 
-class TestRunPythonBlockedBuiltins:
-    """Test that dangerous builtins are blocked."""
+class TestRunPythonFullBuiltins:
+    """Full builtins are exposed — the allowlist bought no security.
+
+    The same agent holds an unrestricted `bash` tool in the same tool belt, so
+    everything the allowlist blocked was one heredoc away. It only cost
+    usability (no `import`, no `except Exception`, no class bodies).
+    """
 
     @pytest.mark.asyncio
-    async def test_dunder_import_blocked(self, run_python_tool):
-        """__import__ is not available."""
-        result = await run_python_tool(code='__import__("os")')
-        assert "Error" in result["content"][0]["text"]
+    async def test_import_works(self, run_python_tool):
+        """import statement works."""
+        result = await run_python_tool(
+            code='import base64\nresult = base64.b64encode(b"hi").decode()'
+        )
+        assert result["content"][0]["text"] == "aGk="
 
     @pytest.mark.asyncio
-    async def test_open_blocked(self, run_python_tool):
-        """open() is not available."""
-        result = await run_python_tool(code='open("/etc/passwd")')
-        assert "Error" in result["content"][0]["text"]
+    async def test_import_os_works(self, run_python_tool):
+        """import os works (parity with the bash tool the agent already has)."""
+        result = await run_python_tool(code="import os\nresult = type(os.sep).__name__")
+        assert result["content"][0]["text"] == "str"
 
     @pytest.mark.asyncio
-    async def test_eval_blocked(self, run_python_tool):
-        """eval() is not available."""
-        result = await run_python_tool(code='eval("1+1")')
-        assert "Error" in result["content"][0]["text"]
+    async def test_try_except_exception(self, run_python_tool):
+        """try/except Exception works — used to NameError on Exception."""
+        result = await run_python_tool(
+            code="try:\n    1 / 0\nexcept Exception as e:\n    result = type(e).__name__"
+        )
+        assert result["content"][0]["text"] == "ZeroDivisionError"
 
     @pytest.mark.asyncio
-    async def test_exec_blocked(self, run_python_tool):
-        """exec() is not available (inside exec'd code)."""
-        result = await run_python_tool(code='exec("x=1")')
-        assert "Error" in result["content"][0]["text"]
+    async def test_class_definition(self, run_python_tool):
+        """Class definitions work — used to fail on missing __build_class__."""
+        code = (
+            "class Point:\n"
+            "    def __init__(self, x):\n"
+            "        self.x = x\n"
+            "\n"
+            "result = Point(7).x"
+        )
+        result = await run_python_tool(code=code)
+        assert result["content"][0]["text"] == "7"
 
     @pytest.mark.asyncio
-    async def test_import_statement_blocked(self, run_python_tool):
-        """import statement is blocked (no __import__ in builtins)."""
-        result = await run_python_tool(code="import os")
-        assert "Error" in result["content"][0]["text"]
+    async def test_getattr_and_dir(self, run_python_tool):
+        """Reflection builtins are available."""
+        result = await run_python_tool(
+            code='result = getattr("abc", "upper")()'
+        )
+        assert result["content"][0]["text"] == "ABC"
 
     @pytest.mark.asyncio
-    async def test_os_not_in_namespace(self, run_python_tool):
-        """os module is not injected into the namespace."""
-        result = await run_python_tool(code='os.system("echo hi")')
-        assert "Error" in result["content"][0]["text"]
-
-    @pytest.mark.asyncio
-    async def test_subprocess_not_in_namespace(self, run_python_tool):
-        """subprocess module is not injected."""
-        result = await run_python_tool(code='subprocess.run(["echo"])')
-        assert "Error" in result["content"][0]["text"]
+    async def test_open_available(self, run_python_tool):
+        """open() is available (errors come from the OS, not a sandbox)."""
+        result = await run_python_tool(
+            code=(
+                "import tempfile, os\n"
+                "path = os.path.join(tempfile.gettempdir(), 'nous_run_python_probe.txt')\n"
+                "open(path, 'w').write('ok')\n"
+                "result = open(path).read()\n"
+                "os.remove(path)"
+            )
+        )
+        assert result["content"][0]["text"] == "ok"
 
 
 # ---------------------------------------------------------------------------
@@ -456,8 +489,25 @@ class TestRunPythonWriteCap:
 # ---------------------------------------------------------------------------
 
 
+async def _wait_for_idle(timeout: float = 3.0) -> int:
+    """Poll until no run_python execution occupies a worker thread."""
+    from nous.api.tools import run_python_active_runs
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if run_python_active_runs() == 0:
+            break
+        await asyncio.sleep(0.02)
+    return run_python_active_runs()
+
+
 class TestRunPythonTimeout:
-    """Test timeout enforcement."""
+    """Test timeout enforcement.
+
+    The deadline is enforced by a sys.settrace hook running inside the worker
+    thread, so Python-level runaway code is actually interrupted — not merely
+    abandoned by the awaiting coroutine.
+    """
 
     @pytest.mark.asyncio
     async def test_timeout_triggers(self):
@@ -476,6 +526,105 @@ class TestRunPythonTimeout:
         text = result["content"][0]["text"]
         assert "Error" in text
         assert "timed out" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_builtinless_spin_loop_is_stopped(self):
+        """`while True: pass` uses zero builtins — it must still be killed.
+
+        Asserts on the observable: the call returns a timeout error, no live
+        thread is left behind, and total wall time stays near the deadline.
+        """
+        from nous.api.tools import create_programmatic_tools, run_python_active_runs
+
+        assert await _wait_for_idle() == 0, "test started with a run in flight"
+        baseline_threads = threading.active_count()
+
+        tools = create_programmatic_tools(
+            AsyncMock(),
+            AsyncMock(),
+            Settings(programmatic_tools_enabled=True, programmatic_tools_timeout=1),
+        )
+        started = time.monotonic()
+        result = await tools["run_python"](code="while True: pass")
+        elapsed = time.monotonic() - started
+
+        assert result["is_error"] is True
+        assert "timed out" in result["content"][0]["text"].lower()
+        # The trace hook, not the outer wait_for, ended the run.
+        assert elapsed < 1 + 2.0, f"run outlived its deadline ({elapsed:.1f}s)"
+        assert run_python_active_runs() == 0
+        # Worker thread is gone (executor teardown is async — allow a moment).
+        deadline = time.monotonic() + 3.0
+        while threading.active_count() > baseline_threads and time.monotonic() < deadline:
+            await asyncio.sleep(0.02)
+        assert threading.active_count() <= baseline_threads
+
+    @pytest.mark.asyncio
+    async def test_timeout_not_swallowed_by_except_exception(self):
+        """A script catching Exception cannot swallow its own deadline."""
+        from nous.api.tools import create_programmatic_tools
+
+        tools = create_programmatic_tools(
+            AsyncMock(),
+            AsyncMock(),
+            Settings(programmatic_tools_enabled=True, programmatic_tools_timeout=1),
+        )
+        code = "try:\n    while True:\n        pass\nexcept Exception:\n    result = 'swallowed'"
+        result = await tools["run_python"](code=code)
+        assert result["is_error"] is True
+        assert "timed out" in result["content"][0]["text"].lower()
+        assert await _wait_for_idle() == 0
+
+
+# ---------------------------------------------------------------------------
+# Concurrency cap tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunPythonConcurrencyCap:
+    """Test the max-concurrent-executions cap."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_when_saturated(self):
+        """A run beyond the cap is rejected instead of stacking threads."""
+        from nous.api.tools import create_programmatic_tools, run_python_active_runs
+
+        assert await _wait_for_idle() == 0, "test started with a run in flight"
+
+        tools = create_programmatic_tools(
+            AsyncMock(),
+            AsyncMock(),
+            Settings(
+                programmatic_tools_enabled=True,
+                programmatic_tools_timeout=5,
+                programmatic_tools_max_concurrent=1,
+            ),
+        )
+        # time.sleep releases the GIL, so the event loop stays responsive.
+        occupied = asyncio.create_task(
+            tools["run_python"](code="import time\ntime.sleep(1)\nresult = 'done'")
+        )
+        for _ in range(100):
+            await asyncio.sleep(0.02)
+            if run_python_active_runs() == 1:
+                break
+        assert run_python_active_runs() == 1
+
+        rejected = await tools["run_python"](code="result = 1")
+        assert rejected["is_error"] is True
+        assert "concurrent" in rejected["content"][0]["text"].lower()
+
+        assert (await occupied)["content"][0]["text"] == "done"
+        assert await _wait_for_idle() == 0
+
+    @pytest.mark.asyncio
+    async def test_slot_released_after_run(self, run_python_tool):
+        """A completed run frees its slot."""
+        from nous.api.tools import run_python_active_runs
+
+        await run_python_tool(code="result = 1")
+        assert await _wait_for_idle() == 0
+        assert run_python_active_runs() == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`run_python` blocked the harmless and permitted the harmful. This fixes both halves.

**P2 — the builtins allowlist is gone.** `SAFE_BUILTINS` (27 names) provided zero
security: the same agent holds an unrestricted `bash` tool in the same tool belt,
running full `python3` as a subprocess with the same env, credentials and
filesystem. There is no actor who has `run_python` but not `bash`. What the
allowlist did do was break harmless code — `import`, `try/except Exception`
(NameError on `Exception`), class definitions — costing the agent wasted turns.
The namespace now gets real `builtins`. The pre-injected convenience modules
(`json`, `re`, `math`, `datetime`, `collections`, `itertools`, `functools`,
`statistics`) stay, and the `_MAX_WRITES = 5` `learn_fact` cap and memory-function
wiring are untouched — that cap is memory hygiene, not sandboxing.

**P1 — the timeout is now real.** `asyncio.wait_for` cancels the *await*, not the
worker thread, and `executor.shutdown(cancel_futures=True)` only drops *queued*
futures. `while True: pass` needs zero builtins, sailed through the allowlist,
survived the timeout, held the GIL, and degraded the whole API — that exec runs on
a thread inside pid 1, alongside the event loop and the Postgres pool.

## P1: chose Option A (in-process kill switch)

Option B (subprocess isolation) would need an IPC bridge back to the parent's
asyncio DB pool for `recall_deep`/`learn_fact`/etc. — an RPC layer to reimplement
the one property that makes this tool worth having over `bash` (direct in-process
memory access). Nothing about the failure mode requires it: the observed hole is a
Python-level spin loop, which a trace hook does interrupt. So Option A, ~40 lines:

- `ScriptDeadlineExceeded(BaseException)` — deliberately **not** an `Exception`
  subclass, so now that `except Exception` works, agent code cannot swallow its
  own deadline.
- A `sys.settrace` hook installed inside the worker thread, checking
  `time.monotonic()` every 64 traced events (cheap; empirically fires within
  milliseconds of the deadline) and raising in the executing frame.
- `NOUS_PROGRAMMATIC_TOOLS_MAX_CONCURRENT` (default 4, `ge=1`). Over the cap,
  the call is rejected with a clear error and a WARNING log instead of stacking
  threads. `run_python_active_runs()` exposes the count; the per-run INFO log
  now includes `N/M slots in use`.
- The slot is released by the worker thread itself, so a thread that outlives its
  deadline keeps holding its slot — that is what bounds the blast radius.

### What the timeout now guarantees — and what it does not

**Guarantees:** any runaway that is executing Python bytecode — `while True: pass`,
runaway recursion, a pathological comprehension — is interrupted at the deadline,
the call returns `is_error` with a timeout message, and the worker thread exits.
Test-proven, including the case where the script wraps the loop in
`except Exception`.

**Does not guarantee:** a thread blocked *below* Python level cannot be
interrupted by any in-process mechanism — `time.sleep(3600)`, a blocking socket
read, a long C extension call. No trace event ever fires, so the hook never runs.
For those, the awaiting coroutine gives up after `timeout + 2s` and returns the
timeout error, but the thread lives until its call returns. That is precisely why
the concurrency cap exists: the leak is bounded at `max_concurrent` threads rather
than unbounded. A bare `except:` (catching `BaseException`) inside an infinite loop
can also re-swallow the deadline exception forever — an explicit, documented
residual, not something a subprocess design would fix any better than closing the
tool to the agent.

## Tests

`tests/test_run_python.py`: 60 passed in ~23s.

New coverage: `import base64` / `import os`; `try/except Exception`; class
definition; `getattr`; `open()` round-trip; **`while True: pass` stopped at the
deadline** (asserts timeout error + `run_python_active_runs() == 0` + thread count
back to baseline + elapsed under deadline+grace); deadline not swallowed by
`except Exception`; concurrency cap rejects when saturated and releases slots; two
config tests.

The `TestRunPythonBlockedBuiltins` class was replaced by `TestRunPythonFullBuiltins`
— those tests asserted the exact behaviour P2 removes (`import os` must error), so
they could not survive unchanged. Every other pre-existing test is untouched and
passes.

Lint: `ruff check nous/api/tools.py` reports 55 findings before and 55 after this
change — no new ones (all pre-existing E501/UP037 noise; CI lint is advisory).
`tests/test_run_python.py` is ruff-clean.

Also ran `tests/test_episode_id_injection.py tests/test_compaction.py
tests/test_execution_ledger.py tests/test_config.py`: 187 passed, 2 failed —
`test_config.py::test_date_leg_settings_defaults` and
`TestDAGTimeoutValidation::test_default_equals_max_is_ok`, both caused by ambient
`NOUS_*` env vars in this job's environment (e.g. `NOUS_DATE_LEG_ENABLED=true`)
leaking into bare `Settings()` construction. Unrelated to this change.

## Out of scope (noticed, not touched)

- `docs/implementation/012.3-programmatic-tool-calling.md` still quotes the
  `SAFE_BUILTINS` snippet. Left as-is — it is a historical build spec, not live docs.
- Those two `test_config.py` tests are environment-sensitive: they call bare
  `Settings()` and so assert defaults that any operator env var overrides. Worth
  hardening separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
