### PR TITLE
fix(tests): repair red main — stub profile flags in temporal_recall settings mocks

### DIFF
--- a/tests/test_temporal_recall.py
+++ b/tests/test_temporal_recall.py
@@ -252,6 +252,11 @@ class TestTemporalContextTier:
         s.anti_hallucination_prompt = False
         s.identity_prompt = ""
         s.context_window = 0
+        # PR #574 (profile core/intent split) reads these on the Tier-1
+        # path; a bare MagicMock is truthy and its attrs are MagicMocks,
+        # which blow up the `> 0` budget/probation comparisons.
+        s.profile_core_enabled = False
+        s.profile_intent_leg_enabled = False
         return s
 
     @pytest.fixture
@@ -267,6 +272,11 @@ class TestTemporalContextTier:
         s.anti_hallucination_prompt = False
         s.identity_prompt = ""
         s.context_window = 0
+        # PR #574 (profile core/intent split) reads these on the Tier-1
+        # path; a bare MagicMock is truthy and its attrs are MagicMocks,
+        # which blow up the `> 0` budget/probation comparisons.
+        s.profile_core_enabled = False
+        s.profile_intent_leg_enabled = False
         return s
 
     @pytest.fixture
@@ -611,6 +621,11 @@ class TestBudgetBoost:
         s.anti_hallucination_prompt = False
         s.identity_prompt = ""
         s.context_window = 0
+        # PR #574 (profile core/intent split) reads these on the Tier-1
+        # path; a bare MagicMock is truthy and its attrs are MagicMocks,
+        # which blow up the `> 0` budget/probation comparisons.
+        s.profile_core_enabled = False
+        s.profile_intent_leg_enabled = False
         return s
 
     @pytest.fixture


### PR DESCRIPTION
## Problem

`main` has been red since PR #574 (`21b809c`, *User Profile core/intent split*) merged on Jul 24 17:26. Every run since fails with **6 failed / 5385 passed**, all in `tests/test_temporal_recall.py`:

```
TypeError: '>' not supported between instances of 'MagicMock' and 'int'
```

## Root cause

#574 added two Tier-1 code paths that compare a settings value against an int:

| location | comparison | gate |
|---|---|---|
| `nous/cognitive/context.py:545` | `_prob_days > 0` | `profile_core_enabled` |
| `nous/cognitive/context.py:881` | `profile_intent_leg_budget > 0` | `profile_intent_leg_enabled` |

`test_temporal_recall.py` builds its `settings` / `settings_disabled` fixtures from a bare `MagicMock()`. Both gates read as truthy, execution enters the branch, and the comparison gets a `MagicMock` instead of an int.

#574 *did* update `test_tiered_context.py` and `test_profile_facts_api.py` — but those construct real `Settings` objects via `model_copy(update=...)`, so they were never exposed. `test_temporal_recall.py` was the only MagicMock-based consumer and was missed.

## Fix

Explicitly stub both flags to `False` in the three MagicMock settings fixtures, consistent with how `relevance_floor_enabled`, `staleness_penalty_enabled`, `budget_scale_enabled` etc. are already stubbed in the same fixtures. Test-only change — **no production code touched**.

## Verification

```
before:  6 failed, 23 passed, 5 errors
after:  34 passed
```

Adjacent suites (`test_tiered_context.py`, `test_profile_facts_api.py`) are untouched by this diff.

## Follow-up (not in this PR)

Same latent hazard is visible as a swallowed warning on this path:
`Procedure catalog build failed: '<' not supported between instances of 'int' and 'MagicMock'` — caught and logged rather than raised, so it doesn't fail CI. Worth a separate look at whether `context.py` should coerce these settings reads defensively (`int(getattr(...) or 0)`) instead of relying on every test fixture stubbing new flags. Filing separately to keep this PR surgical.