### PR TITLE
feat(eval): leg visibility from pipeline-reported attempted legs (N7 follow-up)

### DIFF
--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -765,11 +765,15 @@ async def _run_stages(
     if getattr(settings, "keyed_fact_leg_enabled", False) and (
         search_all or "fact" in search_types
     ):
-        acc.attempted_legs.add("keyed")
         try:
             vocab = await heart.facts.entity_key_vocabulary()
             candidates = extract_entity_candidates(query, vocab=vocab)
             if candidates:
+                # Marked here, not at the block: a query yielding no entity
+                # candidates never reaches the fetch, and reporting it as a
+                # keyed leg that ran and found nothing is the same false
+                # attribution corrected for the graph seed loops.
+                acc.attempted_legs.add("keyed")
                 acc.keyed_leg_used = True
                 acc.keyed_results = await heart.facts.fetch_by_entity_keys(
                     candidates, limit=getattr(settings, "keyed_fact_leg_k", 8)
@@ -940,7 +944,6 @@ async def _run_stages(
         and (search_all or "fact" in search_types)
         and _is_classification_shaped(query, getattr(settings, "exemplar_max_query_words", 64))
     ):
-        acc.attempted_legs.add("exemplar")
         try:
             if await heart.facts.has_exemplars():
                 acc.exemplar_leg_used = True
@@ -950,6 +953,10 @@ async def _run_stages(
                 embedder = getattr(heart, "_embeddings", None)
                 q_vec = (await embedder.embed(query)) if embedder is not None else None
                 if q_vec:
+                    # Marked only once BOTH gates pass (a non-empty exemplar
+                    # store and a usable query vector); either failing means
+                    # no fetch is issued, so the leg was not attempted.
+                    acc.attempted_legs.add("exemplar")
                     # Codex r8: exclude the F071 already-in-context fact set from
                     # the fetch so ids the assembly-time F071 filter will drop do
                     # NOT spend the K budget (which would starve fresh

--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -721,7 +721,6 @@ async def _run_stages(
         # (chunks_searched stays False) from "flag on but stage failed"
         # (chunks_searched True + n_stage_errors["chunk_recall"] non-zero).
         acc.chunks_searched = True
-        acc.attempted_legs.add("chunk")
         try:
             acc.chunk_results = await _search_episode_chunks(
                 heart=heart,
@@ -740,6 +739,9 @@ async def _run_stages(
                 # conflating them IS the bug.
                 limit=settings.episode_chunk_recall_limit,
                 settings=settings,
+                # The helper marks "chunk" only where it actually queries —
+                # the vector path returns early with no embedder/vector.
+                attempted=acc.attempted_legs,
             )
         except Exception:
             # Match the sibling stages' pattern (spreading_activation,
@@ -1255,9 +1257,6 @@ async def _run_stages(
                 )
 
         if use_spreading:
-            # Spreading branch taken. Its rows are labelled
-            # "spreading_activation" regardless of stage_origin.
-            acc.attempted_legs.add("spreading_activation")
             try:
                 from nous.brain.schemas import NeighborResult
                 from nous.brain.spreading_activation import (
@@ -1269,6 +1268,16 @@ async def _run_stages(
                         (d.id, "decision", d.score or 0.5)
                         for d in decision_results[: settings.graph_recall_max_expand]
                     ] + heart_fact_seeds
+                    # Spreading branch taken AND it has something to spread
+                    # from. ``spreading_activation_search`` returns
+                    # immediately on empty seeds without issuing its CTE
+                    # (spreading_activation.py:111-112) — reachable with
+                    # graph_recall_max_expand=0 and no heart fact seeds — so
+                    # marking at the branch would claim a query that never
+                    # ran. Rows from here are labelled "spreading_activation"
+                    # regardless of stage_origin.
+                    if seeds:
+                        acc.attempted_legs.add("spreading_activation")
                     # Heart-seeded spreading re-reaches existing heart/
                     # chunk candidates AND prior graph-stage outputs
                     # (Stage 2 decisions, Path A neighbors) constantly —
@@ -1894,8 +1903,17 @@ async def _search_episode_chunks(
     agent_id: str,
     limit: int,
     settings: "Settings | None" = None,
+    attempted: "set[str] | None" = None,
 ) -> list[tuple[UUID, str, float]]:
     """F067: search over heart.episode_chunks.
+
+    ``attempted`` is an optional sink the helper adds ``"chunk"`` to at each
+    point it is about to ISSUE a query. The caller cannot compute this: the
+    vector path returns early with no embedder or an empty query vector,
+    while the hybrid path still runs keyword-only in that case, so only this
+    function knows whether a retrieval actually happened. Marking at the
+    call site would report the leg as attempted-and-silent on a run where it
+    never queried at all.
 
     Default (``chunk_hybrid_search_enabled`` off): vector-only cosine search,
     byte-identical to the original F067 leg; returns ``[]`` when no embedder
@@ -1923,6 +1941,9 @@ async def _search_episode_chunks(
 
         query_vec = (await embedder.embed(query)) if embedder is not None else None
         query_vec = query_vec or None  # empty embed → keyword-only fallback
+        # Hybrid always queries (keyword-only when the vector is absent).
+        if attempted is not None:
+            attempted.add("chunk")
         async with heart.db.session() as s:
             ranked = await heart_search.hybrid_search(
                 s,
@@ -1959,6 +1980,10 @@ async def _search_episode_chunks(
     query_vec = await embedder.embed(query)
     if not query_vec:
         return []
+    # Vector path: both early returns above skip the query entirely, so
+    # the leg is only attempted from here.
+    if attempted is not None:
+        attempted.add("chunk")
     vec_lit = "[" + ",".join(f"{v:.6f}" for v in query_vec) + "]"
     async with heart.db.session() as s:
         # P1.1: include episode_id so the formatter can session-group chunks.

--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -170,6 +170,13 @@ class PipelineStats:
     # exclusion set was passed. Surfaced in recall_deep INFO log so the
     # duplication-tax measurement is grep-able from prod.
     excluded_in_context: int = 0
+    # N7 follow-up: legs this call ATTEMPTED, marked at each stage's entry
+    # before its work ran — so a leg that executed and produced nothing is
+    # still named. Lets a consumer distinguish "this leg was never run" from
+    # "it ran and returned nothing" — which no set of config flags can
+    # answer, since the one-hop fallback is skipped when spreading succeeds
+    # and that is decided at runtime.
+    attempted_legs: frozenset[str] = frozenset()
     # F080: True iff coherent ranking was active for this call (censors +
     # procedures excluded from the ranked pool). Observability only — not
     # formatted into recall_deep text, so it does not affect the snapshot.
@@ -315,6 +322,14 @@ class _PipelineAccumulator:
     # Per-stage error counter — incremented when a try/except around a stage
     # call catches an exception. Surfaced via PipelineStats.n_stage_errors.
     stage_errors: dict[str, int] = field(default_factory=dict)
+
+    # N7 follow-up: legs this call ATTEMPTED, marked at each stage's entry
+    # BEFORE its work runs — so a leg that ran and produced nothing is still
+    # named. Consumers (the eval harness) previously re-derived this from
+    # config flags, which cannot be correct: whether the one-hop fallback
+    # runs depends on whether spreading succeeded at RUNTIME, and no
+    # combination of flags predicts that. The producer reports it instead.
+    attempted_legs: set[str] = field(default_factory=set)
 
 
 # ---------------------------------------------------------------------------
@@ -607,6 +622,7 @@ async def run_recall_pipeline(
         n_stage_errors=dict(acc.stage_errors),
         contradiction_edges=list(acc.contradictions),
         excluded_in_context=excluded_in_context,  # F071
+        attempted_legs=frozenset(acc.attempted_legs),
         coherent_ranking_applied=acc.coherent_ranking_applied,  # F080: reflects the filter actually running (search_all only)
         keyed_leg_used=acc.keyed_leg_used,  # R3.3 (F085)
         n_keyed=len(keyed),
@@ -674,6 +690,7 @@ async def _run_stages(
 
         if heart_types:
             acc.searched_heart = True
+            acc.attempted_legs.add("heart_primary")
             acc.heart_types_searched = heart_types
             heart_results = await heart.recall(
                 query, limit=limit, types=heart_types,
@@ -704,6 +721,7 @@ async def _run_stages(
         # (chunks_searched stays False) from "flag on but stage failed"
         # (chunks_searched True + n_stage_errors["chunk_recall"] non-zero).
         acc.chunks_searched = True
+        acc.attempted_legs.add("chunk")
         try:
             acc.chunk_results = await _search_episode_chunks(
                 heart=heart,
@@ -747,6 +765,7 @@ async def _run_stages(
     if getattr(settings, "keyed_fact_leg_enabled", False) and (
         search_all or "fact" in search_types
     ):
+        acc.attempted_legs.add("keyed")
         try:
             vocab = await heart.facts.entity_key_vocabulary()
             candidates = extract_entity_candidates(query, vocab=vocab)
@@ -768,6 +787,7 @@ async def _run_stages(
         # completion without raising.
         rounds = getattr(settings, "keyed_fact_leg_rounds", 1)
         if rounds >= 2 and acc.keyed_results:
+            acc.attempted_legs.add("keyed_r2")
             try:
                 acc.keyed_r2_ran = True
                 r1_ids = [row.id for row in acc.keyed_results]
@@ -920,6 +940,7 @@ async def _run_stages(
         and (search_all or "fact" in search_types)
         and _is_classification_shaped(query, getattr(settings, "exemplar_max_query_words", 64))
     ):
+        acc.attempted_legs.add("exemplar")
         try:
             if await heart.facts.has_exemplars():
                 acc.exemplar_leg_used = True
@@ -980,6 +1001,8 @@ async def _run_stages(
         and settings.graph_recall_enabled
         and settings.cross_type_linking_enabled
     ):
+        # Stage 2 entered: heart->decision cross-type expansion.
+        acc.attempted_legs.add("heart_graph")
         seen_graph: dict[UUID, "NeighborResult"] = {}
         for hr in acc.heart_results[:3]:
             if hr.type in ("fact", "episode"):
@@ -1047,6 +1070,8 @@ async def _run_stages(
         # Flag-gated so prod retrieval shape is unchanged by default.
         # ------------------------------------------------------------------
         if settings.heart_graph_all_types_enabled:
+            # Stage 2b entered (Path A): heart->any-type neighbours.
+            acc.attempted_legs.add("heart_graph_memory")
             mem_limit = max(1, int(settings.heart_graph_neighbors_per_seed))
             seen_mem: dict[UUID, "NeighborResult"] = {}
             heart_ids: set[UUID] = {hr.id for hr in acc.heart_results}
@@ -1152,6 +1177,7 @@ async def _run_stages(
 
     if search_all or "decision" in search_types:
         acc.searched_decisions = True
+        acc.attempted_legs.add("brain")
         decision_results = await brain.query(query, limit=limit)
 
     # F022 extension (2026-07-11): heart FACT seeds for spreading. Top-3
@@ -1210,6 +1236,9 @@ async def _run_stages(
                 )
 
         if use_spreading:
+            # Spreading branch taken. Its rows are labelled
+            # "spreading_activation" regardless of stage_origin.
+            acc.attempted_legs.add("spreading_activation")
             try:
                 from nous.brain.schemas import NeighborResult
                 from nous.brain.spreading_activation import (
@@ -1311,6 +1340,11 @@ async def _run_stages(
 
         if not use_spreading:
             # Fall back to 1-hop expansion
+            # Fallback taken (NOT taken when spreading succeeded) — a runtime
+            # branch no config flag can predict. It emits decision rows tagged
+            # brain_graph AND non-decision neighbours tagged heart_graph_memory.
+            acc.attempted_legs.add("brain_graph")
+            acc.attempted_legs.add("heart_graph_memory")
             seen_hop: dict[UUID, "NeighborResult"] = {}
             for dec in decision_results[: settings.graph_recall_max_expand]:
                 if dec.score is None:

--- a/nous/api/retrieval_pipeline.py
+++ b/nous/api/retrieval_pipeline.py
@@ -1001,8 +1001,15 @@ async def _run_stages(
         and settings.graph_recall_enabled
         and settings.cross_type_linking_enabled
     ):
-        # Stage 2 entered: heart->decision cross-type expansion.
-        acc.attempted_legs.add("heart_graph")
+        # Stage 2 attempted only when a seed will actually enter the loop
+        # below. The outer block also fires on chunk-only retrieval (via
+        # acc.chunk_results, for Stage 2b's benefit), where this loop makes
+        # no neighbour query at all — marking there would report
+        # heart_graph as attempted-and-silent on every chunk-only qrel,
+        # which is the false attribution this instrumentation exists to
+        # prevent.
+        if any(hr.type in ("fact", "episode") for hr in acc.heart_results[:3]):
+            acc.attempted_legs.add("heart_graph")
         seen_graph: dict[UUID, "NeighborResult"] = {}
         for hr in acc.heart_results[:3]:
             if hr.type in ("fact", "episode"):
@@ -1070,8 +1077,6 @@ async def _run_stages(
         # Flag-gated so prod retrieval shape is unchanged by default.
         # ------------------------------------------------------------------
         if settings.heart_graph_all_types_enabled:
-            # Stage 2b entered (Path A): heart->any-type neighbours.
-            acc.attempted_legs.add("heart_graph_memory")
             mem_limit = max(1, int(settings.heart_graph_neighbors_per_seed))
             seen_mem: dict[UUID, "NeighborResult"] = {}
             heart_ids: set[UUID] = {hr.id for hr in acc.heart_results}
@@ -1098,6 +1103,13 @@ async def _run_stages(
                  float(item[2]) if len(item) > 2 and item[2] is not None else None)
                 for item in acc.chunk_results[:3]
             )
+            # Stage 2b (Path A) attempted only once usable seeds exist. An
+            # explicit procedure/censor scope reaches here with a non-empty
+            # acc.heart_results but produces NO seeds — Path A accepts only
+            # fact/episode rows and chunks — so no brain.neighbors call is
+            # made and the leg must not be reported as attempted-and-silent.
+            if mem_seeds:
+                acc.attempted_legs.add("heart_graph_memory")
             # Per-type fan-out — one ``LIMIT`` window per neighbor type so
             # chunks don't crowd facts/episodes (or vice versa) out of a
             # single small union limit. Order is irrelevant; the global
@@ -1339,12 +1351,26 @@ async def _run_stages(
                 use_spreading = False
 
         if not use_spreading:
-            # Fall back to 1-hop expansion
-            # Fallback taken (NOT taken when spreading succeeded) — a runtime
-            # branch no config flag can predict. It emits decision rows tagged
-            # brain_graph AND non-decision neighbours tagged heart_graph_memory.
-            acc.attempted_legs.add("brain_graph")
-            acc.attempted_legs.add("heart_graph_memory")
+            # Fall back to 1-hop expansion.
+            #
+            # Marked only when a decision will actually be expanded. This
+            # branch is reachable via heart_fact_seeds alone (fact-only
+            # retrieval with spreading off), where decision_results is empty
+            # and the loop below issues no neighbour query — reporting the
+            # legs there would claim the fallback ran when it did not. The
+            # `score is None` skip inside the loop is mirrored here for the
+            # same reason.
+            #
+            # When it DOES run it emits decision rows tagged brain_graph AND
+            # non-decision neighbours tagged heart_graph_memory; which of the
+            # two branches executes is a runtime decision no config flag can
+            # predict.
+            if any(
+                d.score is not None
+                for d in decision_results[: settings.graph_recall_max_expand]
+            ):
+                acc.attempted_legs.add("brain_graph")
+                acc.attempted_legs.add("heart_graph_memory")
             seen_hop: dict[UUID, "NeighborResult"] = {}
             for dec in decision_results[: settings.graph_recall_max_expand]:
                 if dec.score is None:

--- a/nous_eval/metrics.py
+++ b/nous_eval/metrics.py
@@ -341,8 +341,14 @@ def leg_visibility(
     scoring at 30 turns a measured leg into a false "inconclusive".
 
     ``attempted_legs`` comes from ``PipelineStats.attempted_legs`` — the
-    PIPELINE's own report of which legs it entered, unioned across qrels by
-    the runner. It is required for correctness, not convenience: a leg that
+    PIPELINE's own report of which legs it entered. When omitted it is
+    derived from the union of ``QrelResult.attempted_legs`` over the qrels
+    ACTUALLY PASSED IN, which is what a filtered call needs: if spreading
+    ran for source A while source B took the one-hop fallback, a
+    config-wide union would seed ``spreading_activation`` into source B's
+    report and misreport it as silent-but-attempted. Pass an explicit set
+    only to widen beyond the given qrels. It matters for correctness, not
+    convenience: a leg that
     emitted zero rows on every qrel appears nowhere in ``retrieved_legs``,
     so without it the most extreme case of an unobserved arm is omitted from
     this report entirely — silently, and precisely when the warning matters
@@ -380,8 +386,17 @@ def leg_visibility(
             if best <= cutoff:
                 within[leg] = within.get(leg, 0) + 1
 
-    # Seed attempted-but-silent legs so zero emission is REPORTED, not omitted.
-    for leg in attempted_legs or ():
+    # Seed attempted-but-silent legs so zero emission is REPORTED, not
+    # omitted. Default to the union over the qrels PASSED IN so a
+    # source-filtered call never inherits a leg another source attempted.
+    if attempted_legs is None:
+        attempted_legs = {
+            leg
+            for q in per_qrel
+            if q.error is None
+            for leg in q.attempted_legs
+        }
+    for leg in attempted_legs:
         ranks_by_leg.setdefault(leg, [])
 
     out = []

--- a/nous_eval/metrics.py
+++ b/nous_eval/metrics.py
@@ -16,8 +16,9 @@ explicitly, so callers can branch on it if they need to.
 from __future__ import annotations
 
 import math
+from collections.abc import Iterable
 from dataclasses import dataclass, field
-from statistics import mean
+from statistics import mean, median
 
 from nous_eval.retrieval_runner import QrelResult
 
@@ -47,11 +48,11 @@ class MetricsResult:
     different denominator.
 
     A true ``recall@served`` — scored over the rows the formatter actually
-    RENDERS, i.e. what the model receives — is deliberately NOT here. Two
-    attempts at deriving that in the harness both overstated it, because
-    doing so means re-implementing the formatter's section-eligibility
-    rules in a second place. It lands in the follow-up (PR #583) alongside
-    the leg-visibility work, once the formatter reports the IDs it rendered.
+    RENDERS — is still not here. Two attempts at deriving it in the harness
+    both overstated it, because doing so means re-implementing the
+    formatter's section-eligibility rules in a second place. Landing it
+    correctly needs the formatter to report the IDs it emitted, which is a
+    separate change from this one; see the note on ``leg_visibility``.
     """
 
     mrr: float
@@ -284,6 +285,127 @@ def compute_delta(
         n_pairs=n_pairs,
     )
 
+
+
+# ---------------------------------------------------------------------------
+# N7 follow-up: leg visibility
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LegVisibility:
+    """Whether the scoring window actually observed one retrieval leg.
+
+    The load-bearing field is ``participation_rate``: of ALL valid qrels in
+    the run, the fraction where this leg placed at least one row within
+    ``cutoff``. That answers the operator's real question — "how much of the
+    experiment could this leg have influenced?" — which neither a pooled
+    median nor an emission-conditioned ratio answers.
+
+    Two denominators were tried and rejected. A median over every row lets a
+    leg's own long tail hide its head: a leg emitting rank 1 plus a tail at
+    20-30 on every qrel scores on every query while its median sits below
+    the cutline. Dividing by the qrels where the leg happened to emit is the
+    opposite error: a leg reaching the cutoff on 1 qrel of 100 reads 1.00,
+    "fully observed", while touching 1% of the run. The denominator is
+    ``n_qrels_evaluated``; ``n_qrels_present`` is kept beside it so emission
+    coverage and in-window coverage stay separately legible.
+
+    ``visible`` is True when the leg reached the window on at least one
+    qrel. Read it WITH ``participation_rate`` — a leg at 0.03 was
+    technically observed but a null for it is still uninformative.
+    ``median_rank`` / ``best_rank`` are diagnostics only.
+    """
+
+    leg: str
+    n_rows: int
+    n_qrels_evaluated: int
+    n_qrels_present: int
+    n_qrels_within_cutoff: int
+    participation_rate: float
+    median_rank: float
+    best_rank: int
+    cutoff: int
+    visible: bool
+
+
+def leg_visibility(
+    per_qrel: list[QrelResult],
+    cutoff: int = 10,
+    attempted_legs: "Iterable[str] | None" = None,
+) -> list[LegVisibility]:
+    """Report which legs the scoring window actually observed.
+
+    ``cutoff`` must be the depth the run scored at (``EvalSettings.top_k``);
+    the verdict inverts with it, so a caller that lets it default while
+    scoring at 30 turns a measured leg into a false "inconclusive".
+
+    ``attempted_legs`` comes from ``PipelineStats.attempted_legs`` — the
+    PIPELINE's own report of which legs it entered, unioned across qrels by
+    the runner. It is required for correctness, not convenience: a leg that
+    emitted zero rows on every qrel appears nowhere in ``retrieved_legs``,
+    so without it the most extreme case of an unobserved arm is omitted from
+    this report entirely — silently, and precisely when the warning matters
+    most. Legs named here but never seen are emitted with ``n_rows=0`` and
+    ``participation_rate=0.0`` so absence is stated rather than implied.
+
+    An earlier version derived that set from config flags instead. That
+    cannot be correct: the one-hop fallback is skipped when spreading
+    activation succeeds, which is decided at runtime, so no combination of
+    flags predicts it. Deriving a producer's control flow inside a consumer
+    reproduced the pipeline's branching in a second place and was wrong a
+    different way each time it was patched.
+
+    Ranks are 1-based positions in the served block. Visibility is computed
+    PER QREL — a leg counts as observed on a qrel when any of its rows lands
+    at rank <= cutoff — then aggregated. Returns one row per leg, least
+    observed first.
+    """
+    ranks_by_leg: dict[str, list[int]] = {}
+    present: dict[str, int] = {}
+    within: dict[str, int] = {}
+    n_evaluated = 0
+
+    for q in per_qrel:
+        if q.error is not None:
+            continue
+        n_evaluated += 1
+        best_in_qrel: dict[str, int] = {}
+        for pos, leg in enumerate(q.retrieved_legs, start=1):
+            ranks_by_leg.setdefault(leg, []).append(pos)
+            if leg not in best_in_qrel or pos < best_in_qrel[leg]:
+                best_in_qrel[leg] = pos
+        for leg, best in best_in_qrel.items():
+            present[leg] = present.get(leg, 0) + 1
+            if best <= cutoff:
+                within[leg] = within.get(leg, 0) + 1
+
+    # Seed attempted-but-silent legs so zero emission is REPORTED, not omitted.
+    for leg in attempted_legs or ():
+        ranks_by_leg.setdefault(leg, [])
+
+    out = []
+    for leg, ranks in ranks_by_leg.items():
+        n_within = within.get(leg, 0)
+        out.append(
+            LegVisibility(
+                leg=leg,
+                n_rows=len(ranks),
+                n_qrels_evaluated=n_evaluated,
+                n_qrels_present=present.get(leg, 0),
+                n_qrels_within_cutoff=n_within,
+                participation_rate=(n_within / n_evaluated) if n_evaluated else 0.0,
+                # A silent leg has no ranks; report sentinels rather than
+                # raising on median([]) / min([]).
+                median_rank=float(median(ranks)) if ranks else 0.0,
+                best_rank=min(ranks) if ranks else 0,
+                cutoff=cutoff,
+                visible=n_within > 0,
+            )
+        )
+    # Least-observed first; median as a stable tiebreak (deepest first).
+    out.sort(key=lambda v: (v.participation_rate, -v.median_rank))
+    return out
 
 
 # ---------------------------------------------------------------------------

--- a/nous_eval/report.py
+++ b/nous_eval/report.py
@@ -27,6 +27,7 @@ from nous_eval.metrics import (
     compute_delta,
     compute_metrics,
     filter_by_sources,
+    leg_visibility,
 )
 
 if TYPE_CHECKING:
@@ -316,6 +317,10 @@ def render_markdown(
     lines.append("")
     lines.append(_recall_curve_table(run_results, top_k))
     lines.append("")
+    _leg_table = _leg_visibility_table(run_results, top_k)
+    if _leg_table:
+        lines.append(_leg_table)
+        lines.append("")
 
     # Gate decision
     if gate_decision is not None:
@@ -418,6 +423,58 @@ def _recall_curve_table(run_results: list["RunResult"], top_k: int = 10) -> str:
     return header + "\n" + "\n".join(rows)
 
 
+def _leg_visibility_table(run_results: list["RunResult"], top_k: int = 10) -> str:
+    """N7 follow-up: which legs the scoring depth actually observed.
+
+    ``top_k`` MUST be the depth the matrix scored at — the verdict inverts
+    with it. Legs come from the pipeline's own ``attempted_legs`` report, so
+    a leg that ran and emitted nothing is still listed.
+    """
+    lines = []
+    for r in run_results:
+        vis = leg_visibility(
+            r.per_qrel, cutoff=top_k, attempted_legs=r.attempted_legs,
+        )
+        if not vis:
+            continue
+        lines.append(f"\n**{r.config.name}**\n")
+        lines.append(
+            "| leg | rows | qrels w/ row | qrels within k | of all qrels "
+            "| participation | median rank | best rank | observed@%d |"
+            % vis[0].cutoff
+        )
+        lines.append("|---|---:|---:|---:|---:|---:|---:|---:|:---:|")
+        for v in vis:
+            mark = "yes" if v.visible else "**NO**"
+            # A leg that emitted nothing has no ranks — em-dashes rather
+            # than 0.0/0, which would imply a rank that never existed.
+            med = f"{v.median_rank:.1f}" if v.n_rows else "—"
+            best = f"{v.best_rank}" if v.n_rows else "—"
+            label = v.leg if v.n_rows else f"{v.leg} *(silent)*"
+            lines.append(
+                f"| {label} | {v.n_rows} | {v.n_qrels_present} | "
+                f"{v.n_qrels_within_cutoff} | {v.n_qrels_evaluated} | "
+                f"{v.participation_rate:.2f} | {med} | {best} | {mark} |"
+            )
+    if not lines:
+        return ""
+    return (
+        "\n### Leg visibility (N7)\n\n"
+        "**participation** is `qrels within k / ALL valid qrels` — how much "
+        "of the experiment this leg could have influenced. It is NOT "
+        "conditioned on the leg having emitted anything, so a leg returning "
+        "rows on 1 qrel in 100 reads 0.01, not 1.00. Treat a null from a leg "
+        "at or near **0.00** as **inconclusive**, not negative: the "
+        "measurement never reached it. (median/best rank are diagnostics — a "
+        "leg's own long tail can drag its median below the cutline while its "
+        "head scores every qrel.) Legs marked ***(silent)*** were ENTERED by "
+        "the pipeline but emitted zero rows on every qrel; they are listed "
+        "explicitly because an absent row would otherwise read as 'nothing "
+        "to report' exactly when the arm contributed nothing at all.\n"
+        + "\n".join(lines)
+    )
+
+
 def _delta_table(
     base: MetricsResult, exp: MetricsResult, top_k: int = 10
 ) -> str:
@@ -501,6 +558,29 @@ def render_json(
                 "metrics": _metrics_to_dict(
                     compute_metrics(r.per_qrel, top_k=top_k)
                 ),
+                # N7 follow-up: persist the visibility analysis and the
+                # pipeline's attempted-leg report, so historical eval_runs
+                # analysis can tell whether an old null came from a leg
+                # below the cutoff — or from one that never ran at all.
+                "attempted_legs": list(r.attempted_legs),
+                "leg_visibility": [
+                    {
+                        "leg": v.leg,
+                        "n_rows": v.n_rows,
+                        "n_qrels_evaluated": v.n_qrels_evaluated,
+                        "n_qrels_present": v.n_qrels_present,
+                        "n_qrels_within_cutoff": v.n_qrels_within_cutoff,
+                        "participation_rate": v.participation_rate,
+                        "median_rank": v.median_rank,
+                        "best_rank": v.best_rank,
+                        "cutoff": v.cutoff,
+                        "visible": v.visible,
+                    }
+                    for v in leg_visibility(
+                        r.per_qrel, cutoff=top_k,
+                        attempted_legs=r.attempted_legs,
+                    )
+                ],
                 "per_qrel": [
                     {
                         "index": q.qrel_index,

--- a/nous_eval/report.py
+++ b/nous_eval/report.py
@@ -599,6 +599,14 @@ def render_json(
                         # N1/codex-P1: non-empty means these metrics are based
                         # on a PARTIAL retrieval (e.g. the fact leg crashed).
                         "stage_errors": q.stage_errors,
+                        # N7 follow-up: the PER-QREL attempted set. The
+                        # config-wide union above cannot substitute — if
+                        # spreading ran for one source and the one-hop
+                        # fallback for another, only this distinguishes
+                        # "never attempted here" from "attempted and silent",
+                        # so source/query-level visibility stays
+                        # reconstructable from the archived report alone.
+                        "attempted_legs": sorted(q.attempted_legs),
                     }
                     for q in r.per_qrel
                 ],

--- a/nous_eval/retrieval.py
+++ b/nous_eval/retrieval.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING
 
 from nous.config import Settings
 from nous_eval.config import EvalSettings
-from nous_eval.metrics import compute_metrics
+from nous_eval.metrics import compute_metrics, leg_visibility
 from nous_eval.qrels_loader import QrelSource, load_qrels
 from nous_eval.report import (
     decide_gate_f050,
@@ -1068,6 +1068,27 @@ def _metrics_compact(run: "RunResult", top_k: int = 10) -> dict:
         "top_k": top_k,
         "recall_curve": {str(k): v for k, v in sorted(m.recall_curve.items())},
         "n_qrels_partial": sum(1 for q in run.per_qrel if q.stage_errors),
+        # N7 follow-up: this payload is built INDEPENDENTLY of the JSON
+        # report file, so it needs its own copy — the report file is not
+        # guaranteed to still exist when a regression analysis runs.
+        "attempted_legs": list(run.attempted_legs),
+        "leg_visibility": [
+            {
+                "leg": v.leg,
+                "n_rows": v.n_rows,
+                "n_qrels_evaluated": v.n_qrels_evaluated,
+                "n_qrels_present": v.n_qrels_present,
+                "n_qrels_within_cutoff": v.n_qrels_within_cutoff,
+                "participation_rate": v.participation_rate,
+                "median_rank": v.median_rank,
+                "best_rank": v.best_rank,
+                "cutoff": v.cutoff,
+                "visible": v.visible,
+            }
+            for v in leg_visibility(
+                run.per_qrel, cutoff=top_k, attempted_legs=run.attempted_legs,
+            )
+        ],
     }
 
 

--- a/nous_eval/retrieval_runner.py
+++ b/nous_eval/retrieval_runner.py
@@ -111,11 +111,11 @@ class QrelResult:
     ``n_gold_in_top_k`` are top-K scoped.
 
     ``retrieved_legs`` labels each served row with the leg that produced it,
-    aligned 1:1 with ``retrieved_ids``. It is raw provenance only — the
-    visibility VERDICT built on top of it is deferred to a follow-up PR
-    (see the note in ``nous_eval.metrics``), because deriving it correctly
-    requires the pipeline to report which legs it attempted rather than the
-    harness re-deriving pipeline control flow from config flags.
+    aligned 1:1 with ``retrieved_ids``; ``attempted_legs`` is the pipeline's
+    own report of which legs it ENTERED. Both are needed by
+    ``metrics.leg_visibility``: the first says where a leg's rows landed,
+    the second names legs that ran and emitted nothing — which appear in no
+    ``retrieved_legs`` list and would otherwise vanish from the report.
     """
 
     qrel_index: int
@@ -137,6 +137,10 @@ class QrelResult:
     # setting ``error``) so the run is not silently dropped from aggregates:
     # the failure is reported, not hidden and not zero-scored.
     stage_errors: dict[str, int] = field(default_factory=dict)
+    # N7 follow-up: PipelineStats.attempted_legs for this qrel — which legs
+    # the pipeline ENTERED, reported by the pipeline itself rather than
+    # inferred from config.
+    attempted_legs: frozenset[str] = frozenset()
 
 
 @dataclass(frozen=True)
@@ -147,6 +151,14 @@ class RunResult:
     per_qrel: list[QrelResult]
     duration_seconds: float
     pipeline_stats_summary: dict[str, int] = field(default_factory=dict)
+    # N7 follow-up: union of PipelineStats.attempted_legs across this
+    # config's qrels — the PIPELINE's own report of which legs it entered.
+    # Union rather than intersection because a leg attempted on any qrel was
+    # genuinely exercised by the run; the per-qrel detail lives in
+    # QrelResult.retrieved_legs. Needed because a leg that emits zero rows
+    # everywhere appears in no retrieved_legs list and would otherwise drop
+    # out of the visibility report entirely.
+    attempted_legs: list[str] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -220,11 +232,13 @@ async def run_matrix(
                     "spreading_activation_used": 0,
                     "contradiction_checks_ran": 0,
                 }
+                attempted: set[str] = set()
                 for idx, qrel in enumerate(qrels):
                     qr, ran_flags = await _run_one(
                         heart, brain, eval_scoped, qrel, idx, top_k
                     )
                     per_qrel.append(qr)
+                    attempted |= qr.attempted_legs
                     for k, v in ran_flags.items():
                         # bool is a subclass of int — check it FIRST, or the
                         # stage flags would be summed as 1/0 instead of
@@ -242,6 +256,7 @@ async def run_matrix(
                         per_qrel=per_qrel,
                         duration_seconds=duration,
                         pipeline_stats_summary=stats_totals,
+                        attempted_legs=sorted(attempted),
                     )
                 )
                 logger.info(
@@ -610,6 +625,7 @@ async def _run_one(
             rank_of_first_gold=rank,
             n_gold_in_top_k=n_in_top,
             n_gold_total=len(qrel.gold_ids),
+            attempted_legs=frozenset(getattr(stats, "attempted_legs", ()) or ()),
             error=None,
             # Real failures only — non-error diagnostics are excluded so
             # ``_stage_error_summary`` never calls a healthy run partial.

--- a/tests/test_n7_leg_visibility.py
+++ b/tests/test_n7_leg_visibility.py
@@ -1,0 +1,246 @@
+"""N7 follow-up — leg visibility from pipeline-reported attempted legs.
+
+The predecessor derived "which legs ran" from config flags inside the eval
+harness. That reproduced pipeline control flow in a second place and could
+not be correct: the one-hop graph fallback is SKIPPED when spreading
+activation succeeds, which is decided at runtime. Four review rounds each
+tightened the flag model and each time a producer or branch escaped it.
+
+Here the pipeline reports what it entered (``PipelineStats.attempted_legs``,
+marked at each stage's entry BEFORE its work) and the harness consumes that.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+
+def _qrel(retrieved, gold, legs=None, error=None, attempted=()):
+    from nous_eval.retrieval_runner import QrelResult
+
+    return QrelResult(
+        qrel_index=0,
+        qrel_query="q",
+        qrel_source="hand",
+        retrieved_ids=list(retrieved),
+        retrieved_types=["fact"] * len(retrieved),
+        retrieved_legs=list(legs or []),
+        attempted_legs=frozenset(attempted),
+        rank_of_first_gold=None,
+        n_gold_in_top_k=0,
+        n_gold_total=len(gold),
+        gold_ids=list(gold),
+        error=error,
+    )
+
+
+def _run(per_qrel, name="baseline", attempted=()):
+    from nous_eval.retrieval_runner import RetrievalConfig, RunResult
+
+    return RunResult(
+        config=RetrievalConfig(name=name),
+        per_qrel=list(per_qrel),
+        duration_seconds=1.0,
+        attempted_legs=list(attempted),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The pipeline reports its own attempted legs
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineReportsAttemptedLegs:
+    def test_stats_exposes_attempted_legs(self):
+        from nous.api.retrieval_pipeline import PipelineStats
+
+        assert PipelineStats().attempted_legs == frozenset()
+
+    def test_every_leg_is_marked_at_a_stage_entry(self):
+        """Each label _leg_of can emit must have a producer-side mark."""
+        import inspect
+
+        from nous.api import retrieval_pipeline
+
+        src = inspect.getsource(retrieval_pipeline)
+        for leg in (
+            "heart_primary", "chunk", "keyed", "keyed_r2", "exemplar",
+            "brain", "heart_graph", "heart_graph_memory",
+            "spreading_activation", "brain_graph",
+        ):
+            assert f'attempted_legs.add("{leg}")' in src, (
+                f"{leg} can be produced but is never marked as attempted, so "
+                "a run where it emits nothing would drop out of the report"
+            )
+
+    def test_fallback_marks_both_labels_it_can_emit(self):
+        """The 1-hop fallback yields brain_graph AND heart_graph_memory rows.
+
+        Codex round 8 found the flag-derived model missed this: Stage 4's
+        untyped neighbours include non-decision nodes, which
+        _graph_expanded_to_pipeline tags heart_graph_memory.
+        """
+        import inspect
+
+        from nous.api import retrieval_pipeline
+
+        src = inspect.getsource(retrieval_pipeline)
+        idx = src.index("if not use_spreading:")
+        window = src[idx: idx + 700]
+        assert 'attempted_legs.add("brain_graph")' in window
+        assert 'attempted_legs.add("heart_graph_memory")' in window
+
+    def test_spreading_marked_inside_its_own_branch(self):
+        """Marked under `if use_spreading`, NOT alongside the fallback.
+
+        These are mutually exclusive at runtime — the distinction the flag
+        model could not represent.
+        """
+        import inspect
+
+        from nous.api import retrieval_pipeline
+
+        src = inspect.getsource(retrieval_pipeline)
+        taken = src.index("if use_spreading:")
+        fallback = src.index("if not use_spreading:")
+        mark = src.index('attempted_legs.add("spreading_activation")')
+        assert taken < mark < fallback, (
+            "spreading must be marked in the branch that actually ran"
+        )
+
+
+# ---------------------------------------------------------------------------
+# leg_visibility consumes it
+# ---------------------------------------------------------------------------
+
+
+class TestVisibilityUsesAttemptedLegs:
+    def test_attempted_but_silent_leg_is_reported(self):
+        from nous_eval.metrics import leg_visibility
+
+        qs = [_qrel([uuid4()], [], ["heart_primary"]) for _ in range(5)]
+        vis = {
+            v.leg: v
+            for v in leg_visibility(qs, attempted_legs=["heart_primary", "keyed"])
+        }
+
+        assert "keyed" in vis, (
+            "a leg the pipeline ENTERED that emitted nothing is the most "
+            "extreme unobserved case — omitting its row hides the warning "
+            "exactly when it matters most"
+        )
+        assert vis["keyed"].n_rows == 0
+        assert vis["keyed"].participation_rate == 0.0
+        assert vis["keyed"].visible is False
+
+    def test_leg_never_attempted_is_not_invented(self):
+        """A disabled arm must NOT be reported as enabled-but-silent."""
+        from nous_eval.metrics import leg_visibility
+
+        qs = [_qrel([uuid4()], [], ["heart_primary"])]
+        legs = {v.leg for v in leg_visibility(qs, attempted_legs=["heart_primary"])}
+        assert "spreading_activation" not in legs
+
+    def test_silent_leg_does_not_crash_on_empty_ranks(self):
+        from nous_eval.metrics import leg_visibility
+
+        vis = {v.leg: v for v in leg_visibility([], attempted_legs=["keyed"])}
+        assert vis["keyed"].median_rank == 0.0
+        assert vis["keyed"].best_rank == 0
+        assert vis["keyed"].n_qrels_evaluated == 0
+
+    def test_head_and_tail_leg_is_visible(self):
+        """A leg's own tail must not hide its head (pooled-median trap)."""
+        from nous_eval.metrics import leg_visibility
+
+        legs = ["chunk"] + ["heart_primary"] * 18 + ["chunk"] * 11
+        ids = [uuid4() for _ in legs]
+        vis = {v.leg: v for v in leg_visibility([_qrel(ids, [], legs)])}
+
+        assert vis["chunk"].median_rank > 10
+        assert vis["chunk"].visible is True
+        assert vis["chunk"].participation_rate == 1.0
+
+    def test_sparse_leg_denominator_is_all_qrels(self):
+        """1-of-10 must read 0.10, not 1.00 (emission-conditioned trap)."""
+        from nous_eval.metrics import leg_visibility
+
+        qs = [
+            _qrel([uuid4()], [], ["keyed"]),
+            *[_qrel([uuid4()], [], ["heart_primary"]) for _ in range(9)],
+        ]
+        vis = {v.leg: v for v in leg_visibility(qs)}
+        assert vis["keyed"].n_qrels_evaluated == 10
+        assert vis["keyed"].participation_rate == pytest.approx(0.1)
+
+    def test_cutoff_inverts_the_verdict(self):
+        from nous_eval.metrics import leg_visibility
+
+        legs = ["heart_primary"] * 10 + ["keyed"] * 10
+        ids = [uuid4() for _ in legs]
+        q = _qrel(ids, [], legs)
+
+        at10 = {v.leg: v.visible for v in leg_visibility([q], cutoff=10)}
+        at30 = {v.leg: v.visible for v in leg_visibility([q], cutoff=30)}
+        assert at10["keyed"] is False
+        assert at30["keyed"] is True
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+class TestReporting:
+    def test_markdown_flags_silent_legs(self):
+        from nous_eval.report import render_markdown
+
+        rr = _run(
+            [_qrel([uuid4()], [], ["heart_primary"])],
+            attempted=["heart_primary", "exemplar"],
+        )
+        md = render_markdown([rr], [])
+        assert "exemplar *(silent)*" in md
+        assert "emitted zero rows" in md
+
+    def test_markdown_uses_configured_cutoff(self):
+        from nous_eval.report import render_markdown
+
+        rr = _run(
+            [_qrel([uuid4()], [], ["heart_primary"])], attempted=["heart_primary"]
+        )
+        assert "observed@30" in render_markdown([rr], [], top_k=30)
+
+    def test_json_persists_visibility_and_attempted(self):
+        from nous_eval.report import render_json
+
+        legs = ["heart_primary"] * 10 + ["keyed"] * 10
+        ids = [uuid4() for _ in legs]
+        rr = _run(
+            [_qrel(ids, [], legs)], attempted=["heart_primary", "keyed", "exemplar"]
+        )
+        cfg = json.loads(render_json([rr], []))["configs"][0]
+
+        assert cfg["attempted_legs"] == ["heart_primary", "keyed", "exemplar"]
+        vis = {v["leg"]: v for v in cfg["leg_visibility"]}
+        assert vis["keyed"]["visible"] is False
+        assert vis["exemplar"]["n_rows"] == 0, "silent leg persisted too"
+
+    def test_eval_runs_payload_carries_it(self):
+        from nous_eval.retrieval import _metrics_compact
+
+        rr = _run(
+            [_qrel([uuid4()], [], ["heart_primary"])],
+            attempted=["heart_primary", "keyed"],
+        )
+        payload = _metrics_compact(rr, top_k=20)
+        assert payload["attempted_legs"] == ["heart_primary", "keyed"]
+        assert {v["leg"] for v in payload["leg_visibility"]} == {
+            "heart_primary", "keyed",
+        }
+        assert payload["leg_visibility"][0]["cutoff"] == 20

--- a/tests/test_n7_leg_visibility.py
+++ b/tests/test_n7_leg_visibility.py
@@ -69,7 +69,7 @@ class TestPipelineReportsAttemptedLegs:
 
         src = inspect.getsource(retrieval_pipeline)
         for leg in (
-            "heart_primary", "chunk", "keyed", "keyed_r2", "exemplar",
+            "heart_primary", "keyed", "keyed_r2", "exemplar",
             "brain", "heart_graph", "heart_graph_memory",
             "spreading_activation", "brain_graph",
         ):
@@ -77,6 +77,11 @@ class TestPipelineReportsAttemptedLegs:
                 f"{leg} can be produced but is never marked as attempted, so "
                 "a run where it emits nothing would drop out of the report"
             )
+        # chunk is marked INSIDE _search_episode_chunks via the `attempted`
+        # sink — the caller cannot know whether the vector path returned
+        # early on a missing embedder.
+        assert 'attempted.add("chunk")' in src
+        assert "attempted=acc.attempted_legs," in src
 
     def test_fallback_marks_both_labels_it_can_emit(self):
         """The 1-hop fallback yields brain_graph AND heart_graph_memory rows.
@@ -139,6 +144,31 @@ class TestPipelineReportsAttemptedLegs:
         e = src.index('attempted_legs.add("exemplar")')
         assert "if q_vec:" in src[e - 400: e], (
             "exemplar must be gated on has_exemplars() AND a query vector"
+        )
+
+        # Spreading: graph_recall_max_expand=0 with no heart fact seeds
+        # builds an empty seed list, and the CTE is never issued.
+        s = src.index('attempted_legs.add("spreading_activation")')
+        assert "if seeds:" in src[s - 200: s], (
+            "spreading must be gated on non-empty seeds"
+        )
+
+    def test_chunk_marked_only_where_it_queries(self):
+        """The vector path returns early with no embedder / empty vector."""
+        import inspect
+
+        from nous.api import retrieval_pipeline
+
+        src = inspect.getsource(retrieval_pipeline._search_episode_chunks)
+        # Both marks must sit AFTER the two early returns.
+        early = src.index("if not query_vec:")
+        marks = [
+            i for i in range(len(src))
+            if src.startswith('attempted.add("chunk")', i)
+        ]
+        assert len(marks) == 2, "one mark per query path (hybrid, vector)"
+        assert any(m > early for m in marks), (
+            "the vector-path mark must follow the empty-vector early return"
         )
 
     def test_spreading_marked_inside_its_own_branch(self):

--- a/tests/test_n7_leg_visibility.py
+++ b/tests/test_n7_leg_visibility.py
@@ -129,6 +129,18 @@ class TestPipelineReportsAttemptedLegs:
             "the fallback must be gated on an expandable decision"
         )
 
+        # Keyed: a query with no entity candidates never reaches the fetch.
+        m = src.index('attempted_legs.add("keyed")')
+        assert "if candidates:" in src[m - 400: m], (
+            "keyed must be gated on extracted candidates"
+        )
+
+        # Exemplar: empty exemplar store, or no query vector, means no fetch.
+        e = src.index('attempted_legs.add("exemplar")')
+        assert "if q_vec:" in src[e - 400: e], (
+            "exemplar must be gated on has_exemplars() AND a query vector"
+        )
+
     def test_spreading_marked_inside_its_own_branch(self):
         """Marked under `if use_spreading`, NOT alongside the fallback.
 

--- a/tests/test_n7_leg_visibility.py
+++ b/tests/test_n7_leg_visibility.py
@@ -231,6 +231,53 @@ class TestReporting:
         assert vis["keyed"]["visible"] is False
         assert vis["exemplar"]["n_rows"] == 0, "silent leg persisted too"
 
+    def test_per_qrel_attempted_legs_serialized(self):
+        """The config-wide union cannot substitute for per-qrel detail."""
+        from nous_eval.report import render_json
+
+        qs = [
+            _qrel([uuid4()], [], ["heart_primary"], attempted=["spreading_activation"]),
+            _qrel([uuid4()], [], ["heart_primary"], attempted=["brain_graph"]),
+        ]
+        rr = _run(qs, attempted=["spreading_activation", "brain_graph"])
+        pq = json.loads(render_json([rr], []))["configs"][0]["per_qrel"]
+
+        assert pq[0]["attempted_legs"] == ["spreading_activation"]
+        assert pq[1]["attempted_legs"] == ["brain_graph"], (
+            "without this an archived consumer filtering to one source sees "
+            "the union and cannot tell a leg was never attempted there"
+        )
+
+    def test_filtered_subset_does_not_inherit_other_sources_legs(self):
+        """A source-filtered call must not seed another source's legs."""
+        from nous_eval.metrics import leg_visibility
+
+        spread_q = _qrel(
+            [uuid4()], [], ["heart_primary"], attempted=["spreading_activation"]
+        )
+        fallback_q = _qrel(
+            [uuid4()], [], ["heart_primary"], attempted=["brain_graph"]
+        )
+
+        # Derived from the qrels passed in, not a config-wide union.
+        only_fallback = {v.leg for v in leg_visibility([fallback_q])}
+        assert "brain_graph" in only_fallback
+        assert "spreading_activation" not in only_fallback, (
+            "spreading was never attempted for this subset — reporting it "
+            "as silent-but-attempted misattributes the runtime branch"
+        )
+
+        both = {v.leg for v in leg_visibility([spread_q, fallback_q])}
+        assert {"spreading_activation", "brain_graph"} <= both
+
+    def test_explicit_attempted_still_wins(self):
+        """Callers can widen beyond the given qrels when they mean to."""
+        from nous_eval.metrics import leg_visibility
+
+        q = _qrel([uuid4()], [], ["heart_primary"], attempted=["heart_primary"])
+        legs = {v.leg for v in leg_visibility([q], attempted_legs=["exemplar"])}
+        assert "exemplar" in legs
+
     def test_eval_runs_payload_carries_it(self):
         from nous_eval.retrieval import _metrics_compact
 

--- a/tests/test_n7_leg_visibility.py
+++ b/tests/test_n7_leg_visibility.py
@@ -91,9 +91,43 @@ class TestPipelineReportsAttemptedLegs:
 
         src = inspect.getsource(retrieval_pipeline)
         idx = src.index("if not use_spreading:")
-        window = src[idx: idx + 700]
+        # Window must reach past the explanatory comment block to the marks.
+        window = src[idx: idx + 1400]
         assert 'attempted_legs.add("brain_graph")' in window
         assert 'attempted_legs.add("heart_graph_memory")' in window
+
+    def test_markers_require_seeds_not_just_block_entry(self):
+        """Entering a stage's `if` is not the same as doing its work.
+
+        Each of these blocks is reachable in a configuration where its work
+        loop iterates an empty seed list and issues no neighbour query.
+        Marking at block entry would report the leg as attempted-and-silent
+        on exactly those runs — the false attribution this whole mechanism
+        exists to prevent.
+        """
+        import inspect
+
+        from nous.api import retrieval_pipeline
+
+        src = inspect.getsource(retrieval_pipeline)
+
+        # Stage 2: chunk-only retrieval enters the block with no heart seed.
+        i = src.index('attempted_legs.add("heart_graph")')
+        assert 'any(hr.type in ("fact", "episode")' in src[i - 400: i], (
+            "heart_graph must be gated on a fact/episode seed existing"
+        )
+
+        # Stage 2b: procedure/censor scope yields no Path-A seeds.
+        j = src.index('attempted_legs.add("heart_graph_memory")')
+        assert "if mem_seeds:" in src[j - 200: j], (
+            "heart_graph_memory must be gated on non-empty mem_seeds"
+        )
+
+        # Stage 4 fallback: fact-only retrieval reaches it with no decisions.
+        k = src.index('attempted_legs.add("brain_graph")')
+        assert "d.score is not None" in src[k - 400: k], (
+            "the fallback must be gated on an expandable decision"
+        )
 
     def test_spreading_marked_inside_its_own_branch(self):
         """Marked under `if use_spreading`, NOT alongside the fallback.


### PR DESCRIPTION
Rebuilt on current `main`. Implements the redesign this PR was opened to hold.

## The problem it fixes

The predecessor derived *"which legs ran"* from config flags **inside the eval harness**, reproducing pipeline control flow in a second place. That cannot be correct: the one-hop graph fallback is skipped when spreading activation succeeds, decided **at runtime**, so no combination of flags predicts it.

Four review rounds each tightened the flag model, and each time another producer or branch escaped it:

| round | escape |
|---|---|
| 5 | silent legs omitted entirely |
| 7 | `heart_graph` also needs `cross_type_linking_enabled` |
| 8 | `brain` never seeded; `brain_graph` seeded when the fallback is skipped; `heart_graph_memory` also produced by Stage 4 |

Those aren't three bugs. They're one wrong design emitting bugs on demand.

## The fix: the producer reports what it did

`_PipelineAccumulator.attempted_legs` is marked at each stage's **entry**, before its work runs, so a leg that executed and produced nothing is still named. Surfaced as `PipelineStats.attempted_legs`.

Eleven marks, including the runtime branch the flag model could not represent:

```python
if use_spreading:
    acc.attempted_legs.add("spreading_activation")
...
if not use_spreading:
    acc.attempted_legs.add("brain_graph")
    acc.attempted_legs.add("heart_graph_memory")   # untyped Stage 4 neighbours
```

**All three round-8 findings resolve by construction, not by patch.**

## Harness

`QrelResult.attempted_legs` carries the per-qrel report; `RunResult.attempted_legs` unions across the config. `leg_visibility(per_qrel, cutoff, attempted_legs)` seeds silent legs from that. **`_expected_legs` is not reintroduced.**

Two earlier corrections were independently right and are retained:
- visibility is computed **per qrel** — a leg's own long tail must not hide its head
- the participation denominator is **all valid qrels**, not the qrels where the leg emitted (1-of-100 reads `0.01`, not `1.00`)

## Still out of scope

`recall@served` needs the **formatter** to report the IDs it rendered — a different producer, a separate change. Two harness-side derivations of it both overstated; a third attempt doesn't belong here.

## Testing

14 new tests. Four assert the **producer** side directly rather than only the consumer:
- every label `_leg_of` can emit has a corresponding mark
- the fallback marks *both* labels it can emit
- spreading is marked inside its own branch, not beside the fallback

302 passed across eval + integration + pipeline suites. The one remaining local failure (`test_f065_configs`) is pre-existing `.env`-vs-code-default drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM4pvwqABxRQZQHDWVDUnE
