### PR TITLE
fix(intent): make keyword extraction deterministic across processes (N10)

### DIFF
--- a/nous/cognitive/intent.py
+++ b/nous/cognitive/intent.py
@@ -139,14 +139,36 @@ class IntentClassifier:
                     )
 
         # Topic keywords: capitalized words + long words + ALL-CAPS acronyms (F19)
+        #
+        # N10 (2026-08-02): dedup via ``dict.fromkeys``, NOT ``set``. These
+        # keywords are joined into ``query_text`` at plan_retrieval (:199-201)
+        # and become the embedded retrieval query for every memory type, so
+        # their ORDER is part of the query string. ``set`` iteration order for
+        # str depends on PYTHONHASHSEED, which CPython randomises per process:
+        # measured 5 distinct orderings of one sentence across 5 seeds. That
+        # made identical user input retrieve differently on different
+        # processes, made the ``[:10]`` cap drop a DIFFERENT keyword per run
+        # once a message yielded more than ten, and fragmented the F050
+        # expansion cache (keyed on a hash of this text).
+        #
+        # ``dict.fromkeys`` is order-preserving and deterministic, so it also
+        # restores source word order — which matters because embeddings are
+        # order-sensitive. Whether a keyword bag is the right query
+        # representation AT ALL is a separate open question; this is only the
+        # determinism fix.
         words = re.findall(
             r"\b[A-Z][a-z]+\b|\b\w{6,}\b|\b[A-Z]{2,}\b", input_text
         )
-        signals.topic_keywords = list(set(w.lower() for w in words))[:10]
+        signals.topic_keywords = list(dict.fromkeys(w.lower() for w in words))[:10]
 
         # Entity mentions (proper nouns -- capitalized words not at sentence start)
+        # Same N10 treatment. No retrieval consumer reads this today (only
+        # layer.py:670 copies it onto a rebuilt IntentSignals), so this is
+        # consistency rather than a measured fix — but leaving one of two
+        # adjacent dedups hash-order-dependent is how the next reader
+        # concludes the ordering is deliberate.
         entity_candidates = re.findall(r"(?<!^)(?<!\. )\b[A-Z][a-z]+\b", input_text)
-        signals.entity_mentions = list(set(entity_candidates))[:10]
+        signals.entity_mentions = list(dict.fromkeys(entity_candidates))[:10]
 
         return signals
 

--- a/tests/test_n10_keyword_determinism.py
+++ b/tests/test_n10_keyword_determinism.py
@@ -1,0 +1,167 @@
+"""N10 — keyword extraction must be deterministic across processes.
+
+``IntentClassifier.classify`` deduped its keyword and entity lists with
+``set``, whose iteration order for ``str`` depends on ``PYTHONHASHSEED``.
+CPython randomises that per process, so identical user input produced a
+different ``topic_keywords`` ORDER — and, past the ``[:10]`` cap, a
+different keyword SET — on every run. Those keywords are joined into the
+embedded retrieval query, so the same question retrieved differently
+depending on which process served it.
+
+THESE TESTS MUST SPAWN SUBPROCESSES. ``PYTHONHASHSEED`` is fixed for an
+interpreter's lifetime, so a same-process assertion cannot observe the
+defect at all and would pass just as happily against the broken code.
+``test_the_guard_can_actually_fail`` exists to prove this suite has that
+power, by running the OLD implementation and requiring it to disagree.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Deliberately long enough to blow past the [:10] cap so the test covers
+# membership drift, not just ordering.
+SENTENCE = (
+    "Who is the mutual friend of our author and what country granted "
+    "citizenship to their spouse after the Helsinki conference, and which "
+    "organisation published the original manuscript?"
+)
+
+# Seeds chosen to disagree under the old implementation (verified: 5/5
+# distinct). "0" disables randomisation, the rest force different tables.
+SEEDS = ("0", "1", "2", "12345", "99999")
+
+_CLASSIFY_SNIPPET = """
+import json, sys
+from nous.cognitive.schemas import FrameSelection
+from nous.cognitive.intent import IntentClassifier
+
+frame = FrameSelection(frame_id="conversation", frame_name="Conversation", confidence=1.0, match_method="default")
+sig = IntentClassifier().classify(sys.argv[1], frame)
+print(json.dumps({"kw": sig.topic_keywords, "ents": sig.entity_mentions}))
+"""
+
+# The pre-N10 implementation, reproduced verbatim so the guard's power can
+# be demonstrated without reverting the source.
+_OLD_SNIPPET = """
+import json, re, sys
+t = sys.argv[1]
+words = re.findall(r"\\b[A-Z][a-z]+\\b|\\b\\w{6,}\\b|\\b[A-Z]{2,}\\b", t)
+print(json.dumps({"kw": list(set(w.lower() for w in words))[:10]}))
+"""
+
+
+def _run(code: str, seed: str) -> str:
+    """Run ``code`` in a fresh interpreter under ``PYTHONHASHSEED=seed``."""
+    env = dict(os.environ, PYTHONHASHSEED=seed, PYTHONPATH=str(REPO_ROOT))
+    proc = subprocess.run(
+        [sys.executable, "-c", code, SENTENCE],
+        env=env,
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    if proc.returncode != 0:
+        pytest.fail(f"subprocess failed (seed={seed}):\n{proc.stderr}")
+    return proc.stdout.strip()
+
+
+class TestKeywordDeterminism:
+    def test_classify_is_identical_across_hash_seeds(self):
+        outputs = {seed: _run(_CLASSIFY_SNIPPET, seed) for seed in SEEDS}
+        distinct = set(outputs.values())
+        assert len(distinct) == 1, (
+            "N10: classify() must return identical signals regardless of "
+            "PYTHONHASHSEED — topic_keywords are joined into the embedded "
+            "retrieval query, so a varying order means the same question "
+            "retrieves differently per process.\n"
+            + "\n".join(f"  seed={s}: {o}" for s, o in outputs.items())
+        )
+
+    def test_the_guard_can_actually_fail(self):
+        """Prove this suite would catch a reintroduction.
+
+        A determinism test that cannot fail is decoration. Running the
+        pre-N10 expression across the same seeds must produce MORE than one
+        result — if it doesn't, these seeds no longer discriminate and the
+        test above is silently vacuous.
+        """
+        distinct = {_run(_OLD_SNIPPET, seed) for seed in SEEDS}
+        assert len(distinct) > 1, (
+            "the chosen PYTHONHASHSEED values no longer expose set-ordering "
+            "instability, so test_classify_is_identical_across_hash_seeds "
+            "proves nothing — pick seeds that disagree"
+        )
+
+
+class TestOrderPreservation:
+    """dict.fromkeys keeps first-appearance order; embeddings care."""
+
+    def test_keywords_follow_source_word_order(self):
+        from nous.cognitive.schemas import FrameSelection
+        from nous.cognitive.intent import IntentClassifier
+
+        text = "Zebra alpha Mikhail bandwidth zebra Mikhail"
+        frame = FrameSelection(frame_id="conversation", frame_name="Conversation", confidence=1.0, match_method="default")
+        kws = IntentClassifier().classify(text, frame).topic_keywords
+
+        assert kws == ["zebra", "mikhail", "bandwidth"], (
+            "first-appearance order, deduped, lowercased"
+        )
+
+    def test_cap_keeps_the_first_ten_not_an_arbitrary_ten(self):
+        from nous.cognitive.schemas import FrameSelection
+        from nous.cognitive.intent import IntentClassifier
+
+        words = [f"keyword{i:02d}" for i in range(15)]
+        frame = FrameSelection(frame_id="conversation", frame_name="Conversation", confidence=1.0, match_method="default")
+        kws = IntentClassifier().classify(" ".join(words), frame).topic_keywords
+
+        assert kws == words[:10], (
+            "the [:10] cap must drop a STABLE tail; under set() it dropped a "
+            "different keyword each run, changing query content not just order"
+        )
+
+    def test_entities_follow_source_order(self):
+        from nous.cognitive.schemas import FrameSelection
+        from nous.cognitive.intent import IntentClassifier
+
+        text = "We met Yulia and Dmitri, then Yulia again in Prague."
+        frame = FrameSelection(frame_id="conversation", frame_name="Conversation", confidence=1.0, match_method="default")
+        ents = IntentClassifier().classify(text, frame).entity_mentions
+
+        assert ents == ["Yulia", "Dmitri", "Prague"]
+
+
+class TestBehaviourPreserved:
+    """Dedup + lowercasing + cap semantics are unchanged."""
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("", []),
+            ("ok", []),  # no token matches the regex
+            ("Alpha alpha ALPHA", ["alpha"]),  # dedup is still case-folded
+        ],
+    )
+    def test_dedup_semantics_unchanged(self, text, expected):
+        from nous.cognitive.schemas import FrameSelection
+        from nous.cognitive.intent import IntentClassifier
+
+        frame = FrameSelection(frame_id="conversation", frame_name="Conversation", confidence=1.0, match_method="default")
+        assert IntentClassifier().classify(text, frame).topic_keywords == expected
+
+    def test_cap_still_ten(self):
+        from nous.cognitive.schemas import FrameSelection
+        from nous.cognitive.intent import IntentClassifier
+
+        text = " ".join(f"distinct{i:02d}" for i in range(30))
+        frame = FrameSelection(frame_id="conversation", frame_name="Conversation", confidence=1.0, match_method="default")
+        assert len(IntentClassifier().classify(text, frame).topic_keywords) == 10


### PR DESCRIPTION
Implements **N10** from the #582 addendum: keyword extraction was non-deterministic across processes.

## The defect

`IntentClassifier.classify` deduped with `set`, whose iteration order for `str` depends on `PYTHONHASHSEED` — randomised per process by CPython. Those keywords are joined into `query_text` (`intent.py:199-201`) and become the **embedded retrieval query for every memory type**, so the ordering is part of the query string, not an internal detail.

**Reproduced before fixing** — same sentence, five seeds, five distinct results:

```
seed=0     country who citizenship spouse author friend mutual granted
seed=1     who spouse friend mutual citizenship granted country author
seed=2     citizenship granted friend spouse author mutual country who
seed=12345 country who author citizenship spouse granted mutual friend
seed=99999 citizenship author country spouse granted mutual who friend
```

And it is **not merely cosmetic**. Once a message yields more than ten keywords, the `[:10]` cap drops a *different* keyword each run — so the content differs, not just the order. On a longer sentence, across seeds:

| seed | present | absent |
|---|---|---|
| 0 | `who`, `organisation` | `friend`, `mutual`, `granted` |
| 1 | `friend`, `mutual`, `granted` | `country`, `organisation` |
| 2 | `published`, `organisation` | `who`, `mutual`, `manuscript` |

Consequences: identical user input retrieved differently depending on which process served it, and the F050 expansion cache (keyed on a hash of this text) fragmented across orderings.

## The fix

```diff
-signals.topic_keywords = list(set(w.lower() for w in words))[:10]
+signals.topic_keywords = list(dict.fromkeys(w.lower() for w in words))[:10]
```

`dict.fromkeys` is order-preserving and deterministic. It also restores source word order, which matters because embeddings are order-sensitive.

## One thing the addendum missed

`intent.py:149` has the **identical** `list(set(...))[:10]` pattern for `entity_mentions`, two lines below. Fixed too — but labelled honestly in the source as consistency rather than a measured fix, because it has **no current retrieval consumer** (only `layer.py:670` copies it onto a rebuilt `IntentSignals`; `plan_retrieval` never reads it).

Leaving one of two adjacent dedups hash-order-dependent is how the next reader concludes the ordering was deliberate.

## Scope

This is the **determinism fix only**. Whether a keyword bag is the right query representation at all is a separate open question with its own measurement — the addendum explicitly declines to settle it, and so does this PR. Nothing here changes *what* gets extracted, only that the same input yields the same answer twice.

## Testing

9 new tests in `tests/test_n10_keyword_determinism.py`. They **spawn subprocesses** with differing `PYTHONHASHSEED` — a same-process assertion cannot observe this defect at all and would pass just as happily against the broken code.

`test_the_guard_can_actually_fail` runs the pre-N10 expression across the same seeds and asserts it disagrees, so the suite proves its own power rather than assuming it. A determinism test that cannot fail is decoration.

Verified directly: reverting `intent.py` makes `test_classify_is_identical_across_hash_seeds` fail with `5 != 1`, then restoring makes it pass.

The 12 failures under `-k "intent or context or frame"` are **byte-identical before and after** this change (unreachable Postgres in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM4pvwqABxRQZQHDWVDUnE
