### PR TITLE
docs(dag): tell the agent that finished DAGs announce themselves

### DIFF
--- a/nous/api/tools.py
+++ b/nous/api/tools.py
@@ -3888,7 +3888,13 @@ def register_dag_tools(
 
     dispatcher.register("dag_create", dag_create, {
         "type": "object",
-        "description": "Create a DAG to orchestrate subtasks and checks with dependency tracking.",
+        "description": (
+            "Create a DAG to orchestrate subtasks and checks with dependency tracking. "
+            "You do NOT need to poll for the result: when the DAG reaches a terminal "
+            "state its outcome is delivered to you automatically (F087), so create it "
+            "and move on. Use dag_manage only when the user asks about progress "
+            "mid-flight, or to cancel or retry."
+        ),
         "properties": {
             "name": {"type": "string", "description": "DAG name"},
             "description": {"type": "string"},
@@ -3907,7 +3913,7 @@ def register_dag_tools(
                         "tools": {"type": "array", "items": {"type": "string"}},
                         "frame_type": {"type": "string"},
                         "model": {"type": "string"},
-                        "timeout_seconds": {"type": "integer", "minimum": 1, "description": "Execution timeout in seconds (default: NOUS_DAG_NODE_DEFAULT_TIMEOUT, ceiling: NOUS_DAG_NODE_MAX_TIMEOUT)"},
+                        "timeout_seconds": {"type": "integer", "minimum": 1, "description": "Execution timeout in seconds (default: NOUS_DAG_NODE_DEFAULT_TIMEOUT, ceiling: NOUS_DAG_NODE_MAX_TIMEOUT). F087: now a REAL bound — a node still executing past this plus NOUS_DAG_NODE_TIMEOUT_GRACE_SECONDS is cancelled and failed, so size it to the work rather than leaving the default on a long job."},
                         "stall_timeout_seconds": {"type": "integer", "minimum": 0, "description": "F064.1: max seconds without activity before failing this node. 0 = disabled for this node. Unset = inherit NOUS_DAG_NODE_DEFAULT_STALL_TIMEOUT."},
                         "completion_condition": {"type": "string"},
                         "completion_check": {"type": "string", "description": "Shell command polled each tick. Exit 0 = success, 1 = failed, 2 = still running."},
@@ -3953,7 +3959,12 @@ def register_dag_tools(
 
     dispatcher.register("dag_manage", dag_manage, {
         "type": "object",
-        "description": "List, inspect, cancel, or retry nodes in DAGs.",
+        "description": (
+            "List, inspect, cancel, or retry nodes in DAGs. Not needed to collect "
+            "results — a finished DAG announces itself. 'retry_node' re-queues a "
+            "failed node (and any descendants it alone blocked); it is refused on a "
+            "cancelled DAG, since cancellation is deliberate."
+        ),
         "properties": {
             "action": {"type": "string", "enum": ["list", "status", "cancel", "retry_node"]},
             "dag_id": {"type": "string"},


### PR DESCRIPTION
Follow-up to #585. F087 changed how an agent should *use* DAGs, but only the operator-facing docs were updated — the agent-facing tool descriptions still describe the pre-F087 world.

The env vars were fine: all ten F087 settings in `config.py` have matching entries in CLAUDE.md, exact 1:1. This PR closes the other half.

## What the agent was still being told

**Polling is no longer necessary — but nothing says so.** Before F087, calling `dag_manage status` in a loop was the *only* way to learn a DAG's outcome, so it is precisely the habit an agent would form and keep. Results are now delivered automatically when a DAG reaches a terminal state, making that loop pure waste of turns and tokens. `dag_create` now says so directly, and `dag_manage` says it is not needed to collect results.

**`timeout_seconds` is a real bound now.** It used to be advice passed down to the subtask, which meant leaving the default on a long job was merely imprecise. The wall-clock reaper enforces it independently, so the same default now gets a long job cancelled. The field description says that, and names the grace setting.

**`retry_node` is refused on a cancelled DAG.** Mentioned so the agent understands the error rather than retrying into it.

## Scope

Description strings only — no behaviour change, no new settings, no schema change.

## Verification

- DAG tool + delivery + durability suites: **89 passed**
- Ruff findings on `tools.py` unchanged from `main` (55 before, 55 after) — confirmed by running ruff against `git show main:nous/api/tools.py`, since that file carries a large pre-existing count and a raw number would say nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM4pvwqABxRQZQHDWVDUnE
