### PR TITLE
fix(heartbeat): stop silently dropping run-stats writes (#590)

### DIFF
--- a/nous/heartbeat/runner.py
+++ b/nous/heartbeat/runner.py
@@ -216,52 +216,53 @@ class HeartbeatRunner:
         break check execution, abort the tick loop, or (for
         trigger_check) change the caller's own exception contract.
 
-        Retries once (2 total attempts) with a short fixed 0.1s gap —
-        matching the existing _embed_with_retry(attempts=2) convention
-        elsewhere in the codebase (nous/heart/facts.py,
-        nous/heart/procedures.py) for this class of fast-operation
-        transient-blip retry. No exponential backoff: this is a
-        single-row UPDATE, not a rate-limited external API, so a short
-        fixed gap is enough to let a transient connection-pool/deadlock
-        condition clear without meaningfully slowing the tick loop, which
-        runs every due check through this same sequential loop — any
-        added per-check latency here is directly additive across a tick.
-        The guaranteed worst-case ADDED latency from this policy is one
-        0.1s sleep per check; the retried attempt's own execution time is
-        not bounded by this method (the DB layer configures no query or
-        connection timeout), but that risk already existed for the
-        single non-retried attempt today — this policy does not
-        introduce it, only adds one more bounded-gap attempt.
+        NO RETRY, deliberately (codex P2 on the original version of this
+        fix, which retried once). update_run_stats writes a RELATIVE
+        increment (`run_count = run_count + 1`), not an absolute value —
+        if the UPDATE commits on the server but the client never learns
+        that (e.g. the connection drops after commit, before the
+        acknowledgement arrives), we cannot tell "the write never
+        landed" from "the write landed and we just didn't hear back". A
+        retry in the second case double-counts a single execution,
+        silently corrupting the exact two consumers this fix protects:
+        F034.3's self-tuner and #589's `run_count - error_count` gate.
+        That is a worse failure than the one #590 filed — #590's ask is
+        visibility, and one ERROR-logged attempt already delivers it.
+        Considered and rejected: retrying only on
+        sqlalchemy.exc.TimeoutError (pool-checkout timeout — provably
+        never reached the server, so provably safe) is real, but covers
+        only pool exhaustion. The likelier failure for a live connection
+        mid-UPDATE — a dropped connection — is exactly the ambiguous
+        case with no safe classification, so a retry that skips the
+        common case in exchange for a "which exceptions are safe" list
+        that breaks quietly on a driver upgrade is a bad trade. Making
+        the write itself idempotent (an execution-scoped dedup key) would
+        close this properly, but needs a schema change — proportionate
+        only if a real double-count is ever observed, not for a defect
+        whose filed symptom is a missing log line.
 
-        On exhaustion, escalates to ERROR with exc_info, naming the check
-        and which record was lost. The point of #590 is that a silent
-        drop leaves no consumer able to distinguish "did not run" from
-        "ran, and we failed to record it" — F034.3's self-tuning,
+        Escalates to ERROR with exc_info on any failure, naming the
+        check and which record was lost. The point of #590 is that a
+        silent drop leaves no consumer able to distinguish "did not run"
+        from "ran, and we failed to record it" — F034.3's self-tuning,
         /heartbeat/status, the dashboard, and #589's completion gate all
         read this table and need that distinction.
         """
         if not isinstance(check, DynamicCheck) or self._dynamic_loader is None:
             return
-        last_exc: Exception | None = None
-        for attempt in range(2):
-            if attempt == 1:
-                await asyncio.sleep(0.1)
-            try:
-                await self._dynamic_loader.update_run_stats(
-                    check.check_id, success=success, error_msg=error_msg,
-                )
-                return
-            except Exception as exc:
-                last_exc = exc
-        outcome = "success" if success else "failure"
-        logger.error(
-            "F034.5/#590: failed to record %s run stats for check '%s' "
-            "after retry — this run's record is LOST (downstream "
-            "consumers cannot distinguish this from the check never "
-            "having run)",
-            outcome, check.name,
-            exc_info=last_exc,
-        )
+        try:
+            await self._dynamic_loader.update_run_stats(
+                check.check_id, success=success, error_msg=error_msg,
+            )
+        except Exception as exc:
+            outcome = "success" if success else "failure"
+            logger.error(
+                "F034.5/#590: failed to record %s run stats for check "
+                "'%s' — this run's record is LOST (downstream consumers "
+                "cannot distinguish this from the check never having run)",
+                outcome, check.name,
+                exc_info=exc,
+            )
 
     async def _tick(self, urgent_only: bool = False) -> list[Finding]:
         """Run due checks and triage findings."""

--- a/nous/heartbeat/runner.py
+++ b/nous/heartbeat/runner.py
@@ -24,7 +24,7 @@ from nous.config import Settings
 from nous.events import Event, EventBus
 from nous.heart import Heart
 from nous.heartbeat.finding_store import FindingStore
-from nous.heartbeat.registry import CheckRegistry
+from nous.heartbeat.registry import BaseCheck, CheckRegistry
 from nous.heartbeat.dynamic import CALLBACK_RETRY_DELAY_SECONDS, DynamicCheck, DynamicCheckLoader
 from nous.heartbeat.schemas import CheckResult, Finding, FindingAction, HeartbeatResult
 from nous.heartbeat.tuner import HeartbeatTuner
@@ -195,6 +195,74 @@ class HeartbeatRunner:
             except Exception:
                 logger.exception("Heartbeat tick failed")
 
+    async def _record_run_stats(
+        self, check: BaseCheck, *, success: bool, error_msg: str | None = None,
+    ) -> None:
+        """Single choke point for persisting a check's run outcome to the DB.
+
+        Issue #590: DynamicCheckLoader.update_run_stats's caller-side
+        try/except was duplicated across five call sites (two _tick
+        branches, trigger_check's two branches) with inconsistent
+        handling — two of the five (_tick's timeout and exception
+        branches) were a bare `pass`, dropping a FAILED run record with
+        no log line at all. A dropped failure record is worse than a
+        dropped success record: it inflates apparent success rates,
+        which is exactly what F034.3's self-tuning consumes. Root cause
+        of the family (this method exists to close): a durable record of
+        check execution was written best-effort, and its loss was
+        invisible to every caller.
+
+        Never raises into the caller — a stats-write failure must not
+        break check execution, abort the tick loop, or (for
+        trigger_check) change the caller's own exception contract.
+
+        Retries once (2 total attempts) with a short fixed 0.1s gap —
+        matching the existing _embed_with_retry(attempts=2) convention
+        elsewhere in the codebase (nous/heart/facts.py,
+        nous/heart/procedures.py) for this class of fast-operation
+        transient-blip retry. No exponential backoff: this is a
+        single-row UPDATE, not a rate-limited external API, so a short
+        fixed gap is enough to let a transient connection-pool/deadlock
+        condition clear without meaningfully slowing the tick loop, which
+        runs every due check through this same sequential loop — any
+        added per-check latency here is directly additive across a tick.
+        The guaranteed worst-case ADDED latency from this policy is one
+        0.1s sleep per check; the retried attempt's own execution time is
+        not bounded by this method (the DB layer configures no query or
+        connection timeout), but that risk already existed for the
+        single non-retried attempt today — this policy does not
+        introduce it, only adds one more bounded-gap attempt.
+
+        On exhaustion, escalates to ERROR with exc_info, naming the check
+        and which record was lost. The point of #590 is that a silent
+        drop leaves no consumer able to distinguish "did not run" from
+        "ran, and we failed to record it" — F034.3's self-tuning,
+        /heartbeat/status, the dashboard, and #589's completion gate all
+        read this table and need that distinction.
+        """
+        if not isinstance(check, DynamicCheck) or self._dynamic_loader is None:
+            return
+        last_exc: Exception | None = None
+        for attempt in range(2):
+            if attempt == 1:
+                await asyncio.sleep(0.1)
+            try:
+                await self._dynamic_loader.update_run_stats(
+                    check.check_id, success=success, error_msg=error_msg,
+                )
+                return
+            except Exception as exc:
+                last_exc = exc
+        outcome = "success" if success else "failure"
+        logger.error(
+            "F034.5/#590: failed to record %s run stats for check '%s' "
+            "after retry — this run's record is LOST (downstream "
+            "consumers cannot distinguish this from the check never "
+            "having run)",
+            outcome, check.name,
+            exc_info=last_exc,
+        )
+
     async def _tick(self, urgent_only: bool = False) -> list[Finding]:
         """Run due checks and triage findings."""
         self._tick_count += 1
@@ -234,13 +302,7 @@ class HeartbeatRunner:
                     self._tokens_used_today += result.tokens_used
 
                 # F034.5: Update run stats in DB for dynamic checks
-                if isinstance(check, DynamicCheck) and self._dynamic_loader is not None:
-                    try:
-                        await self._dynamic_loader.update_run_stats(
-                            check.check_id, success=True,
-                        )
-                    except Exception:
-                        logger.warning("F034.5: Failed to update run stats for '%s'", check.name)
+                await self._record_run_stats(check, success=True)
 
                 # #273: Collect self-disabled checks with callbacks
                 if (
@@ -261,24 +323,12 @@ class HeartbeatRunner:
                 check.mark_failure()
                 logger.warning("Heartbeat check '%s' timed out", check.name)
                 # F034.5: Record timeout as error for dynamic checks
-                if isinstance(check, DynamicCheck) and self._dynamic_loader is not None:
-                    try:
-                        await self._dynamic_loader.update_run_stats(
-                            check.check_id, success=False, error_msg="timeout",
-                        )
-                    except Exception:
-                        pass
+                await self._record_run_stats(check, success=False, error_msg="timeout")
             except Exception as exc:
                 check.mark_failure()
                 logger.exception("Heartbeat check '%s' failed", check.name)
                 # F034.5: Record error for dynamic checks
-                if isinstance(check, DynamicCheck) and self._dynamic_loader is not None:
-                    try:
-                        await self._dynamic_loader.update_run_stats(
-                            check.check_id, success=False, error_msg=str(exc)[:200],
-                        )
-                    except Exception:
-                        pass
+                await self._record_run_stats(check, success=False, error_msg=str(exc)[:200])
 
         # #273: Fire callbacks as background tasks (non-blocking)
         for cb_check in callback_candidates:
@@ -895,11 +945,7 @@ class HeartbeatRunner:
             result = await asyncio.wait_for(check.run(), timeout=check.timeout)
             check.mark_success()
             # F034.5: Update DB stats for dynamic checks
-            if isinstance(check, DynamicCheck) and self._dynamic_loader:
-                try:
-                    await self._dynamic_loader.update_run_stats(check.check_id, success=True)
-                except Exception:
-                    logger.debug("Failed to update run stats for %s", name, exc_info=True)
+            await self._record_run_stats(check, success=True)
             if result.tokens_used:
                 self._tokens_used_today += result.tokens_used
             # #273: Fire callback if check self-disabled
@@ -922,11 +968,5 @@ class HeartbeatRunner:
         except Exception as e:
             check.mark_failure()
             # F034.5: Update DB stats for dynamic checks on failure
-            if isinstance(check, DynamicCheck) and self._dynamic_loader:
-                try:
-                    await self._dynamic_loader.update_run_stats(
-                        check.check_id, success=False, error_msg=str(e)[:200],
-                    )
-                except Exception:
-                    logger.debug("Failed to update run stats for %s", name, exc_info=True)
+            await self._record_run_stats(check, success=False, error_msg=str(e)[:200])
             raise

--- a/tests/test_heartbeat_dynamic.py
+++ b/tests/test_heartbeat_dynamic.py
@@ -936,10 +936,15 @@ class TestHeartbeatRunnerDynamic:
         assert "boom" in call_kwargs[1]["error_msg"]
 
     @pytest.mark.asyncio
-    async def test_record_run_stats_retries_transient_failure_and_succeeds(self, caplog):
-        """issue #590: a transient update_run_stats failure (first write
-        raises, retry succeeds) results in the stats being recorded, with
-        no ERROR logged — the retry absorbed the blip.
+    async def test_record_run_stats_write_failure_logs_error_and_does_not_raise(self, caplog):
+        """issue #590: an update_run_stats write failure logs ERROR and
+        does NOT raise into the caller — _tick must complete normally,
+        not abort the whole tick loop over one check's lost stats write.
+
+        No retry (codex P2, resolved by dropping the retry rather than
+        building a safe-classification scheme — see _record_run_stats's
+        docstring): update_run_stats is a relative increment, so a
+        single failed attempt is the whole story, not a first-of-two.
         """
         reg = CheckRegistry()
         check = _make_dynamic_check(name="dyn_1")
@@ -947,46 +952,14 @@ class TestHeartbeatRunnerDynamic:
         reg.register(check)
 
         loader = MagicMock()
-        loader.update_run_stats = AsyncMock(
-            side_effect=[Exception("transient db error"), None]
-        )
+        loader.update_run_stats = AsyncMock(side_effect=Exception("db write failed"))
 
         runner = self._make_runner(registry=reg, dynamic_loader=loader)
 
-        with patch("nous.heartbeat.runner.asyncio.sleep", new_callable=AsyncMock):
-            with caplog.at_level(logging.ERROR, logger="nous.heartbeat.runner"):
-                await runner._tick()
+        with caplog.at_level(logging.ERROR, logger="nous.heartbeat.runner"):
+            findings = await runner._tick()  # must not raise
 
-        assert loader.update_run_stats.call_count == 2, (
-            "Expected a retry after the transient failure."
-        )
-        for call in loader.update_run_stats.call_args_list:
-            assert call.args[0] == "check-uuid-001"
-            assert call.kwargs.get("success") is True
-        errors = [r for r in caplog.records if r.levelname == "ERROR"]
-        assert not errors, f"Expected no ERROR log — the retry succeeded. Got: {errors}"
-
-    @pytest.mark.asyncio
-    async def test_record_run_stats_persistent_failure_logs_error_and_does_not_raise(self, caplog):
-        """issue #590: a persistent update_run_stats failure (every
-        attempt raises) logs ERROR and does NOT raise into the caller —
-        _tick must complete normally, not abort the whole tick loop over
-        one check's lost stats write.
-        """
-        reg = CheckRegistry()
-        check = _make_dynamic_check(name="dyn_1")
-        check.run = AsyncMock(return_value=CheckResult(has_updates=False))
-        reg.register(check)
-
-        loader = MagicMock()
-        loader.update_run_stats = AsyncMock(side_effect=Exception("persistent db error"))
-
-        runner = self._make_runner(registry=reg, dynamic_loader=loader)
-
-        with patch("nous.heartbeat.runner.asyncio.sleep", new_callable=AsyncMock):
-            with caplog.at_level(logging.ERROR, logger="nous.heartbeat.runner"):
-                findings = await runner._tick()  # must not raise
-
+        loader.update_run_stats.assert_called_once()
         assert findings == []
         stats_errors = [
             r for r in caplog.records
@@ -1012,9 +985,8 @@ class TestHeartbeatRunnerDynamic:
 
         runner = self._make_runner(registry=reg, dynamic_loader=loader)
 
-        with patch("nous.heartbeat.runner.asyncio.sleep", new_callable=AsyncMock):
-            with pytest.raises(RuntimeError, match="the real failure"):
-                await runner.trigger_check("dyn_trigger_fail")
+        with pytest.raises(RuntimeError, match="the real failure"):
+            await runner.trigger_check("dyn_trigger_fail")
 
     @pytest.mark.asyncio
     async def test_tick_timeout_records_failure_stats_and_logs_error_when_write_fails(self, caplog):
@@ -1025,13 +997,12 @@ class TestHeartbeatRunnerDynamic:
         """
         reg = CheckRegistry()
         check = _make_dynamic_check(name="dyn_timeout")
-        # asyncio.sleep is patched below (needed for the retry backoff),
-        # which would neuter a REAL wait_for timeout too — raise
-        # asyncio.TimeoutError directly instead. asyncio.wait_for
-        # propagates an exception the awaited coroutine itself raises
-        # unchanged, so this reaches _tick's `except asyncio.TimeoutError:`
-        # branch identically to a genuine timeout, without depending on
-        # real timing.
+        # A real wait_for timeout requires a genuinely slow check.run(),
+        # which is fragile/slow in a test. asyncio.wait_for propagates an
+        # exception the awaited coroutine itself raises unchanged, so
+        # raising asyncio.TimeoutError directly reaches _tick's `except
+        # asyncio.TimeoutError:` branch identically to a genuine timeout,
+        # without depending on real timing.
         check.run = AsyncMock(side_effect=asyncio.TimeoutError())
         check.timeout = 30
         reg.register(check)
@@ -1041,9 +1012,8 @@ class TestHeartbeatRunnerDynamic:
 
         runner = self._make_runner(registry=reg, dynamic_loader=loader)
 
-        with patch("nous.heartbeat.runner.asyncio.sleep", new_callable=AsyncMock):
-            with caplog.at_level(logging.ERROR, logger="nous.heartbeat.runner"):
-                await runner._tick()  # must not raise
+        with caplog.at_level(logging.ERROR, logger="nous.heartbeat.runner"):
+            await runner._tick()  # must not raise
 
         loader.update_run_stats.assert_called_with(
             "check-uuid-001", success=False, error_msg="timeout",
@@ -1072,9 +1042,8 @@ class TestHeartbeatRunnerDynamic:
 
         runner = self._make_runner(registry=reg, dynamic_loader=loader)
 
-        with patch("nous.heartbeat.runner.asyncio.sleep", new_callable=AsyncMock):
-            with caplog.at_level(logging.ERROR, logger="nous.heartbeat.runner"):
-                await runner._tick()  # must not raise
+        with caplog.at_level(logging.ERROR, logger="nous.heartbeat.runner"):
+            await runner._tick()  # must not raise
 
         loader.update_run_stats.assert_called_with(
             "check-uuid-001", success=False, error_msg="boom",

--- a/tests/test_heartbeat_dynamic.py
+++ b/tests/test_heartbeat_dynamic.py
@@ -30,6 +30,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -904,8 +906,13 @@ class TestHeartbeatRunnerDynamic:
         runner = self._make_runner(registry=reg, dynamic_loader=loader)
         await runner._tick()
 
+        # issue #590: the call now routes through _record_run_stats, which
+        # always threads error_msg explicitly (default None) — same
+        # effective behavior as the old call site that omitted it and
+        # relied on update_run_stats's own default, just a different
+        # exact call signature.
         loader.update_run_stats.assert_called_once_with(
-            "check-uuid-001", success=True,
+            "check-uuid-001", success=True, error_msg=None,
         )
 
     @pytest.mark.asyncio
@@ -927,6 +934,166 @@ class TestHeartbeatRunnerDynamic:
         call_kwargs = loader.update_run_stats.call_args
         assert call_kwargs[1]["success"] is False
         assert "boom" in call_kwargs[1]["error_msg"]
+
+    @pytest.mark.asyncio
+    async def test_record_run_stats_retries_transient_failure_and_succeeds(self, caplog):
+        """issue #590: a transient update_run_stats failure (first write
+        raises, retry succeeds) results in the stats being recorded, with
+        no ERROR logged — the retry absorbed the blip.
+        """
+        reg = CheckRegistry()
+        check = _make_dynamic_check(name="dyn_1")
+        check.run = AsyncMock(return_value=CheckResult(has_updates=False))
+        reg.register(check)
+
+        loader = MagicMock()
+        loader.update_run_stats = AsyncMock(
+            side_effect=[Exception("transient db error"), None]
+        )
+
+        runner = self._make_runner(registry=reg, dynamic_loader=loader)
+
+        with patch("nous.heartbeat.runner.asyncio.sleep", new_callable=AsyncMock):
+            with caplog.at_level(logging.ERROR, logger="nous.heartbeat.runner"):
+                await runner._tick()
+
+        assert loader.update_run_stats.call_count == 2, (
+            "Expected a retry after the transient failure."
+        )
+        for call in loader.update_run_stats.call_args_list:
+            assert call.args[0] == "check-uuid-001"
+            assert call.kwargs.get("success") is True
+        errors = [r for r in caplog.records if r.levelname == "ERROR"]
+        assert not errors, f"Expected no ERROR log — the retry succeeded. Got: {errors}"
+
+    @pytest.mark.asyncio
+    async def test_record_run_stats_persistent_failure_logs_error_and_does_not_raise(self, caplog):
+        """issue #590: a persistent update_run_stats failure (every
+        attempt raises) logs ERROR and does NOT raise into the caller —
+        _tick must complete normally, not abort the whole tick loop over
+        one check's lost stats write.
+        """
+        reg = CheckRegistry()
+        check = _make_dynamic_check(name="dyn_1")
+        check.run = AsyncMock(return_value=CheckResult(has_updates=False))
+        reg.register(check)
+
+        loader = MagicMock()
+        loader.update_run_stats = AsyncMock(side_effect=Exception("persistent db error"))
+
+        runner = self._make_runner(registry=reg, dynamic_loader=loader)
+
+        with patch("nous.heartbeat.runner.asyncio.sleep", new_callable=AsyncMock):
+            with caplog.at_level(logging.ERROR, logger="nous.heartbeat.runner"):
+                findings = await runner._tick()  # must not raise
+
+        assert findings == []
+        stats_errors = [
+            r for r in caplog.records
+            if r.levelname == "ERROR" and "stats" in r.getMessage().lower()
+        ]
+        assert stats_errors, "Expected an ERROR log naming the lost stats record."
+        assert "dyn_1" in stats_errors[0].getMessage()
+
+    @pytest.mark.asyncio
+    async def test_trigger_check_failure_reraises_original_exception_after_stats_write_failure(self):
+        """issue #590: trigger_check's failure path must still re-raise the
+        ORIGINAL exception after a stats-write failure — the contract
+        (REST callers see the real error) must survive exactly.
+        """
+        reg = CheckRegistry()
+        check = _make_dynamic_check(name="dyn_trigger_fail")
+        check.run = AsyncMock(side_effect=RuntimeError("the real failure"))
+        check.timeout = 30
+        reg.register(check)
+
+        loader = MagicMock()
+        loader.update_run_stats = AsyncMock(side_effect=Exception("stats write also failed"))
+
+        runner = self._make_runner(registry=reg, dynamic_loader=loader)
+
+        with patch("nous.heartbeat.runner.asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(RuntimeError, match="the real failure"):
+                await runner.trigger_check("dyn_trigger_fail")
+
+    @pytest.mark.asyncio
+    async def test_tick_timeout_records_failure_stats_and_logs_error_when_write_fails(self, caplog):
+        """issue #590: the _tick timeout path used to swallow a
+        stats-write failure with a bare `pass` — completely silent, no
+        log at all. Must fail against the pre-fix implementation: no
+        ERROR is logged for a lost 'timeout' failure record.
+        """
+        reg = CheckRegistry()
+        check = _make_dynamic_check(name="dyn_timeout")
+        # asyncio.sleep is patched below (needed for the retry backoff),
+        # which would neuter a REAL wait_for timeout too — raise
+        # asyncio.TimeoutError directly instead. asyncio.wait_for
+        # propagates an exception the awaited coroutine itself raises
+        # unchanged, so this reaches _tick's `except asyncio.TimeoutError:`
+        # branch identically to a genuine timeout, without depending on
+        # real timing.
+        check.run = AsyncMock(side_effect=asyncio.TimeoutError())
+        check.timeout = 30
+        reg.register(check)
+
+        loader = MagicMock()
+        loader.update_run_stats = AsyncMock(side_effect=Exception("db write failed"))
+
+        runner = self._make_runner(registry=reg, dynamic_loader=loader)
+
+        with patch("nous.heartbeat.runner.asyncio.sleep", new_callable=AsyncMock):
+            with caplog.at_level(logging.ERROR, logger="nous.heartbeat.runner"):
+                await runner._tick()  # must not raise
+
+        loader.update_run_stats.assert_called_with(
+            "check-uuid-001", success=False, error_msg="timeout",
+        )
+        errors = [r for r in caplog.records if r.levelname == "ERROR"]
+        assert errors, (
+            "Expected an ERROR log for the lost timeout-failure stats "
+            "record — the pre-fix bare `pass` produces none."
+        )
+
+    @pytest.mark.asyncio
+    async def test_tick_exception_records_failure_stats_and_logs_error_when_write_fails(self, caplog):
+        """issue #590: the _tick exception path used to swallow a
+        stats-write failure with a bare `pass` — completely silent, no
+        log at all. Must fail against the pre-fix implementation: no
+        ERROR is logged for a lost failure record.
+        """
+        reg = CheckRegistry()
+        check = _make_dynamic_check(name="dyn_exc")
+        check.run = AsyncMock(side_effect=RuntimeError("boom"))
+        check.timeout = 30
+        reg.register(check)
+
+        loader = MagicMock()
+        loader.update_run_stats = AsyncMock(side_effect=Exception("db write failed"))
+
+        runner = self._make_runner(registry=reg, dynamic_loader=loader)
+
+        with patch("nous.heartbeat.runner.asyncio.sleep", new_callable=AsyncMock):
+            with caplog.at_level(logging.ERROR, logger="nous.heartbeat.runner"):
+                await runner._tick()  # must not raise
+
+        loader.update_run_stats.assert_called_with(
+            "check-uuid-001", success=False, error_msg="boom",
+        )
+        # Narrowed to "stats"-mentioning ERROR records: this path already
+        # logs an unrelated ERROR via logger.exception() for the check's
+        # OWN failure (RuntimeError("boom")) regardless of whether the
+        # stats write succeeds — a bare "any ERROR record exists" check
+        # would pass even pre-fix for the wrong reason.
+        stats_errors = [
+            r for r in caplog.records
+            if r.levelname == "ERROR" and "stats" in r.getMessage().lower()
+        ]
+        assert stats_errors, (
+            "Expected an ERROR log specifically about the lost run-stats "
+            "record — the pre-fix bare `pass` produces none (only the "
+            "unrelated 'Heartbeat check failed' ERROR from the check's "
+            "own RuntimeError, not from the stats write)."
+        )
 
     @pytest.mark.asyncio
     async def test_periodic_sync(self):


### PR DESCRIPTION
Fixes #590.

`update_run_stats` writes the durable record of check execution — `run_count`, `error_count`, `last_run_at`. Every caller wrapped it in its own try/except and dropped the failure, so a lost write left no consumer able to distinguish **"did not run"** from **"ran, and we failed to record it."** Those warrant opposite responses.

## Wider than the issue text

#590 named `runner.py:237-243`, but there were **five** sites, handled five different ways:

| Site | Context | Before |
|---|---|---|
| `_tick` | success | `logger.warning`, no `exc_info` |
| `_tick` | timeout | **bare `pass`** |
| `_tick` | exception | **bare `pass`** |
| `trigger_check` | success | `logger.debug` |
| `trigger_check` | failure | `logger.debug` |

The two silent ones are arguably worse than the one that got filed: a lost **failure** record inflates apparent success rates, and F034.3's self-tuning consumes exactly those counters to adjust heartbeat parameters. `/heartbeat/status` and the dashboard under-report from the same loss.

## Change

One choke point — `HeartbeatRunner._record_run_stats(check, *, success, error_msg=None)` — encapsulating the `isinstance(check, DynamicCheck)` guard, the write, and consistent logging. All five sites route through it.

Five near-identical branches is *how* two of them drifted into silence, so the fix is structural rather than five patches. Same shape, and same reasoning, as the terminal-transition choke point in #589.

- **A failed write logs ERROR with `exc_info`**, naming the check and whether a success or failure record was lost. This is what #590 actually asked for: not automatic recovery, but an end to silence.
- **Never raises into the caller.** `trigger_check`'s failure path still re-raises the original exception — covered by a regression test.

## On the retry that isn't here

The first revision of this PR retried twice with a 0.1s backoff. Codex correctly flagged that `update_run_stats` does `run_count = run_count + 1` — a **relative** increment. If Postgres commits but the client misses the acknowledgement, the retry records one execution twice, corrupting the exact consumers this fix exists to protect: F034.3's self-tuner, and #589's `run_count - error_count` completion gate. Removed in `e75a2f0`.

That trade was backwards. A dropped write that logs ERROR is visible and recoverable by a human reading logs; a double-counted execution is silent and permanently wrong, and it degrades the self-tuner's *input* rather than merely its coverage.

A provably-safe subset **was** identified rather than dismissed as fragile: `sqlalchemy.exc.TimeoutError` is cleanly distinguishable for pool-checkout failures, where the query never reached the server. It was rejected because it covers pool exhaustion while the likelier real failure — a connection dropping mid-query — is precisely the ambiguous case with no safe classification. A retry that skips the common case is not worth a driver-internals coupling that breaks quietly on a library upgrade.

Making the write genuinely idempotent needs a schema change. That is the correct fix if a real double-count is ever observed; it is not proportionate to a filed log line. All of this reasoning lives in the code at `_record_run_stats` so the retry does not get re-added in six months.

## Honest notes on the tests

- `test_trigger_check_failure_reraises_original_exception_after_stats_write_failure` does **not** fail pre-fix; that contract already held. It is a regression guard for what this refactor must not break, not a new-behaviour proof. The `_tick` timeout and exception tests do fail pre-fix — those sites were bare `pass`.
- The exception-path test initially passed pre-fix **for the wrong reason** — that branch already calls `logger.exception()` for the check's own error, so a bare "an ERROR exists" assertion was satisfied by an unrelated line. Both ERROR assertions were narrowed to a stats-specific message filter.
- One pre-existing test (`test_tick_updates_run_stats`) asserted an exact call signature with `error_msg` omitted; the choke point now threads `error_msg=None` explicitly. Behaviourally identical to `update_run_stats`'s own default. Updated with a comment rather than silently.
- Removing the retry made three `patch(...asyncio.sleep...)` wrappers vestigial. Left in place they would read as guarding against something; removed.

## Verification

- `tests/test_heartbeat*.py` (7 files): **264 passed**
- Grepped `nous/` for every `update_run_stats` caller — exactly the five above, plus the definition
- No existing test depended on the previous silence (no `caplog` assertions against these sites)
- Confirmed no backoff sleep remains in `_record_run_stats`; the two `asyncio.sleep` calls left in `runner.py` are the pre-existing tick interval and the #273 callback retry

Surfaced while fixing #589, which documents a narrow residual caused by this defect and deliberately did not fix it there — the blast radius is every check type, not DAG logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM4pvwqABxRQZQHDWVDUnE
